### PR TITLE
Fix sessions not rendering in correct folder on mobile

### DIFF
--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -721,7 +721,6 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
           <Sidebar
             sessions={activeSessions}
             folders={folders}
-            sessionFolders={sessionFolders}
             activeSessionId={activeSessionId}
             activeFolderId={activeProject.folderId}
             collapsed={effectiveCollapsed}


### PR DESCRIPTION
## Summary
- Fixed bug where sessions were not rendering in the correct folder on mobile
- Root cause: Sidebar used a separate `sessionFolders` map that could get out of sync with `session.folderId`
- Fixed by using `session.folderId` directly instead of the separate map
- Removed unused `sessionFolders` prop from Sidebar component

## Root Cause Analysis
The previous implementation had two sources of truth for folder membership:
1. `session.folderId` - stored in session object
2. `sessionFolders[session.id]` - stored in FolderContext

When a new session was created:
1. Session is created with `folderId` set
2. `dispatch({ type: "CREATE", session })` triggers UI re-render
3. UI renders before `registerSessionFolder()` updates the map
4. Session appears in root instead of folder

## Fix
Changed all folder membership checks in Sidebar.tsx to use `session.folderId` directly:
- Root sessions filter: `!s.folderId`
- Folder sessions filter: `s.folderId === node.id`
- Drag-drop logic: find session and use its `folderId`

## Test plan
- [x] TypeScript type check passes
- [x] ESLint passes
- [ ] Create a folder in the session sidebar
- [ ] Select the folder to make it active
- [ ] Create a new session via the wizard
- [ ] Verify the new session appears inside the active folder immediately
- [ ] Test on mobile device to confirm the fix
- [ ] Verify drag-drop between folders still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)