### PR TITLE
Fix wizard folder context not set from empty state Advanced button

### DIFF
--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -725,7 +725,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
                     Quick Terminal
                   </Button>
                   <Button
-                    onClick={() => setIsWizardOpen(true)}
+                    onClick={handleOpenWizard}
                     variant="outline"
                     className="border-white/10 text-slate-300 hover:bg-white/5"
                   >


### PR DESCRIPTION
## Summary
- Rebased on latest master
- Fixed: The "Advanced..." button in the empty state UI was calling `setIsWizardOpen(true)` directly, bypassing `handleOpenWizard` which sets `wizardFolderId`
- Sessions created via the wizard from the empty state now correctly inherit the active folder context

## Test plan
- [ ] Select a folder in the sidebar
- [ ] Click "Advanced..." from empty state
- [ ] Create a GitHub/worktree session
- [ ] Verify session appears in the selected folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)