### PR TITLE
Add collapsible sidebar, improved drag-drop, and session reordering

### DIFF
--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -182,10 +182,6 @@ export function Terminal({
           cols: String(cols),
           rows: String(rows),
         });
-        if (cwd) {
-          params.set("cwd", cwd);
-        }
-
         // Include working directory if specified
         if (projectPath) {
           params.set("cwd", projectPath);


### PR DESCRIPTION
## Summary
- **Collapsible sidebar**: Sidebar can collapse to icon-only view (12px width) with tooltips, state persisted to localStorage
- **Improved drag-drop**: Dropping sessions on items within a folder now adds them to that folder (no need to target folder header)
- **Session reordering**: Drag sessions within the same folder to reorder with visual drop indicators

## Test plan
- [ ] Click collapse button in sidebar header - sidebar should shrink to icons
- [ ] Hover over collapsed icons - tooltips should show names
- [ ] Expand sidebar and verify state persists on page refresh
- [ ] Drag a session onto another session inside a folder - should move to that folder
- [ ] Drag a session within the same folder - should reorder with purple drop indicator
- [ ] Verify reordering persists after page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)