### PR TITLE
Add resume Claude Code session feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Resume Claude Session**: Discover and resume previous Claude Code conversations from the folder context menu
+  - Scans `~/.claude/projects/<encoded-path>/` (or profile-isolated equivalent) for `.jsonl` session files
+  - Modal shows recent sessions sorted by last activity with branch, timestamp, and first message preview
+  - Resumes via `claude --resume <session-id>`, appended to the folder's configured startup command
+  - New `GET /api/agent/claude-sessions` endpoint for session discovery
+  - Configurable session limit (default 20, max 50)
 - **Files Section in Sidebar**: New collapsible "Files" section above MCP Servers showing default project files (.env, .env.local, CLAUDE.md, README.md) and pinned files
   - Automatically detects which default files exist on disk for the active folder's project directory
   - Pinned files moved from inline folder tree to this dedicated section, reducing clutter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,7 @@ Located in `src/services/`:
 | `AgentProfileService` | Agent profile CRUD, config file management |
 | `AgentProfileAppearanceService` | Per-profile appearance settings |
 | `AgentConfigTemplateService` | Templates for agent config files (CLAUDE.md, AGENTS.md, etc.) |
+| `ClaudeSessionService` | Discover resumable Claude Code sessions from `.jsonl` files |
 | `TaskService` | Project task CRUD, folder-scoped queries |
 
 **Security**: All shell commands use `execFile` with array arguments (no shell interpolation).
@@ -532,6 +533,9 @@ React Contexts in `src/contexts/`:
 
 ### Agent CLI
 - `GET /api/agent-cli/status` - Get all CLI installation statuses (version, path, install instructions)
+
+### Agent Sessions
+- `GET /api/agent/claude-sessions` - List resumable Claude Code sessions for a project path
 
 ### Agent Profiles
 - `GET /api/profiles/:id/appearance` - Get profile appearance settings

--- a/src/app/api/agent/claude-sessions/route.ts
+++ b/src/app/api/agent/claude-sessions/route.ts
@@ -1,0 +1,47 @@
+/**
+ * GET /api/agent/claude-sessions
+ *
+ * Lists resumable Claude Code sessions for a given project path.
+ * Scans .jsonl files from ~/.claude/projects/<encoded-path>/
+ * or profile-isolated equivalent.
+ *
+ * Query params:
+ *   projectPath  - Absolute path of the project directory (required)
+ *   profileId    - Agent profile ID for profile-isolated config (optional)
+ *   limit        - Max sessions to return (default: 20, max: 50)
+ */
+
+import { NextResponse } from "next/server";
+import { withAuth, errorResponse } from "@/lib/api";
+import { validateProjectPath } from "@/lib/api-validation";
+import * as ClaudeSessionService from "@/services/claude-session-service";
+import * as AgentProfileService from "@/services/agent-profile-service";
+
+export const GET = withAuth(async (request, { userId }) => {
+  const { searchParams } = new URL(request.url);
+  const rawPath = searchParams.get("projectPath");
+  const profileId = searchParams.get("profileId");
+  const rawLimit = parseInt(searchParams.get("limit") ?? "20", 10);
+  const limit = Math.min(Math.max(1, rawLimit), 50);
+
+  const projectPath = validateProjectPath(rawPath ?? undefined);
+  if (!projectPath) {
+    return errorResponse("Valid absolute projectPath is required", 400, "INVALID_PROJECT_PATH");
+  }
+
+  // Resolve profile config dir if a profileId is provided
+  let profileConfigDir: string | undefined;
+  if (profileId) {
+    const profile = await AgentProfileService.getProfile(profileId, userId);
+    if (profile) {
+      profileConfigDir = profile.configDir;
+    }
+  }
+
+  const sessions = await ClaudeSessionService.listSessions(projectPath, {
+    limit,
+    profileConfigDir,
+  });
+
+  return NextResponse.json({ sessions });
+});

--- a/src/app/api/agent/claude-sessions/route.ts
+++ b/src/app/api/agent/claude-sessions/route.ts
@@ -12,12 +12,12 @@
  */
 
 import { NextResponse } from "next/server";
-import { withAuth, errorResponse } from "@/lib/api";
+import { withApiAuth, errorResponse } from "@/lib/api";
 import { validateProjectPath } from "@/lib/api-validation";
 import * as ClaudeSessionService from "@/services/claude-session-service";
 import * as AgentProfileService from "@/services/agent-profile-service";
 
-export const GET = withAuth(async (request, { userId }) => {
+export const GET = withApiAuth(async (request, { userId }) => {
   const { searchParams } = new URL(request.url);
   const rawPath = searchParams.get("projectPath");
   const profileId = searchParams.get("profileId");

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -58,6 +58,7 @@ export const POST = withApiAuth(async (request, { userId }) => {
       profileId?: string;
       agentProvider?: string;
       autoLaunchAgent?: boolean;
+      agentFlags?: string[];
     }>(request);
     if ("error" in result) return result.error;
     const body = result.data;
@@ -86,6 +87,7 @@ export const POST = withApiAuth(async (request, { userId }) => {
       profileId: body.profileId,
       agentProvider: body.agentProvider as CreateSessionInput["agentProvider"],
       autoLaunchAgent: body.autoLaunchAgent,
+      agentFlags: body.agentFlags,
       // Feature session fields
       startupCommand: body.startupCommand,
       featureDescription: body.featureDescription,

--- a/src/components/github/IssueCard.tsx
+++ b/src/components/github/IssueCard.tsx
@@ -5,7 +5,7 @@
  */
 
 import Image from "next/image";
-import { cn } from "@/lib/utils";
+import { cn, formatRelativeTime } from "@/lib/utils";
 import {
   CircleDot,
   CircleCheck,
@@ -193,22 +193,4 @@ export function IssueCard({
       </ContextMenuContent>
     </ContextMenu>
   );
-}
-
-/**
- * Format a date string to relative time (e.g., "2h ago", "3d ago")
- */
-function formatRelativeTime(dateString: string): string {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMs / 3600000);
-  const diffDays = Math.floor(diffMs / 86400000);
-
-  if (diffMins < 1) return "now";
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 30) return `${diffDays}d ago`;
-  return date.toLocaleDateString();
 }

--- a/src/components/github/IssuesModal.tsx
+++ b/src/components/github/IssuesModal.tsx
@@ -22,7 +22,7 @@ import {
   X,
   Tag,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, formatRelativeTime } from "@/lib/utils";
 import {
   useRepositoryIssues,
   type GitHubIssueDTO,
@@ -519,24 +519,4 @@ function IssuesModalContent({
       )}
     </>
   );
-}
-
-/**
- * Format a date string to relative time
- */
-function formatRelativeTime(dateString: string): string {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMs / 3600000);
-  const diffDays = Math.floor(diffMs / 86400000);
-
-  if (diffMins < 1) return "just now";
-  if (diffMins < 60)
-    return `${diffMins} minute${diffMins === 1 ? "" : "s"} ago`;
-  if (diffHours < 24)
-    return `${diffHours} hour${diffHours === 1 ? "" : "s"} ago`;
-  if (diffDays < 30) return `${diffDays} day${diffDays === 1 ? "" : "s"} ago`;
-  return date.toLocaleDateString();
 }

--- a/src/components/github/PRsModal.tsx
+++ b/src/components/github/PRsModal.tsx
@@ -27,7 +27,7 @@ import {
   User,
   GitBranch,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, formatRelativeTime } from "@/lib/utils";
 import { useGitHubStats } from "@/contexts/GitHubStatsContext";
 import type { PullRequest } from "@/types/github-stats";
 import {
@@ -489,22 +489,4 @@ function PRCard({ pr, onOpenInGitHub, onCopyUrl, onCheckoutBranch }: PRCardProps
       </ContextMenuContent>
     </ContextMenu>
   );
-}
-
-/**
- * Format a date string to relative time
- */
-function formatRelativeTime(dateString: string): string {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMs / 3600000);
-  const diffDays = Math.floor(diffMs / 86400000);
-
-  if (diffMins < 1) return "now";
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 30) return `${diffDays}d ago`;
-  return date.toLocaleDateString();
 }

--- a/src/components/github/RepositoriesTab.tsx
+++ b/src/components/github/RepositoriesTab.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useState } from "react";
-import { cn } from "@/lib/utils";
+import { cn, formatRelativeTime } from "@/lib/utils";
 import {
   RefreshCw,
   ExternalLink,
@@ -78,20 +78,7 @@ export function RepositoriesTab({
     window.open(url, "_blank", "noopener,noreferrer");
   };
 
-  const formatRelativeTime = (dateString: string) => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMs / 3600000);
-    const diffDays = Math.floor(diffMs / 86400000);
 
-    if (diffMins < 1) return "now";
-    if (diffMins < 60) return `${diffMins}m`;
-    if (diffHours < 24) return `${diffHours}h`;
-    if (diffDays < 30) return `${diffDays}d`;
-    return date.toLocaleDateString();
-  };
 
   // Group repositories by owner
   const groupedRepos = state.repositories.reduce(
@@ -163,7 +150,6 @@ export function RepositoriesTab({
                   : undefined
               }
               creatingWorktree={creatingWorktree}
-              formatRelativeTime={formatRelativeTime}
             />
           ))
         )}
@@ -194,7 +180,6 @@ interface OwnerGroupProps {
   onOpenGitHub: (url: string) => void;
   onCreateWorktree?: (repoId: string, prNumber: number) => void;
   creatingWorktree: number | null;
-  formatRelativeTime: (dateString: string) => string;
 }
 
 function OwnerGroup({
@@ -205,7 +190,6 @@ function OwnerGroup({
   onOpenGitHub,
   onCreateWorktree,
   creatingWorktree,
-  formatRelativeTime,
 }: OwnerGroupProps) {
   return (
     <div className="space-y-0.5">
@@ -227,7 +211,6 @@ function OwnerGroup({
           onOpenGitHub={onOpenGitHub}
           onCreateWorktree={onCreateWorktree}
           creatingWorktree={creatingWorktree}
-          formatRelativeTime={formatRelativeTime}
         />
       ))}
     </div>
@@ -245,7 +228,6 @@ interface RepoItemProps {
   onOpenGitHub: (url: string) => void;
   onCreateWorktree?: (repoId: string, prNumber: number) => void;
   creatingWorktree: number | null;
-  formatRelativeTime: (dateString: string) => string;
 }
 
 function RepoItem({
@@ -255,7 +237,6 @@ function RepoItem({
   onOpenGitHub,
   onCreateWorktree,
   creatingWorktree,
-  formatRelativeTime,
 }: RepoItemProps) {
   const hasPRs = repo.pullRequests.length > 0;
   const hasContent = hasPRs;
@@ -369,7 +350,6 @@ function RepoItem({
               onOpenGitHub={onOpenGitHub}
               onCreateWorktree={onCreateWorktree}
               isCreating={creatingWorktree === pr.number}
-              formatRelativeTime={formatRelativeTime}
             />
           ))}
           {repo.pullRequests.length > 5 && (
@@ -396,7 +376,6 @@ interface PRItemProps {
   onOpenGitHub: (url: string) => void;
   onCreateWorktree?: (repoId: string, prNumber: number) => void;
   isCreating: boolean;
-  formatRelativeTime: (dateString: string) => string;
 }
 
 function PRItem({
@@ -405,7 +384,6 @@ function PRItem({
   onOpenGitHub,
   onCreateWorktree,
   isCreating,
-  formatRelativeTime,
 }: PRItemProps) {
   return (
     <ContextMenu>

--- a/src/components/github/RepositoryCard.tsx
+++ b/src/components/github/RepositoryCard.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useState } from "react";
-import { cn } from "@/lib/utils";
+import { cn, formatRelativeTime } from "@/lib/utils";
 import {
   ChevronDown,
   ChevronRight,
@@ -74,20 +74,6 @@ export function RepositoryCard({
     }
   };
 
-  const formatRelativeTime = (dateString: string) => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMs / 3600000);
-    const diffDays = Math.floor(diffMs / 86400000);
-
-    if (diffMins < 1) return "just now";
-    if (diffMins < 60) return `${diffMins}m ago`;
-    if (diffHours < 24) return `${diffHours}h ago`;
-    if (diffDays < 30) return `${diffDays}d ago`;
-    return date.toLocaleDateString();
-  };
 
   return (
     <div

--- a/src/components/session/ResumeSessionModal.tsx
+++ b/src/components/session/ResumeSessionModal.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { History, GitBranch, Clock, Loader2, Terminal } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn, formatRelativeTime } from "@/lib/utils";
+import type { ClaudeSessionSummary } from "@/types/claude-session";
+
+interface ResumeSessionModalProps {
+  open: boolean;
+  onClose: () => void;
+  projectPath: string;
+  profileId?: string;
+  onResume: (sessionId: string) => Promise<void>;
+  limit?: number;
+}
+
+export function ResumeSessionModal({
+  open,
+  onClose,
+  projectPath,
+  profileId,
+  onResume,
+  limit = 20,
+}: ResumeSessionModalProps) {
+  const [sessions, setSessions] = useState<ClaudeSessionSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [resumingId, setResumingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !projectPath) return;
+
+    const fetchSessions = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams({
+          projectPath,
+          limit: String(limit),
+        });
+        if (profileId) params.set("profileId", profileId);
+
+        const res = await fetch(`/api/agent/claude-sessions?${params}`);
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.error ?? "Failed to load sessions");
+        }
+        const data = await res.json();
+        setSessions(data.sessions ?? []);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load sessions");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchSessions();
+  }, [open, projectPath, profileId, limit]);
+
+  const handleResume = async (session: ClaudeSessionSummary) => {
+    setResumingId(session.sessionId);
+    try {
+      await onResume(session.sessionId);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to resume session");
+    } finally {
+      setResumingId(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v: boolean) => !v && onClose()}>
+      <DialogContent className="sm:max-w-[560px] bg-popover/95 backdrop-blur-xl border-border">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <History className="w-5 h-5" />
+            Resume Claude Session
+          </DialogTitle>
+          <DialogDescription>
+            Select a previous Claude Code conversation to resume in a new terminal.
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading && (
+          <div className="flex items-center justify-center py-12 text-muted-foreground">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" />
+            Loading sessions...
+          </div>
+        )}
+
+        {error && (
+          <div className="text-sm text-destructive px-1 py-2">{error}</div>
+        )}
+
+        {!loading && !error && sessions.length === 0 && (
+          <div className="text-sm text-muted-foreground text-center py-10">
+            No resumable sessions found for this project.
+          </div>
+        )}
+
+        {!loading && sessions.length > 0 && (
+          <ScrollArea className="max-h-[380px] pr-3">
+            <div className="space-y-2">
+              {sessions.map((session: ClaudeSessionSummary) => (
+                <button
+                  key={session.sessionId}
+                  type="button"
+                  onClick={() => handleResume(session)}
+                  disabled={resumingId !== null}
+                  className={cn(
+                    "w-full text-left flex flex-col gap-1.5 rounded-md border px-3 py-2.5",
+                    "bg-card hover:bg-accent/50 transition-colors cursor-pointer",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    resumingId === session.sessionId && "opacity-70"
+                  )}
+                >
+                  {/* Header row */}
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <Terminal className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+                      <span className="text-xs font-mono text-muted-foreground truncate">
+                        {session.sessionId.slice(0, 8)}
+                      </span>
+                      {session.gitBranch && (
+                        <span className="flex items-center gap-1 text-xs text-muted-foreground shrink-0">
+                          <GitBranch className="w-3 h-3" />
+                          {session.gitBranch}
+                        </span>
+                      )}
+                    </div>
+                    <span className="flex items-center gap-1 text-xs text-muted-foreground shrink-0">
+                      {resumingId === session.sessionId ? (
+                        <Loader2 className="w-3 h-3 animate-spin" />
+                      ) : (
+                        <Clock className="w-3 h-3" />
+                      )}
+                      {formatRelativeTime(session.lastModified)}
+                    </span>
+                  </div>
+
+                  {/* First user message preview */}
+                  {session.firstUserMessage && (
+                    <p className="text-xs text-foreground/80 line-clamp-2 leading-snug">
+                      {session.firstUserMessage}
+                    </p>
+                  )}
+                </button>
+              ))}
+            </div>
+          </ScrollArea>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/session/ResumeSessionModal.tsx
+++ b/src/components/session/ResumeSessionModal.tsx
@@ -101,7 +101,13 @@ export function ResumeSessionModal({
           <div className="text-sm text-destructive px-1 py-2">{error}</div>
         )}
 
-        {!loading && !error && sessions.length === 0 && (
+        {!loading && !error && !projectPath && (
+          <div className="text-sm text-muted-foreground text-center py-10">
+            No working directory configured for this folder. Set a default working directory in folder settings to discover sessions.
+          </div>
+        )}
+
+        {!loading && !error && projectPath && sessions.length === 0 && (
           <div className="text-sm text-muted-foreground text-center py-10">
             No resumable sessions found for this project.
           </div>

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -1043,6 +1043,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
           agentProvider: "claude",
           autoLaunchAgent: true,
           agentFlags: ["--resume", claudeSessionId.replace(/[^a-zA-Z0-9\-_]/g, "")],
+          profileId: resumeModalProfileId || undefined,
         });
         if (newSession && folderId) {
           registerSessionFolder(newSession.id, folderId);
@@ -1056,6 +1057,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
     [
       resumeModalFolderId,
       resumeModalProjectPath,
+      resumeModalProfileId,
       createSession,
       registerSessionFolder,
       setActiveFolder,

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -10,6 +10,7 @@ import { KeyboardShortcutsPanel } from "@/components/KeyboardShortcutsPanel";
 import { RecordingsModal } from "@/components/session/RecordingsModal";
 import { SaveRecordingModal } from "@/components/session/SaveRecordingModal";
 import { TrashModal } from "@/components/trash/TrashModal";
+import { ResumeSessionModal } from "./ResumeSessionModal";
 import { CreateScheduleModal, SchedulesModal } from "@/components/schedule";
 import { ProfilesModal } from "@/components/profiles/ProfilesModal";
 import { PortManagerModal } from "@/components/ports/PortManagerModal";
@@ -241,6 +242,12 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
   // Trash state from context
   const { count: trashCount, trashSession, getTrashForFolder, deleteItem: deleteTrashItem } = useTrashContext();
   const [isTrashOpen, setIsTrashOpen] = useState(false);
+
+  // Resume Claude Session modal state
+  const [isResumeModalOpen, setIsResumeModalOpen] = useState(false);
+  const [resumeModalFolderId, setResumeModalFolderId] = useState<string | null>(null);
+  const [resumeModalProjectPath, setResumeModalProjectPath] = useState("");
+  const [resumeModalProfileId, setResumeModalProfileId] = useState<string | undefined>(undefined);
 
   // Schedule modal state
   const [isCreateScheduleOpen, setIsCreateScheduleOpen] = useState(false);
@@ -1001,6 +1008,66 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
     ]
   );
 
+  // Handler to open the Resume Claude Session modal for a folder
+  const handleFolderResumeClaudeSession = useCallback(
+    (folderId: string) => {
+      const prefs = resolvePreferencesForFolder(folderId);
+      const profileId = sessions.find(
+        (s: { folderId: string | null; profileId: string | null }) =>
+          s.folderId === folderId && s.profileId
+      )?.profileId ?? undefined;
+
+      setResumeModalFolderId(folderId);
+      setResumeModalProjectPath(prefs.defaultWorkingDirectory || "");
+      setResumeModalProfileId(profileId);
+      setIsResumeModalOpen(true);
+    },
+    [resolvePreferencesForFolder, sessions]
+  );
+
+  const handleResumeModalClose = useCallback(() => {
+    setIsResumeModalOpen(false);
+    setResumeModalFolderId(null);
+  }, []);
+
+  // Handler to resume a specific Claude Code session
+  const handleResumeClaudeSession = useCallback(
+    async (claudeSessionId: string) => {
+      const folderId = resumeModalFolderId ?? undefined;
+      const prefs = folderId
+        ? resolvePreferencesForFolder(folderId)
+        : currentPreferences;
+
+      try {
+        const newSession = await createSession({
+          name: `Resume ${claudeSessionId.slice(0, 8)}`,
+          projectPath: prefs.defaultWorkingDirectory || undefined,
+          folderId,
+          terminalType: "agent",
+          agentProvider: "claude",
+          autoLaunchAgent: true,
+          agentFlags: ["--resume", claudeSessionId],
+        });
+        if (newSession && folderId) {
+          registerSessionFolder(newSession.id, folderId);
+          setActiveFolder(folderId);
+        }
+      } catch (error) {
+        logSessionError("resume claude session", error);
+        throw error;
+      }
+    },
+    [
+      resumeModalFolderId,
+      currentPreferences,
+      resolvePreferencesForFolder,
+      createSession,
+      registerSessionFolder,
+      setActiveFolder,
+      logSessionError,
+    ]
+  );
+
   const handleFolderClick = useCallback(
     (folderId: string) => {
       setActiveFolder(folderId);
@@ -1374,6 +1441,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
             onFolderSettings={handleFolderSettings}
             onFolderNewSession={handleFolderNewSession}
             onFolderNewAgent={handleFolderNewAgent}
+            onFolderResumeClaudeSession={handleFolderResumeClaudeSession}
             onFolderAdvancedSession={handleFolderAdvancedSession}
             onFolderNewWorktree={handleFolderNewWorktree}
             onFolderMove={handleMoveFolder}
@@ -1698,6 +1766,15 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
 
       {/* Trash Modal */}
       <TrashModal open={isTrashOpen} onClose={() => setIsTrashOpen(false)} />
+
+      {/* Resume Claude Session Modal */}
+      <ResumeSessionModal
+        open={isResumeModalOpen}
+        onClose={handleResumeModalClose}
+        projectPath={resumeModalProjectPath}
+        profileId={resumeModalProfileId}
+        onResume={handleResumeClaudeSession}
+      />
 
       {/* Create Schedule Modal */}
       <CreateScheduleModal

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -1013,8 +1013,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
     (folderId: string) => {
       const prefs = resolvePreferencesForFolder(folderId);
       const profileId = sessions.find(
-        (s: { folderId: string | null; profileId: string | null }) =>
-          s.folderId === folderId && s.profileId
+        (s) => s.folderId === folderId && s.profileId
       )?.profileId ?? undefined;
 
       setResumeModalFolderId(folderId);
@@ -1034,19 +1033,16 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
   const handleResumeClaudeSession = useCallback(
     async (claudeSessionId: string) => {
       const folderId = resumeModalFolderId ?? undefined;
-      const prefs = folderId
-        ? resolvePreferencesForFolder(folderId)
-        : currentPreferences;
 
       try {
         const newSession = await createSession({
           name: `Resume ${claudeSessionId.slice(0, 8)}`,
-          projectPath: prefs.defaultWorkingDirectory || undefined,
+          projectPath: resumeModalProjectPath || undefined,
           folderId,
           terminalType: "agent",
           agentProvider: "claude",
           autoLaunchAgent: true,
-          agentFlags: ["--resume", claudeSessionId],
+          agentFlags: ["--resume", claudeSessionId.replace(/[^a-zA-Z0-9\-_]/g, "")],
         });
         if (newSession && folderId) {
           registerSessionFolder(newSession.id, folderId);
@@ -1059,8 +1055,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
     },
     [
       resumeModalFolderId,
-      currentPreferences,
-      resolvePreferencesForFolder,
+      resumeModalProjectPath,
       createSession,
       registerSessionFolder,
       setActiveFolder,

--- a/src/components/session/Sidebar.tsx
+++ b/src/components/session/Sidebar.tsx
@@ -7,7 +7,7 @@ import {
   PanelLeftClose, PanelLeft,
   SplitSquareHorizontal, SplitSquareVertical, Minus,
   GitPullRequest, CircleDot, Clock, CalendarClock, KeyRound, Fingerprint, Network,
-  Pin, PinOff,
+  Pin, PinOff, History,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { TerminalSession } from "@/types/session";
@@ -103,6 +103,7 @@ interface SidebarProps {
   onFolderSettings: (folderId: string, folderName: string, initialTab?: "general" | "appearance" | "repository" | "environment") => void;
   onFolderNewSession: (folderId: string) => void;
   onFolderNewAgent: (folderId: string) => void;
+  onFolderResumeClaudeSession: (folderId: string) => void;
   onFolderAdvancedSession: (folderId: string) => void;
   onFolderNewWorktree: (folderId: string) => void;
   onFolderMove: (folderId: string, newParentId: string | null) => void;
@@ -181,6 +182,7 @@ export function Sidebar({
   onFolderSettings,
   onFolderNewSession,
   onFolderNewAgent,
+  onFolderResumeClaudeSession,
   onFolderAdvancedSession,
   onFolderNewWorktree,
   onFolderMove,
@@ -1932,6 +1934,10 @@ export function Sidebar({
                               <ContextMenuItem onClick={() => onFolderNewAgent(node.id)}>
                                 <Sparkles className="w-3.5 h-3.5 mr-2" />
                                 New Agent
+                              </ContextMenuItem>
+                              <ContextMenuItem onClick={() => onFolderResumeClaudeSession(node.id)}>
+                                <History className="w-3.5 h-3.5 mr-2" />
+                                Resume Claude Session...
                               </ContextMenuItem>
                               <ContextMenuItem onClick={() => onFolderAdvancedSession(node.id)}>
                                 <Settings className="w-3.5 h-3.5 mr-2" />

--- a/src/components/tmux/TmuxSessionList.tsx
+++ b/src/components/tmux/TmuxSessionList.tsx
@@ -4,36 +4,12 @@ import { Terminal, X, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import type { TmuxSessionResponse } from "@/types/tmux";
-import { cn } from "@/lib/utils";
+import { cn, formatRelativeTime } from "@/lib/utils";
 
 interface TmuxSessionListProps {
   sessions: TmuxSessionResponse[];
   onTerminate: (sessionName: string) => void;
   terminating: string | null;
-}
-
-/**
- * Formats a relative time string from a date.
- */
-function formatRelativeTime(dateStr: string): string {
-  const date = new Date(dateStr);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffSeconds = Math.floor(diffMs / 1000);
-  const diffMinutes = Math.floor(diffSeconds / 60);
-  const diffHours = Math.floor(diffMinutes / 60);
-  const diffDays = Math.floor(diffHours / 24);
-
-  if (diffDays > 0) {
-    return `${diffDays}d ago`;
-  }
-  if (diffHours > 0) {
-    return `${diffHours}h ago`;
-  }
-  if (diffMinutes > 0) {
-    return `${diffMinutes}m ago`;
-  }
-  return "Just now";
 }
 
 export function TmuxSessionList({

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,6 +6,26 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
+ * Format an ISO timestamp as a human-readable relative time string.
+ */
+export function formatRelativeTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    const diffMs = Date.now() - d.getTime();
+    const diffMins = Math.floor(diffMs / 60_000);
+    if (diffMins < 1) return "just now";
+    if (diffMins < 60) return `${diffMins}m ago`;
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays < 7) return `${diffDays}d ago`;
+    return d.toLocaleDateString();
+  } catch {
+    return iso;
+  }
+}
+
+/**
  * Safely parse a JSON string with a fallback value.
  * Returns fallback on null/undefined input or invalid JSON.
  * Logs a warning on parse failure for diagnostics.

--- a/src/services/claude-session-service.ts
+++ b/src/services/claude-session-service.ts
@@ -106,6 +106,7 @@ function parseSessionFile(filePath: string): Promise<{
 
         // Stop reading once we have both pieces
         if (header && firstUserMessage) {
+          stream.on("error", () => {});
           rl.close();
           stream.destroy();
         }
@@ -114,8 +115,15 @@ function parseSessionFile(filePath: string): Promise<{
       }
     });
 
-    rl.on("close", () => resolve(header ? { ...header, firstUserMessage } : null));
-    rl.on("error", () => resolve(null));
+    rl.on("close", () => {
+      stream.destroy();
+      resolve(header ? { ...header, firstUserMessage } : null);
+    });
+    rl.on("error", () => {
+      rl.close();
+      stream.destroy();
+      resolve(null);
+    });
   });
 }
 

--- a/src/services/claude-session-service.ts
+++ b/src/services/claude-session-service.ts
@@ -47,8 +47,9 @@ function parseSessionFile(filePath: string): Promise<{
   firstUserMessage?: string;
 } | null> {
   return new Promise((resolve) => {
+    const stream = createReadStream(filePath, { encoding: "utf8" });
     const rl = createInterface({
-      input: createReadStream(filePath, { encoding: "utf8" }),
+      input: stream,
       crlfDelay: Infinity,
     });
 
@@ -106,6 +107,7 @@ function parseSessionFile(filePath: string): Promise<{
         // Stop reading once we have both pieces
         if (header && firstUserMessage) {
           rl.close();
+          stream.destroy();
         }
       } catch {
         // Skip malformed lines

--- a/src/services/claude-session-service.ts
+++ b/src/services/claude-session-service.ts
@@ -1,0 +1,185 @@
+/**
+ * Claude Session Service
+ *
+ * Discovers resumable Claude Code sessions by scanning .jsonl files
+ * from ~/.claude/projects/<encoded-path>/ (or profile-isolated equivalent).
+ */
+
+import { createReadStream } from "fs";
+import { readdir, stat } from "fs/promises";
+import { createInterface } from "readline";
+import { join, basename } from "path";
+import { homedir } from "os";
+import type { ClaudeSessionSummary } from "@/types/claude-session";
+
+export type { ClaudeSessionSummary };
+
+export interface ListSessionsOptions {
+  limit?: number;
+  profileConfigDir?: string;
+}
+
+/**
+ * Encode a filesystem path to the Claude projects directory name.
+ * Claude replaces all non-alphanumeric characters with "-".
+ */
+export function encodePath(fsPath: string): string {
+  return fsPath.replace(/[^a-zA-Z0-9]/g, "-");
+}
+
+function getProjectsDir(profileConfigDir?: string): string {
+  const claudeDir = profileConfigDir
+    ? join(profileConfigDir, ".claude")
+    : join(homedir(), ".claude");
+  return join(claudeDir, "projects");
+}
+
+/**
+ * Parse a .jsonl session file using streaming to extract header and first user message.
+ * Reads only the first lines needed, then stops — avoids loading multi-MB files into memory.
+ */
+function parseSessionFile(filePath: string): Promise<{
+  sessionId?: string;
+  cwd?: string;
+  gitBranch?: string;
+  version?: string;
+  timestamp?: string;
+  firstUserMessage?: string;
+} | null> {
+  return new Promise((resolve) => {
+    const rl = createInterface({
+      input: createReadStream(filePath, { encoding: "utf8" }),
+      crlfDelay: Infinity,
+    });
+
+    let header: {
+      sessionId?: string;
+      cwd?: string;
+      gitBranch?: string;
+      version?: string;
+      timestamp?: string;
+    } | null = null;
+    let firstUserMessage: string | undefined;
+
+    rl.on("line", (line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+
+      try {
+        const entry = JSON.parse(trimmed);
+
+        // Extract header from first system line
+        if (!header && entry.type === "system" && entry.cwd) {
+          header = {
+            sessionId: entry.sessionId,
+            cwd: entry.cwd,
+            gitBranch: entry.gitBranch,
+            version: entry.version,
+            timestamp: entry.timestamp,
+          };
+        }
+
+        // Extract first real user message
+        if (!firstUserMessage && entry.type === "user") {
+          const msg = entry.message?.content;
+          let text: string | undefined;
+
+          if (typeof msg === "string") {
+            text = msg;
+          } else if (Array.isArray(msg)) {
+            const textBlock = msg.find(
+              (b: { type: string; text?: string }) => b.type === "text"
+            );
+            if (textBlock?.text) text = textBlock.text as string;
+          }
+
+          if (
+            text &&
+            !text.startsWith("<command-") &&
+            !text.startsWith("<local-command-") &&
+            !text.includes("Caveat:")
+          ) {
+            firstUserMessage = text.slice(0, 200);
+          }
+        }
+
+        // Stop reading once we have both pieces
+        if (header && firstUserMessage) {
+          rl.close();
+        }
+      } catch {
+        // Skip malformed lines
+      }
+    });
+
+    rl.on("close", () => resolve(header ? { ...header, firstUserMessage } : null));
+    rl.on("error", () => resolve(null));
+  });
+}
+
+/**
+ * List resumable Claude Code sessions for a given project path.
+ * Returns sessions sorted by last modification time (newest first).
+ */
+export async function listSessions(
+  projectPath: string,
+  options: ListSessionsOptions = {}
+): Promise<ClaudeSessionSummary[]> {
+  if (!projectPath) return [];
+
+  const { limit = 20, profileConfigDir } = options;
+  const encodedPath = encodePath(projectPath);
+  const projectsDir = getProjectsDir(profileConfigDir);
+  const sessionDir = join(projectsDir, encodedPath);
+
+  let files: string[];
+  try {
+    const entries = await readdir(sessionDir);
+    files = entries
+      .filter((f: string) => f.endsWith(".jsonl"))
+      .map((f: string) => join(sessionDir, f));
+  } catch {
+    return [];
+  }
+
+  // Stat files in parallel for mtime-based sorting
+  const withMtime = await Promise.all(
+    files.map(async (filePath) => {
+      try {
+        const s = await stat(filePath);
+        return { filePath, mtime: s.mtimeMs };
+      } catch {
+        return { filePath, mtime: 0 };
+      }
+    })
+  );
+
+  // Sort newest first, take top candidates (oversample to handle unparseable files)
+  withMtime.sort((a, b) => b.mtime - a.mtime);
+  const CANDIDATE_MULTIPLIER = 2;
+  const candidates = withMtime.slice(0, limit * CANDIDATE_MULTIPLIER);
+
+  // Parse candidates in parallel (streaming reads are cheap)
+  const parsed = await Promise.all(
+    candidates.map(async ({ filePath, mtime }) => {
+      const result = await parseSessionFile(filePath);
+      return { filePath, mtime, parsed: result };
+    })
+  );
+
+  return parsed
+    .filter((r) => r.parsed?.cwd && r.parsed?.timestamp)
+    .slice(0, limit)
+    .map(({ filePath, mtime, parsed: p }) => {
+      const sessionId = p!.sessionId ?? basename(filePath, ".jsonl");
+      return {
+        sessionId,
+        cwd: p!.cwd!,
+        gitBranch: p!.gitBranch,
+        version: p!.version,
+        timestamp: p!.timestamp!,
+        lastModified: new Date(mtime).toISOString(),
+        firstUserMessage: p!.firstUserMessage,
+      };
+    });
+}

--- a/src/types/claude-session.ts
+++ b/src/types/claude-session.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared types for Claude Code session discovery.
+ * Used by both the server service and client modal.
+ */
+
+export interface ClaudeSessionSummary {
+  sessionId: string;
+  cwd: string;
+  gitBranch?: string;
+  version?: string;
+  timestamp: string;
+  lastModified: string;
+  firstUserMessage?: string;
+}


### PR DESCRIPTION
## Summary

- Adds "Resume Claude Session..." context menu item on folders to discover and resume prior Claude Code conversations
- Scans `.jsonl` session files from `~/.claude/projects/<encoded-path>/` (or profile-isolated equivalent) using streaming reads
- Presents sessions in a modal dialog sorted by last activity, with branch, timestamp, and first message preview
- Creates new agent session with `--resume <session-id>` flag appended to the folder's configured startup command
- New `GET /api/agent/claude-sessions` endpoint with `withApiAuth` for session discovery
- Consolidates `formatRelativeTime` into `src/lib/utils.ts`, removing 6 duplicate local copies

## New files
- `src/services/claude-session-service.ts` — Service to discover resumable sessions via streaming `.jsonl` parsing
- `src/app/api/agent/claude-sessions/route.ts` — API endpoint with path validation and profile isolation
- `src/components/session/ResumeSessionModal.tsx` — Modal UI for session selection
- `src/types/claude-session.ts` — Shared type definition

## Modified files
- `src/components/session/Sidebar.tsx` — New context menu item
- `src/components/session/SessionManager.tsx` — Modal state, open/close/resume handlers
- `src/lib/utils.ts` — Shared `formatRelativeTime` utility
- `CLAUDE.md` — New endpoint and service documentation
- `CHANGELOG.md` — Feature entry
- 5 GitHub/tmux components — Migrated to shared `formatRelativeTime`

## Test plan
- [ ] Right-click a folder with a configured working directory, verify "Resume Claude Session..." appears
- [ ] Click the menu item, verify modal opens showing recent Claude sessions
- [ ] Verify sessions display session ID, git branch, relative time, and first message preview
- [ ] Click a session to resume, verify new agent session is created with `--resume` flag
- [ ] Test with a folder that has no working directory configured, verify informative message
- [ ] Test with a folder that has no Claude sessions, verify "No resumable sessions found"
- [ ] Verify relative time formatting is consistent across GitHub tabs, tmux list, and resume modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)