### PR TITLE
Fix worktree path and session persistence issues

### DIFF
--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -712,7 +712,6 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
                           fontFamily={prefs.fontFamily}
                           notificationsEnabled={true}
                           isRecording={isRecording && isActiveSession}
-                          onSessionExit={() => closeSession(session.id)}
                           onOutput={isRecording && isActiveSession ? recordOutput : undefined}
                           onDimensionsChange={isRecording && isActiveSession ? updateDimensions : undefined}
                         />

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -182,6 +182,9 @@ export function Terminal({
           cols: String(cols),
           rows: String(rows),
         });
+        if (cwd) {
+          params.set("cwd", cwd);
+        }
 
         // Include working directory if specified
         if (projectPath) {

--- a/src/components/terminal/TerminalWithKeyboard.tsx
+++ b/src/components/terminal/TerminalWithKeyboard.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useRef, useCallback } from "react";
+import { useRef, useCallback, useState } from "react";
 import { Terminal } from "./Terminal";
 import { MobileKeyboard } from "./MobileKeyboard";
+import { Button } from "@/components/ui/button";
+import { RotateCcw, Terminal as TerminalIcon } from "lucide-react";
 import type { ConnectionStatus } from "@/types/terminal";
 
 interface TerminalWithKeyboardProps {
@@ -39,9 +41,25 @@ export function TerminalWithKeyboard({
   onDimensionsChange,
 }: TerminalWithKeyboardProps) {
   const wsRef = useRef<WebSocket | null>(null);
+  const [hasExited, setHasExited] = useState(false);
+  const [exitCode, setExitCode] = useState<number | null>(null);
+  const [restartKey, setRestartKey] = useState(0);
 
   const handleWebSocketReady = useCallback((ws: WebSocket | null) => {
     wsRef.current = ws;
+  }, []);
+
+  const handleSessionExit = useCallback((code: number) => {
+    setHasExited(true);
+    setExitCode(code);
+    onSessionExit?.(code);
+  }, [onSessionExit]);
+
+  const handleRestart = useCallback(() => {
+    setHasExited(false);
+    setExitCode(null);
+    // Increment key to force Terminal component to remount and reconnect
+    setRestartKey((k) => k + 1);
   }, []);
 
   const handleMobileKeyPress = useCallback(
@@ -73,8 +91,9 @@ export function TerminalWithKeyboard({
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex-1 min-h-0">
+      <div className="flex-1 min-h-0 relative">
         <Terminal
+          key={restartKey}
           sessionId={sessionId}
           tmuxSessionName={tmuxSessionName}
           sessionName={sessionName}
@@ -87,10 +106,36 @@ export function TerminalWithKeyboard({
           isRecording={isRecording}
           onStatusChange={onStatusChange}
           onWebSocketReady={handleWebSocketReady}
-          onSessionExit={onSessionExit}
+          onSessionExit={handleSessionExit}
           onOutput={onOutput}
           onDimensionsChange={onDimensionsChange}
         />
+
+        {/* Restart overlay when session has exited */}
+        {hasExited && (
+          <div className="absolute inset-0 flex items-center justify-center bg-slate-950/80 backdrop-blur-sm z-20">
+            <div className="text-center p-6 rounded-xl bg-slate-900/90 border border-white/10 shadow-2xl max-w-sm">
+              <div className="mx-auto w-12 h-12 rounded-lg bg-amber-500/20 flex items-center justify-center mb-4">
+                <TerminalIcon className="w-6 h-6 text-amber-400" />
+              </div>
+              <h3 className="text-lg font-semibold text-white mb-2">
+                Session Ended
+              </h3>
+              <p className="text-sm text-slate-400 mb-4">
+                {exitCode === 0
+                  ? "The terminal exited normally."
+                  : `The terminal exited with code ${exitCode}.`}
+              </p>
+              <Button
+                onClick={handleRestart}
+                className="bg-gradient-to-r from-violet-600 to-purple-600 hover:from-violet-700 hover:to-purple-700 text-white"
+              >
+                <RotateCcw className="w-4 h-4 mr-2" />
+                Restart Session
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
       <MobileKeyboard onKeyPress={handleMobileKeyPress} />
     </div>

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -3,7 +3,8 @@
  */
 
 export interface GitHubRepository {
-  id: number;
+  id: string; // Database UUID
+  githubId: number; // GitHub's numeric ID
   name: string;
   fullName: string;
   cloneUrl: string;


### PR DESCRIPTION
## Summary
- Fix parameter mismatch between frontend and worktree API endpoint causing worktrees to be created in wrong location
- Use database UUIDs instead of GitHub numeric IDs for repository references
- Add restart overlay when terminal exits instead of auto-closing sessions
- Sessions now persist until manually deleted from sidebar

## Test plan
- [ ] Create a new worktree from a GitHub repo - verify it's created in the correct project folder
- [ ] Exit a terminal session (type `exit`) - verify restart overlay appears
- [ ] Click "Restart Session" - verify terminal reconnects in correct directory
- [ ] Verify session remains in sidebar until manually closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)