### PR TITLE
Add folder drag-and-drop reordering in sidebar

### DIFF
--- a/src/app/api/folders/reorder/route.ts
+++ b/src/app/api/folders/reorder/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { getAuthSession } from "@/lib/auth-utils";
+import * as FolderService from "@/services/folder-service";
+
+/**
+ * POST /api/folders/reorder - Reorder folders (update sort order)
+ */
+export async function POST(request: Request) {
+  try {
+    const session = await getAuthSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { folderIds } = body;
+
+    if (!Array.isArray(folderIds)) {
+      return NextResponse.json(
+        { error: "folderIds must be an array" },
+        { status: 400 }
+      );
+    }
+
+    await FolderService.reorderFolders(session.user.id, folderIds);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error reordering folders:", error);
+    return NextResponse.json(
+      { error: "Failed to reorder folders" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -164,6 +164,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
     toggleFolder,
     moveSessionToFolder,
     moveFolderToParent,
+    reorderFolders,
     registerSessionFolder,
   } = useFolderContext();
 
@@ -469,6 +470,17 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
       }
     },
     [moveFolderToParent]
+  );
+
+  const handleReorderFolders = useCallback(
+    async (folderIds: string[]) => {
+      try {
+        await reorderFolders(folderIds);
+      } catch (error) {
+        console.error("Failed to reorder folders:", error);
+      }
+    },
+    [reorderFolders]
   );
 
   const handleRenameFolder = useCallback(
@@ -925,6 +937,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
             onFolderAdvancedSession={handleFolderAdvancedSession}
             onFolderNewWorktree={handleFolderNewWorktree}
             onFolderMove={handleMoveFolder}
+            onFolderReorder={handleReorderFolders}
           />
         </div>
       </div>

--- a/src/services/folder-service.ts
+++ b/src/services/folder-service.ts
@@ -256,6 +256,31 @@ export async function deleteFolder(
 }
 
 /**
+ * Reorder folders (update sortOrder for sibling folders).
+ * Accepts an array of folder IDs in the desired order.
+ * All folders must belong to the same parent (or all be root folders).
+ */
+export async function reorderFolders(
+  userId: string,
+  folderIds: string[]
+): Promise<void> {
+  // Update each folder with its new sort order
+  await Promise.all(
+    folderIds.map((id, index) =>
+      db
+        .update(sessionFolders)
+        .set({ sortOrder: index, updatedAt: new Date() })
+        .where(
+          and(
+            eq(sessionFolders.id, id),
+            eq(sessionFolders.userId, userId)
+          )
+        )
+    )
+  );
+}
+
+/**
  * Move a session to a folder (or remove from folder if folderId is null).
  * SECURITY: Validates that both the session and folder belong to the user.
  */


### PR DESCRIPTION
## Summary
- Add folder reordering via drag-and-drop in the sidebar
- Folders can now be reordered by dragging them above or below sibling folders (same parent level)
- When dragging to a different parent level, the existing move-to-folder behavior is preserved
- Visual drop indicators show where folders will be placed

## Test plan
- [ ] Create multiple folders at the root level
- [ ] Drag a folder above/below another to verify reorder works
- [ ] Verify reorder is persisted after page refresh
- [ ] Create nested folders and verify sibling reordering works at each level
- [ ] Drag a folder to a different parent to verify move behavior still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)