### PR TITLE
Add Files section with default project files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Hooks are automatically installed and merged with existing settings at session creation
   - Status broadcast via WebSocket to all connected clients for cross-tab visibility
 
+### Changed
+
+- Pinned files now scoped to the active folder in the Files section (previously visible inline across all folders simultaneously)
+
+### Removed
+
+- Drag-to-reorder for pinned files in the sidebar (use folder settings to reorder)
+
 ### Fixed
 
 - Worktree sessions now show GitBranch icon instead of generic terminal icon in sidebar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Files Section in Sidebar**: New collapsible "Files" section above MCP Servers showing default project files (.env, .env.local, CLAUDE.md, README.md) and pinned files
+  - Automatically detects which default files exist on disk for the active folder's project directory
+  - Pinned files moved from inline folder tree to this dedicated section, reducing clutter
+  - Active file highlighting matches the current editor session
+  - Pin icon indicator distinguishes user-pinned files from auto-discovered defaults
+  - Collapsed sidebar shows file count badge
+  - New `/api/files/exists` batch endpoint for lightweight file existence checks
 - **Agent Activity Status Indicators**: Real-time agent activity shown in sidebar via colored Sparkles icons
   - Green breathing animation when agent is running (tool use in progress)
   - Yellow breathing animation when agent is waiting for user input

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -490,6 +490,11 @@ React Contexts in `src/contexts/`:
 ### Directories
 - `GET /api/directories` - Browse filesystem directories (secure, restricted to allowed paths)
 
+### Files
+- `POST /api/files/exists` - Batch check file existence on disk
+- `GET /api/files/read` - Read file contents for editor
+- `POST /api/files/write` - Write file contents
+
 ### Images
 - `POST /api/images` - Upload and save image
 

--- a/src/app/api/files/exists/route.ts
+++ b/src/app/api/files/exists/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { withApiAuth, errorResponse } from "@/lib/api";
+import { validateProjectPath } from "@/lib/api-validation";
+import { stat } from "fs/promises";
+
+/**
+ * POST /api/files/exists
+ *
+ * Check which files from a list of paths exist on disk.
+ * Returns a record of path -> boolean.
+ * SECURITY: Paths must be within the user's home directory or /tmp.
+ */
+export const POST = withApiAuth(async (request) => {
+  const body = await request.json();
+  const paths: unknown = body.paths;
+
+  if (!Array.isArray(paths) || paths.length === 0) {
+    return errorResponse("'paths' must be a non-empty array of strings", 400);
+  }
+
+  if (paths.length > 20) {
+    return errorResponse("Maximum 20 paths per request", 400);
+  }
+
+  const results: Record<string, boolean> = {};
+
+  await Promise.all(
+    paths.map(async (p: unknown) => {
+      if (typeof p !== "string") return;
+      const validated = validateProjectPath(p);
+      if (!validated) {
+        results[p] = false;
+        return;
+      }
+      try {
+        const stats = await stat(validated);
+        results[p] = stats.isFile();
+      } catch {
+        results[p] = false;
+      }
+    })
+  );
+
+  return NextResponse.json({ exists: results });
+});

--- a/src/app/api/files/exists/route.ts
+++ b/src/app/api/files/exists/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { withApiAuth, errorResponse } from "@/lib/api";
+import { withAuth, errorResponse } from "@/lib/api";
 import { validateProjectPath } from "@/lib/api-validation";
 import { stat } from "fs/promises";
 
@@ -10,7 +10,7 @@ import { stat } from "fs/promises";
  * Returns a record of path -> boolean.
  * SECURITY: Paths must be within the user's home directory or /tmp.
  */
-export const POST = withApiAuth(async (request) => {
+export const POST = withAuth(async (request) => {
   const body = await request.json();
   const paths: unknown = body.paths;
 

--- a/src/components/session/FilesSection.tsx
+++ b/src/components/session/FilesSection.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import {
+  Files,
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  Pin,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { usePreferencesContext } from "@/contexts/PreferencesContext";
+import { useSessionContext } from "@/contexts/SessionContext";
+import type { PinnedFile } from "@/types/pinned-files";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+const DEFAULT_FILE_NAMES = [".env", ".env.local", "CLAUDE.md", "README.md"];
+
+interface FilesSectionProps {
+  activeFolderId: string | null;
+  collapsed?: boolean;
+  getFolderPinnedFiles: (folderId: string) => PinnedFile[];
+  onOpenFile: (folderId: string, file: PinnedFile) => void;
+  activeSessionId: string | null;
+}
+
+async function checkFilesExist(
+  paths: string[]
+): Promise<Record<string, boolean>> {
+  try {
+    const res = await fetch("/api/files/exists", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ paths }),
+    });
+    if (!res.ok) return {};
+    const data = await res.json();
+    return data.exists ?? {};
+  } catch {
+    return {};
+  }
+}
+
+export function FilesSection({
+  activeFolderId,
+  collapsed = false,
+  getFolderPinnedFiles,
+  onOpenFile,
+  activeSessionId,
+}: FilesSectionProps) {
+  const { resolvePreferencesForFolder } = usePreferencesContext();
+  const { sessions } = useSessionContext();
+  const [expanded, setExpanded] = useState(true);
+  const [defaultFiles, setDefaultFiles] = useState<PinnedFile[]>([]);
+
+  // Resolve working directory for the active folder
+  const resolvedPrefs = activeFolderId
+    ? resolvePreferencesForFolder(activeFolderId)
+    : null;
+  const baseDir =
+    resolvedPrefs?.localRepoPath ||
+    resolvedPrefs?.defaultWorkingDirectory ||
+    null;
+
+  const pinnedFiles = useMemo(
+    () => (activeFolderId ? getFolderPinnedFiles(activeFolderId) : []),
+    [activeFolderId, getFolderPinnedFiles]
+  );
+
+  const pinnedPaths = useMemo(
+    () => new Set(pinnedFiles.map((f) => f.path)),
+    [pinnedFiles]
+  );
+
+  // Probe default file existence when base directory changes
+  useEffect(() => {
+    if (!baseDir) return;
+
+    let cancelled = false;
+    const normalizedBase = baseDir.replace(/\/$/, "");
+    const candidates = DEFAULT_FILE_NAMES.map((name) => ({
+      name,
+      path: `${normalizedBase}/${name}`,
+    }));
+
+    checkFilesExist(candidates.map((c) => c.path)).then((results) => {
+      if (cancelled) return;
+      const found: PinnedFile[] = [];
+      for (const candidate of candidates) {
+        if (results[candidate.path]) {
+          found.push({
+            id: `default-${candidate.name}`,
+            path: candidate.path,
+            name: candidate.name,
+            sortOrder: found.length,
+            createdAt: new Date(0).toISOString(),
+          });
+        }
+      }
+      setDefaultFiles(found);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [baseDir]);
+
+  // Merge: pinned files first, then default files not already pinned.
+  // When baseDir is null, skip defaultFiles since they belong to a previous directory.
+  const allFiles = useMemo(
+    () => [
+      ...pinnedFiles,
+      ...(baseDir ? defaultFiles.filter((f) => !pinnedPaths.has(f.path)) : []),
+    ],
+    [pinnedFiles, defaultFiles, pinnedPaths, baseDir]
+  );
+
+  // Don't render when no folder is selected
+  if (!activeFolderId) {
+    return null;
+  }
+
+  // Collapsed sidebar: icon + count badge
+  if (collapsed) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            className={cn(
+              "relative w-full flex items-center justify-center p-2 rounded-md",
+              "text-muted-foreground hover:text-foreground hover:bg-accent/50",
+              "transition-colors"
+            )}
+          >
+            <Files className="w-4 h-4" />
+            {allFiles.length > 0 && (
+              <span className="absolute -top-1 -right-1 w-4 h-4 text-[10px] bg-primary text-primary-foreground rounded-full flex items-center justify-center">
+                {allFiles.length}
+              </span>
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right">
+          Files ({allFiles.length})
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <div className="border-t border-border">
+      {/* Section header */}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className={cn(
+          "w-full flex items-center gap-2 px-3 py-2",
+          "text-xs text-muted-foreground hover:text-foreground",
+          "hover:bg-accent/30 transition-colors"
+        )}
+      >
+        {expanded ? (
+          <ChevronDown className="w-3.5 h-3.5" />
+        ) : (
+          <ChevronRight className="w-3.5 h-3.5" />
+        )}
+        <Files className="w-3.5 h-3.5" />
+        <span className="font-medium">Files</span>
+        {allFiles.length > 0 && (
+          <span className="ml-auto text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+            {allFiles.length}
+          </span>
+        )}
+      </button>
+
+      {/* Expanded content */}
+      {expanded && (
+        <div className="px-2 pb-2 space-y-0.5">
+          {/* Empty state: no working directory configured */}
+          {!baseDir && allFiles.length === 0 && (
+            <p className="px-2 py-3 text-center text-xs text-muted-foreground">
+              Set a working directory in folder settings
+            </p>
+          )}
+
+          {/* File rows */}
+          {allFiles.map((file) => {
+            const isPinned = pinnedPaths.has(file.path);
+            const fileSession = sessions.find(
+              (s) =>
+                s.terminalType === "file" &&
+                s.status !== "closed" &&
+                s.typeMetadata?.filePath === file.path
+            );
+            const isFileActive = fileSession?.id === activeSessionId;
+
+            return (
+              <button
+                key={file.id}
+                onClick={() => onOpenFile(activeFolderId!, file)}
+                className={cn(
+                  "w-full flex items-center gap-2 px-2 py-1.5 rounded-md",
+                  "text-xs transition-colors text-left",
+                  isFileActive
+                    ? "text-foreground bg-primary/20 border border-border"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                )}
+                title={file.path}
+              >
+                <FileText
+                  className={cn(
+                    "w-3.5 h-3.5 shrink-0",
+                    isFileActive ? "text-primary" : "text-blue-400"
+                  )}
+                />
+                <span className="truncate">{file.name}</span>
+                {isPinned && (
+                  <Pin className="w-2.5 h-2.5 shrink-0 ml-auto text-muted-foreground/50" />
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -310,7 +310,6 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
     resolvePreferencesForFolder,
     getEnvironmentForFolder,
     getFolderPreferences,
-    updateFolderPreferences,
   } = usePreferencesContext();
 
   // Secrets state from context
@@ -820,18 +819,6 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
       });
     },
     [activeSessions, setActiveSession, createSession, closeSession]
-  );
-
-  // Reorder pinned files within a folder
-  const handleReorderPinnedFiles = useCallback(
-    async (folderId: string, files: PinnedFile[]) => {
-      try {
-        await updateFolderPreferences(folderId, { pinnedFiles: files });
-      } catch (error) {
-        console.error("Failed to reorder pinned files:", error);
-      }
-    },
-    [updateFolderPreferences]
   );
 
   // Handle creating a worktree from an issue
@@ -1385,7 +1372,6 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
             onViewPRs={handleViewPRs}
             getFolderPinnedFiles={handleGetFolderPinnedFiles}
             onOpenPinnedFile={handleOpenPinnedFile}
-            onReorderPinnedFiles={handleReorderPinnedFiles}
           />
       </div>
 

--- a/src/components/session/Sidebar.tsx
+++ b/src/components/session/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import {
-  X, Plus, Terminal, Settings, FileText,
+  X, Plus, Terminal, Settings,
   Folder, FolderOpen, Pencil, Trash2, Sparkles, GitBranch,
   PanelLeftClose, PanelLeft,
   SplitSquareHorizontal, SplitSquareVertical, Minus,
@@ -43,6 +43,7 @@ import { useProfileContext } from "@/contexts/ProfileContext";
 import { usePortContext } from "@/contexts/PortContext";
 import { useSessionMCP, useSessionMCPAutoLoad } from "@/contexts/SessionMCPContext";
 import { MCPServersSection } from "@/components/mcp";
+import { FilesSection } from "./FilesSection";
 import { useSessionContext } from "@/contexts/SessionContext";
 
 export interface SessionFolder {
@@ -117,7 +118,6 @@ interface SidebarProps {
   onViewPRs?: (folderId: string) => void;
   getFolderPinnedFiles?: (folderId: string) => PinnedFile[];
   onOpenPinnedFile?: (folderId: string, file: PinnedFile) => void;
-  onReorderPinnedFiles?: (folderId: string, files: PinnedFile[]) => void;
 }
 
 /**
@@ -193,7 +193,6 @@ export function Sidebar({
   onViewPRs,
   getFolderPinnedFiles,
   onOpenPinnedFile,
-  onReorderPinnedFiles,
 }: SidebarProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingType, setEditingType] = useState<"session" | "folder" | null>(null);
@@ -214,10 +213,6 @@ export function Sidebar({
   const folderInputRef = useRef<HTMLInputElement>(null);
   const resizeStartXRef = useRef<number>(0);
   const resizeStartWidthRef = useRef<number>(0);
-
-  // Pinned file drag-reorder state
-  const [draggingPinnedFile, setDraggingPinnedFile] = useState<{ folderId: string; fileId: string } | null>(null);
-  const [pinnedDropTarget, setPinnedDropTarget] = useState<{ fileId: string; position: "before" | "after" } | null>(null);
 
   // Secrets modal state
   const [secretsModalOpen, setSecretsModalOpen] = useState(false);
@@ -668,9 +663,6 @@ export function Sidebar({
   }, [folders, dropFolderPosition, dropTargetFolderId, dragOverFolderId, onFolderReorder, onFolderMove, isDescendantOf]);
 
   const handleDragOver = (e: React.DragEvent, folderId: string | null) => {
-    // Don't interfere with pinned file reordering
-    if (draggingPinnedFile) return;
-
     e.preventDefault();
     e.stopPropagation();
 
@@ -707,7 +699,6 @@ export function Sidebar({
 
   // Handler for dragging a folder over another folder (for reordering or nesting)
   const handleFolderDragOver = (e: React.DragEvent, targetFolderId: string, targetParentId: string | null) => {
-    if (draggingPinnedFile) return;
     e.preventDefault();
     e.stopPropagation();
 
@@ -768,7 +759,6 @@ export function Sidebar({
 
   // Handler for dropping a folder on another folder (for reordering or moving)
   const handleFolderDrop = (e: React.DragEvent, targetFolderId: string) => {
-    if (draggingPinnedFile) return;
     e.preventDefault();
     e.stopPropagation();
 
@@ -826,9 +816,6 @@ export function Sidebar({
   };
 
   const handleDrop = (e: React.DragEvent, folderId: string | null) => {
-    // Don't interfere with pinned file reordering
-    if (draggingPinnedFile) return;
-
     e.preventDefault();
     e.stopPropagation();
     const id = e.dataTransfer.getData("text/plain");
@@ -853,7 +840,6 @@ export function Sidebar({
 
   // Handler for dropping on a session (for reordering)
   const handleSessionDrop = (e: React.DragEvent, targetSessionId: string, targetFolderId: string | null) => {
-    if (draggingPinnedFile) return;
     e.preventDefault();
     e.stopPropagation();
     const draggedId = e.dataTransfer.getData("text/plain");
@@ -931,7 +917,6 @@ export function Sidebar({
 
   // Handler for dragging over a session (for reordering)
   const handleSessionDragOver = (e: React.DragEvent, targetSessionId: string, targetFolderId: string | null) => {
-    if (draggingPinnedFile) return;
     e.preventDefault();
     e.stopPropagation();
     e.dataTransfer.dropEffect = "move";
@@ -2049,103 +2034,6 @@ export function Sidebar({
                             treeLineLeft: node.depth * 12 + 8 + 7,
                             trashCount: getFolderTrashCount(node.id),
                           })}
-                          {/* Pinned files for this folder */}
-                          {getFolderPinnedFiles && onOpenPinnedFile &&
-                            getFolderPinnedFiles(node.id).map((file, idx, arr) => {
-                              const isLast = getFolderTrashCount(node.id) === 0 && idx === arr.length - 1;
-                              // Check if this pinned file's session is currently active
-                              const fileSession = activeSessions.find(
-                                (s) => s.terminalType === "file" && s.typeMetadata?.filePath === file.path
-                              );
-                              const isFileActive = fileSession?.id === activeSessionId;
-                              const isDraggingThis = draggingPinnedFile?.fileId === file.id;
-                              const isDropBefore = pinnedDropTarget?.fileId === file.id && pinnedDropTarget.position === "before";
-                              const isDropAfter = pinnedDropTarget?.fileId === file.id && pinnedDropTarget.position === "after";
-                              return (
-                                <div
-                                  key={`pinned-${file.id}`}
-                                  className="tree-item"
-                                  data-tree-last={isLast ? "true" : undefined}
-                                  style={{
-                                    '--tree-connector-left': `${node.depth * 12 + 8 + 7}px`,
-                                    '--tree-connector-width': '8px',
-                                  } as React.CSSProperties}
-                                >
-                                  {isDropBefore && (
-                                    <div className="h-0.5 bg-primary rounded-full mx-2" style={{ marginLeft: `${(node.depth + 1) * 12 + 8}px` }} />
-                                  )}
-                                  <div
-                                    role="button"
-                                    tabIndex={0}
-                                    draggable
-                                    onDragStart={(e) => {
-                                      e.stopPropagation();
-                                      e.dataTransfer.effectAllowed = "move";
-                                      e.dataTransfer.setData("text/x-pinned-file", file.id);
-                                      setDraggingPinnedFile({ folderId: node.id, fileId: file.id });
-                                    }}
-                                    onDragEnd={() => {
-                                      setDraggingPinnedFile(null);
-                                      setPinnedDropTarget(null);
-                                    }}
-                                    onDragOver={(e) => {
-                                      // Only accept pinned file drags within the same folder
-                                      if (!draggingPinnedFile || draggingPinnedFile.folderId !== node.id || draggingPinnedFile.fileId === file.id) return;
-                                      e.preventDefault();
-                                      e.stopPropagation();
-                                      const rect = e.currentTarget.getBoundingClientRect();
-                                      const midY = rect.top + rect.height / 2;
-                                      setPinnedDropTarget({ fileId: file.id, position: e.clientY < midY ? "before" : "after" });
-                                    }}
-                                    onDragLeave={(e) => {
-                                      if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                                        setPinnedDropTarget(null);
-                                      }
-                                    }}
-                                    onDrop={(e) => {
-                                      e.preventDefault();
-                                      e.stopPropagation();
-                                      if (!draggingPinnedFile || !pinnedDropTarget || !onReorderPinnedFiles || !getFolderPinnedFiles) return;
-                                      const files = [...getFolderPinnedFiles(node.id)];
-                                      const fromIdx = files.findIndex((f) => f.id === draggingPinnedFile.fileId);
-                                      const toIdx = files.findIndex((f) => f.id === pinnedDropTarget.fileId);
-                                      if (fromIdx === -1 || toIdx === -1 || fromIdx === toIdx) return;
-                                      const [moved] = files.splice(fromIdx, 1);
-                                      const insertIdx = pinnedDropTarget.position === "before" ? toIdx : toIdx + 1;
-                                      files.splice(fromIdx < toIdx ? insertIdx - 1 : insertIdx, 0, moved);
-                                      // Update sortOrder based on new positions
-                                      const reordered = files.map((f, i) => ({ ...f, sortOrder: i }));
-                                      onReorderPinnedFiles(node.id, reordered);
-                                      setDraggingPinnedFile(null);
-                                      setPinnedDropTarget(null);
-                                    }}
-                                    onClick={() => onOpenPinnedFile(node.id, file)}
-                                    onKeyDown={(e) => {
-                                      if (e.key === "Enter" || e.key === " ") {
-                                        e.preventDefault();
-                                        onOpenPinnedFile(node.id, file);
-                                      }
-                                    }}
-                                    style={{ marginLeft: `${(node.depth + 1) * 12}px` }}
-                                    className={cn(
-                                      "group flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer",
-                                      "transition-colors duration-150",
-                                      isDraggingThis && "opacity-50",
-                                      isFileActive
-                                        ? "text-foreground bg-primary/20 border border-border"
-                                        : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
-                                    )}
-                                    title={file.path}
-                                  >
-                                    <FileText className={cn("w-3.5 h-3.5 shrink-0", isFileActive ? "text-primary" : "text-blue-400")} />
-                                    <span className="text-xs truncate">{file.name}</span>
-                                  </div>
-                                  {isDropAfter && (
-                                    <div className="h-0.5 bg-primary rounded-full mx-2" style={{ marginLeft: `${(node.depth + 1) * 12 + 8}px` }} />
-                                  )}
-                                </div>
-                              );
-                            })}
                           {/* Trash indicator for folder - always last when present */}
                           {getFolderTrashCount(node.id) > 0 && (
                             <div
@@ -2217,6 +2105,17 @@ export function Sidebar({
             </>
           )}
       </div>
+
+      {/* Files Section - default + pinned files for active folder */}
+      {getFolderPinnedFiles && onOpenPinnedFile && (
+        <FilesSection
+          activeFolderId={activeFolderId}
+          collapsed={collapsed}
+          getFolderPinnedFiles={getFolderPinnedFiles}
+          onOpenFile={onOpenPinnedFile}
+          activeSessionId={activeSessionId}
+        />
+      )}
 
       {/* MCP Servers Section - only show when agent session is selected */}
       {isAgentSession && mcpSupported && (


### PR DESCRIPTION
## Summary
- New collapsible **Files** section in the sidebar (above MCP Servers) that auto-discovers default project files (`.env`, `.env.local`, `CLAUDE.md`, `README.md`) and shows them alongside user-pinned files
- Pinned files moved from inline folder tree into this dedicated section, reducing sidebar clutter
- New lightweight `/api/files/exists` batch endpoint for file existence checks using `stat()` only

## Test plan
- [ ] Select a folder with a configured working directory — verify default files appear
- [ ] Pin a file that matches a default (e.g., CLAUDE.md) — verify it shows once, not duplicated
- [ ] Switch between folders — verify files update for each folder's project
- [ ] Collapse sidebar — verify Files icon with count badge appears
- [ ] Click a file — verify it opens in the CodeMirror editor
- [ ] Verify pinned files no longer appear inline in the folder tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)