### PR TITLE
Fix worktree sessions not being moved to active folder on mobile

### DIFF
--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -112,9 +112,13 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
       githubRepoId?: string;
       worktreeBranch?: string;
     }) => {
-      await createSession(data);
+      const newSession = await createSession(data);
+      // Move to active folder if one is selected (same behavior as quick new session)
+      if (activeProject.folderId && newSession) {
+        await moveSessionToFolder(newSession.id, activeProject.folderId);
+      }
     },
-    [createSession]
+    [createSession, activeProject.folderId, moveSessionToFolder]
   );
 
   const handleQuickNewSession = useCallback(async () => {


### PR DESCRIPTION
## Summary
- Fixed bug where worktree sessions created via the NewSessionWizard were not being moved into the active folder
- This was especially noticeable on mobile where folder organization is important for navigation
- Added folder assignment logic to `handleCreateSession` to match the behavior of `handleQuickNewSession` and `handleFolderNewSession`

## Test plan
- [ ] Create a folder in the session sidebar
- [ ] Select the folder to make it active
- [ ] Create a new worktree session via the wizard (From GitHub > select repo > select branch with worktree)
- [ ] Verify the new session appears inside the active folder
- [ ] Test on mobile device to confirm the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)