### PR TITLE
Fix terminal losing focus during text selection

### DIFF
--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -92,6 +92,7 @@ export function Terminal({
 
       terminal.open(terminalRef.current);
       fitAddon.fit();
+      terminal.focus();
 
       xtermRef.current = terminal;
       fitAddonRef.current = fitAddon;
@@ -219,9 +220,15 @@ export function Terminal({
           // Only trigger resize when dimensions actually change from non-zero to new values
           // This catches the transition from hidden (0x0) to visible
           if (width > 0 && height > 0 && (width !== lastWidth || height !== lastHeight)) {
+            // Transition from hidden (0x0) to visible - focus the terminal
+            const wasHidden = lastWidth === 0 && lastHeight === 0;
             lastWidth = width;
             lastHeight = height;
             handleResize();
+            // Focus terminal when it becomes visible (tab switch)
+            if (wasHidden) {
+              terminal.focus();
+            }
           }
         }
       });
@@ -361,6 +368,11 @@ export function Terminal({
     [sendImageToTerminal]
   );
 
+  // Focus terminal on click/mousedown to ensure it maintains focus during selection
+  const handleContainerMouseDown = useCallback(() => {
+    xtermRef.current?.focus();
+  }, []);
+
   return (
     <div
       ref={terminalRef}
@@ -368,6 +380,7 @@ export function Terminal({
         isDragging ? "ring-2 ring-blue-500 ring-opacity-50" : ""
       }`}
       style={{ backgroundColor: getThemeBackground(theme) }}
+      onMouseDown={handleContainerMouseDown}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}


### PR DESCRIPTION
## Summary
- Fixed issue where selecting text in the terminal would quickly lose focus, preventing copy
- Added explicit xterm.js focus management on initialization, mousedown, and tab switch
- Terminal now maintains focus throughout drag-select operations

## Test plan
- [ ] Open a terminal session
- [ ] Try to select text by clicking and dragging
- [ ] Verify selection is maintained and can be copied
- [ ] Switch between terminal tabs and verify focus is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)