### PR TITLE
feat: add project task tracker sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Project Task Tracker Sidebar**: Collapsible right sidebar for project-scoped task management
+  - Three sections: Manual Tasks, Agent Tasks, and GitHub Issues
+  - Tasks support 4-level priority (Critical/High/Medium/Low), custom labels, subtasks, and due dates
+  - Agent tasks created automatically via MCP tools or REST API (5 new MCP tools: task_list, task_create, task_update, task_complete, task_delete)
+  - GitHub issues displayed from linked repos with "Link to task" action
+  - Folder-scoped: tasks track with each project folder independently
+  - Collapsible to 48px icon strip with open task count badge
+  - Resizable via drag handle (240-500px)
+  - Toggle via Cmd+. keyboard shortcut or header button
+  - Consistent glassmorphism design with existing UI patterns
 - **Agent Activity Status Indicators**: Real-time agent activity shown in sidebar via colored Sparkles icons
   - Green breathing animation when agent is running (tool use in progress)
   - Yellow breathing animation when agent is waiting for user input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Agent Activity Status Indicators**: Real-time agent activity shown in sidebar via colored Sparkles icons
+  - Green breathing animation when agent is running (tool use in progress)
+  - Yellow breathing animation when agent is waiting for user input
+  - Solid red when agent exited with error
+  - Gray when idle or no recent activity
+  - Uses Claude Code hooks (PreToolUse/Stop) to report status back to terminal server
+  - Hooks are automatically installed and merged with existing settings at session creation
+  - Status broadcast via WebSocket to all connected clients for cross-tab visibility
+
 ### Fixed
 
 - Worktree sessions now show GitBranch icon instead of generic terminal icon in sidebar

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,18 +22,35 @@ Remote Dev is a web-based terminal interface built with **Next.js 16**, **React 
 # Development (runs Next.js + terminal server concurrently)
 bun run dev
 
-# Or run separately
-bun run dev:next      # Next.js dev server with Turbopack (port 3000)
-bun run dev:terminal  # Terminal WebSocket server (port 3001)
+# Or run separately (ports come from .env.local)
+bun run dev:next      # Next.js dev server with Turbopack (port $PORT, default 6001)
+bun run dev:terminal  # Terminal WebSocket server (port $TERMINAL_PORT, default 6002)
 
 # Production
 bun run build
 bun run start          # Next.js server
 bun run start:terminal # Terminal server
 
+# Process manager (alternative to bun run dev)
+bun run rdv            # Interactive CLI: start/stop/restart/status
+bun run rdv:dev        # Start both servers in dev mode (background)
+bun run rdv:prod       # Start both servers in prod mode (background)
+bun run rdv:stop       # Stop all servers
+bun run rdv:restart    # Restart all servers
+bun run rdv:status     # Show server status
+
 # Code quality
 bun run lint
 bun run typecheck
+
+# Testing (Vitest)
+bun run test           # Run tests in watch mode
+bun run test:run       # Run tests once
+bun run test:ui        # Open Vitest UI
+bun run test:coverage  # Run tests with coverage
+
+# MCP
+bun run mcp            # Standalone MCP server on stdio
 
 # Database
 bun run db:push      # Push schema changes to SQLite
@@ -41,6 +58,7 @@ bun run db:generate  # Generate migration files
 bun run db:migrate   # Run migrations
 bun run db:studio    # Open Drizzle Studio
 bun run db:seed      # Seed authorized users
+bun run db:migrate-agents  # One-time agent session migration
 ```
 
 ## Architecture
@@ -48,8 +66,8 @@ bun run db:seed      # Seed authorized users
 ### Two-Server Model
 
 The application runs two servers:
-1. **Next.js** (port 3000) - Web UI, authentication, API routes, static assets
-2. **Terminal Server** (port 3001) - WebSocket server with PTY/tmux (runs via `tsx` for node-pty compatibility)
+1. **Next.js** (port `$PORT`, default 6001) - Web UI, authentication, API routes, static assets
+2. **Terminal Server** (port `$TERMINAL_PORT`, default 6002) - WebSocket server with PTY/tmux (runs via `tsx` for node-pty compatibility)
 
 ### Terminal Flow with tmux Persistence
 
@@ -289,6 +307,47 @@ Remote Dev supports multiple AI coding agents with unified management:
 └── .env               # Secrets from provider
 ```
 
+### Electron Desktop App
+
+Desktop application wrapper providing native OS integration:
+- Tray icon with quick actions
+- Auto-updater for seamless updates
+- Cloudflare tunnel integration for remote access
+- Cross-platform support (macOS, Linux, Windows)
+- Embedded process manager for Next.js + terminal server
+
+**Key Scripts:**
+```bash
+bun run electron:dev         # Dev mode: Next.js + terminal + Electron
+bun run electron:dist        # Build distributable for current platform
+bun run electron:dist:mac    # Build macOS distributable
+bun run electron:dist:linux  # Build Linux distributable
+bun run electron:dist:win    # Build Windows distributable
+```
+
+**Key Files:**
+| File | Purpose |
+|------|---------|
+| `electron/main/index.ts` | Main process entry point |
+| `electron/main/process-manager.ts` | Manages Next.js and terminal server processes |
+| `electron/main/cloudflared.ts` | Cloudflare tunnel management |
+| `electron/main/tray.ts` | System tray icon and menu |
+| `electron/main/auto-updater.ts` | Auto-update logic |
+| `electron/main/config.ts` | Electron app configuration |
+
+### Testing
+
+- **Vitest** with **happy-dom** environment
+- Config: `vitest.config.ts`
+
+**Commands:**
+```bash
+bun run test           # Run tests in watch mode
+bun run test:run       # Run tests once
+bun run test:ui        # Open Vitest UI
+bun run test:coverage  # Run tests with coverage
+```
+
 ### UI Components
 
 - **shadcn/ui** components in `src/components/ui/`
@@ -496,6 +555,7 @@ Required in `.env.local`:
 AUTH_SECRET=<generate with: openssl rand -base64 32>
 PORT=6001
 TERMINAL_PORT=6002
+NEXT_PUBLIC_TERMINAL_PORT=6002  # Must match TERMINAL_PORT (client-side WebSocket)
 NEXTAUTH_URL=http://localhost:6001
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,12 +149,12 @@ Optional MCP server for AI agent integration. Enables Claude Desktop, Cursor, an
 **Architecture:**
 - Runs on stdio transport alongside the terminal server
 - Uses local trust model (no additional authentication)
-- Provides 24 tools, 6 resources, and 5 workflow prompts
+- Provides 29 tools, 6 resources, and 5 workflow prompts
 
 **Components:**
 | Component | Count | Description |
 |-----------|-------|-------------|
-| Tools | 24 | Session management, git/worktree operations, folder/preferences |
+| Tools | 29 | Session management, git/worktree operations, folder/preferences, task management |
 | Resources | 6 | Read-only access to sessions and folders |
 | Prompts | 5 | Workflow templates for common tasks |
 
@@ -246,6 +246,7 @@ src/
 | `worktree_trash_metadata` | Worktree-specific trash metadata |
 | `port_registry` | Port allocations for environment variable conflict detection |
 | `folder_secrets_config` | Per-folder secrets provider configuration |
+| `project_task` | Project tasks with priority, labels, subtasks, and due dates |
 
 ### Service Layer
 
@@ -271,6 +272,7 @@ Located in `src/services/`:
 | `AgentProfileService` | Agent profile CRUD, config file management |
 | `AgentProfileAppearanceService` | Per-profile appearance settings |
 | `AgentConfigTemplateService` | Templates for agent config files (CLAUDE.md, AGENTS.md, etc.) |
+| `TaskService` | Project task CRUD, folder-scoped queries |
 
 **Security**: All shell commands use `execFile` with array arguments (no shell interpolation).
 
@@ -379,6 +381,7 @@ bun run test:coverage  # Run tests with coverage
 | `PathInput.tsx` | Text input with browse button for directory selection |
 | `AgentCLIStatusPanel.tsx` | CLI installation status for all supported agents |
 | `AgentProfileAppearanceSettings.tsx` | Per-profile theming with mode toggle and color schemes |
+| `TaskSidebar.tsx` | Right sidebar for project-scoped task tracking |
 
 ### State Management
 
@@ -395,6 +398,7 @@ React Contexts in `src/contexts/`:
 | `TrashContext` | Trash items state and operations |
 | `SecretsContext` | Secrets provider configurations and state |
 | `PortContext` | Port allocations, framework detection, monitoring |
+| `TaskContext` | Project tasks state with folder-scoped CRUD |
 
 **Preference Inheritance**: Default → User Settings → Folder Preferences
 
@@ -528,6 +532,13 @@ React Contexts in `src/contexts/`:
 - `GET /api/profiles/:id/appearance` - Get profile appearance settings
 - `PUT /api/profiles/:id/appearance` - Update profile appearance (mode, schemes, terminal settings)
 - `DELETE /api/profiles/:id/appearance` - Reset profile appearance to defaults
+
+### Tasks
+- `GET /api/tasks` - List tasks (optional `?folderId=` filter)
+- `POST /api/tasks` - Create task
+- `GET /api/tasks/:id` - Get task details
+- `PATCH /api/tasks/:id` - Update task
+- `DELETE /api/tasks/:id` - Delete task
 
 ## Quick Setup
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -74,6 +74,7 @@ AUTH_SECRET=<your-generated-secret>
 # Server ports (customize as needed)
 PORT=6001
 TERMINAL_PORT=6002
+NEXT_PUBLIC_TERMINAL_PORT=6002  # Must match TERMINAL_PORT (client-side WebSocket)
 NEXTAUTH_URL=http://localhost:6001
 
 # Optional: GitHub OAuth (see GitHub Setup below)
@@ -149,7 +150,7 @@ The script will:
 ./scripts/init.sh --email your@email.com
 
 # Custom ports
-./scripts/init.sh --port 3000 --terminal-port 3001
+./scripts/init.sh --port 6001 --terminal-port 6002
 ```
 
 ## GitHub Integration Setup
@@ -237,6 +238,30 @@ bun run dev:next
 bun run dev:terminal
 ```
 
+### Process Manager
+
+As an alternative to `bun run dev`, you can use the process manager to run servers in the background:
+
+```bash
+bun run rdv            # Interactive CLI: start/stop/restart/status
+bun run rdv:dev        # Start both servers in dev mode (background)
+bun run rdv:prod       # Start both servers in prod mode (background)
+bun run rdv:stop       # Stop all servers
+bun run rdv:restart    # Restart all servers
+bun run rdv:status     # Show server status
+```
+
+### Testing
+
+Run tests with Vitest:
+
+```bash
+bun run test           # Run tests in watch mode
+bun run test:run       # Run tests once
+bun run test:ui        # Open Vitest UI
+bun run test:coverage  # Run tests with coverage
+```
+
 ### Code Quality
 
 Before committing:
@@ -276,9 +301,12 @@ For production, ensure all variables are set:
 
 ```bash
 AUTH_SECRET=<strong-random-secret>
+PORT=6001
+TERMINAL_PORT=6002
+NEXT_PUBLIC_TERMINAL_PORT=6002
+NEXTAUTH_URL=http://localhost:6001  # Should match $PORT
 GITHUB_CLIENT_ID=<if-using-github>
 GITHUB_CLIENT_SECRET=<if-using-github>
-NEXTAUTH_URL=http://localhost:3000
 ```
 
 ## Troubleshooting
@@ -287,7 +315,7 @@ NEXTAUTH_URL=http://localhost:3000
 
 1. Check if terminal server is running:
    ```bash
-   lsof -i :3001
+   lsof -i :6002   # Or your $TERMINAL_PORT
    ```
 
 2. Start it manually:
@@ -297,7 +325,7 @@ NEXTAUTH_URL=http://localhost:3000
 
 3. Check for port conflicts:
    ```bash
-   TERMINAL_PORT=3002 bun run dev:terminal
+   TERMINAL_PORT=6003 bun run dev:terminal
    ```
 
 ### "tmux: command not found"

--- a/drizzle/0009_fat_ultragirl.sql
+++ b/drizzle/0009_fat_ultragirl.sql
@@ -1,0 +1,24 @@
+CREATE TABLE `project_task` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`folder_id` text,
+	`title` text NOT NULL,
+	`description` text,
+	`status` text DEFAULT 'open' NOT NULL,
+	`priority` text DEFAULT 'medium' NOT NULL,
+	`source` text DEFAULT 'manual' NOT NULL,
+	`labels` text DEFAULT '[]' NOT NULL,
+	`subtasks` text DEFAULT '[]' NOT NULL,
+	`due_date` integer,
+	`github_issue_url` text,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`folder_id`) REFERENCES `session_folder`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `project_task_user_idx` ON `project_task` (`user_id`);--> statement-breakpoint
+CREATE INDEX `project_task_folder_idx` ON `project_task` (`folder_id`);--> statement-breakpoint
+CREATE INDEX `project_task_user_folder_idx` ON `project_task` (`user_id`,`folder_id`);--> statement-breakpoint
+ALTER TABLE `folder_preferences` ADD `pinned_files` text;

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,5480 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "63610428-0d29-4dd9-bd73-25f608fea84a",
+  "prevId": "81da4a85-ed90-4e95-933a-0920158ed5ed",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "name": "account_provider_providerAccountId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_activity_event": {
+      "name": "agent_activity_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_provider": {
+          "name": "agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_activity_user_idx": {
+          "name": "agent_activity_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "agent_activity_session_idx": {
+          "name": "agent_activity_session_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "agent_activity_provider_idx": {
+          "name": "agent_activity_provider_idx",
+          "columns": [
+            "user_id",
+            "agent_provider"
+          ],
+          "isUnique": false
+        },
+        "agent_activity_event_type_idx": {
+          "name": "agent_activity_event_type_idx",
+          "columns": [
+            "user_id",
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "agent_activity_created_idx": {
+          "name": "agent_activity_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_activity_event_user_id_user_id_fk": {
+          "name": "agent_activity_event_user_id_user_id_fk",
+          "tableFrom": "agent_activity_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_activity_event_session_id_terminal_session_id_fk": {
+          "name": "agent_activity_event_session_id_terminal_session_id_fk",
+          "tableFrom": "agent_activity_event",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_config": {
+      "name": "agent_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_type": {
+          "name": "config_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_config_user_idx": {
+          "name": "agent_config_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "agent_config_folder_idx": {
+          "name": "agent_config_folder_idx",
+          "columns": [
+            "folder_id"
+          ],
+          "isUnique": false
+        },
+        "agent_config_unique_idx": {
+          "name": "agent_config_unique_idx",
+          "columns": [
+            "user_id",
+            "folder_id",
+            "provider",
+            "config_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_config_user_id_user_id_fk": {
+          "name": "agent_config_user_id_user_id_fk",
+          "tableFrom": "agent_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_config_folder_id_session_folder_id_fk": {
+          "name": "agent_config_folder_id_session_folder_id_fk",
+          "tableFrom": "agent_config",
+          "tableTo": "session_folder",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_daily_stats": {
+      "name": "agent_daily_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_provider": {
+          "name": "agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "command_count": {
+          "name": "command_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_daily_stats_unique_idx": {
+          "name": "agent_daily_stats_unique_idx",
+          "columns": [
+            "user_id",
+            "date",
+            "agent_provider"
+          ],
+          "isUnique": true
+        },
+        "agent_daily_stats_user_date_idx": {
+          "name": "agent_daily_stats_user_date_idx",
+          "columns": [
+            "user_id",
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_daily_stats_user_id_user_id_fk": {
+          "name": "agent_daily_stats_user_id_user_id_fk",
+          "tableFrom": "agent_daily_stats",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_profile_json_config": {
+      "name": "agent_profile_json_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "is_valid": {
+          "name": "is_valid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "validation_errors": {
+          "name": "validation_errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_profile_json_config_profile_idx": {
+          "name": "agent_profile_json_config_profile_idx",
+          "columns": [
+            "profile_id"
+          ],
+          "isUnique": false
+        },
+        "agent_profile_json_config_user_idx": {
+          "name": "agent_profile_json_config_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "agent_profile_json_config_unique_idx": {
+          "name": "agent_profile_json_config_unique_idx",
+          "columns": [
+            "profile_id",
+            "agent_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_json_config_profile_id_agent_profile_id_fk": {
+          "name": "agent_profile_json_config_profile_id_agent_profile_id_fk",
+          "tableFrom": "agent_profile_json_config",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_profile_json_config_user_id_user_id_fk": {
+          "name": "agent_profile_json_config_user_id_user_id_fk",
+          "tableFrom": "agent_profile_json_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_profile": {
+      "name": "agent_profile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'all'"
+        },
+        "config_dir": {
+          "name": "config_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_profile_user_idx": {
+          "name": "agent_profile_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "agent_profile_default_idx": {
+          "name": "agent_profile_default_idx",
+          "columns": [
+            "user_id",
+            "is_default"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_user_id_user_id_fk": {
+          "name": "agent_profile_user_id_user_id_fk",
+          "tableFrom": "agent_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_key": {
+      "name": "api_key",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_key_user_idx": {
+          "name": "api_key_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "api_key_prefix_idx": {
+          "name": "api_key_prefix_idx",
+          "columns": [
+            "key_prefix"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_key_user_id_user_id_fk": {
+          "name": "api_key_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "appearance_settings": {
+      "name": "appearance_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appearance_mode": {
+          "name": "appearance_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "light_color_scheme": {
+          "name": "light_color_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ocean'"
+        },
+        "dark_color_scheme": {
+          "name": "dark_color_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'midnight'"
+        },
+        "terminal_opacity": {
+          "name": "terminal_opacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "terminal_blur": {
+          "name": "terminal_blur",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "terminal_cursor_style": {
+          "name": "terminal_cursor_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "appearance_settings_user_id_unique": {
+          "name": "appearance_settings_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "appearance_settings_user_idx": {
+          "name": "appearance_settings_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "appearance_settings_user_id_user_id_fk": {
+          "name": "appearance_settings_user_id_user_id_fk",
+          "tableFrom": "appearance_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authorized_user": {
+      "name": "authorized_user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authorized_user_email_unique": {
+          "name": "authorized_user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "color_scheme": {
+      "name": "color_scheme",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_definitions": {
+          "name": "color_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "terminal_palette": {
+          "name": "terminal_palette",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_built_in": {
+          "name": "is_built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "color_scheme_category_idx": {
+          "name": "color_scheme_category_idx",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "color_scheme_sort_idx": {
+          "name": "color_scheme_sort_idx",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "command_execution": {
+      "name": "command_execution",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "command_execution_execution_idx": {
+          "name": "command_execution_execution_idx",
+          "columns": [
+            "execution_id"
+          ],
+          "isUnique": false
+        },
+        "command_execution_command_idx": {
+          "name": "command_execution_command_idx",
+          "columns": [
+            "command_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "command_execution_execution_id_schedule_execution_id_fk": {
+          "name": "command_execution_execution_id_schedule_execution_id_fk",
+          "tableFrom": "command_execution",
+          "tableTo": "schedule_execution",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "command_execution_command_id_schedule_command_id_fk": {
+          "name": "command_execution_command_id_schedule_command_id_fk",
+          "tableFrom": "command_execution",
+          "tableTo": "schedule_command",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "folder_preferences": {
+      "name": "folder_preferences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_working_directory": {
+          "name": "default_working_directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_shell": {
+          "name": "default_shell",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startup_command": {
+          "name": "startup_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_repo_path": {
+          "name": "local_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_vars": {
+          "name": "environment_vars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_files": {
+          "name": "pinned_files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "folder_prefs_folder_user_idx": {
+          "name": "folder_prefs_folder_user_idx",
+          "columns": [
+            "folder_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "folder_prefs_user_idx": {
+          "name": "folder_prefs_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "folder_preferences_folder_id_session_folder_id_fk": {
+          "name": "folder_preferences_folder_id_session_folder_id_fk",
+          "tableFrom": "folder_preferences",
+          "tableTo": "session_folder",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "folder_preferences_user_id_user_id_fk": {
+          "name": "folder_preferences_user_id_user_id_fk",
+          "tableFrom": "folder_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "folder_preferences_github_repo_id_github_repository_id_fk": {
+          "name": "folder_preferences_github_repo_id_github_repository_id_fk",
+          "tableFrom": "folder_preferences",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "github_repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "folder_profile_link": {
+      "name": "folder_profile_link",
+      "columns": {
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "folder_profile_link_profile_idx": {
+          "name": "folder_profile_link_profile_idx",
+          "columns": [
+            "profile_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "folder_profile_link_folder_id_session_folder_id_fk": {
+          "name": "folder_profile_link_folder_id_session_folder_id_fk",
+          "tableFrom": "folder_profile_link",
+          "tableTo": "session_folder",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "folder_profile_link_profile_id_agent_profile_id_fk": {
+          "name": "folder_profile_link_profile_id_agent_profile_id_fk",
+          "tableFrom": "folder_profile_link",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "folder_repository": {
+      "name": "folder_repository",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "folder_repo_folder_user_idx": {
+          "name": "folder_repo_folder_user_idx",
+          "columns": [
+            "folder_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "folder_repo_user_idx": {
+          "name": "folder_repo_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "folder_repository_folder_id_session_folder_id_fk": {
+          "name": "folder_repository_folder_id_session_folder_id_fk",
+          "tableFrom": "folder_repository",
+          "tableTo": "session_folder",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "folder_repository_repository_id_github_repository_id_fk": {
+          "name": "folder_repository_repository_id_github_repository_id_fk",
+          "tableFrom": "folder_repository",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "folder_repository_user_id_user_id_fk": {
+          "name": "folder_repository_user_id_user_id_fk",
+          "tableFrom": "folder_repository",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "folder_secrets_config": {
+      "name": "folder_secrets_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "folder_secrets_config_folder_user_idx": {
+          "name": "folder_secrets_config_folder_user_idx",
+          "columns": [
+            "folder_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "folder_secrets_config_user_idx": {
+          "name": "folder_secrets_config_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "folder_secrets_config_user_enabled_idx": {
+          "name": "folder_secrets_config_user_enabled_idx",
+          "columns": [
+            "user_id",
+            "enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "folder_secrets_config_folder_id_session_folder_id_fk": {
+          "name": "folder_secrets_config_folder_id_session_folder_id_fk",
+          "tableFrom": "folder_secrets_config",
+          "tableTo": "session_folder",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "folder_secrets_config_user_id_user_id_fk": {
+          "name": "folder_secrets_config_user_id_user_id_fk",
+          "tableFrom": "folder_secrets_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_branch_protection": {
+      "name": "github_branch_protection",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_protected": {
+          "name": "is_protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "requires_review": {
+          "name": "requires_review",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "required_reviewers": {
+          "name": "required_reviewers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "requires_status_checks": {
+          "name": "requires_status_checks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "required_checks": {
+          "name": "required_checks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allows_force_pushes": {
+          "name": "allows_force_pushes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "allows_deletions": {
+          "name": "allows_deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_branch_protection_repo_branch_idx": {
+          "name": "github_branch_protection_repo_branch_idx",
+          "columns": [
+            "repository_id",
+            "branch"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "github_branch_protection_repository_id_github_repository_id_fk": {
+          "name": "github_branch_protection_repository_id_github_repository_id_fk",
+          "tableFrom": "github_branch_protection",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_change_notification": {
+      "name": "github_change_notification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_pr_count": {
+          "name": "new_pr_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "new_issue_count": {
+          "name": "new_issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_notifications_user_repo_idx": {
+          "name": "github_notifications_user_repo_idx",
+          "columns": [
+            "user_id",
+            "repository_id"
+          ],
+          "isUnique": true
+        },
+        "github_notifications_user_idx": {
+          "name": "github_notifications_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_change_notification_user_id_user_id_fk": {
+          "name": "github_change_notification_user_id_user_id_fk",
+          "tableFrom": "github_change_notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_change_notification_repository_id_github_repository_id_fk": {
+          "name": "github_change_notification_repository_id_github_repository_id_fk",
+          "tableFrom": "github_change_notification",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_issue": {
+      "name": "github_issue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "assignees": {
+          "name": "assignees",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_issue_repo_idx": {
+          "name": "github_issue_repo_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "github_issue_repo_number_idx": {
+          "name": "github_issue_repo_number_idx",
+          "columns": [
+            "repository_id",
+            "issue_number"
+          ],
+          "isUnique": true
+        },
+        "github_issue_state_idx": {
+          "name": "github_issue_state_idx",
+          "columns": [
+            "repository_id",
+            "state"
+          ],
+          "isUnique": false
+        },
+        "github_issue_cached_idx": {
+          "name": "github_issue_cached_idx",
+          "columns": [
+            "cached_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_issue_repository_id_github_repository_id_fk": {
+          "name": "github_issue_repository_id_github_repository_id_fk",
+          "tableFrom": "github_issue",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_pull_request": {
+      "name": "github_pull_request",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ci_status": {
+          "name": "ci_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_pr_repo_idx": {
+          "name": "github_pr_repo_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "github_pr_repo_number_idx": {
+          "name": "github_pr_repo_number_idx",
+          "columns": [
+            "repository_id",
+            "pr_number"
+          ],
+          "isUnique": false
+        },
+        "github_pr_state_idx": {
+          "name": "github_pr_state_idx",
+          "columns": [
+            "repository_id",
+            "state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_pull_request_repository_id_github_repository_id_fk": {
+          "name": "github_pull_request_repository_id_github_repository_id_fk",
+          "tableFrom": "github_pull_request",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_repository": {
+      "name": "github_repository",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_repo_user_idx": {
+          "name": "github_repo_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "github_repo_github_id_idx": {
+          "name": "github_repo_github_id_idx",
+          "columns": [
+            "user_id",
+            "github_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_repository_user_id_user_id_fk": {
+          "name": "github_repository_user_id_user_id_fk",
+          "tableFrom": "github_repository",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_repository_stats": {
+      "name": "github_repository_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "open_pr_count": {
+          "name": "open_pr_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "open_issue_count": {
+          "name": "open_issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ci_status": {
+          "name": "ci_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ci_status_details": {
+          "name": "ci_status_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_protected": {
+          "name": "branch_protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "branch_protection_details": {
+          "name": "branch_protection_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recent_commits": {
+          "name": "recent_commits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_repository_stats_repository_id_unique": {
+          "name": "github_repository_stats_repository_id_unique",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": true
+        },
+        "github_repo_stats_repo_idx": {
+          "name": "github_repo_stats_repo_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "github_repo_stats_expires_idx": {
+          "name": "github_repo_stats_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_repository_stats_repository_id_github_repository_id_fk": {
+          "name": "github_repository_stats_repository_id_github_repository_id_fk",
+          "tableFrom": "github_repository_stats",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_stats_preferences": {
+      "name": "github_stats_preferences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_pr_count": {
+          "name": "show_pr_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "show_issue_count": {
+          "name": "show_issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "show_ci_status": {
+          "name": "show_ci_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "show_recent_commits": {
+          "name": "show_recent_commits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "show_branch_protection": {
+          "name": "show_branch_protection",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "refresh_interval_minutes": {
+          "name": "refresh_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 15
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_stats_prefs_user_folder_idx": {
+          "name": "github_stats_prefs_user_folder_idx",
+          "columns": [
+            "user_id",
+            "folder_id"
+          ],
+          "isUnique": true
+        },
+        "github_stats_prefs_user_idx": {
+          "name": "github_stats_prefs_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_stats_preferences_user_id_user_id_fk": {
+          "name": "github_stats_preferences_user_id_user_id_fk",
+          "tableFrom": "github_stats_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_stats_preferences_folder_id_session_folder_id_fk": {
+          "name": "github_stats_preferences_folder_id_session_folder_id_fk",
+          "tableFrom": "github_stats_preferences",
+          "tableTo": "session_folder",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_discovered_resource": {
+      "name": "mcp_discovered_resource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_discovered_resource_server_idx": {
+          "name": "mcp_discovered_resource_server_idx",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        },
+        "mcp_discovered_resource_unique_idx": {
+          "name": "mcp_discovered_resource_unique_idx",
+          "columns": [
+            "server_id",
+            "uri"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_discovered_resource_server_id_mcp_server_id_fk": {
+          "name": "mcp_discovered_resource_server_id_mcp_server_id_fk",
+          "tableFrom": "mcp_discovered_resource",
+          "tableTo": "mcp_server",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_discovered_tool": {
+      "name": "mcp_discovered_tool",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_discovered_tool_server_idx": {
+          "name": "mcp_discovered_tool_server_idx",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        },
+        "mcp_discovered_tool_unique_idx": {
+          "name": "mcp_discovered_tool_unique_idx",
+          "columns": [
+            "server_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_discovered_tool_server_id_mcp_server_id_fk": {
+          "name": "mcp_discovered_tool_server_id_mcp_server_id_fk",
+          "tableFrom": "mcp_discovered_tool",
+          "tableTo": "mcp_server",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_server": {
+      "name": "mcp_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'stdio'"
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_start": {
+          "name": "auto_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_server_user_idx": {
+          "name": "mcp_server_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "mcp_server_folder_idx": {
+          "name": "mcp_server_folder_idx",
+          "columns": [
+            "folder_id"
+          ],
+          "isUnique": false
+        },
+        "mcp_server_enabled_idx": {
+          "name": "mcp_server_enabled_idx",
+          "columns": [
+            "user_id",
+            "enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_user_id_user_id_fk": {
+          "name": "mcp_server_user_id_user_id_fk",
+          "tableFrom": "mcp_server",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_server_folder_id_session_folder_id_fk": {
+          "name": "mcp_server_folder_id_session_folder_id_fk",
+          "tableFrom": "mcp_server",
+          "tableTo": "session_folder",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "port_registry": {
+      "name": "port_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variable_name": {
+          "name": "variable_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "port_registry_user_idx": {
+          "name": "port_registry_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "port_registry_folder_idx": {
+          "name": "port_registry_folder_idx",
+          "columns": [
+            "folder_id"
+          ],
+          "isUnique": false
+        },
+        "port_registry_user_port_idx": {
+          "name": "port_registry_user_port_idx",
+          "columns": [
+            "user_id",
+            "port"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "port_registry_folder_id_session_folder_id_fk": {
+          "name": "port_registry_folder_id_session_folder_id_fk",
+          "tableFrom": "port_registry",
+          "tableTo": "session_folder",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "port_registry_user_id_user_id_fk": {
+          "name": "port_registry_user_id_user_id_fk",
+          "tableFrom": "port_registry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profile_appearance_settings": {
+      "name": "profile_appearance_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "appearance_mode": {
+          "name": "appearance_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "light_color_scheme": {
+          "name": "light_color_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ocean'"
+        },
+        "dark_color_scheme": {
+          "name": "dark_color_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'midnight'"
+        },
+        "terminal_opacity": {
+          "name": "terminal_opacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "terminal_blur": {
+          "name": "terminal_blur",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "terminal_cursor_style": {
+          "name": "terminal_cursor_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "profile_appearance_settings_profile_id_unique": {
+          "name": "profile_appearance_settings_profile_id_unique",
+          "columns": [
+            "profile_id"
+          ],
+          "isUnique": true
+        },
+        "profile_appearance_profile_idx": {
+          "name": "profile_appearance_profile_idx",
+          "columns": [
+            "profile_id"
+          ],
+          "isUnique": false
+        },
+        "profile_appearance_user_idx": {
+          "name": "profile_appearance_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "profile_appearance_settings_profile_id_agent_profile_id_fk": {
+          "name": "profile_appearance_settings_profile_id_agent_profile_id_fk",
+          "tableFrom": "profile_appearance_settings",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_appearance_settings_user_id_user_id_fk": {
+          "name": "profile_appearance_settings_user_id_user_id_fk",
+          "tableFrom": "profile_appearance_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profile_git_identity": {
+      "name": "profile_git_identity",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ssh_key_path": {
+          "name": "ssh_key_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpg_key_id": {
+          "name": "gpg_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "profile_git_identity_profile_id_unique": {
+          "name": "profile_git_identity_profile_id_unique",
+          "columns": [
+            "profile_id"
+          ],
+          "isUnique": true
+        },
+        "profile_git_identity_profile_idx": {
+          "name": "profile_git_identity_profile_idx",
+          "columns": [
+            "profile_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "profile_git_identity_profile_id_agent_profile_id_fk": {
+          "name": "profile_git_identity_profile_id_agent_profile_id_fk",
+          "tableFrom": "profile_git_identity",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profile_secrets_config": {
+      "name": "profile_secrets_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "profile_secrets_config_profile_id_unique": {
+          "name": "profile_secrets_config_profile_id_unique",
+          "columns": [
+            "profile_id"
+          ],
+          "isUnique": true
+        },
+        "profile_secrets_config_profile_idx": {
+          "name": "profile_secrets_config_profile_idx",
+          "columns": [
+            "profile_id"
+          ],
+          "isUnique": false
+        },
+        "profile_secrets_config_user_idx": {
+          "name": "profile_secrets_config_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "profile_secrets_config_profile_id_agent_profile_id_fk": {
+          "name": "profile_secrets_config_profile_id_agent_profile_id_fk",
+          "tableFrom": "profile_secrets_config",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_secrets_config_user_id_user_id_fk": {
+          "name": "profile_secrets_config_user_id_user_id_fk",
+          "tableFrom": "profile_secrets_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_task": {
+      "name": "project_task",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "subtasks": {
+          "name": "subtasks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_task_user_idx": {
+          "name": "project_task_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "project_task_folder_idx": {
+          "name": "project_task_folder_idx",
+          "columns": [
+            "folder_id"
+          ],
+          "isUnique": false
+        },
+        "project_task_user_folder_idx": {
+          "name": "project_task_user_folder_idx",
+          "columns": [
+            "user_id",
+            "folder_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_task_user_id_user_id_fk": {
+          "name": "project_task_user_id_user_id_fk",
+          "tableFrom": "project_task",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_task_folder_id_session_folder_id_fk": {
+          "name": "project_task_folder_id_session_folder_id_fk",
+          "tableFrom": "project_task",
+          "tableTo": "session_folder",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedule_command": {
+      "name": "schedule_command",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delay_before_seconds": {
+          "name": "delay_before_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "continue_on_error": {
+          "name": "continue_on_error",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "schedule_command_schedule_idx": {
+          "name": "schedule_command_schedule_idx",
+          "columns": [
+            "schedule_id"
+          ],
+          "isUnique": false
+        },
+        "schedule_command_order_idx": {
+          "name": "schedule_command_order_idx",
+          "columns": [
+            "schedule_id",
+            "order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedule_command_schedule_id_session_schedule_id_fk": {
+          "name": "schedule_command_schedule_id_session_schedule_id_fk",
+          "tableFrom": "schedule_command",
+          "tableTo": "session_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedule_execution": {
+      "name": "schedule_execution",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command_count": {
+          "name": "command_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "schedule_execution_schedule_idx": {
+          "name": "schedule_execution_schedule_idx",
+          "columns": [
+            "schedule_id"
+          ],
+          "isUnique": false
+        },
+        "schedule_execution_started_idx": {
+          "name": "schedule_execution_started_idx",
+          "columns": [
+            "schedule_id",
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedule_execution_schedule_id_session_schedule_id_fk": {
+          "name": "schedule_execution_schedule_id_session_schedule_id_fk",
+          "tableFrom": "schedule_execution",
+          "tableTo": "session_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_folder": {
+      "name": "session_folder",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_folder_user_idx": {
+          "name": "session_folder_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "session_folder_parent_idx": {
+          "name": "session_folder_parent_idx",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "session_folder_user_parent_idx": {
+          "name": "session_folder_user_parent_idx",
+          "columns": [
+            "user_id",
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_folder_user_id_user_id_fk": {
+          "name": "session_folder_user_id_user_id_fk",
+          "tableFrom": "session_folder",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_memory": {
+      "name": "session_memory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_memory_user_idx": {
+          "name": "session_memory_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "session_memory_folder_idx": {
+          "name": "session_memory_folder_idx",
+          "columns": [
+            "folder_id"
+          ],
+          "isUnique": false
+        },
+        "session_memory_type_idx": {
+          "name": "session_memory_type_idx",
+          "columns": [
+            "user_id",
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_memory_user_id_user_id_fk": {
+          "name": "session_memory_user_id_user_id_fk",
+          "tableFrom": "session_memory",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_memory_folder_id_session_folder_id_fk": {
+          "name": "session_memory_folder_id_session_folder_id_fk",
+          "tableFrom": "session_memory",
+          "tableTo": "session_folder",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_recording": {
+      "name": "session_recording",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "terminal_cols": {
+          "name": "terminal_cols",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 80
+        },
+        "terminal_rows": {
+          "name": "terminal_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_recording_user_idx": {
+          "name": "session_recording_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "session_recording_created_idx": {
+          "name": "session_recording_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_recording_user_id_user_id_fk": {
+          "name": "session_recording_user_id_user_id_fk",
+          "tableFrom": "session_recording",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_schedule": {
+      "name": "session_schedule",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'one-time'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'America/Los_Angeles'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "retry_delay_seconds": {
+          "name": "retry_delay_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "timeout_seconds": {
+          "name": "timeout_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 300
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_status": {
+          "name": "last_run_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_schedule_user_idx": {
+          "name": "session_schedule_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "session_schedule_session_idx": {
+          "name": "session_schedule_session_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "session_schedule_next_run_idx": {
+          "name": "session_schedule_next_run_idx",
+          "columns": [
+            "enabled",
+            "next_run_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_schedule_user_id_user_id_fk": {
+          "name": "session_schedule_user_id_user_id_fk",
+          "tableFrom": "session_schedule",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_schedule_session_id_terminal_session_id_fk": {
+          "name": "session_schedule_session_id_terminal_session_id_fk",
+          "tableFrom": "session_schedule",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_template": {
+      "name": "session_template",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_name_pattern": {
+          "name": "session_name_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startup_command": {
+          "name": "startup_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_template_user_idx": {
+          "name": "session_template_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "session_template_usage_idx": {
+          "name": "session_template_usage_idx",
+          "columns": [
+            "user_id",
+            "usage_count"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_template_user_id_user_id_fk": {
+          "name": "session_template_user_id_user_id_fk",
+          "tableFrom": "session_template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_template_folder_id_session_folder_id_fk": {
+          "name": "session_template_folder_id_session_folder_id_fk",
+          "tableFrom": "session_template",
+          "tableTo": "session_folder",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "setup_config": {
+      "name": "setup_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "working_directory": {
+          "name": "working_directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_port": {
+          "name": "next_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3000
+        },
+        "terminal_port": {
+          "name": "terminal_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3001
+        },
+        "wsl_distribution": {
+          "name": "wsl_distribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_start": {
+          "name": "auto_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "check_for_updates": {
+          "name": "check_for_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "split_group": {
+      "name": "split_group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "split_group_user_idx": {
+          "name": "split_group_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "split_group_user_id_user_id_fk": {
+          "name": "split_group_user_id_user_id_fk",
+          "tableFrom": "split_group",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_session": {
+      "name": "terminal_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tmux_session_name": {
+          "name": "tmux_session_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_branch": {
+          "name": "worktree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terminal_type": {
+          "name": "terminal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'shell'"
+        },
+        "agent_provider": {
+          "name": "agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'claude'"
+        },
+        "agent_exit_state": {
+          "name": "agent_exit_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_exit_code": {
+          "name": "agent_exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_exited_at": {
+          "name": "agent_exited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_restart_count": {
+          "name": "agent_restart_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "type_metadata": {
+          "name": "type_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "split_group_id": {
+          "name": "split_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "split_order": {
+          "name": "split_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "split_size": {
+          "name": "split_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_session_tmux_session_name_unique": {
+          "name": "terminal_session_tmux_session_name_unique",
+          "columns": [
+            "tmux_session_name"
+          ],
+          "isUnique": true
+        },
+        "terminal_session_user_status_idx": {
+          "name": "terminal_session_user_status_idx",
+          "columns": [
+            "user_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_session_user_order_idx": {
+          "name": "terminal_session_user_order_idx",
+          "columns": [
+            "user_id",
+            "tab_order"
+          ],
+          "isUnique": false
+        },
+        "terminal_session_split_group_idx": {
+          "name": "terminal_session_split_group_idx",
+          "columns": [
+            "split_group_id"
+          ],
+          "isUnique": false
+        },
+        "terminal_session_user_folder_idx": {
+          "name": "terminal_session_user_folder_idx",
+          "columns": [
+            "user_id",
+            "folder_id"
+          ],
+          "isUnique": false
+        },
+        "terminal_session_type_idx": {
+          "name": "terminal_session_type_idx",
+          "columns": [
+            "user_id",
+            "terminal_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_session_user_id_user_id_fk": {
+          "name": "terminal_session_user_id_user_id_fk",
+          "tableFrom": "terminal_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_session_github_repo_id_github_repository_id_fk": {
+          "name": "terminal_session_github_repo_id_github_repository_id_fk",
+          "tableFrom": "terminal_session",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "github_repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "terminal_session_folder_id_session_folder_id_fk": {
+          "name": "terminal_session_folder_id_session_folder_id_fk",
+          "tableFrom": "terminal_session",
+          "tableTo": "session_folder",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "terminal_session_profile_id_agent_profile_id_fk": {
+          "name": "terminal_session_profile_id_agent_profile_id_fk",
+          "tableFrom": "terminal_session",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "terminal_session_split_group_id_split_group_id_fk": {
+          "name": "terminal_session_split_group_id_split_group_id_fk",
+          "tableFrom": "terminal_session",
+          "tableTo": "split_group",
+          "columnsFrom": [
+            "split_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trash_item": {
+      "name": "trash_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_name": {
+          "name": "resource_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trashed_at": {
+          "name": "trashed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "trash_item_user_type_idx": {
+          "name": "trash_item_user_type_idx",
+          "columns": [
+            "user_id",
+            "resource_type"
+          ],
+          "isUnique": false
+        },
+        "trash_item_expires_idx": {
+          "name": "trash_item_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "trash_item_resource_idx": {
+          "name": "trash_item_resource_idx",
+          "columns": [
+            "resource_type",
+            "resource_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trash_item_user_id_user_id_fk": {
+          "name": "trash_item_user_id_user_id_fk",
+          "tableFrom": "trash_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_working_directory": {
+          "name": "default_working_directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_shell": {
+          "name": "default_shell",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startup_command": {
+          "name": "startup_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "xterm_scrollback": {
+          "name": "xterm_scrollback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 10000
+        },
+        "tmux_history_limit": {
+          "name": "tmux_history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 50000
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'tokyo-night'"
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 14
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'''JetBrainsMono Nerd Font Mono'', monospace'"
+        },
+        "active_folder_id": {
+          "name": "active_folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_folder_id": {
+          "name": "pinned_folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_follow_active_session": {
+          "name": "auto_follow_active_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verificationToken": {
+      "name": "verificationToken",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "columns": [
+            "identifier",
+            "token"
+          ],
+          "name": "verificationToken_identifier_token_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktree_trash_metadata": {
+      "name": "worktree_trash_metadata",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trash_item_id": {
+          "name": "trash_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_local_path": {
+          "name": "repo_local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_branch": {
+          "name": "worktree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_original_path": {
+          "name": "worktree_original_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_trash_path": {
+          "name": "worktree_trash_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_folder_id": {
+          "name": "original_folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_folder_name": {
+          "name": "original_folder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "worktree_trash_metadata_trash_item_id_unique": {
+          "name": "worktree_trash_metadata_trash_item_id_unique",
+          "columns": [
+            "trash_item_id"
+          ],
+          "isUnique": true
+        },
+        "worktree_trash_repo_idx": {
+          "name": "worktree_trash_repo_idx",
+          "columns": [
+            "github_repo_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "worktree_trash_metadata_trash_item_id_trash_item_id_fk": {
+          "name": "worktree_trash_metadata_trash_item_id_trash_item_id_fk",
+          "tableFrom": "worktree_trash_metadata",
+          "tableTo": "trash_item",
+          "columnsFrom": [
+            "trash_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worktree_trash_metadata_github_repo_id_github_repository_id_fk": {
+          "name": "worktree_trash_metadata_github_repo_id_github_repository_id_fk",
+          "tableFrom": "worktree_trash_metadata",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "github_repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1769006110188,
       "tag": "0008_true_shotgun",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1772639472416,
+      "tag": "0009_fat_ultragirl",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
+import { getTask, updateTask, deleteTask } from "@/services/task-service";
+import type { UpdateTaskInput } from "@/types/task";
+
+export const GET = withApiAuth(async (_request, { userId, params }) => {
+  const id = params?.id;
+  if (!id) return errorResponse("Task ID is required", 400);
+
+  const task = await getTask(id, userId);
+  if (!task) return errorResponse("Task not found", 404);
+
+  return NextResponse.json(task);
+});
+
+export const PATCH = withApiAuth(async (request, { userId, params }) => {
+  const id = params?.id;
+  if (!id) return errorResponse("Task ID is required", 400);
+
+  const result = await parseJsonBody<UpdateTaskInput>(request);
+  if ("error" in result) return result.error;
+
+  const task = await updateTask(id, userId, result.data);
+  if (!task) return errorResponse("Task not found", 404);
+
+  return NextResponse.json(task);
+});
+
+export const DELETE = withApiAuth(async (_request, { userId, params }) => {
+  const id = params?.id;
+  if (!id) return errorResponse("Task ID is required", 400);
+
+  const deleted = await deleteTask(id, userId);
+  if (!deleted) return errorResponse("Task not found", 404);
+
+  return new NextResponse(null, { status: 204 });
+});

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
+import { getTasks, createTask } from "@/services/task-service";
+import type { CreateTaskInput } from "@/types/task";
+
+export const GET = withApiAuth(async (request, { userId }) => {
+  const url = new URL(request.url);
+  const folderId = url.searchParams.get("folderId");
+
+  const tasks = await getTasks(userId, folderId);
+  return NextResponse.json(tasks);
+});
+
+export const POST = withApiAuth(async (request, { userId }) => {
+  const result = await parseJsonBody<CreateTaskInput>(request);
+  if ("error" in result) return result.error;
+  const body = result.data;
+
+  if (!body.title?.trim()) {
+    return errorResponse("Task title is required", 400);
+  }
+
+  const task = await createTask(userId, body);
+  return NextResponse.json(task, { status: 201 });
+});

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -5,7 +5,7 @@ import type { CreateTaskInput } from "@/types/task";
 
 export const GET = withApiAuth(async (request, { userId }) => {
   const url = new URL(request.url);
-  const folderId = url.searchParams.get("folderId");
+  const folderId = url.searchParams.get("folderId") ?? undefined;
 
   const tasks = await getTasks(userId, folderId);
   return NextResponse.json(tasks);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ import { GitHubStatsProvider } from "@/contexts/GitHubStatsContext";
 import { GitHubIssuesProvider } from "@/contexts/GitHubIssuesContext";
 import { PortProvider } from "@/contexts/PortContext";
 import { SessionMCPProvider } from "@/contexts/SessionMCPContext";
+import { TaskProvider } from "@/contexts/TaskContext";
 import { SessionManager } from "@/components/session/SessionManager";
 import { Header } from "@/components/header/Header";
 import type { TerminalSession } from "@/types/session";
@@ -111,6 +112,7 @@ export default async function Home() {
                         <TrashProvider>
                           <PortProvider>
                             <ScheduleProvider>
+                              <TaskProvider>
                               <SessionMCPProvider>
                                 <div className="flex h-screen flex-col bg-background">
                                   {/* Header - hidden on mobile, shown in sidebar instead */}
@@ -126,6 +128,7 @@ export default async function Home() {
                                   <SessionManager isGitHubConnected={isGitHubConnected} />
                                 </div>
                               </SessionMCPProvider>
+                              </TaskProvider>
                             </ScheduleProvider>
                           </PortProvider>
                         </TrashProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -113,21 +113,21 @@ export default async function Home() {
                           <PortProvider>
                             <ScheduleProvider>
                               <TaskProvider>
-                              <SessionMCPProvider>
-                                <div className="flex h-screen flex-col bg-background">
-                                  {/* Header - hidden on mobile, shown in sidebar instead */}
-                                  <Header
-                                    isGitHubConnected={isGitHubConnected}
-                                    userEmail={session.user.email || ""}
-                                    onSignOut={async () => {
-                                      "use server";
-                                      await signOut();
-                                    }}
-                                  />
-                                  {/* Main content */}
-                                  <SessionManager isGitHubConnected={isGitHubConnected} />
-                                </div>
-                              </SessionMCPProvider>
+                                <SessionMCPProvider>
+                                  <div className="flex h-screen flex-col bg-background">
+                                    {/* Header - hidden on mobile, shown in sidebar instead */}
+                                    <Header
+                                      isGitHubConnected={isGitHubConnected}
+                                      userEmail={session.user.email || ""}
+                                      onSignOut={async () => {
+                                        "use server";
+                                        await signOut();
+                                      }}
+                                    />
+                                    {/* Main content */}
+                                    <SessionManager isGitHubConnected={isGitHubConnected} />
+                                  </div>
+                                </SessionMCPProvider>
                               </TaskProvider>
                             </ScheduleProvider>
                           </PortProvider>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -13,7 +13,12 @@ import { AppearanceModeToggleCompact } from "@/components/appearance";
 import { GitHubMaintenanceModal } from "@/components/github/GitHubMaintenanceModal";
 import { GitHubProvider, useGitHubContext } from "@/contexts/GitHubContext";
 import { Button } from "@/components/ui/button";
-import { LogOut } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { LogOut, ClipboardList } from "lucide-react";
 import Image from "next/image";
 
 interface HeaderProps {
@@ -51,6 +56,23 @@ function HeaderContent({ isGitHubConnected, userEmail, onSignOut }: HeaderProps)
             />
             <SecretsStatusButton />
             <AppearanceModeToggleCompact />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                  onClick={() =>
+                    window.dispatchEvent(
+                      new CustomEvent("task-sidebar-toggle")
+                    )
+                  }
+                >
+                  <ClipboardList className="w-4 h-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Tasks (⌘.)</TooltipContent>
+            </Tooltip>
           </div>
 
           {/* User settings */}

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -13,6 +13,7 @@ import { TrashModal } from "@/components/trash/TrashModal";
 import { CreateScheduleModal, SchedulesModal } from "@/components/schedule";
 import { ProfilesModal } from "@/components/profiles/ProfilesModal";
 import { PortManagerModal } from "@/components/ports/PortManagerModal";
+import { TaskSidebar } from "@/components/tasks/TaskSidebar";
 import { IssuesModal } from "@/components/github/IssuesModal";
 import { PRsModal } from "@/components/github/PRsModal";
 import type { GitHubIssueDTO } from "@/contexts/GitHubIssuesContext";
@@ -1300,6 +1301,12 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
     return map;
   }, [activeSessions]);
 
+  /** Resolve GitHub repo ID for the task sidebar */
+  const taskSidebarRepoId = useMemo(() => {
+    if (!activeProject.folderId) return null;
+    return resolvePreferencesForFolder(activeProject.folderId)?.githubRepoId ?? null;
+  }, [activeProject.folderId, resolvePreferencesForFolder]);
+
   // On mobile, sidebar is collapsed when drawer is not open
   const effectiveCollapsed = isMobile ? !isMobileSidebarOpen : sidebarCollapsed;
 
@@ -1602,6 +1609,11 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
           </div>
         )}
       </div>
+
+      {/* Right sidebar - Task Tracker */}
+      <TaskSidebar
+        githubRepoId={taskSidebarRepoId}
+      />
 
       {/* New Session Wizard */}
       <NewSessionWizard

--- a/src/components/tasks/TaskSidebar.tsx
+++ b/src/components/tasks/TaskSidebar.tsx
@@ -1,0 +1,782 @@
+"use client";
+
+/**
+ * TaskSidebar - Right sidebar for project task tracking
+ *
+ * Displays manual tasks, agent tasks, and GitHub issues
+ * scoped to the active folder/project.
+ */
+
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { useTaskContext } from "@/contexts/TaskContext";
+import { useRepositoryIssues } from "@/contexts/GitHubIssuesContext";
+import {
+  ClipboardList,
+  Plus,
+  ChevronDown,
+  ChevronRight,
+  PanelRightClose,
+  Bot,
+  CircleDot,
+  CircleCheck,
+  CircleX,
+  Circle,
+  Loader2,
+  Trash2,
+  Check,
+  Calendar,
+  Link2,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type {
+  ProjectTask,
+  TaskStatus,
+  TaskSubtask,
+  UpdateTaskInput,
+} from "@/types/task";
+import { PRIORITY_CONFIG } from "@/types/task";
+
+// --- Sidebar state persistence (mirrors left sidebar pattern) ---
+
+const MIN_WIDTH = 240;
+const MAX_WIDTH = 500;
+const DEFAULT_WIDTH = 300;
+
+function getStoredCollapsed(): boolean {
+  if (typeof window === "undefined") return true;
+  return localStorage.getItem("task-sidebar-collapsed") !== "false";
+}
+
+function getStoredWidth(): number {
+  if (typeof window === "undefined") return DEFAULT_WIDTH;
+  const stored = localStorage.getItem("task-sidebar-width");
+  return stored ? Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, parseInt(stored, 10))) : DEFAULT_WIDTH;
+}
+
+function setStoredCollapsed(val: boolean) {
+  localStorage.setItem("task-sidebar-collapsed", String(val));
+  window.dispatchEvent(new CustomEvent("task-sidebar-collapsed-change"));
+}
+
+function setStoredWidth(val: number) {
+  localStorage.setItem("task-sidebar-width", String(val));
+  window.dispatchEvent(new CustomEvent("task-sidebar-width-change"));
+}
+
+// --- Inline task quick-add ---
+
+interface QuickAddProps {
+  onAdd: (title: string) => void;
+}
+
+function QuickAdd({ onAdd }: QuickAddProps) {
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleSubmit = () => {
+    const trimmed = value.trim();
+    if (trimmed) {
+      onAdd(trimmed);
+      setValue("");
+    }
+  };
+
+  return (
+    <div className="flex gap-1 px-2 py-1.5">
+      <Input
+        ref={inputRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") handleSubmit();
+        }}
+        placeholder="Add a task..."
+        className="h-7 text-xs bg-card border-border"
+      />
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 shrink-0"
+        onClick={handleSubmit}
+        disabled={!value.trim()}
+      >
+        <Plus className="w-3.5 h-3.5" />
+      </Button>
+    </div>
+  );
+}
+
+// --- Task item ---
+
+const STATUS_ICONS: Record<TaskStatus, React.ElementType> = {
+  open: Circle,
+  in_progress: CircleDot,
+  done: CircleCheck,
+  cancelled: CircleX,
+};
+
+const STATUS_COLORS: Record<TaskStatus, string> = {
+  open: "text-muted-foreground",
+  in_progress: "text-chart-2",
+  done: "text-green-500",
+  cancelled: "text-muted-foreground/50",
+};
+
+const NEXT_STATUS: Record<TaskStatus, TaskStatus> = {
+  open: "in_progress",
+  in_progress: "done",
+  done: "open",
+  cancelled: "open",
+};
+
+interface TaskItemProps {
+  task: ProjectTask;
+  onUpdate: (id: string, input: UpdateTaskInput) => void;
+  onDelete: (id: string) => Promise<boolean>;
+}
+
+function TaskItem({ task, onUpdate, onDelete }: TaskItemProps) {
+  const [expanded, setExpanded] = useState(false);
+  const StatusIcon = STATUS_ICONS[task.status];
+  const priorityConfig = PRIORITY_CONFIG[task.priority];
+
+  const completedSubtasks = task.subtasks.filter((s) => s.completed).length;
+  const totalSubtasks = task.subtasks.length;
+
+  const toggleSubtask = (subtaskId: string) => {
+    const updated = task.subtasks.map((s) =>
+      s.id === subtaskId ? { ...s, completed: !s.completed } : s
+    );
+    onUpdate(task.id, { subtasks: updated });
+  };
+
+  const addSubtask = (title: string) => {
+    const newSubtask: TaskSubtask = {
+      id: crypto.randomUUID(),
+      title,
+      completed: false,
+    };
+    onUpdate(task.id, { subtasks: [...task.subtasks, newSubtask] });
+  };
+
+  return (
+    <div
+      className={cn(
+        "group px-2 py-1.5 rounded-md transition-all duration-150",
+        "hover:bg-accent/50",
+        task.status === "done" && "opacity-60"
+      )}
+    >
+      {/* Main row */}
+      <div className="flex items-start gap-1.5">
+        {/* Status toggle */}
+        <button
+          onClick={() =>
+            onUpdate(task.id, { status: NEXT_STATUS[task.status] })
+          }
+          className="mt-0.5 shrink-0"
+        >
+          <StatusIcon
+            className={cn("w-3.5 h-3.5", STATUS_COLORS[task.status])}
+          />
+        </button>
+
+        {/* Title + meta */}
+        <div className="flex-1 min-w-0">
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="w-full text-left"
+          >
+            <span
+              className={cn(
+                "text-xs text-foreground line-clamp-2",
+                task.status === "done" && "line-through"
+              )}
+            >
+              {task.title}
+            </span>
+          </button>
+
+          {/* Meta row */}
+          <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
+            {/* Priority badge */}
+            <span
+              className="text-[10px] px-1 py-0.5 rounded"
+              style={{
+                backgroundColor: `#${priorityConfig.color}20`,
+                color: `#${priorityConfig.color}`,
+              }}
+            >
+              {priorityConfig.label}
+            </span>
+
+            {/* Labels */}
+            {task.labels.slice(0, 2).map((label) => (
+              <span
+                key={label.name}
+                className="text-[10px] px-1 py-0.5 rounded"
+                style={{
+                  backgroundColor: `#${label.color}20`,
+                  color: `#${label.color}`,
+                }}
+              >
+                {label.name}
+              </span>
+            ))}
+            {task.labels.length > 2 && (
+              <span className="text-[10px] text-muted-foreground">
+                +{task.labels.length - 2}
+              </span>
+            )}
+
+            {/* Subtask count */}
+            {totalSubtasks > 0 && (
+              <span className="text-[10px] text-muted-foreground">
+                {completedSubtasks}/{totalSubtasks}
+              </span>
+            )}
+
+            {/* Due date */}
+            {task.dueDate && (
+              <span
+                className={cn(
+                  "text-[10px] flex items-center gap-0.5",
+                  new Date(task.dueDate) < new Date() && task.status !== "done"
+                    ? "text-red-400"
+                    : "text-muted-foreground"
+                )}
+              >
+                <Calendar className="w-2.5 h-2.5" />
+                {new Date(task.dueDate).toLocaleDateString(undefined, {
+                  month: "short",
+                  day: "numeric",
+                })}
+              </span>
+            )}
+
+            {/* Source badge */}
+            {task.source === "agent" && (
+              <Bot className="w-2.5 h-2.5 text-primary/60" />
+            )}
+
+            {/* GitHub link */}
+            {task.githubIssueUrl && (
+              <a
+                href={task.githubIssueUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <Link2 className="w-2.5 h-2.5" />
+              </a>
+            )}
+          </div>
+        </div>
+
+        {/* Delete button (on hover) */}
+        <button
+          onClick={() => onDelete(task.id)}
+          className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0 mt-0.5"
+        >
+          <Trash2 className="w-3 h-3 text-muted-foreground hover:text-destructive" />
+        </button>
+      </div>
+
+      {/* Expanded: subtasks */}
+      {expanded && (
+        <div className="mt-1.5 ml-5 space-y-1">
+          {task.subtasks.map((sub) => (
+            <div key={sub.id} className="flex items-center gap-1.5">
+              <button onClick={() => toggleSubtask(sub.id)}>
+                {sub.completed ? (
+                  <Check className="w-3 h-3 text-green-500" />
+                ) : (
+                  <Circle className="w-3 h-3 text-muted-foreground" />
+                )}
+              </button>
+              <span
+                className={cn(
+                  "text-[11px]",
+                  sub.completed
+                    ? "text-muted-foreground line-through"
+                    : "text-foreground"
+                )}
+              >
+                {sub.title}
+              </span>
+            </div>
+          ))}
+          <SubtaskQuickAdd onAdd={addSubtask} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SubtaskQuickAdd({ onAdd }: { onAdd: (title: string) => void }) {
+  const [value, setValue] = useState("");
+
+  return (
+    <div className="flex items-center gap-1">
+      <Plus className="w-3 h-3 text-muted-foreground shrink-0" />
+      <input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && value.trim()) {
+            onAdd(value.trim());
+            setValue("");
+          }
+        }}
+        placeholder="Add subtask..."
+        className="flex-1 bg-transparent text-[11px] text-foreground placeholder:text-muted-foreground/50 outline-none"
+      />
+    </div>
+  );
+}
+
+// --- Section header ---
+
+interface SectionHeaderProps {
+  icon: React.ElementType;
+  title: string;
+  count: number;
+  expanded: boolean;
+  onToggle: () => void;
+  action?: React.ReactNode;
+}
+
+function SectionHeader({
+  icon: Icon,
+  title,
+  count,
+  expanded,
+  onToggle,
+  action,
+}: SectionHeaderProps) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5">
+      <button
+        onClick={onToggle}
+        className="flex items-center gap-2 flex-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {expanded ? (
+          <ChevronDown className="w-3 h-3" />
+        ) : (
+          <ChevronRight className="w-3 h-3" />
+        )}
+        <Icon className="w-3.5 h-3.5" />
+        <span className="font-medium">{title}</span>
+        {count > 0 && (
+          <span className="ml-auto text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+            {count}
+          </span>
+        )}
+      </button>
+      {action}
+    </div>
+  );
+}
+
+// --- GitHub issue link item ---
+
+interface GitHubIssueLinkProps {
+  issue: { number: number; title: string; htmlUrl: string; state: string };
+  onLink: () => void;
+}
+
+function GitHubIssueLink({ issue, onLink }: GitHubIssueLinkProps) {
+  return (
+    <div className="flex items-start gap-1.5 px-2 py-1 rounded-md hover:bg-accent/50 transition-colors group">
+      {issue.state === "open" ? (
+        <CircleDot className="w-3.5 h-3.5 text-chart-2 mt-0.5 shrink-0" />
+      ) : (
+        <CircleCheck className="w-3.5 h-3.5 text-muted-foreground mt-0.5 shrink-0" />
+      )}
+      <div className="flex-1 min-w-0">
+        <a
+          href={issue.htmlUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-foreground hover:underline line-clamp-1"
+        >
+          <span className="text-primary mr-1">#{issue.number}</span>
+          {issue.title}
+        </a>
+      </div>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={onLink}
+            className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0 mt-0.5"
+          >
+            <Link2 className="w-3 h-3 text-muted-foreground hover:text-foreground" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="left">Create task from issue</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
+
+// --- Main TaskSidebar ---
+
+interface TaskSidebarProps {
+  githubRepoId: string | null;
+}
+
+export function TaskSidebar({ githubRepoId }: TaskSidebarProps) {
+  const { tasks, loading, createTask, updateTask, deleteTask, activeFolderId } =
+    useTaskContext();
+
+  // Sidebar state
+  const [collapsed, setCollapsed] = useState(getStoredCollapsed);
+  const [width, setWidth] = useState(getStoredWidth);
+
+  // Section expand state
+  const [manualExpanded, setManualExpanded] = useState(true);
+  const [agentExpanded, setAgentExpanded] = useState(true);
+  const [issuesExpanded, setIssuesExpanded] = useState(false);
+
+  // GitHub issues from existing context
+  const { issues: rawIssues, isLoading: issuesLoading, refresh: refreshIssues } =
+    useRepositoryIssues(githubRepoId);
+
+  const githubIssues = useMemo(
+    () =>
+      rawIssues.map((issue) => ({
+        number: issue.number,
+        title: issue.title,
+        htmlUrl: issue.htmlUrl,
+        state: issue.state,
+      })),
+    [rawIssues]
+  );
+
+  // Fetch GitHub issues when section is expanded
+  useEffect(() => {
+    if (issuesExpanded && githubRepoId) {
+      refreshIssues();
+    }
+  }, [issuesExpanded, githubRepoId, refreshIssues]);
+
+  // Listen for collapse state changes (cross-tab sync)
+  useEffect(() => {
+    const onCollapsedChange = () => setCollapsed(getStoredCollapsed());
+    const onWidthChange = () => setWidth(getStoredWidth());
+    const onToggle = () => {
+      const next = !getStoredCollapsed();
+      setStoredCollapsed(next);
+      setCollapsed(next);
+    };
+
+    window.addEventListener("task-sidebar-collapsed-change", onCollapsedChange);
+    window.addEventListener("task-sidebar-width-change", onWidthChange);
+    window.addEventListener("task-sidebar-toggle", onToggle);
+
+    return () => {
+      window.removeEventListener(
+        "task-sidebar-collapsed-change",
+        onCollapsedChange
+      );
+      window.removeEventListener("task-sidebar-width-change", onWidthChange);
+      window.removeEventListener("task-sidebar-toggle", onToggle);
+    };
+  }, []);
+
+  // Keyboard shortcut: Cmd+.
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === ".") {
+        e.preventDefault();
+        const next = !getStoredCollapsed();
+        setStoredCollapsed(next);
+        setCollapsed(next);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  // Resize handle
+  const resizeRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const latestWidthRef = useRef(width);
+  useEffect(() => {
+    latestWidthRef.current = width;
+  }, [width]);
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      resizeRef.current = { startX: e.clientX, startWidth: width };
+
+      const handleMouseMove = (e: MouseEvent) => {
+        if (!resizeRef.current) return;
+        // Dragging left = increasing width (since sidebar is on the right)
+        const delta = resizeRef.current.startX - e.clientX;
+        const newWidth = Math.max(
+          MIN_WIDTH,
+          Math.min(MAX_WIDTH, resizeRef.current.startWidth + delta)
+        );
+        setWidth(newWidth);
+      };
+
+      const handleMouseUp = () => {
+        resizeRef.current = null;
+        setStoredWidth(latestWidthRef.current);
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+    },
+    [width]
+  );
+
+  // Toggle collapse
+  const toggleCollapsed = useCallback(() => {
+    const next = !collapsed;
+    setStoredCollapsed(next);
+    setCollapsed(next);
+  }, [collapsed]);
+
+  // Split tasks by source
+  const manualTasks = useMemo(
+    () => tasks.filter((t) => t.source === "manual"),
+    [tasks]
+  );
+  const agentTasks = useMemo(
+    () => tasks.filter((t) => t.source === "agent"),
+    [tasks]
+  );
+
+  const openTaskCount = useMemo(
+    () => tasks.filter((t) => t.status === "open" || t.status === "in_progress").length,
+    [tasks]
+  );
+
+  const activeManualCount = useMemo(
+    () => manualTasks.filter((t) => t.status !== "done" && t.status !== "cancelled").length,
+    [manualTasks]
+  );
+
+  const activeAgentCount = useMemo(
+    () => agentTasks.filter((t) => t.status !== "done" && t.status !== "cancelled").length,
+    [agentTasks]
+  );
+
+  // Handlers
+  const handleAddTask = useCallback(
+    (title: string) => {
+      createTask({ title, folderId: activeFolderId });
+    },
+    [createTask, activeFolderId]
+  );
+
+  const handleLinkIssue = useCallback(
+    (issue: { number: number; title: string; htmlUrl: string }) => {
+      createTask({
+        title: issue.title,
+        folderId: activeFolderId,
+        githubIssueUrl: issue.htmlUrl,
+        description: `Linked from GitHub #${issue.number}`,
+      });
+    },
+    [createTask, activeFolderId]
+  );
+
+  // Collapsed state - icon strip
+  if (collapsed) {
+    return (
+      <div className="w-12 shrink-0 h-full flex flex-col items-center py-2 border-l border-border bg-card/30">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={toggleCollapsed}
+              className={cn(
+                "relative p-2 rounded-md transition-colors",
+                "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+              )}
+            >
+              <ClipboardList className="w-4 h-4" />
+              {openTaskCount > 0 && (
+                <span className="absolute -top-1 -right-1 w-4 h-4 text-[10px] bg-primary text-primary-foreground rounded-full flex items-center justify-center">
+                  {openTaskCount > 9 ? "9+" : openTaskCount}
+                </span>
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            Tasks ({openTaskCount} open)
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="shrink-0 h-full flex flex-col bg-card/50 backdrop-blur-md border-l border-border relative"
+      style={{ width }}
+    >
+      {/* Resize handle (left edge) */}
+      <div
+        className="absolute top-0 left-0 w-1 h-full cursor-col-resize hover:bg-primary/30 transition-colors z-10"
+        onMouseDown={handleResizeStart}
+      />
+
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
+        <ClipboardList className="w-4 h-4 text-primary shrink-0" />
+        <span className="text-xs font-semibold text-foreground flex-1">
+          Tasks
+        </span>
+        {openTaskCount > 0 && (
+          <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+            {openTaskCount}
+          </span>
+        )}
+        <button
+          onClick={toggleCollapsed}
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <PanelRightClose className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* No folder selected */}
+      {!activeFolderId ? (
+        <div className="flex-1 flex items-center justify-center px-4">
+          <p className="text-xs text-muted-foreground text-center">
+            Select a project folder to view tasks
+          </p>
+        </div>
+      ) : (
+        <ScrollArea className="flex-1">
+          <div className="py-1">
+            {/* Manual Tasks Section */}
+            <div>
+              <SectionHeader
+                icon={ClipboardList}
+                title="Tasks"
+                count={activeManualCount}
+                expanded={manualExpanded}
+                onToggle={() => setManualExpanded(!manualExpanded)}
+              />
+              {manualExpanded && (
+                <>
+                  <QuickAdd onAdd={handleAddTask} />
+                  <div className="space-y-0.5 px-1">
+                    {manualTasks.length === 0 ? (
+                      <p className="text-[11px] text-muted-foreground px-3 py-2">
+                        No tasks yet. Add one above.
+                      </p>
+                    ) : (
+                      manualTasks.map((task) => (
+                        <TaskItem
+                          key={task.id}
+                          task={task}
+                          onUpdate={updateTask}
+                          onDelete={deleteTask}
+                        />
+                      ))
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+
+            {/* Separator */}
+            <div className="border-t border-border my-1" />
+
+            {/* Agent Tasks Section */}
+            <div>
+              <SectionHeader
+                icon={Bot}
+                title="Agent Tasks"
+                count={activeAgentCount}
+                expanded={agentExpanded}
+                onToggle={() => setAgentExpanded(!agentExpanded)}
+              />
+              {agentExpanded && (
+                <div className="space-y-0.5 px-1">
+                  {agentTasks.length === 0 ? (
+                    <p className="text-[11px] text-muted-foreground px-3 py-2">
+                      No agent tasks. Agents create tasks via MCP or API.
+                    </p>
+                  ) : (
+                    agentTasks.map((task) => (
+                      <TaskItem
+                        key={task.id}
+                        task={task}
+                        onUpdate={updateTask}
+                        onDelete={deleteTask}
+                      />
+                    ))
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Separator */}
+            <div className="border-t border-border my-1" />
+
+            {/* GitHub Issues Section */}
+            <div>
+              <SectionHeader
+                icon={CircleDot}
+                title="GitHub Issues"
+                count={githubIssues.length}
+                expanded={issuesExpanded}
+                onToggle={() => setIssuesExpanded(!issuesExpanded)}
+              />
+              {issuesExpanded && (
+                <div className="space-y-0.5 px-1">
+                  {!githubRepoId ? (
+                    <p className="text-[11px] text-muted-foreground px-3 py-2">
+                      Link a GitHub repo to this folder to see issues.
+                    </p>
+                  ) : issuesLoading ? (
+                    <div className="flex items-center gap-2 px-3 py-2">
+                      <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
+                      <span className="text-[11px] text-muted-foreground">Loading issues...</span>
+                    </div>
+                  ) : githubIssues.length === 0 ? (
+                    <p className="text-[11px] text-muted-foreground px-3 py-2">
+                      No issues found.
+                    </p>
+                  ) : (
+                    githubIssues.map((issue) => (
+                      <GitHubIssueLink
+                        key={issue.number}
+                        issue={issue}
+                        onLink={() => handleLinkIssue(issue)}
+                      />
+                    ))
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </ScrollArea>
+      )}
+
+      {/* Loading overlay */}
+      {loading && (
+        <div className="absolute inset-0 bg-card/50 flex items-center justify-center">
+          <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/contexts/TaskContext.tsx
+++ b/src/contexts/TaskContext.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  type ReactNode,
+} from "react";
+import type {
+  ProjectTask,
+  CreateTaskInput,
+  UpdateTaskInput,
+} from "@/types/task";
+import { usePreferencesContext } from "./PreferencesContext";
+
+/** Hydrate date strings from API response into Date objects */
+function hydrateTask(raw: Record<string, unknown>): ProjectTask {
+  return {
+    ...(raw as unknown as ProjectTask),
+    createdAt: new Date(raw.createdAt as string),
+    updatedAt: new Date(raw.updatedAt as string),
+    dueDate: raw.dueDate ? new Date(raw.dueDate as string) : null,
+  };
+}
+
+interface TaskContextValue {
+  tasks: ProjectTask[];
+  loading: boolean;
+  error: string | null;
+  activeFolderId: string | null;
+  refreshTasks: () => Promise<void>;
+  createTask: (input: CreateTaskInput) => Promise<ProjectTask | null>;
+  updateTask: (
+    id: string,
+    input: UpdateTaskInput
+  ) => Promise<ProjectTask | null>;
+  deleteTask: (id: string) => Promise<boolean>;
+}
+
+const TaskContext = createContext<TaskContextValue | null>(null);
+
+export function useTaskContext() {
+  const context = useContext(TaskContext);
+  if (!context) {
+    throw new Error("useTaskContext must be used within a TaskProvider");
+  }
+  return context;
+}
+
+interface TaskProviderProps {
+  children: ReactNode;
+}
+
+export function TaskProvider({ children }: TaskProviderProps) {
+  const [tasks, setTasks] = useState<ProjectTask[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { activeProject } = usePreferencesContext();
+  const activeFolderId = activeProject.folderId;
+
+  const refreshTasks = useCallback(async () => {
+    if (!activeFolderId) {
+      setTasks([]);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetch(
+        `/api/tasks?folderId=${encodeURIComponent(activeFolderId)}`
+      );
+      if (!response.ok) {
+        throw new Error("Failed to fetch tasks");
+      }
+      const data = await response.json();
+      setTasks(data.map(hydrateTask));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  }, [activeFolderId]);
+
+  // Reload when active folder changes
+  useEffect(() => {
+    refreshTasks();
+  }, [refreshTasks]);
+
+  const createTask = useCallback(
+    async (input: CreateTaskInput): Promise<ProjectTask | null> => {
+      try {
+        const response = await fetch("/api/tasks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            ...input,
+            folderId: input.folderId ?? activeFolderId,
+          }),
+        });
+        if (!response.ok) {
+          throw new Error("Failed to create task");
+        }
+        const task = hydrateTask(await response.json());
+        setTasks((prev) => [task, ...prev]);
+        return task;
+      } catch (err) {
+        console.error("Error creating task:", err);
+        return null;
+      }
+    },
+    [activeFolderId]
+  );
+
+  const updateTask = useCallback(
+    async (
+      id: string,
+      input: UpdateTaskInput
+    ): Promise<ProjectTask | null> => {
+      try {
+        const response = await fetch(`/api/tasks/${id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(input),
+        });
+        if (!response.ok) {
+          throw new Error("Failed to update task");
+        }
+        const task = hydrateTask(await response.json());
+        setTasks((prev) => prev.map((t) => (t.id === id ? task : t)));
+        return task;
+      } catch (err) {
+        console.error("Error updating task:", err);
+        return null;
+      }
+    },
+    []
+  );
+
+  const deleteTask = useCallback(async (id: string): Promise<boolean> => {
+    try {
+      const response = await fetch(`/api/tasks/${id}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        throw new Error("Failed to delete task");
+      }
+      setTasks((prev) => prev.filter((t) => t.id !== id));
+      return true;
+    } catch (err) {
+      console.error("Error deleting task:", err);
+      return false;
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      tasks,
+      loading,
+      error,
+      activeFolderId,
+      refreshTasks,
+      createTask,
+      updateTask,
+      deleteTask,
+    }),
+    [
+      tasks,
+      loading,
+      error,
+      activeFolderId,
+      refreshTasks,
+      createTask,
+      updateTask,
+      deleteTask,
+    ]
+  );
+
+  return <TaskContext.Provider value={value}>{children}</TaskContext.Provider>;
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -8,6 +8,7 @@ import type { AgentProvider, AgentConfigType, MCPTransport } from "@/types/agent
 import type { AgentProviderType } from "@/types/session";
 import type { TerminalType, AgentExitState } from "@/types/terminal-type";
 import type { AppearanceMode, ColorSchemeCategory, ColorSchemeId } from "@/types/appearance";
+import type { TaskPriority, TaskStatus, TaskSource } from "@/types/task";
 
 export const users = sqliteTable("user", {
   id: text("id")
@@ -1434,5 +1435,45 @@ export const profileAppearanceSettings = sqliteTable(
   (table) => [
     index("profile_appearance_profile_idx").on(table.profileId),
     index("profile_appearance_user_idx").on(table.userId),
+  ]
+);
+
+/**
+ * Project tasks for the task tracker sidebar.
+ * Tasks are folder-scoped and can be created manually or by agents.
+ */
+export const projectTasks = sqliteTable(
+  "project_task",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    folderId: text("folder_id").references(() => sessionFolders.id, {
+      onDelete: "cascade",
+    }),
+    title: text("title").notNull(),
+    description: text("description"),
+    status: text("status").$type<TaskStatus>().notNull().default("open"),
+    priority: text("priority").$type<TaskPriority>().notNull().default("medium"),
+    source: text("source").$type<TaskSource>().notNull().default("manual"),
+    labels: text("labels").notNull().default("[]"), // JSON: TaskLabel[]
+    subtasks: text("subtasks").notNull().default("[]"), // JSON: TaskSubtask[]
+    dueDate: integer("due_date", { mode: "timestamp_ms" }),
+    githubIssueUrl: text("github_issue_url"),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("project_task_user_idx").on(table.userId),
+    index("project_task_folder_idx").on(table.folderId),
+    index("project_task_user_folder_idx").on(table.userId, table.folderId),
   ]
 );

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,12 +8,14 @@ export function cn(...inputs: ClassValue[]) {
 /**
  * Safely parse a JSON string with a fallback value.
  * Returns fallback on null/undefined input or invalid JSON.
+ * Logs a warning on parse failure for diagnostics.
  */
 export function safeJsonParse<T>(value: string | null | undefined, fallback: T): T {
   if (!value) return fallback;
   try {
     return JSON.parse(value) as T;
   } catch {
+    console.warn("Failed to parse JSON:", value.substring(0, 100));
     return fallback;
   }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,16 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Safely parse a JSON string with a fallback value.
+ * Returns fallback on null/undefined input or invalid JSON.
+ */
+export function safeJsonParse<T>(value: string | null | undefined, fallback: T): T {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -7,6 +7,7 @@ import { sessionTools } from "./session-tools.js";
 import { gitTools } from "./git-tools.js";
 import { folderTools } from "./folder-tools.js";
 import { profileTools } from "./profile-tools.js";
+import { taskTools } from "./task-tools.js";
 import type { RegisteredTool } from "../types.js";
 
 /**
@@ -30,12 +31,16 @@ import type { RegisteredTool } from "../types.js";
  * Profile Tools:
  * - profile_list, profile_create, profile_get, profile_update, profile_delete
  * - profile_set_git_identity, profile_link_folder, profile_unlink_folder
+ *
+ * Task Tools:
+ * - task_list, task_create, task_update, task_complete, task_delete
  */
 export const allTools: RegisteredTool[] = [
   ...sessionTools,
   ...gitTools,
   ...folderTools,
   ...profileTools,
+  ...taskTools,
 ];
 
 /**

--- a/src/mcp/tools/task-tools.ts
+++ b/src/mcp/tools/task-tools.ts
@@ -141,7 +141,7 @@ const taskUpdate = createTool({
     const task = await TaskService.updateTask(taskId, context.userId, updates);
 
     if (!task) {
-      return successResult({ success: false, error: "Task not found" });
+      return successResult({ success: false, error: "Task not found", code: "TASK_NOT_FOUND" });
     }
 
     return successResult({
@@ -173,7 +173,7 @@ const taskComplete = createTool({
     );
 
     if (!task) {
-      return successResult({ success: false, error: "Task not found" });
+      return successResult({ success: false, error: "Task not found", code: "TASK_NOT_FOUND" });
     }
 
     return successResult({
@@ -197,7 +197,7 @@ const taskDelete = createTool({
 
     return successResult({
       success: deleted,
-      ...(deleted ? {} : { error: "Task not found" }),
+      ...(deleted ? {} : { error: "Task not found", code: "TASK_NOT_FOUND" }),
     });
   },
 });

--- a/src/mcp/tools/task-tools.ts
+++ b/src/mcp/tools/task-tools.ts
@@ -1,0 +1,211 @@
+/**
+ * Task Tools - Project Task Management
+ *
+ * Tools for creating and managing project tasks from AI agents.
+ */
+import { z } from "zod";
+import { createTool } from "../registry.js";
+import { successResult } from "../utils/error-handler.js";
+import * as TaskService from "@/services/task-service";
+import type { RegisteredTool } from "../types.js";
+
+// Shared Zod schemas to stay in sync with TaskStatus/TaskPriority types
+const taskStatusSchema = z.enum(["open", "in_progress", "done", "cancelled"]);
+const taskPrioritySchema = z.enum(["critical", "high", "medium", "low"]);
+const taskLabelSchema = z.object({
+  name: z.string(),
+  color: z.string().describe("Hex color without #"),
+});
+
+/**
+ * task_list - List tasks for a folder
+ */
+const taskList = createTool({
+  name: "task_list",
+  description:
+    "List project tasks, optionally filtered by folder. Returns tasks with priority, status, labels, and subtasks.",
+  inputSchema: z.object({
+    folderId: z
+      .string()
+      .uuid()
+      .optional()
+      .describe("Filter by folder ID. Omit to get all tasks."),
+    status: taskStatusSchema
+      .optional()
+      .describe("Filter by task status"),
+  }),
+  handler: async (input, context) => {
+    const tasks = await TaskService.getTasks(context.userId, input.folderId, input.status);
+
+    return successResult({
+      success: true,
+      count: tasks.length,
+      tasks: tasks.map((t) => ({
+        id: t.id,
+        title: t.title,
+        description: t.description,
+        status: t.status,
+        priority: t.priority,
+        source: t.source,
+        labels: t.labels,
+        subtasks: t.subtasks,
+        dueDate: t.dueDate?.toISOString() ?? null,
+        githubIssueUrl: t.githubIssueUrl,
+        folderId: t.folderId,
+      })),
+    });
+  },
+});
+
+/**
+ * task_create - Create a new task
+ */
+const taskCreate = createTool({
+  name: "task_create",
+  description:
+    "Create a new project task. Agent-created tasks are automatically tagged with source='agent'.",
+  inputSchema: z.object({
+    title: z.string().min(1).describe("Task title"),
+    folderId: z
+      .string()
+      .uuid()
+      .optional()
+      .describe("Folder to create the task in"),
+    description: z.string().optional().describe("Task description"),
+    priority: taskPrioritySchema
+      .optional()
+      .describe("Task priority (default: medium)"),
+    labels: z
+      .array(taskLabelSchema)
+      .optional()
+      .describe("Task labels"),
+    dueDate: z
+      .string()
+      .optional()
+      .describe("Due date as ISO 8601 string"),
+  }),
+  handler: async (input, context) => {
+    const task = await TaskService.createTask(context.userId, {
+      ...input,
+      source: "agent",
+    });
+
+    return successResult({
+      success: true,
+      task: {
+        id: task.id,
+        title: task.title,
+        status: task.status,
+        priority: task.priority,
+        source: task.source,
+        folderId: task.folderId,
+      },
+    });
+  },
+});
+
+/**
+ * task_update - Update an existing task
+ */
+const taskUpdate = createTool({
+  name: "task_update",
+  description: "Update a project task's properties.",
+  inputSchema: z.object({
+    taskId: z.string().uuid().describe("The task ID to update"),
+    title: z.string().optional().describe("New task title"),
+    description: z.string().optional().describe("New description"),
+    status: taskStatusSchema
+      .optional()
+      .describe("New status"),
+    priority: taskPrioritySchema
+      .optional()
+      .describe("New priority"),
+    labels: z
+      .array(taskLabelSchema)
+      .optional()
+      .describe("Replace all labels"),
+    subtasks: z
+      .array(
+        z.object({
+          id: z.string(),
+          title: z.string(),
+          completed: z.boolean(),
+        })
+      )
+      .optional()
+      .describe("Replace all subtasks"),
+    dueDate: z.string().nullable().optional().describe("Due date (ISO 8601) or null to clear"),
+  }),
+  handler: async (input, context) => {
+    const { taskId, ...updates } = input;
+    const task = await TaskService.updateTask(taskId, context.userId, updates);
+
+    if (!task) {
+      return successResult({ success: false, error: "Task not found" });
+    }
+
+    return successResult({
+      success: true,
+      task: {
+        id: task.id,
+        title: task.title,
+        status: task.status,
+        priority: task.priority,
+      },
+    });
+  },
+});
+
+/**
+ * task_complete - Mark a task as done
+ */
+const taskComplete = createTool({
+  name: "task_complete",
+  description: "Mark a project task as done.",
+  inputSchema: z.object({
+    taskId: z.string().uuid().describe("The task ID to complete"),
+  }),
+  handler: async (input, context) => {
+    const task = await TaskService.updateTask(
+      input.taskId,
+      context.userId,
+      { status: "done" }
+    );
+
+    if (!task) {
+      return successResult({ success: false, error: "Task not found" });
+    }
+
+    return successResult({
+      success: true,
+      task: { id: task.id, title: task.title, status: task.status },
+    });
+  },
+});
+
+/**
+ * task_delete - Delete a task
+ */
+const taskDelete = createTool({
+  name: "task_delete",
+  description: "Permanently delete a project task.",
+  inputSchema: z.object({
+    taskId: z.string().uuid().describe("The task ID to delete"),
+  }),
+  handler: async (input, context) => {
+    const deleted = await TaskService.deleteTask(input.taskId, context.userId);
+
+    return successResult({
+      success: deleted,
+      ...(deleted ? {} : { error: "Task not found" }),
+    });
+  },
+});
+
+export const taskTools: RegisteredTool[] = [
+  taskList,
+  taskCreate,
+  taskUpdate,
+  taskComplete,
+  taskDelete,
+];

--- a/src/services/agent-profile-service.ts
+++ b/src/services/agent-profile-service.ts
@@ -23,6 +23,7 @@ import { homedir } from "os";
 import { createSecretsProvider, isProviderSupported } from "./secrets";
 import { encrypt, decryptSafe } from "@/lib/encryption";
 import { AgentProfileServiceError } from "@/lib/errors";
+import { safeJsonParse } from "@/lib/utils";
 import { getProfilesDir } from "@/lib/paths";
 import { ProfileIsolation } from "@/domain/value-objects/ProfileIsolation";
 import type {
@@ -82,20 +83,7 @@ function validateSshKeyPath(keyPath: string): string {
   return resolved;
 }
 
-/**
- * Safely parse JSON with fallback to empty object
- */
-function safeJsonParse<T extends Record<string, unknown> = Record<string, string>>(
-  json: string,
-  fallback: T = {} as T
-): T {
-  try {
-    return JSON.parse(json) as T;
-  } catch {
-    console.error("Failed to parse JSON:", json.substring(0, 100));
-    return fallback;
-  }
-}
+// safeJsonParse imported from @/lib/utils
 
 /**
  * Get all profiles for a user
@@ -900,7 +888,7 @@ function mapDbToSecretsConfig(
     profileId: dbRecord.profileId,
     userId: dbRecord.userId,
     provider: dbRecord.provider as ProfileSecretsProviderType,
-    providerConfig: safeJsonParse(decryptedConfig ?? "{}"),
+    providerConfig: safeJsonParse(decryptedConfig ?? "{}", {} as Record<string, string>),
     enabled: dbRecord.enabled ?? true,
     lastFetchedAt: dbRecord.lastFetchedAt ? new Date(dbRecord.lastFetchedAt) : null,
     createdAt: new Date(dbRecord.createdAt),

--- a/src/services/agent-profile-service.ts
+++ b/src/services/agent-profile-service.ts
@@ -83,8 +83,6 @@ function validateSshKeyPath(keyPath: string): string {
   return resolved;
 }
 
-// safeJsonParse imported from @/lib/utils
-
 /**
  * Get all profiles for a user
  */

--- a/src/services/github-stats-service.ts
+++ b/src/services/github-stats-service.ts
@@ -612,8 +612,6 @@ async function updatePullRequests(
   }
 }
 
-// safeJsonParse imported from @/lib/utils
-
 /**
  * Update branch protection in database
  */

--- a/src/services/github-stats-service.ts
+++ b/src/services/github-stats-service.ts
@@ -13,6 +13,7 @@ import {
   githubChangeNotifications,
 } from "@/db/schema";
 import { eq, and, inArray } from "drizzle-orm";
+import { safeJsonParse } from "@/lib/utils";
 import * as GitHubService from "./github-service";
 import * as GraphQLService from "./github-graphql-service";
 import * as CacheService from "./cache-service";
@@ -91,9 +92,9 @@ export async function getEnrichedRepositories(
     const [owner] = repo.fullName.split("/");
 
     // Parse JSON fields with safe fallback
-    const ciStatusDetails = safeParseJson(stat?.ciStatusDetails, null);
-    const recentCommits = safeParseJson<CommitInfo[]>(stat?.recentCommits, []);
-    const branchProtection = safeParseJson<BranchProtection | null>(stat?.branchProtectionDetails, null);
+    const ciStatusDetails = safeJsonParse(stat?.ciStatusDetails, null);
+    const recentCommits = safeJsonParse<CommitInfo[]>(stat?.recentCommits, []);
+    const branchProtection = safeJsonParse<BranchProtection | null>(stat?.branchProtectionDetails, null);
 
     const repositoryStats: RepositoryStats = {
       repositoryId: repo.id,
@@ -611,17 +612,7 @@ async function updatePullRequests(
   }
 }
 
-/**
- * Safely parse JSON string with fallback value
- */
-function safeParseJson<T>(value: string | null | undefined, fallback: T): T {
-  if (!value) return fallback;
-  try {
-    return JSON.parse(value) as T;
-  } catch {
-    return fallback;
-  }
-}
+// safeJsonParse imported from @/lib/utils
 
 /**
  * Update branch protection in database

--- a/src/services/task-service.ts
+++ b/src/services/task-service.ts
@@ -1,0 +1,161 @@
+import { db } from "@/db";
+import { projectTasks } from "@/db/schema";
+import { eq, and, desc, asc, isNull } from "drizzle-orm";
+import type {
+  ProjectTask,
+  CreateTaskInput,
+  UpdateTaskInput,
+  TaskLabel,
+  TaskSubtask,
+  TaskStatus,
+} from "@/types/task";
+import { safeJsonParse } from "@/lib/utils";
+
+/**
+ * Parse a raw DB row into a ProjectTask with JSON fields decoded.
+ */
+function parseTaskRow(row: typeof projectTasks.$inferSelect): ProjectTask {
+  return {
+    id: row.id,
+    userId: row.userId,
+    folderId: row.folderId,
+    title: row.title,
+    description: row.description,
+    status: row.status,
+    priority: row.priority,
+    source: row.source,
+    labels: safeJsonParse<TaskLabel[]>(row.labels, []),
+    subtasks: safeJsonParse<TaskSubtask[]>(row.subtasks, []),
+    dueDate: row.dueDate,
+    githubIssueUrl: row.githubIssueUrl,
+    sortOrder: row.sortOrder,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/**
+ * Get all tasks for a user, optionally filtered by folder and/or status.
+ */
+export async function getTasks(
+  userId: string,
+  folderId?: string | null,
+  status?: TaskStatus
+): Promise<ProjectTask[]> {
+  const conditions = [eq(projectTasks.userId, userId)];
+
+  if (folderId !== undefined) {
+    if (folderId === null) {
+      conditions.push(isNull(projectTasks.folderId));
+    } else {
+      conditions.push(eq(projectTasks.folderId, folderId));
+    }
+  }
+
+  if (status) {
+    conditions.push(eq(projectTasks.status, status));
+  }
+
+  const results = await db
+    .select()
+    .from(projectTasks)
+    .where(and(...conditions))
+    .orderBy(asc(projectTasks.sortOrder), desc(projectTasks.createdAt));
+
+  return results.map(parseTaskRow);
+}
+
+/**
+ * Get a single task by ID.
+ */
+export async function getTask(
+  taskId: string,
+  userId: string
+): Promise<ProjectTask | null> {
+  const results = await db
+    .select()
+    .from(projectTasks)
+    .where(
+      and(eq(projectTasks.id, taskId), eq(projectTasks.userId, userId))
+    );
+
+  return results[0] ? parseTaskRow(results[0]) : null;
+}
+
+/**
+ * Create a new task.
+ */
+export async function createTask(
+  userId: string,
+  input: CreateTaskInput
+): Promise<ProjectTask> {
+  const [row] = await db
+    .insert(projectTasks)
+    .values({
+      userId,
+      folderId: input.folderId ?? null,
+      title: input.title,
+      description: input.description ?? null,
+      status: input.status ?? "open",
+      priority: input.priority ?? "medium",
+      source: input.source ?? "manual",
+      labels: JSON.stringify(input.labels ?? []),
+      subtasks: JSON.stringify(input.subtasks ?? []),
+      dueDate: input.dueDate ? new Date(input.dueDate) : null,
+      githubIssueUrl: input.githubIssueUrl ?? null,
+    })
+    .returning();
+
+  return parseTaskRow(row);
+}
+
+/**
+ * Update an existing task.
+ */
+export async function updateTask(
+  taskId: string,
+  userId: string,
+  input: UpdateTaskInput
+): Promise<ProjectTask | null> {
+  const updates: Record<string, unknown> = { updatedAt: new Date() };
+
+  if (input.title !== undefined) updates.title = input.title;
+  if (input.description !== undefined) updates.description = input.description;
+  if (input.status !== undefined) updates.status = input.status;
+  if (input.priority !== undefined) updates.priority = input.priority;
+  if (input.labels !== undefined) updates.labels = JSON.stringify(input.labels);
+  if (input.subtasks !== undefined)
+    updates.subtasks = JSON.stringify(input.subtasks);
+  if (input.dueDate !== undefined)
+    updates.dueDate = input.dueDate ? new Date(input.dueDate) : null;
+  if (input.githubIssueUrl !== undefined)
+    updates.githubIssueUrl = input.githubIssueUrl;
+  if (input.sortOrder !== undefined) updates.sortOrder = input.sortOrder;
+
+  const results = await db
+    .update(projectTasks)
+    .set(updates)
+    .where(
+      and(eq(projectTasks.id, taskId), eq(projectTasks.userId, userId))
+    )
+    .returning();
+
+  return results[0] ? parseTaskRow(results[0]) : null;
+}
+
+/**
+ * Delete a task.
+ */
+export async function deleteTask(
+  taskId: string,
+  userId: string
+): Promise<boolean> {
+  const result = await db
+    .delete(projectTasks)
+    .where(
+      and(eq(projectTasks.id, taskId), eq(projectTasks.userId, userId))
+    )
+    .returning({ id: projectTasks.id });
+
+  return result.length > 0;
+}

--- a/src/services/tmux-service.ts
+++ b/src/services/tmux-service.ts
@@ -120,17 +120,13 @@ export async function createSession(
     args.push("-c", cwd);
   }
 
-  // Inject environment variables directly into the session using -e flags.
-  // This ensures the shell inside the session inherits these vars, regardless
-  // of whether a tmux server is already running (tmux 3.2+).
-  if (env) {
-    for (const [key, value] of Object.entries(env)) {
-      args.push("-e", `${key}=${value}`);
-    }
-  }
+  // Pass environment variables as the process environment for tmux.
+  // This sets the initial PTY shell environment (Layer 1 of Two-Layer Model).
+  // Session-level persistent env (Layer 2) is set via setSessionEnvironment().
+  const execOptions = env ? { env: { ...process.env, ...env } } : undefined;
 
   try {
-    await execFile("tmux", args);
+    await execFile("tmux", args, execOptions);
 
     // Enable mouse mode for scrolling in alternate screen apps (vim, less, claude code, etc.)
     // Use Shift+click to bypass and select text with xterm.js

--- a/src/services/tmux-service.ts
+++ b/src/services/tmux-service.ts
@@ -120,12 +120,17 @@ export async function createSession(
     args.push("-c", cwd);
   }
 
-  // Build execution options with environment overlay
-  // Note: lib/exec.ts now filters out framework internal vars automatically
-  const execOptions = env ? { env: env as NodeJS.ProcessEnv } : undefined;
+  // Inject environment variables directly into the session using -e flags.
+  // This ensures the shell inside the session inherits these vars, regardless
+  // of whether a tmux server is already running (tmux 3.2+).
+  if (env) {
+    for (const [key, value] of Object.entries(env)) {
+      args.push("-e", `${key}=${value}`);
+    }
+  }
 
   try {
-    await execFile("tmux", args, execOptions);
+    await execFile("tmux", args);
 
     // Enable mouse mode for scrolling in alternate screen apps (vim, less, claude code, etc.)
     // Use Shift+click to bypass and select text with xterm.js

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,0 +1,85 @@
+/**
+ * Project Task Types
+ *
+ * Type definitions for the project task tracker feature.
+ * Tasks are folder-scoped and support manual + agent sources.
+ */
+
+export type TaskPriority = "critical" | "high" | "medium" | "low";
+export type TaskStatus = "open" | "in_progress" | "done" | "cancelled";
+export type TaskSource = "manual" | "agent";
+
+export interface TaskLabel {
+  name: string;
+  color: string; // hex color without #
+}
+
+export interface TaskSubtask {
+  id: string;
+  title: string;
+  completed: boolean;
+}
+
+export interface ProjectTask {
+  id: string;
+  userId: string;
+  folderId: string | null;
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  priority: TaskPriority;
+  source: TaskSource;
+  labels: TaskLabel[];
+  subtasks: TaskSubtask[];
+  dueDate: Date | null;
+  githubIssueUrl: string | null;
+  sortOrder: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateTaskInput {
+  folderId?: string | null;
+  title: string;
+  description?: string | null;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  source?: TaskSource;
+  labels?: TaskLabel[];
+  subtasks?: TaskSubtask[];
+  dueDate?: string | null; // ISO string
+  githubIssueUrl?: string | null;
+}
+
+export interface UpdateTaskInput {
+  title?: string;
+  description?: string | null;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  labels?: TaskLabel[];
+  subtasks?: TaskSubtask[];
+  dueDate?: string | null; // ISO string
+  githubIssueUrl?: string | null;
+  sortOrder?: number;
+}
+
+/** Default labels for new projects */
+export const DEFAULT_TASK_LABELS: TaskLabel[] = [
+  { name: "Bug", color: "e11d48" },
+  { name: "Feature", color: "8b5cf6" },
+  { name: "Task", color: "3b82f6" },
+  { name: "Improvement", color: "f59e0b" },
+  { name: "Documentation", color: "6b7280" },
+];
+
+/** Priority display config */
+export const PRIORITY_CONFIG: Record<
+  TaskPriority,
+  { label: string; color: string; sortWeight: number }
+> = {
+  critical: { label: "Critical", color: "ef4444", sortWeight: 0 },
+  high: { label: "High", color: "f97316", sortWeight: 1 },
+  medium: { label: "Medium", color: "eab308", sortWeight: 2 },
+  low: { label: "Low", color: "6b7280", sortWeight: 3 },
+};
+


### PR DESCRIPTION
## Summary

- Add collapsible right sidebar with three sections: Manual Tasks, Agent Tasks, and GitHub Issues
- Tasks are folder-scoped (project-specific), supporting priorities, custom labels, subtasks, and due dates
- 5 new MCP tools (`task_list`, `task_create`, `task_update`, `task_complete`, `task_delete`) for agent-created tasks
- REST API endpoints (`GET/POST /api/tasks`, `GET/PATCH/DELETE /api/tasks/:id`) with dual session/API key auth
- New `project_task` SQLite table with JSON columns for labels and subtasks
- Consolidated duplicate `safeJsonParse` into shared utility in `src/lib/utils.ts`
- Toggle via Cmd+. keyboard shortcut or header button

## Test plan

- [ ] Verify sidebar opens/closes via Cmd+. and header button
- [ ] Create, update, complete, and delete manual tasks
- [ ] Verify tasks are scoped to active folder (switching folders shows different tasks)
- [ ] Test MCP tools create agent-sourced tasks
- [ ] Verify GitHub issues section loads when repo is linked
- [ ] Test resize handle persists width on mouseup
- [ ] Verify collapsed sidebar shows open task count badge
- [ ] Run `bun run typecheck` and `bun run lint` pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)