### PR TITLE
Fix Shift+Enter not working in terminal apps

### DIFF
--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -202,6 +202,13 @@ export function Terminal({
           }
         }
 
+        // Shift+Enter - xterm.js may not send Enter when Shift is held
+        // Manually send carriage return to ensure Enter works in terminal apps
+        if (event.shiftKey && event.key === "Enter") {
+          ws.send(JSON.stringify({ type: "input", data: "\r" }));
+          return false;
+        }
+
         return true; // Let xterm handle other key combinations
       });
 


### PR DESCRIPTION
## Summary
- Fixed Shift+Enter key combination not sending Enter to terminal apps
- Added custom key event handler in xterm.js to intercept Shift+Enter and manually send carriage return
- xterm.js was incorrectly dropping the Enter key when Shift modifier was held

## Test plan
- [ ] Open a terminal session
- [ ] Press Shift+Enter - should behave the same as regular Enter
- [ ] Verify in apps that use Shift+Enter for multi-line input (e.g., readline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)