### PR TITLE
Fix terminal not loading after session deletion

### DIFF
--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -843,6 +843,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
 
     return (
       <TerminalWithKeyboard
+        key={session.id}
         sessionId={session.id}
         tmuxSessionName={session.tmuxSessionName}
         sessionName={session.name}
@@ -1074,6 +1075,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
                     return (
                       <div className="absolute inset-0 z-10">
                         <TerminalWithKeyboard
+                          key={session.id}
                           ref={(ref) => {
                             if (ref) {
                               terminalRefsMap.current.set(session.id, ref);


### PR DESCRIPTION
## Summary
- Add `key` prop to `TerminalWithKeyboard` components to force proper React remount when switching sessions
- Fixes bug where deleting a session would not properly load other terminals
- Fixes modal not dismissing after delete action
- Fixes terminal resize issues on session load

## Test plan
- [ ] Create two terminal sessions
- [ ] Close one session (type `exit` or Ctrl+D)
- [ ] Click Delete on the overlay
- [ ] Verify the other session loads and resizes properly
- [ ] Test with worktree sessions and "Delete Worktree" option

🤖 Generated with [Claude Code](https://claude.com/claude-code)