### PR TITLE
Enable terminal scrollback with mouse wheel support

### DIFF
--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -124,6 +124,7 @@ export function Terminal({
         fontFamily,
         theme: getTerminalTheme(theme),
         allowProposedApi: true,
+        scrollback: 10000,
       });
 
       fitAddon = new FitAddon();

--- a/src/services/tmux-service.ts
+++ b/src/services/tmux-service.ts
@@ -107,6 +107,15 @@ export async function createSession(
   try {
     await execFile("tmux", args);
 
+    // Enable mouse mode for scrollback support
+    await execFile("tmux", [
+      "set-option",
+      "-t",
+      sessionName,
+      "mouse",
+      "on",
+    ]);
+
     // Execute startup command if provided
     if (startupCommand && startupCommand.trim()) {
       await sendKeys(sessionName, startupCommand.trim());


### PR DESCRIPTION
## Summary
- Enable tmux mouse mode when creating new sessions for scrollback support
- Increase xterm.js scrollback buffer from default 1000 to 10,000 lines

## Test plan
- [ ] Create a new terminal session
- [ ] Verify mouse wheel scrolling works in the terminal
- [ ] Verify Shift+PageUp/PageDown scrolling works
- [ ] Existing sessions will need `tmux set-option -t <session> mouse on` or recreation

🤖 Generated with [Claude Code](https://claude.com/claude-code)