### PR TITLE
Fix split terminal resize and unify split state management

### DIFF
--- a/src/components/terminal/SplitPane.tsx
+++ b/src/components/terminal/SplitPane.tsx
@@ -251,13 +251,10 @@ export function SplitPaneContainer({
 
       const deltaPercent = (delta / totalSize) * 100;
 
+      const currentPane = findPane(layout, containerId) as ContainerPane | null;
+      const currentRatio = currentPane?.splitRatio ?? 50;
       onLayoutChange(
-        updateSplitRatio(
-          layout,
-          containerId,
-          (findPane(layout, containerId) as ContainerPane | null)?.splitRatio ??
-            50 + deltaPercent
-        )
+        updateSplitRatio(layout, containerId, currentRatio + deltaPercent)
       );
     },
     [layout, onLayoutChange]


### PR DESCRIPTION
## Summary
- Fix operator precedence bug in SplitPane.tsx that prevented resize from working
- Connect SessionManager to SplitContext for database-backed splits
- Remove local split state in favor of shared context state
- Sidebar and terminal view now use the same split state

## Test plan
- [ ] Create a split terminal using ⌘D or ⌘⇧D
- [ ] Verify the resize handle between panes can be dragged to adjust sizes
- [ ] Verify split state is reflected in the sidebar
- [ ] Refresh the page and verify split state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)