### PR TITLE
Add multi-GitHub account support with per-folder binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Safe-area inset CSS utilities for iPhone notch and home indicator support (`pt-safe-top`, `pb-safe-bottom`, `pl-safe-left`, `pr-safe-right`)
   - Safe-area padding applied to sidebar, mobile header bar, terminal container, and mobile keyboard toolbar
   - PWA-aware top padding when running as installed app without browser chrome
+- **Multi-GitHub Account Support**: Link multiple GitHub accounts (personal, work, etc.) with per-folder binding
+  - New "Accounts" tab in GitHub Maintenance modal to manage linked accounts (add, set default, unlink)
+  - Per-folder GitHub account binding in folder preferences — sessions in a folder automatically get that account's credentials
+  - Full `gh` CLI auth: each account gets an isolated `GH_CONFIG_DIR` with `hosts.yml` provisioned at link time
+  - Environment injection pipeline: sessions receive `GH_TOKEN`, `GH_CONFIG_DIR`, and `GITHUB_USER` based on folder binding or default account
+  - Explicit default account — user must designate one account as the default; first account linked is auto-default
+  - Clean Architecture implementation: `GitHubAccount` domain entity, 6 use cases, repository port, gh CLI config gateway
+  - New DB tables: `github_account_metadata`, `folder_github_account_link`
+  - Migration script for existing users: `bun run db:migrate-github-accounts`
 - **Files Section in Sidebar**: New collapsible "Files" section above MCP Servers showing default project files (.env, .env.local, CLAUDE.md, README.md) and pinned files
   - Automatically detects which default files exist on disk for the active folder's project directory
   - Pinned files moved from inline folder tree to this dedicated section, reducing clutter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Remote Dev is a web-based terminal interface built with **Next.js 16**, **React 19**, **xterm.js**, and **NextAuth v5**. It provides:
 - Multiple persistent terminal sessions via tmux
 - GitHub OAuth integration with repository browsing
+- **Multi-GitHub account** linking with per-folder account binding
 - Git worktree support for branch isolation
 - Session recording and playback
 - Session templates for reusable configurations
@@ -59,6 +60,7 @@ bun run db:migrate   # Run migrations
 bun run db:studio    # Open Drizzle Studio
 bun run db:seed      # Seed authorized users
 bun run db:migrate-agents  # One-time agent session migration
+bun run db:migrate-github-accounts  # Backfill GitHub account metadata from existing OAuth accounts
 ```
 
 ## Architecture
@@ -246,6 +248,8 @@ src/
 | `worktree_trash_metadata` | Worktree-specific trash metadata |
 | `port_registry` | Port allocations for environment variable conflict detection |
 | `folder_secrets_config` | Per-folder secrets provider configuration |
+| `github_account_metadata` | Linked GitHub account metadata (login, avatar, default flag, config dir) |
+| `folder_github_account_link` | Per-folder GitHub account bindings |
 | `project_task` | Project tasks with priority, labels, subtasks, and due dates |
 
 ### Service Layer
@@ -399,6 +403,7 @@ React Contexts in `src/contexts/`:
 | `TrashContext` | Trash items state and operations |
 | `SecretsContext` | Secrets provider configurations and state |
 | `PortContext` | Port allocations, framework detection, monitoring |
+| `GitHubAccountContext` | Multi-GitHub account state with folder bindings |
 | `TaskContext` | Project tasks state with folder-scoped CRUD |
 
 **Preference Inheritance**: Default → User Settings → Folder Preferences
@@ -482,6 +487,9 @@ React Contexts in `src/contexts/`:
 - `POST /api/github/worktrees/check` - Check worktree status
 - `GET /api/auth/github/link` - Start OAuth flow
 - `GET /api/auth/github/callback` - OAuth callback
+- `GET /api/github/accounts` - List linked GitHub accounts with folder bindings
+- `PATCH /api/github/accounts/:accountId` - Set default, bind/unbind folder
+- `DELETE /api/github/accounts/:accountId` - Unlink a GitHub account
 
 ### API Keys
 - `GET /api/keys` - List user's API keys

--- a/drizzle/0011_multi_gh_accounts.sql
+++ b/drizzle/0011_multi_gh_accounts.sql
@@ -1,0 +1,25 @@
+-- Multi GitHub Accounts support
+-- Adds metadata table for GitHub accounts and folder-to-account binding
+
+CREATE TABLE IF NOT EXISTS `github_account_metadata` (
+  `provider_account_id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL REFERENCES `user`(`id`) ON DELETE CASCADE,
+  `login` text NOT NULL,
+  `display_name` text,
+  `avatar_url` text NOT NULL,
+  `email` text,
+  `is_default` integer DEFAULT false NOT NULL,
+  `config_dir` text NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS `github_account_metadata_user_idx` ON `github_account_metadata` (`user_id`);
+
+CREATE TABLE IF NOT EXISTS `folder_github_account_link` (
+  `folder_id` text PRIMARY KEY NOT NULL REFERENCES `session_folder`(`id`) ON DELETE CASCADE,
+  `provider_account_id` text NOT NULL,
+  `created_at` integer NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS `folder_gh_account_link_account_idx` ON `folder_github_account_link` (`provider_account_id`);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "db:studio": "drizzle-kit studio",
     "db:seed": "bun run src/db/seed.ts",
     "db:migrate-agents": "bun run scripts/migrate-agent-sessions.ts",
+    "db:migrate-github-accounts": "bun run scripts/migrate-github-accounts.ts",
     "terminal:build": "bun build src/server/index.ts --outdir dist-terminal --target node --external node-pty --external better-sqlite3 --sourcemap",
     "electron:build": "tsc -p electron/tsconfig.json",
     "electron:dev": "bun run electron:build && concurrently --kill-others -n next,term,electron -c blue,green,yellow \"bun run dev:next\" \"bun run dev:terminal\" \"electron .\"",

--- a/scripts/migrate-github-accounts.ts
+++ b/scripts/migrate-github-accounts.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env bun
+/**
+ * Migration script: Backfill github_account_metadata from existing OAuth accounts.
+ *
+ * For users who already have a GitHub OAuth account linked via the `account` table,
+ * this script creates the corresponding `github_account_metadata` entry with:
+ * - login/avatar fetched from GitHub API using the stored token
+ * - isDefault = true (since they only have one account)
+ * - configDir pointing to ~/.remote-dev/gh-configs/{providerAccountId}/
+ *
+ * It also provisions the gh CLI config (hosts.yml) for each account.
+ *
+ * Run with: bun run scripts/migrate-github-accounts.ts
+ *
+ * Options:
+ *   --dry-run   Show what would be changed without making changes
+ */
+
+import { db } from "../src/db";
+import { accounts, githubAccountMetadata } from "../src/db/schema";
+import { eq, and } from "drizzle-orm";
+import { decryptSafe } from "../src/lib/encryption";
+import { getGhConfigsDir } from "../src/lib/paths";
+import { join } from "path";
+import { mkdir, writeFile, chmod } from "fs/promises";
+
+const dryRun = process.argv.includes("--dry-run");
+
+async function main() {
+  console.log(`🔄 Backfilling github_account_metadata from existing OAuth accounts...\n`);
+  if (dryRun) console.log("  (dry run mode - no changes will be made)\n");
+
+  // Find all GitHub OAuth accounts
+  const githubOAuthAccounts = await db.query.accounts.findMany({
+    where: eq(accounts.provider, "github"),
+  });
+
+  console.log(`  Found ${githubOAuthAccounts.length} GitHub OAuth account(s)\n`);
+
+  let migrated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const oauthAccount of githubOAuthAccounts) {
+    const { userId, providerAccountId, access_token } = oauthAccount;
+
+    // Check if metadata already exists
+    const existing = await db.query.githubAccountMetadata.findFirst({
+      where: eq(githubAccountMetadata.providerAccountId, providerAccountId),
+    });
+
+    if (existing) {
+      console.log(`  ✓ ${providerAccountId} - already migrated (skipping)`);
+      skipped++;
+      continue;
+    }
+
+    // Decrypt token
+    const token = access_token ? decryptSafe(access_token) : null;
+    if (!token) {
+      console.log(`  ✗ ${providerAccountId} - no valid token (skipping)`);
+      failed++;
+      continue;
+    }
+
+    // Fetch user info from GitHub API
+    let login: string;
+    let displayName: string | null = null;
+    let avatarUrl: string;
+    let email: string | null = null;
+
+    try {
+      const res = await fetch("https://api.github.com/user", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github.v3+json",
+        },
+      });
+
+      if (!res.ok) {
+        console.log(`  ✗ ${providerAccountId} - GitHub API error ${res.status} (skipping)`);
+        failed++;
+        continue;
+      }
+
+      const user = await res.json();
+      login = user.login;
+      displayName = user.name ?? null;
+      avatarUrl = user.avatar_url;
+      email = user.email ?? null;
+    } catch (err) {
+      console.log(`  ✗ ${providerAccountId} - fetch failed: ${err}`);
+      failed++;
+      continue;
+    }
+
+    const configDir = join(getGhConfigsDir(), providerAccountId);
+
+    if (!dryRun) {
+      // Create metadata entry
+      const now = new Date();
+      await db.insert(githubAccountMetadata).values({
+        providerAccountId,
+        userId,
+        login,
+        displayName,
+        avatarUrl,
+        email,
+        isDefault: true,
+        configDir,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      // Provision gh CLI config
+      await mkdir(configDir, { recursive: true });
+      const hostsContent = `github.com:\n    oauth_token: ${token}\n    user: ${login}\n    git_protocol: https\n`;
+      const hostsPath = join(configDir, "hosts.yml");
+      await writeFile(hostsPath, hostsContent, { mode: 0o600 });
+      await chmod(configDir, 0o700);
+    }
+
+    console.log(`  ${dryRun ? "Would migrate" : "✓ Migrated"} ${providerAccountId} (@${login})`);
+    migrated++;
+  }
+
+  console.log(`\n📊 Results:`);
+  console.log(`  Migrated: ${migrated}`);
+  console.log(`  Skipped (already done): ${skipped}`);
+  console.log(`  Failed: ${failed}`);
+}
+
+main().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/src/app/api/auth/github/callback/route.ts
+++ b/src/app/api/auth/github/callback/route.ts
@@ -4,6 +4,7 @@ import { accounts } from "@/db/schema";
 import { and, eq } from "drizzle-orm";
 import { validateSignedState } from "@/lib/oauth-state";
 import { encrypt } from "@/lib/encryption";
+import { linkGitHubAccountUseCase } from "@/infrastructure/container";
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
@@ -18,7 +19,7 @@ export async function GET(request: NextRequest) {
   const stateResult = validateSignedState(state);
   if (!stateResult.valid) {
     console.warn("OAuth state validation failed:", stateResult.error);
-    return NextResponse.redirect(new URL(`/?error=${stateResult.error}`, request.url));
+    return NextResponse.redirect(new URL(`/?error=${encodeURIComponent(stateResult.error)}`, request.url));
   }
 
   const stateData = stateResult.payload;
@@ -108,6 +109,22 @@ export async function GET(request: NextRequest) {
       token_type,
       scope,
     });
+  }
+
+  // Link GitHub account metadata and provision gh CLI config
+  try {
+    await linkGitHubAccountUseCase.execute({
+      userId: stateData.userId,
+      providerAccountId: String(githubUser.id),
+      login: githubUser.login,
+      displayName: githubUser.name ?? null,
+      avatarUrl: githubUser.avatar_url,
+      email: githubUser.email ?? null,
+      accessToken: access_token,
+    });
+  } catch (error) {
+    console.error("Failed to link GitHub account metadata:", error);
+    // Non-fatal: the OAuth account was already saved above
   }
 
   return NextResponse.redirect(new URL("/?github=connected", request.url));

--- a/src/app/api/github/accounts/[accountId]/route.ts
+++ b/src/app/api/github/accounts/[accountId]/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+import { withAuth, errorResponse } from "@/lib/api";
+import {
+  unlinkGitHubAccountUseCase,
+  setDefaultGitHubAccountUseCase,
+  bindFolderToGitHubAccountUseCase,
+  unbindFolderFromGitHubAccountUseCase,
+} from "@/infrastructure/container";
+import { EntityNotFoundError } from "@/domain/errors/DomainError";
+
+/**
+ * PATCH /api/github/accounts/:accountId
+ * Update account properties (e.g., set as default, bind/unbind folder)
+ *
+ * Body: { action: "set-default" | "bind-folder" | "unbind-folder", folderId?: string }
+ */
+export const PATCH = withAuth(async (request, { userId, params }) => {
+  const accountId = params?.accountId;
+  if (!accountId) {
+    return errorResponse("Account ID required", 400);
+  }
+
+  try {
+    const body = await request.json();
+
+    if (body.action === "set-default") {
+      await setDefaultGitHubAccountUseCase.execute({
+        userId,
+        providerAccountId: accountId,
+      });
+      return NextResponse.json({ success: true });
+    }
+
+    if (body.action === "bind-folder") {
+      if (!body.folderId) {
+        return errorResponse("folderId required", 400);
+      }
+      await bindFolderToGitHubAccountUseCase.execute({
+        userId,
+        folderId: body.folderId,
+        providerAccountId: accountId,
+      });
+      return NextResponse.json({ success: true });
+    }
+
+    if (body.action === "unbind-folder") {
+      if (!body.folderId) {
+        return errorResponse("folderId required", 400);
+      }
+      await unbindFolderFromGitHubAccountUseCase.execute({
+        folderId: body.folderId,
+        userId,
+      });
+      return NextResponse.json({ success: true });
+    }
+
+    return errorResponse("Unknown action", 400);
+  } catch (error) {
+    if (error instanceof EntityNotFoundError) {
+      return errorResponse(error.message, 404, error.code);
+    }
+    console.error("[api/github/accounts] PATCH error:", error);
+    return errorResponse("Failed to update account", 500);
+  }
+});
+
+/**
+ * DELETE /api/github/accounts/:accountId
+ * Unlink a specific GitHub account
+ */
+export const DELETE = withAuth(async (_request, { userId, params }) => {
+  const accountId = params?.accountId;
+  if (!accountId) {
+    return errorResponse("Account ID required", 400);
+  }
+
+  try {
+    await unlinkGitHubAccountUseCase.execute({
+      userId,
+      providerAccountId: accountId,
+    });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof EntityNotFoundError) {
+      return errorResponse(error.message, 404, error.code);
+    }
+    console.error("[api/github/accounts] DELETE error:", error);
+    return errorResponse("Failed to unlink account", 500);
+  }
+});

--- a/src/app/api/github/accounts/route.ts
+++ b/src/app/api/github/accounts/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { withAuth, errorResponse } from "@/lib/api";
+import { listGitHubAccountsUseCase } from "@/infrastructure/container";
+
+/**
+ * GET /api/github/accounts
+ * List all linked GitHub accounts for the authenticated user
+ */
+export const GET = withAuth(async (_request, { userId }) => {
+  try {
+    const result = await listGitHubAccountsUseCase.execute(userId);
+
+    return NextResponse.json({
+      accounts: result.accounts.map((a) => a.toPlainObject()),
+      folderBindings: Object.fromEntries(result.folderBindings),
+    });
+  } catch (error) {
+    console.error("[api/github/accounts] Error listing accounts:", error);
+    return errorResponse("Failed to list GitHub accounts", 500);
+  }
+});

--- a/src/app/api/github/accounts/route.ts
+++ b/src/app/api/github/accounts/route.ts
@@ -11,7 +11,12 @@ export const GET = withAuth(async (_request, { userId }) => {
     const result = await listGitHubAccountsUseCase.execute(userId);
 
     return NextResponse.json({
-      accounts: result.accounts.map((a) => a.toPlainObject()),
+      accounts: result.accounts.map((a) => {
+        // Strip configDir (server-side path) from client response
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { configDir, ...rest } = a.toPlainObject();
+        return rest;
+      }),
       folderBindings: Object.fromEntries(result.folderBindings),
     });
   } catch (error) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import { signOut } from "@/auth";
 import { getAuthSession } from "@/lib/auth-utils";
 import { db } from "@/db";
-import { terminalSessions, accounts, sessionFolders } from "@/db/schema";
+import { terminalSessions, accounts, sessionFolders, githubAccountMetadata } from "@/db/schema";
 import { eq, and, inArray } from "drizzle-orm";
 import { SessionProvider } from "@/contexts/SessionContext";
 import { FolderProvider } from "@/contexts/FolderContext";
@@ -18,6 +18,7 @@ import { GitHubIssuesProvider } from "@/contexts/GitHubIssuesContext";
 import { PortProvider } from "@/contexts/PortContext";
 import { SessionMCPProvider } from "@/contexts/SessionMCPContext";
 import { TaskProvider } from "@/contexts/TaskContext";
+import { GitHubAccountProvider } from "@/contexts/GitHubAccountContext";
 import { SessionManager } from "@/components/session/SessionManager";
 import { Header } from "@/components/header/Header";
 import type { TerminalSession } from "@/types/session";
@@ -61,7 +62,7 @@ export default async function Home() {
     sortOrder: f.sortOrder ?? 0,
   }));
 
-  // Check if GitHub is connected
+  // Check if GitHub is connected (any OAuth account or metadata entries)
   const githubAccount = await db.query.accounts.findFirst({
     where: and(
       eq(accounts.userId, session.user.id),
@@ -69,6 +70,13 @@ export default async function Home() {
     ),
   });
   const isGitHubConnected = !!githubAccount;
+
+  // Check if user has GitHub account metadata (for multi-account context)
+  const hasGitHubAccounts = await db.query.githubAccountMetadata.findFirst({
+    where: eq(githubAccountMetadata.userId, session.user.id),
+    columns: { providerAccountId: true },
+  });
+  const initialHasGitHubAccounts = !!hasGitHubAccounts;
 
   // Map database sessions to TypeScript type
   const initialSessions: TerminalSession[] = dbSessions.map((s) => ({
@@ -106,6 +114,7 @@ export default async function Home() {
           <ProfileProvider>
             <TemplateProvider>
               <RecordingProvider>
+                <GitHubAccountProvider initialHasAccounts={initialHasGitHubAccounts}>
                 <GitHubStatsProvider isGitHubConnected={isGitHubConnected}>
                   <GitHubIssuesProvider>
                     <SessionProvider initialSessions={initialSessions}>
@@ -137,6 +146,7 @@ export default async function Home() {
                     </SessionProvider>
                   </GitHubIssuesProvider>
                 </GitHubStatsProvider>
+                </GitHubAccountProvider>
               </RecordingProvider>
             </TemplateProvider>
           </ProfileProvider>

--- a/src/application/ports/GhCliConfigGateway.ts
+++ b/src/application/ports/GhCliConfigGateway.ts
@@ -1,0 +1,16 @@
+/**
+ * GhCliConfigGateway - Port interface for managing gh CLI configuration files.
+ *
+ * The gh CLI reads authentication from $GH_CONFIG_DIR/hosts.yml.
+ * Each GitHub account gets its own isolated config directory.
+ */
+
+export interface GhCliConfigGateway {
+  /** Write hosts.yml for a GitHub account, creating the directory if needed. */
+  writeHostsConfig(configDir: string, token: string, login: string): Promise<void>;
+  removeConfig(configDir: string): Promise<void>;
+  isConfigValid(configDir: string): Promise<boolean>;
+
+  /** Compute the config directory path for a given account (pure, no I/O). */
+  getConfigDir(providerAccountId: string): string;
+}

--- a/src/application/ports/GitHubAccountRepository.ts
+++ b/src/application/ports/GitHubAccountRepository.ts
@@ -1,0 +1,34 @@
+/**
+ * GitHubAccountRepository - Port interface for GitHub account persistence.
+ *
+ * Repository methods return domain entities (GitHubAccount), not database records.
+ */
+
+import type { GitHubAccount } from "@/domain/entities/GitHubAccount";
+
+export interface GitHubAccountRepository {
+  findByProviderAccountId(providerAccountId: string, userId: string): Promise<GitHubAccount | null>;
+  findByUser(userId: string): Promise<GitHubAccount[]>;
+  findDefault(userId: string): Promise<GitHubAccount | null>;
+
+  /** Find the GitHub account bound to a folder, or null if unbound. */
+  findByFolder(folderId: string, userId: string): Promise<GitHubAccount | null>;
+
+  getAccessToken(providerAccountId: string, userId: string): Promise<string | null>;
+  save(account: GitHubAccount): Promise<GitHubAccount>;
+
+  /** Deletes metadata only -- does NOT delete the underlying NextAuth account row. */
+  delete(providerAccountId: string, userId: string): Promise<boolean>;
+
+  /** Atomically set one account as default and clear all others for the user. */
+  setDefault(providerAccountId: string, userId: string): Promise<void>;
+
+  bindFolder(folderId: string, providerAccountId: string): Promise<void>;
+  unbindFolder(folderId: string): Promise<void>;
+
+  /** Returns a map of folderId -> providerAccountId. */
+  findFolderBindings(userId: string): Promise<Map<string, string>>;
+
+  /** Returns the userId that owns this account, or null. */
+  findOwner(providerAccountId: string): Promise<string | null>;
+}

--- a/src/application/ports/GitHubAccountRepository.ts
+++ b/src/application/ports/GitHubAccountRepository.ts
@@ -26,6 +26,9 @@ export interface GitHubAccountRepository {
   bindFolder(folderId: string, providerAccountId: string): Promise<void>;
   unbindFolder(folderId: string): Promise<void>;
 
+  /** Remove all folder bindings for a given account. */
+  unbindFoldersByAccount(providerAccountId: string): Promise<void>;
+
   /** Returns a map of folderId -> providerAccountId. */
   findFolderBindings(userId: string): Promise<Map<string, string>>;
 

--- a/src/application/use-cases/github-accounts/BindFolderToGitHubAccountUseCase.ts
+++ b/src/application/use-cases/github-accounts/BindFolderToGitHubAccountUseCase.ts
@@ -1,0 +1,33 @@
+/**
+ * BindFolderToGitHubAccountUseCase - Binds a folder to a specific GitHub account.
+ *
+ * All sessions created in this folder will auto-inject the bound account's
+ * GH_TOKEN and GH_CONFIG_DIR environment variables.
+ */
+
+import { EntityNotFoundError } from "@/domain/errors/DomainError";
+import type { GitHubAccountRepository } from "@/application/ports/GitHubAccountRepository";
+import type { FolderRepository } from "@/application/ports/FolderRepository";
+
+export interface BindFolderInput {
+  userId: string;
+  folderId: string;
+  providerAccountId: string;
+}
+
+export class BindFolderToGitHubAccountUseCase {
+  constructor(
+    private readonly accountRepo: GitHubAccountRepository,
+    private readonly folderRepo: FolderRepository
+  ) {}
+
+  async execute(input: BindFolderInput): Promise<void> {
+    const folder = await this.folderRepo.findById(input.folderId, input.userId);
+    if (!folder) throw new EntityNotFoundError("Folder", input.folderId);
+
+    const account = await this.accountRepo.findByProviderAccountId(input.providerAccountId, input.userId);
+    if (!account) throw new EntityNotFoundError("GitHubAccount", input.providerAccountId);
+
+    await this.accountRepo.bindFolder(input.folderId, input.providerAccountId);
+  }
+}

--- a/src/application/use-cases/github-accounts/LinkGitHubAccountUseCase.ts
+++ b/src/application/use-cases/github-accounts/LinkGitHubAccountUseCase.ts
@@ -1,0 +1,87 @@
+/**
+ * LinkGitHubAccountUseCase - Orchestrates linking a GitHub account after OAuth.
+ *
+ * Handles:
+ * 1. Conflict detection (account already linked to different user)
+ * 2. Metadata persistence
+ * 3. gh CLI config provisioning
+ * 4. Default account promotion (first account = default)
+ */
+
+import { GitHubAccount } from "@/domain/entities/GitHubAccount";
+import { GitHubAccountConflictError } from "@/domain/errors/DomainError";
+import type { GitHubAccountRepository } from "@/application/ports/GitHubAccountRepository";
+import type { GhCliConfigGateway } from "@/application/ports/GhCliConfigGateway";
+
+export interface LinkGitHubAccountInput {
+  userId: string;
+  providerAccountId: string;
+  login: string;
+  displayName: string | null;
+  avatarUrl: string;
+  email: string | null;
+  /** Raw (decrypted) access token for gh CLI config */
+  accessToken: string;
+}
+
+export interface LinkGitHubAccountOutput {
+  account: GitHubAccount;
+  isNewAccount: boolean;
+  isDefault: boolean;
+}
+
+export class LinkGitHubAccountUseCase {
+  constructor(
+    private readonly accountRepo: GitHubAccountRepository,
+    private readonly ghCliConfig: GhCliConfigGateway
+  ) {}
+
+  async execute(input: LinkGitHubAccountInput): Promise<LinkGitHubAccountOutput> {
+    // Prevent linking an account already owned by a different user
+    const existingOwner = await this.accountRepo.findOwner(input.providerAccountId);
+    if (existingOwner && existingOwner !== input.userId) {
+      throw new GitHubAccountConflictError(input.login, existingOwner);
+    }
+
+    const existing = await this.accountRepo.findByProviderAccountId(
+      input.providerAccountId,
+      input.userId
+    );
+
+    // First account for this user becomes the default
+    const userAccounts = await this.accountRepo.findByUser(input.userId);
+    const isDefault = existing?.isDefault ?? userAccounts.length === 0;
+
+    const configDir = this.ghCliConfig.getConfigDir(input.providerAccountId);
+
+    const account = existing
+      ? existing.updateMetadata(input.login, input.displayName, input.avatarUrl, input.email)
+      : GitHubAccount.create({
+          providerAccountId: input.providerAccountId,
+          userId: input.userId,
+          login: input.login,
+          displayName: input.displayName,
+          avatarUrl: input.avatarUrl,
+          email: input.email,
+          isDefault,
+          configDir,
+        });
+
+    await this.ghCliConfig.writeHostsConfig(configDir, input.accessToken, input.login);
+
+    let saved: GitHubAccount;
+    try {
+      saved = await this.accountRepo.save(account);
+    } catch (error) {
+      // Compensating action: clean up config if DB save fails
+      await this.ghCliConfig.removeConfig(configDir).catch(() => {});
+      throw error;
+    }
+
+    if (isDefault && !existing?.isDefault) {
+      await this.accountRepo.setDefault(input.providerAccountId, input.userId);
+    }
+
+    return { account: saved, isNewAccount: !existing, isDefault };
+  }
+}

--- a/src/application/use-cases/github-accounts/ListGitHubAccountsUseCase.ts
+++ b/src/application/use-cases/github-accounts/ListGitHubAccountsUseCase.ts
@@ -1,0 +1,24 @@
+/**
+ * ListGitHubAccountsUseCase - Lists all GitHub accounts for a user.
+ */
+
+import type { GitHubAccount } from "@/domain/entities/GitHubAccount";
+import type { GitHubAccountRepository } from "@/application/ports/GitHubAccountRepository";
+
+export interface ListGitHubAccountsOutput {
+  accounts: GitHubAccount[];
+  folderBindings: Map<string, string>;
+}
+
+export class ListGitHubAccountsUseCase {
+  constructor(private readonly accountRepo: GitHubAccountRepository) {}
+
+  async execute(userId: string): Promise<ListGitHubAccountsOutput> {
+    const [accounts, folderBindings] = await Promise.all([
+      this.accountRepo.findByUser(userId),
+      this.accountRepo.findFolderBindings(userId),
+    ]);
+
+    return { accounts, folderBindings };
+  }
+}

--- a/src/application/use-cases/github-accounts/SetDefaultGitHubAccountUseCase.ts
+++ b/src/application/use-cases/github-accounts/SetDefaultGitHubAccountUseCase.ts
@@ -1,0 +1,28 @@
+/**
+ * SetDefaultGitHubAccountUseCase - Sets a GitHub account as the user's default.
+ */
+
+import { EntityNotFoundError } from "@/domain/errors/DomainError";
+import type { GitHubAccountRepository } from "@/application/ports/GitHubAccountRepository";
+
+export interface SetDefaultGitHubAccountInput {
+  userId: string;
+  providerAccountId: string;
+}
+
+export class SetDefaultGitHubAccountUseCase {
+  constructor(private readonly accountRepo: GitHubAccountRepository) {}
+
+  async execute(input: SetDefaultGitHubAccountInput): Promise<void> {
+    const account = await this.accountRepo.findByProviderAccountId(
+      input.providerAccountId,
+      input.userId
+    );
+
+    if (!account) {
+      throw new EntityNotFoundError("GitHubAccount", input.providerAccountId);
+    }
+
+    await this.accountRepo.setDefault(input.providerAccountId, input.userId);
+  }
+}

--- a/src/application/use-cases/github-accounts/UnbindFolderFromGitHubAccountUseCase.ts
+++ b/src/application/use-cases/github-accounts/UnbindFolderFromGitHubAccountUseCase.ts
@@ -1,0 +1,26 @@
+/**
+ * UnbindFolderFromGitHubAccountUseCase - Removes GitHub account binding from a folder.
+ */
+
+import type { GitHubAccountRepository } from "@/application/ports/GitHubAccountRepository";
+import type { FolderRepository } from "@/application/ports/FolderRepository";
+import { EntityNotFoundError } from "@/domain/errors/DomainError";
+
+export interface UnbindFolderInput {
+  folderId: string;
+  userId: string;
+}
+
+export class UnbindFolderFromGitHubAccountUseCase {
+  constructor(
+    private readonly accountRepo: GitHubAccountRepository,
+    private readonly folderRepo: FolderRepository,
+  ) {}
+
+  async execute(input: UnbindFolderInput): Promise<void> {
+    const folder = await this.folderRepo.findById(input.folderId, input.userId);
+    if (!folder) throw new EntityNotFoundError("Folder", input.folderId);
+
+    await this.accountRepo.unbindFolder(input.folderId);
+  }
+}

--- a/src/application/use-cases/github-accounts/UnlinkGitHubAccountUseCase.ts
+++ b/src/application/use-cases/github-accounts/UnlinkGitHubAccountUseCase.ts
@@ -1,0 +1,50 @@
+/**
+ * UnlinkGitHubAccountUseCase - Disconnects a specific GitHub account.
+ *
+ * Handles:
+ * 1. Removing gh CLI config
+ * 2. Deleting metadata
+ * 3. Optionally deleting the NextAuth account row
+ * 4. Promoting another account to default if needed
+ */
+
+import { EntityNotFoundError } from "@/domain/errors/DomainError";
+import type { GitHubAccountRepository } from "@/application/ports/GitHubAccountRepository";
+import type { GhCliConfigGateway } from "@/application/ports/GhCliConfigGateway";
+
+export interface UnlinkGitHubAccountInput {
+  userId: string;
+  providerAccountId: string;
+}
+
+export class UnlinkGitHubAccountUseCase {
+  constructor(
+    private readonly accountRepo: GitHubAccountRepository,
+    private readonly ghCliConfig: GhCliConfigGateway
+  ) {}
+
+  async execute(input: UnlinkGitHubAccountInput): Promise<void> {
+    const account = await this.accountRepo.findByProviderAccountId(
+      input.providerAccountId,
+      input.userId
+    );
+
+    if (!account) {
+      throw new EntityNotFoundError("GitHubAccount", input.providerAccountId);
+    }
+
+    await this.ghCliConfig.removeConfig(account.configDir).catch(() => {});
+    await this.accountRepo.delete(input.providerAccountId, input.userId);
+
+    // Promote another account to default if needed
+    if (account.isDefault) {
+      const remaining = await this.accountRepo.findByUser(input.userId);
+      if (remaining.length > 0) {
+        await this.accountRepo.setDefault(
+          remaining[0].providerAccountId,
+          input.userId
+        );
+      }
+    }
+  }
+}

--- a/src/application/use-cases/github-accounts/UnlinkGitHubAccountUseCase.ts
+++ b/src/application/use-cases/github-accounts/UnlinkGitHubAccountUseCase.ts
@@ -34,6 +34,7 @@ export class UnlinkGitHubAccountUseCase {
     }
 
     await this.ghCliConfig.removeConfig(account.configDir).catch(() => {});
+    await this.accountRepo.unbindFoldersByAccount(input.providerAccountId);
     await this.accountRepo.delete(input.providerAccountId, input.userId);
 
     // Promote another account to default if needed

--- a/src/application/use-cases/github-accounts/index.ts
+++ b/src/application/use-cases/github-accounts/index.ts
@@ -1,0 +1,17 @@
+export { LinkGitHubAccountUseCase } from "./LinkGitHubAccountUseCase";
+export type { LinkGitHubAccountInput, LinkGitHubAccountOutput } from "./LinkGitHubAccountUseCase";
+
+export { UnlinkGitHubAccountUseCase } from "./UnlinkGitHubAccountUseCase";
+export type { UnlinkGitHubAccountInput } from "./UnlinkGitHubAccountUseCase";
+
+export { SetDefaultGitHubAccountUseCase } from "./SetDefaultGitHubAccountUseCase";
+export type { SetDefaultGitHubAccountInput } from "./SetDefaultGitHubAccountUseCase";
+
+export { BindFolderToGitHubAccountUseCase } from "./BindFolderToGitHubAccountUseCase";
+export type { BindFolderInput } from "./BindFolderToGitHubAccountUseCase";
+
+export { UnbindFolderFromGitHubAccountUseCase } from "./UnbindFolderFromGitHubAccountUseCase";
+export type { UnbindFolderInput } from "./UnbindFolderFromGitHubAccountUseCase";
+
+export { ListGitHubAccountsUseCase } from "./ListGitHubAccountsUseCase";
+export type { ListGitHubAccountsOutput } from "./ListGitHubAccountsUseCase";

--- a/src/components/github/AccountSwitcher.tsx
+++ b/src/components/github/AccountSwitcher.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+/**
+ * AccountSwitcher - Manage linked GitHub accounts.
+ *
+ * Displays a list of linked accounts with actions:
+ * - Set as default
+ * - Unlink
+ * - Add another account
+ */
+
+import { useState } from "react";
+import {
+  Github,
+  Star,
+  Trash2,
+  Plus,
+  Loader2,
+  ExternalLink,
+  AlertCircle,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useGitHubAccounts, type LinkedGitHubAccount } from "@/contexts/GitHubAccountContext";
+
+export function AccountSwitcher() {
+  const {
+    accounts,
+    loading,
+    error,
+    setDefault,
+    unlinkAccount,
+    addAccount,
+  } = useGitHubAccounts();
+
+  const [unlinkTarget, setUnlinkTarget] = useState<LinkedGitHubAccount | null>(null);
+  const [isUnlinking, setIsUnlinking] = useState(false);
+  const [settingDefault, setSettingDefault] = useState<string | null>(null);
+
+  const handleSetDefault = async (providerAccountId: string) => {
+    setSettingDefault(providerAccountId);
+    try {
+      await setDefault(providerAccountId);
+    } finally {
+      setSettingDefault(null);
+    }
+  };
+
+  const handleUnlink = async () => {
+    if (!unlinkTarget) return;
+    setIsUnlinking(true);
+    try {
+      await unlinkAccount(unlinkTarget.providerAccountId);
+      setUnlinkTarget(null);
+    } finally {
+      setIsUnlinking(false);
+    }
+  };
+
+  if (loading && accounts.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="space-y-4">
+        {error && (
+          <div className="flex items-center gap-2 p-3 rounded-lg bg-destructive/10 border border-destructive/30 text-destructive text-sm">
+            <AlertCircle className="w-4 h-4 shrink-0" />
+            {error}
+          </div>
+        )}
+
+        {accounts.length === 0 ? (
+          <div className="flex flex-col items-center py-8 gap-4">
+            <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center">
+              <Github className="w-8 h-8 text-muted-foreground" />
+            </div>
+            <p className="text-sm text-muted-foreground text-center">
+              No GitHub accounts linked.
+              <br />
+              Add an account to get started.
+            </p>
+            <Button onClick={addAccount} className="gap-2">
+              <Github className="w-4 h-4" />
+              Connect GitHub Account
+            </Button>
+          </div>
+        ) : (
+          <>
+            <div className="space-y-2">
+              {accounts.map((account) => (
+                <div
+                  key={account.providerAccountId}
+                  className="flex items-center gap-3 p-3 rounded-lg border border-border bg-card/30 hover:bg-card/50 transition-colors"
+                >
+                  <img
+                    src={account.avatarUrl}
+                    alt={account.login}
+                    className="w-10 h-10 rounded-full"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <p className="font-medium text-foreground truncate">
+                        {account.displayName || account.login}
+                      </p>
+                      {account.isDefault && (
+                        <Badge variant="secondary" className="text-xs shrink-0">
+                          Default
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="text-sm text-muted-foreground truncate">
+                      @{account.login}
+                      {account.email && ` · ${account.email}`}
+                    </p>
+                  </div>
+
+                  <div className="flex items-center gap-1 shrink-0">
+                    {!account.isDefault && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            onClick={() => handleSetDefault(account.providerAccountId)}
+                            disabled={settingDefault === account.providerAccountId}
+                          >
+                            {settingDefault === account.providerAccountId ? (
+                              <Loader2 className="w-4 h-4 animate-spin" />
+                            ) : (
+                              <Star className="w-4 h-4" />
+                            )}
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Set as default</TooltipContent>
+                      </Tooltip>
+                    )}
+
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8"
+                          onClick={() =>
+                            window.open(`https://github.com/${account.login}`, "_blank")
+                          }
+                        >
+                          <ExternalLink className="w-4 h-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>View on GitHub</TooltipContent>
+                    </Tooltip>
+
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8 text-destructive hover:text-destructive"
+                          onClick={() => setUnlinkTarget(account)}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Unlink account</TooltipContent>
+                    </Tooltip>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={addAccount}
+              className="gap-2 w-full"
+            >
+              <Plus className="w-4 h-4" />
+              Add Another GitHub Account
+            </Button>
+          </>
+        )}
+      </div>
+
+      {/* Unlink confirmation */}
+      <AlertDialog
+        open={!!unlinkTarget}
+        onOpenChange={(open) => !open && setUnlinkTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Unlink GitHub Account?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove the connection to{" "}
+              <strong>@{unlinkTarget?.login}</strong>. Sessions using this
+              account will fall back to the default account.
+              {unlinkTarget?.isDefault && accounts.length > 1 && (
+                <span className="block mt-2 text-amber-500">
+                  This is your default account. Another account will be promoted
+                  as the new default.
+                </span>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isUnlinking}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleUnlink}
+              disabled={isUnlinking}
+              className="bg-destructive hover:bg-destructive/90"
+            >
+              {isUnlinking ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Unlinking...
+                </>
+              ) : (
+                "Unlink"
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/github/FolderAccountBinder.tsx
+++ b/src/components/github/FolderAccountBinder.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+/**
+ * FolderAccountBinder - Select which GitHub account a folder should use.
+ *
+ * Shown inside FolderPreferencesModal. Allows the user to bind
+ * a specific GitHub account to a folder, or use the default.
+ */
+
+import { useState } from "react";
+import { Github, Loader2 } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useGitHubAccounts } from "@/contexts/GitHubAccountContext";
+
+const USE_DEFAULT = "__default__";
+
+interface FolderAccountBinderProps {
+  folderId: string;
+}
+
+export function FolderAccountBinder({ folderId }: FolderAccountBinderProps) {
+  const {
+    accounts,
+    folderBindings,
+    bindFolder,
+    unbindFolder,
+    defaultAccount,
+  } = useGitHubAccounts();
+
+  const [saving, setSaving] = useState(false);
+
+  const boundAccountId = folderBindings[folderId] ?? USE_DEFAULT;
+
+  const handleChange = async (value: string) => {
+    setSaving(true);
+    try {
+      if (value === USE_DEFAULT) {
+        await unbindFolder(folderId);
+      } else {
+        await bindFolder(folderId, value);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (accounts.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No GitHub accounts linked. Connect an account in GitHub settings.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Github className="w-4 h-4 text-muted-foreground" />
+        <span className="text-sm font-medium text-foreground">
+          GitHub Account
+        </span>
+        {saving && <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />}
+      </div>
+      <Select value={boundAccountId} onValueChange={handleChange} disabled={saving}>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="Select account" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={USE_DEFAULT}>
+            <span className="flex items-center gap-2">
+              Use Default
+              {defaultAccount && (
+                <span className="text-muted-foreground text-xs">
+                  (@{defaultAccount.login})
+                </span>
+              )}
+            </span>
+          </SelectItem>
+          {accounts.map((account) => (
+            <SelectItem
+              key={account.providerAccountId}
+              value={account.providerAccountId}
+            >
+              <span className="flex items-center gap-2">
+                <img
+                  src={account.avatarUrl}
+                  alt={account.login}
+                  className="w-4 h-4 rounded-full"
+                />
+                @{account.login}
+                {account.isDefault && (
+                  <span className="text-muted-foreground text-xs">(default)</span>
+                )}
+              </span>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="text-xs text-muted-foreground">
+        Sessions in this folder will use the selected account for GitHub operations and <code>gh</code> CLI auth.
+      </p>
+    </div>
+  );
+}

--- a/src/components/github/GitHubMaintenanceModal.tsx
+++ b/src/components/github/GitHubMaintenanceModal.tsx
@@ -45,6 +45,8 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useGitHubContext } from "@/contexts/GitHubContext";
 import { CachedRepositoryCard } from "./CachedRepositoryCard";
+import { AccountSwitcher } from "./AccountSwitcher";
+import { useGitHubAccounts } from "@/contexts/GitHubAccountContext";
 
 interface GitHubMaintenanceModalProps {
   open: boolean;
@@ -68,7 +70,8 @@ export function GitHubMaintenanceModal({
     disconnect,
   } = useGitHubContext();
 
-  const [activeTab, setActiveTab] = useState<"repositories" | "settings">(
+  const { accounts: ghAccounts } = useGitHubAccounts();
+  const [activeTab, setActiveTab] = useState<"repositories" | "accounts" | "settings">(
     "repositories"
   );
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -123,8 +126,8 @@ export function GitHubMaintenanceModal({
     }).format(date);
   };
 
-  // Disconnected state
-  if (!isConnected) {
+  // Disconnected state (no accounts at all)
+  if (!isConnected && ghAccounts.length === 0) {
     return (
       <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
         <DialogContent className="sm:max-w-[450px] bg-popover/95 backdrop-blur-xl border-border">
@@ -183,12 +186,20 @@ export function GitHubMaintenanceModal({
           <Tabs
             value={activeTab}
             onValueChange={(v) =>
-              setActiveTab(v as "repositories" | "settings")
+              setActiveTab(v as "repositories" | "accounts" | "settings")
             }
             className="flex-1 flex flex-col min-h-0"
           >
-            <TabsList className="grid w-full grid-cols-2 shrink-0">
+            <TabsList className="grid w-full grid-cols-3 shrink-0">
               <TabsTrigger value="repositories">Repositories</TabsTrigger>
+              <TabsTrigger value="accounts">
+                Accounts
+                {ghAccounts.length > 0 && (
+                  <span className="ml-1.5 text-xs text-muted-foreground">
+                    ({ghAccounts.length})
+                  </span>
+                )}
+              </TabsTrigger>
               <TabsTrigger value="settings">Settings</TabsTrigger>
             </TabsList>
 
@@ -297,6 +308,14 @@ export function GitHubMaintenanceModal({
                   Last synced: {formatDate(stats.lastSync)}
                 </div>
               )}
+            </TabsContent>
+
+            {/* Accounts Tab */}
+            <TabsContent
+              value="accounts"
+              className="flex-1 mt-4"
+            >
+              <AccountSwitcher />
             </TabsContent>
 
             {/* Settings Tab */}

--- a/src/components/header/GitHubConnectButton.tsx
+++ b/src/components/header/GitHubConnectButton.tsx
@@ -1,9 +1,13 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Github } from "lucide-react";
+import { Github, Plus } from "lucide-react";
 
-export function GitHubConnectButton() {
+interface GitHubConnectButtonProps {
+  isConnected?: boolean;
+}
+
+export function GitHubConnectButton({ isConnected = false }: GitHubConnectButtonProps) {
   return (
     <Button
       variant="ghost"
@@ -13,8 +17,17 @@ export function GitHubConnectButton() {
         window.location.href = "/api/auth/github/link";
       }}
     >
-      <Github className="w-4 h-4 mr-2" />
-      Connect GitHub
+      {isConnected ? (
+        <>
+          <Plus className="w-4 h-4 mr-2" />
+          Add GitHub Account
+        </>
+      ) : (
+        <>
+          <Github className="w-4 h-4 mr-2" />
+          Connect GitHub
+        </>
+      )}
     </Button>
   );
 }

--- a/src/components/preferences/FolderPreferencesModal.tsx
+++ b/src/components/preferences/FolderPreferencesModal.tsx
@@ -34,6 +34,7 @@ import { UnsavedChangesDialog } from "@/components/common/UnsavedChangesDialog";
 import { ProfileSelector } from "@/components/profiles/ProfileSelector";
 import { useProfileContext } from "@/contexts/ProfileContext";
 import { PinnedFilesTab } from "./PinnedFilesTab";
+import { FolderAccountBinder } from "@/components/github/FolderAccountBinder";
 
 // Helper to get electron API for directory selection (only in Electron)
 function getElectronSelectDirectory(): (() => Promise<string | null>) | null {
@@ -855,6 +856,11 @@ export function FolderPreferencesModal({
 
             {/* Repository Tab */}
             <TabsContent value="repository" className="mt-0 space-y-4">
+              {/* GitHub Account Binding */}
+              <div className="p-3 rounded-lg border border-border bg-card/30">
+                <FolderAccountBinder folderId={folderId} />
+              </div>
+
               <div className="space-y-2">
                 <p className="text-sm text-muted-foreground">
                   Link a repository to enable worktree creation from this folder.

--- a/src/contexts/GitHubAccountContext.tsx
+++ b/src/contexts/GitHubAccountContext.tsx
@@ -28,7 +28,6 @@ export interface LinkedGitHubAccount {
   avatarUrl: string;
   email: string | null;
   isDefault: boolean;
-  configDir: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/contexts/GitHubAccountContext.tsx
+++ b/src/contexts/GitHubAccountContext.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+/**
+ * GitHubAccountContext - Context for managing multiple linked GitHub accounts.
+ *
+ * Provides:
+ * - List of linked GitHub accounts with metadata
+ * - Folder-to-account bindings
+ * - CRUD operations: set default, bind/unbind folder, unlink
+ * - "Add Account" flow via OAuth
+ */
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  type ReactNode,
+} from "react";
+
+export interface LinkedGitHubAccount {
+  providerAccountId: string;
+  userId: string;
+  login: string;
+  displayName: string | null;
+  avatarUrl: string;
+  email: string | null;
+  isDefault: boolean;
+  configDir: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface GitHubAccountContextValue {
+  accounts: LinkedGitHubAccount[];
+  folderBindings: Record<string, string>; // folderId -> providerAccountId
+  loading: boolean;
+  error: string | null;
+
+  // Actions
+  refresh: () => Promise<void>;
+  setDefault: (providerAccountId: string) => Promise<void>;
+  unlinkAccount: (providerAccountId: string) => Promise<void>;
+  bindFolder: (folderId: string, providerAccountId: string) => Promise<void>;
+  unbindFolder: (folderId: string) => Promise<void>;
+  addAccount: () => void;
+
+  // Helpers
+  getAccountForFolder: (folderId: string) => LinkedGitHubAccount | undefined;
+  defaultAccount: LinkedGitHubAccount | undefined;
+}
+
+const GitHubAccountContext = createContext<GitHubAccountContextValue | null>(null);
+
+interface GitHubAccountProviderProps {
+  children: ReactNode;
+  initialHasAccounts?: boolean;
+}
+
+export function GitHubAccountProvider({
+  children,
+  initialHasAccounts = false,
+}: GitHubAccountProviderProps) {
+  const [accounts, setAccounts] = useState<LinkedGitHubAccount[]>([]);
+  const [folderBindings, setFolderBindings] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [initialized, setInitialized] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/github/accounts");
+      if (!res.ok) throw new Error("Failed to fetch accounts");
+      const data = await res.json();
+      setAccounts(data.accounts ?? []);
+      setFolderBindings(data.folderBindings ?? {});
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+      setInitialized(true);
+    }
+  }, []);
+
+  // Load accounts on mount if we know there are accounts
+  useEffect(() => {
+    if (initialHasAccounts && !initialized) {
+      refresh();
+    } else {
+      setInitialized(true);
+    }
+  }, [initialHasAccounts, initialized, refresh]);
+
+  const setDefault = useCallback(async (providerAccountId: string) => {
+    setError(null);
+    try {
+      const res = await fetch(`/api/github/accounts/${providerAccountId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "set-default" }),
+      });
+      if (!res.ok) throw new Error("Failed to set default account");
+      // Optimistic update
+      setAccounts((prev) =>
+        prev.map((a) => ({
+          ...a,
+          isDefault: a.providerAccountId === providerAccountId,
+        }))
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  }, []);
+
+  const unlinkAccount = useCallback(async (providerAccountId: string) => {
+    setError(null);
+    try {
+      const res = await fetch(`/api/github/accounts/${providerAccountId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to unlink account");
+      // Refresh to get accurate state from server (default promotion, binding cleanup)
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  }, [refresh]);
+
+  const bindFolder = useCallback(async (folderId: string, providerAccountId: string) => {
+    setError(null);
+    try {
+      const res = await fetch(`/api/github/accounts/${providerAccountId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "bind-folder", folderId }),
+      });
+      if (!res.ok) throw new Error("Failed to bind folder");
+      setFolderBindings((prev) => ({ ...prev, [folderId]: providerAccountId }));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  }, []);
+
+  const unbindFolder = useCallback(async (folderId: string) => {
+    setError(null);
+    // Find which account is currently bound to get the accountId for the API call
+    const providerAccountId = folderBindings[folderId];
+    if (!providerAccountId) return;
+    try {
+      const res = await fetch(`/api/github/accounts/${providerAccountId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "unbind-folder", folderId }),
+      });
+      if (!res.ok) throw new Error("Failed to unbind folder");
+      setFolderBindings((prev) => {
+        const updated = { ...prev };
+        delete updated[folderId];
+        return updated;
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  }, [folderBindings]);
+
+  const addAccount = useCallback(() => {
+    window.location.href = "/api/auth/github/link";
+  }, []);
+
+  const getAccountForFolder = useCallback(
+    (folderId: string) => {
+      const accountId = folderBindings[folderId];
+      if (!accountId) return undefined;
+      return accounts.find((a) => a.providerAccountId === accountId);
+    },
+    [accounts, folderBindings]
+  );
+
+  const defaultAccount = useMemo(
+    () => accounts.find((a) => a.isDefault),
+    [accounts]
+  );
+
+  const value = useMemo(
+    () => ({
+      accounts,
+      folderBindings,
+      loading,
+      error,
+      refresh,
+      setDefault,
+      unlinkAccount,
+      bindFolder,
+      unbindFolder,
+      addAccount,
+      getAccountForFolder,
+      defaultAccount,
+    }),
+    [
+      accounts,
+      folderBindings,
+      loading,
+      error,
+      refresh,
+      setDefault,
+      unlinkAccount,
+      bindFolder,
+      unbindFolder,
+      addAccount,
+      getAccountForFolder,
+      defaultAccount,
+    ]
+  );
+
+  return (
+    <GitHubAccountContext.Provider value={value}>
+      {children}
+    </GitHubAccountContext.Provider>
+  );
+}
+
+export function useGitHubAccounts() {
+  const context = useContext(GitHubAccountContext);
+  if (!context) {
+    throw new Error("useGitHubAccounts must be used within a GitHubAccountProvider");
+  }
+  return context;
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -215,6 +215,51 @@ export const folderPreferences = sqliteTable(
   ]
 );
 
+// GitHub account metadata - augments the NextAuth accounts table with display info
+// Keyed by providerAccountId (GitHub numeric user ID as string)
+export const githubAccountMetadata = sqliteTable(
+  "github_account_metadata",
+  {
+    providerAccountId: text("provider_account_id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    login: text("login").notNull(),
+    displayName: text("display_name"),
+    avatarUrl: text("avatar_url").notNull(),
+    email: text("email"),
+    isDefault: integer("is_default", { mode: "boolean" }).notNull().default(false),
+    configDir: text("config_dir").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("github_account_metadata_user_idx").on(table.userId),
+  ]
+);
+
+// Binds a folder to a specific GitHub account for environment injection
+export const folderGitHubAccountLinks = sqliteTable(
+  "folder_github_account_link",
+  {
+    folderId: text("folder_id")
+      .primaryKey()
+      .references(() => sessionFolders.id, { onDelete: "cascade" }),
+    providerAccountId: text("provider_account_id")
+      .notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("folder_gh_account_link_account_idx").on(table.providerAccountId),
+  ]
+);
+
 // Port registry for environment variable port conflict detection
 export const portRegistry = sqliteTable(
   "port_registry",

--- a/src/domain/entities/GitHubAccount.ts
+++ b/src/domain/entities/GitHubAccount.ts
@@ -1,0 +1,190 @@
+/**
+ * GitHubAccount - Domain entity representing a linked GitHub account.
+ *
+ * This entity encapsulates metadata about a GitHub OAuth account linked to a user.
+ * It is immutable - state changes return a new GitHubAccount instance.
+ *
+ * Invariants:
+ * - A GitHubAccount must have a valid providerAccountId
+ * - A GitHubAccount must have a valid userId
+ * - A GitHubAccount must have a login (GitHub username)
+ * - Only one account per user can be the default
+ */
+
+import { GitHubAccountId } from "../value-objects/GitHubAccountId";
+import { InvalidValueError } from "../errors/DomainError";
+
+export interface GitHubAccountProps {
+  id: GitHubAccountId;
+  userId: string;
+  login: string;
+  displayName: string | null;
+  avatarUrl: string;
+  email: string | null;
+  isDefault: boolean;
+  configDir: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateGitHubAccountProps {
+  providerAccountId: string;
+  userId: string;
+  login: string;
+  displayName?: string | null;
+  avatarUrl: string;
+  email?: string | null;
+  isDefault?: boolean;
+  configDir: string;
+}
+
+export class GitHubAccount {
+  private constructor(private readonly props: GitHubAccountProps) {
+    this.validateInvariants();
+  }
+
+  private validateInvariants(): void {
+    if (!this.props.userId) {
+      throw new InvalidValueError("GitHubAccount.userId", this.props.userId, "Must be a non-empty string");
+    }
+    if (!this.props.login) {
+      throw new InvalidValueError("GitHubAccount.login", this.props.login, "Must be a non-empty string");
+    }
+    if (!this.props.configDir?.startsWith("/")) {
+      throw new InvalidValueError("GitHubAccount.configDir", this.props.configDir, "Must be an absolute path");
+    }
+  }
+
+  static create(props: CreateGitHubAccountProps): GitHubAccount {
+    const now = new Date();
+    return new GitHubAccount({
+      id: GitHubAccountId.create(props.providerAccountId),
+      userId: props.userId,
+      login: props.login,
+      displayName: props.displayName ?? null,
+      avatarUrl: props.avatarUrl,
+      email: props.email ?? null,
+      isDefault: props.isDefault ?? false,
+      configDir: props.configDir,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  static reconstitute(props: GitHubAccountProps): GitHubAccount {
+    return new GitHubAccount(props);
+  }
+
+  // -- Domain Methods --
+
+  setAsDefault(): GitHubAccount {
+    if (this.props.isDefault) return this;
+    return this.withUpdates({ isDefault: true });
+  }
+
+  clearDefault(): GitHubAccount {
+    if (!this.props.isDefault) return this;
+    return this.withUpdates({ isDefault: false });
+  }
+
+  updateMetadata(
+    login: string,
+    displayName: string | null,
+    avatarUrl: string,
+    email: string | null
+  ): GitHubAccount {
+    return this.withUpdates({ login, displayName, avatarUrl, email });
+  }
+
+  // -- Query Methods --
+
+  isDefaultAccount(): boolean {
+    return this.props.isDefault;
+  }
+
+  belongsTo(userId: string): boolean {
+    return this.props.userId === userId;
+  }
+
+  // -- Getters --
+
+  get id(): GitHubAccountId {
+    return this.props.id;
+  }
+
+  get providerAccountId(): string {
+    return this.props.id.providerAccountId;
+  }
+
+  get userId(): string {
+    return this.props.userId;
+  }
+
+  get login(): string {
+    return this.props.login;
+  }
+
+  get displayName(): string | null {
+    return this.props.displayName;
+  }
+
+  get avatarUrl(): string {
+    return this.props.avatarUrl;
+  }
+
+  get email(): string | null {
+    return this.props.email;
+  }
+
+  get isDefault(): boolean {
+    return this.props.isDefault;
+  }
+
+  get configDir(): string {
+    return this.props.configDir;
+  }
+
+  get createdAt(): Date {
+    return this.props.createdAt;
+  }
+
+  get updatedAt(): Date {
+    return this.props.updatedAt;
+  }
+
+  // -- Serialization --
+
+  toPlainObject(): {
+    providerAccountId: string;
+    userId: string;
+    login: string;
+    displayName: string | null;
+    avatarUrl: string;
+    email: string | null;
+    isDefault: boolean;
+    configDir: string;
+    createdAt: string;
+    updatedAt: string;
+  } {
+    return {
+      providerAccountId: this.props.id.providerAccountId,
+      userId: this.props.userId,
+      login: this.props.login,
+      displayName: this.props.displayName,
+      avatarUrl: this.props.avatarUrl,
+      email: this.props.email,
+      isDefault: this.props.isDefault,
+      configDir: this.props.configDir,
+      createdAt: this.props.createdAt.toISOString(),
+      updatedAt: this.props.updatedAt.toISOString(),
+    };
+  }
+
+  private withUpdates(updates: Partial<GitHubAccountProps>): GitHubAccount {
+    return new GitHubAccount({
+      ...this.props,
+      ...updates,
+      updatedAt: new Date(),
+    });
+  }
+}

--- a/src/domain/errors/DomainError.ts
+++ b/src/domain/errors/DomainError.ts
@@ -77,3 +77,30 @@ export class BusinessRuleViolationError extends DomainError {
     );
   }
 }
+
+/**
+ * Thrown when a GitHub account is already linked to a different user.
+ */
+export class GitHubAccountConflictError extends DomainError {
+  constructor(
+    public readonly login: string,
+    public readonly existingUserId: string
+  ) {
+    super(
+      `GitHub account @${login} is already linked to another user`,
+      "GITHUB_ACCOUNT_CONFLICT"
+    );
+  }
+}
+
+/**
+ * Thrown when no default GitHub account is configured but one is required.
+ */
+export class NoDefaultGitHubAccountError extends DomainError {
+  constructor(public readonly userId: string) {
+    super(
+      "No default GitHub account configured",
+      "NO_DEFAULT_GITHUB_ACCOUNT"
+    );
+  }
+}

--- a/src/domain/value-objects/GitHubAccountEnvironment.ts
+++ b/src/domain/value-objects/GitHubAccountEnvironment.ts
@@ -1,0 +1,54 @@
+/**
+ * GitHubAccountEnvironment - Value object for GitHub account environment injection.
+ *
+ * Encapsulates the environment variables needed to authenticate with GitHub
+ * in a terminal session: GH_TOKEN for API access and GH_CONFIG_DIR for gh CLI config.
+ *
+ * Parallel to ProfileIsolation, which generates XDG-based isolation vars.
+ */
+
+import { InvalidValueError } from "../errors/DomainError";
+import { TmuxEnvironment } from "./TmuxEnvironment";
+
+export class GitHubAccountEnvironment {
+  private constructor(
+    private readonly accessToken: string,
+    private readonly configDir: string,
+    private readonly login: string | null
+  ) {}
+
+  static create(
+    accessToken: string,
+    configDir: string,
+    login?: string | null
+  ): GitHubAccountEnvironment {
+    if (!accessToken) {
+      throw new InvalidValueError("GitHubAccountEnvironment.accessToken", "(redacted)", "Must be a non-empty string");
+    }
+    if (!configDir?.startsWith("/")) {
+      throw new InvalidValueError("GitHubAccountEnvironment.configDir", configDir, "Must be an absolute path");
+    }
+    return new GitHubAccountEnvironment(accessToken, configDir, login ?? null);
+  }
+
+  toEnvironment(): TmuxEnvironment {
+    const vars: Record<string, string> = {
+      GH_TOKEN: this.accessToken,
+      GH_CONFIG_DIR: this.configDir,
+    };
+
+    if (this.login) {
+      vars.GITHUB_USER = this.login;
+    }
+
+    return TmuxEnvironment.create(vars);
+  }
+
+  getConfigDir(): string {
+    return this.configDir;
+  }
+
+  equals(other: GitHubAccountEnvironment): boolean {
+    return this.configDir === other.configDir;
+  }
+}

--- a/src/domain/value-objects/GitHubAccountId.ts
+++ b/src/domain/value-objects/GitHubAccountId.ts
@@ -1,0 +1,44 @@
+/**
+ * GitHubAccountId - Value object wrapping the composite key for a GitHub account.
+ *
+ * The `accounts` table uses (provider, providerAccountId) as the composite PK.
+ * This value object ensures the pair is always passed together and validated.
+ */
+
+import { InvalidValueError } from "../errors/DomainError";
+
+export class GitHubAccountId {
+  readonly provider = "github" as const;
+
+  private constructor(readonly providerAccountId: string) {}
+
+  static create(providerAccountId: string): GitHubAccountId {
+    if (!providerAccountId) {
+      throw new InvalidValueError(
+        "GitHubAccountId.providerAccountId",
+        providerAccountId,
+        "Must be a non-empty string"
+      );
+    }
+    return new GitHubAccountId(providerAccountId);
+  }
+
+  static fromString(value: string): GitHubAccountId {
+    if (!value || !value.startsWith("github:")) {
+      throw new InvalidValueError(
+        "GitHubAccountId",
+        value,
+        'Must be in format "github:{providerAccountId}"'
+      );
+    }
+    return GitHubAccountId.create(value.slice("github:".length));
+  }
+
+  toString(): string {
+    return `github:${this.providerAccountId}`;
+  }
+
+  equals(other: GitHubAccountId): boolean {
+    return this.providerAccountId === other.providerAccountId;
+  }
+}

--- a/src/infrastructure/container.ts
+++ b/src/infrastructure/container.ts
@@ -11,9 +11,11 @@
 import { DrizzleSessionRepository } from "./persistence/repositories/DrizzleSessionRepository";
 import { DrizzleFolderRepository } from "./persistence/repositories/DrizzleFolderRepository";
 import { DrizzleGitHubIssueRepository } from "./persistence/repositories/DrizzleGitHubIssueRepository";
+import { DrizzleGitHubAccountRepository } from "./persistence/repositories/DrizzleGitHubAccountRepository";
 import { TmuxGatewayImpl } from "./external/tmux/TmuxGatewayImpl";
 import { WorktreeGatewayImpl } from "./external/worktree/WorktreeGatewayImpl";
 import { GitHubIssueGatewayImpl } from "./external/github/GitHubIssueGatewayImpl";
+import { GhCliConfigGatewayImpl } from "./external/github/GhCliConfigGatewayImpl";
 import { SystemEnvironmentGateway } from "./external/environment/SystemEnvironmentGateway";
 import type { SessionRepository } from "@/application/ports/SessionRepository";
 import type { FolderRepository } from "@/application/ports/FolderRepository";
@@ -22,6 +24,8 @@ import type { WorktreeGateway } from "@/application/ports/WorktreeGateway";
 import type { EnvironmentGateway } from "@/application/ports/EnvironmentGateway";
 import type { GitHubIssueRepository } from "@/application/ports/GitHubIssueRepository";
 import type { GitHubIssueGateway } from "@/application/ports/GitHubIssueGateway";
+import type { GitHubAccountRepository } from "@/application/ports/GitHubAccountRepository";
+import type { GhCliConfigGateway } from "@/application/ports/GhCliConfigGateway";
 
 // Session Use Cases
 import { CreateSessionUseCase } from "@/application/use-cases/session/CreateSessionUseCase";
@@ -54,6 +58,16 @@ import {
   MarkIssuesSeenUseCase,
 } from "@/application/use-cases/github";
 
+// GitHub Account Use Cases
+import {
+  LinkGitHubAccountUseCase,
+  UnlinkGitHubAccountUseCase,
+  SetDefaultGitHubAccountUseCase,
+  BindFolderToGitHubAccountUseCase,
+  UnbindFolderFromGitHubAccountUseCase,
+  ListGitHubAccountsUseCase,
+} from "@/application/use-cases/github-accounts";
+
 // Agent Use Cases
 import { RestartAgentUseCase } from "@/application/use-cases/session/RestartAgentUseCase";
 
@@ -78,6 +92,8 @@ export const folderRepository: FolderRepository = new DrizzleFolderRepository();
  * Uses Drizzle ORM for SQLite persistence.
  */
 export const githubIssueRepository: GitHubIssueRepository = new DrizzleGitHubIssueRepository();
+
+export const githubAccountRepository: GitHubAccountRepository = new DrizzleGitHubAccountRepository();
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Gateway Instances
@@ -106,6 +122,8 @@ export const githubIssueGateway: GitHubIssueGateway = new GitHubIssueGatewayImpl
  * Provides access to system environment variables.
  */
 export const environmentGateway: EnvironmentGateway = new SystemEnvironmentGateway();
+
+export const ghCliConfigGateway: GhCliConfigGateway = new GhCliConfigGatewayImpl();
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Use Case Instances
@@ -261,6 +279,38 @@ export const markIssuesSeenUseCase = new MarkIssuesSeenUseCase(
 );
 
 // ─────────────────────────────────────────────────────────────────────────────
+// GitHub Account Use Case Instances
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const linkGitHubAccountUseCase = new LinkGitHubAccountUseCase(
+  githubAccountRepository,
+  ghCliConfigGateway
+);
+
+export const unlinkGitHubAccountUseCase = new UnlinkGitHubAccountUseCase(
+  githubAccountRepository,
+  ghCliConfigGateway
+);
+
+export const setDefaultGitHubAccountUseCase = new SetDefaultGitHubAccountUseCase(
+  githubAccountRepository
+);
+
+export const bindFolderToGitHubAccountUseCase = new BindFolderToGitHubAccountUseCase(
+  githubAccountRepository,
+  folderRepository
+);
+
+export const unbindFolderFromGitHubAccountUseCase = new UnbindFolderFromGitHubAccountUseCase(
+  githubAccountRepository,
+  folderRepository
+);
+
+export const listGitHubAccountsUseCase = new ListGitHubAccountsUseCase(
+  githubAccountRepository
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Test Helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -272,9 +322,11 @@ export interface Container {
   sessionRepository: SessionRepository;
   folderRepository: FolderRepository;
   githubIssueRepository: GitHubIssueRepository;
+  githubAccountRepository: GitHubAccountRepository;
   tmuxGateway: TmuxGateway;
   worktreeGateway: WorktreeGateway;
   githubIssueGateway: GitHubIssueGateway;
+  ghCliConfigGateway: GhCliConfigGateway;
   environmentGateway: EnvironmentGateway;
 }
 
@@ -285,9 +337,11 @@ export const defaultContainer: Container = {
   sessionRepository,
   folderRepository,
   githubIssueRepository,
+  githubAccountRepository,
   tmuxGateway,
   worktreeGateway,
   githubIssueGateway,
+  ghCliConfigGateway,
   environmentGateway,
 };
 

--- a/src/infrastructure/external/github/GhCliConfigGatewayImpl.ts
+++ b/src/infrastructure/external/github/GhCliConfigGatewayImpl.ts
@@ -1,0 +1,49 @@
+/**
+ * GhCliConfigGatewayImpl - Manages gh CLI configuration files on disk.
+ *
+ * Creates per-account config directories with hosts.yml files that the
+ * gh CLI reads for authentication when GH_CONFIG_DIR is set.
+ */
+
+import { mkdir, writeFile, rm, access } from "fs/promises";
+import { join } from "path";
+import { getGhConfigsDir } from "@/lib/paths";
+import type { GhCliConfigGateway } from "@/application/ports/GhCliConfigGateway";
+
+export class GhCliConfigGatewayImpl implements GhCliConfigGateway {
+  getConfigDir(providerAccountId: string): string {
+    return join(getGhConfigsDir(), providerAccountId);
+  }
+
+  async writeHostsConfig(
+    configDir: string,
+    token: string,
+    login: string
+  ): Promise<void> {
+    await mkdir(configDir, { recursive: true, mode: 0o700 });
+
+    // gh CLI hosts.yml format
+    const content = [
+      "github.com:",
+      `    oauth_token: ${token}`,
+      `    user: ${login}`,
+      "    git_protocol: https",
+      "",
+    ].join("\n");
+
+    await writeFile(join(configDir, "hosts.yml"), content, { mode: 0o600 });
+  }
+
+  async removeConfig(configDir: string): Promise<void> {
+    await rm(configDir, { recursive: true, force: true });
+  }
+
+  async isConfigValid(configDir: string): Promise<boolean> {
+    try {
+      await access(join(configDir, "hosts.yml"));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/infrastructure/persistence/mappers/GitHubAccountMapper.ts
+++ b/src/infrastructure/persistence/mappers/GitHubAccountMapper.ts
@@ -1,0 +1,47 @@
+/**
+ * GitHubAccountMapper - Maps between database records and GitHubAccount domain entities.
+ */
+
+import { GitHubAccount } from "@/domain/entities/GitHubAccount";
+import { GitHubAccountId } from "@/domain/value-objects/GitHubAccountId";
+import type { githubAccountMetadata } from "@/db/schema";
+
+export type GitHubAccountDbRecord = typeof githubAccountMetadata.$inferSelect;
+
+export class GitHubAccountMapper {
+  /**
+   * Convert a database record to a domain entity.
+   */
+  static toDomain(record: GitHubAccountDbRecord): GitHubAccount {
+    return GitHubAccount.reconstitute({
+      id: GitHubAccountId.create(record.providerAccountId),
+      userId: record.userId,
+      login: record.login,
+      displayName: record.displayName,
+      avatarUrl: record.avatarUrl,
+      email: record.email,
+      isDefault: record.isDefault,
+      configDir: record.configDir,
+      createdAt: new Date(record.createdAt),
+      updatedAt: new Date(record.updatedAt),
+    });
+  }
+
+  /**
+   * Convert a domain entity to database insert values.
+   */
+  static toPersistence(entity: GitHubAccount): GitHubAccountDbRecord {
+    return {
+      providerAccountId: entity.providerAccountId,
+      userId: entity.userId,
+      login: entity.login,
+      displayName: entity.displayName,
+      avatarUrl: entity.avatarUrl,
+      email: entity.email,
+      isDefault: entity.isDefault,
+      configDir: entity.configDir,
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+    };
+  }
+}

--- a/src/infrastructure/persistence/repositories/DrizzleGitHubAccountRepository.ts
+++ b/src/infrastructure/persistence/repositories/DrizzleGitHubAccountRepository.ts
@@ -115,7 +115,10 @@ export class DrizzleGitHubAccountRepository implements GitHubAccountRepository {
       ),
     });
 
-    return saved ? GitHubAccountMapper.toDomain(saved) : account;
+    if (!saved) {
+      throw new Error(`Failed to save GitHubAccount: cross-user conflict for ${account.providerAccountId}`);
+    }
+    return GitHubAccountMapper.toDomain(saved);
   }
 
   async delete(providerAccountId: string, userId: string): Promise<boolean> {
@@ -174,6 +177,12 @@ export class DrizzleGitHubAccountRepository implements GitHubAccountRepository {
     await db
       .delete(folderGitHubAccountLinks)
       .where(eq(folderGitHubAccountLinks.folderId, folderId));
+  }
+
+  async unbindFoldersByAccount(providerAccountId: string): Promise<void> {
+    await db
+      .delete(folderGitHubAccountLinks)
+      .where(eq(folderGitHubAccountLinks.providerAccountId, providerAccountId));
   }
 
   async findFolderBindings(userId: string): Promise<Map<string, string>> {

--- a/src/infrastructure/persistence/repositories/DrizzleGitHubAccountRepository.ts
+++ b/src/infrastructure/persistence/repositories/DrizzleGitHubAccountRepository.ts
@@ -1,0 +1,205 @@
+/**
+ * DrizzleGitHubAccountRepository - Drizzle ORM implementation of GitHubAccountRepository.
+ *
+ * Handles persistence of GitHub account metadata and folder bindings.
+ * Token access goes through the NextAuth `accounts` table with decryption.
+ */
+
+import { db } from "@/db";
+import {
+  githubAccountMetadata,
+  folderGitHubAccountLinks,
+  accounts,
+  sessionFolders,
+} from "@/db/schema";
+import { eq, and, desc, inArray } from "drizzle-orm";
+import { decryptSafe } from "@/lib/encryption";
+import type { GitHubAccount } from "@/domain/entities/GitHubAccount";
+import type { GitHubAccountRepository } from "@/application/ports/GitHubAccountRepository";
+import { GitHubAccountMapper } from "../mappers/GitHubAccountMapper";
+
+export class DrizzleGitHubAccountRepository implements GitHubAccountRepository {
+  async findByProviderAccountId(
+    providerAccountId: string,
+    userId: string
+  ): Promise<GitHubAccount | null> {
+    const record = await db.query.githubAccountMetadata.findFirst({
+      where: and(
+        eq(githubAccountMetadata.providerAccountId, providerAccountId),
+        eq(githubAccountMetadata.userId, userId)
+      ),
+    });
+    return record ? GitHubAccountMapper.toDomain(record) : null;
+  }
+
+  async findByUser(userId: string): Promise<GitHubAccount[]> {
+    const records = await db.query.githubAccountMetadata.findMany({
+      where: eq(githubAccountMetadata.userId, userId),
+      orderBy: [
+        desc(githubAccountMetadata.isDefault),
+        desc(githubAccountMetadata.createdAt),
+      ],
+    });
+    return records.map(GitHubAccountMapper.toDomain);
+  }
+
+  async findDefault(userId: string): Promise<GitHubAccount | null> {
+    const record = await db.query.githubAccountMetadata.findFirst({
+      where: and(
+        eq(githubAccountMetadata.userId, userId),
+        eq(githubAccountMetadata.isDefault, true)
+      ),
+    });
+    if (record) return GitHubAccountMapper.toDomain(record);
+
+    // Fallback: return the first account if no default is set
+    const fallback = await db.query.githubAccountMetadata.findFirst({
+      where: eq(githubAccountMetadata.userId, userId),
+    });
+    return fallback ? GitHubAccountMapper.toDomain(fallback) : null;
+  }
+
+  async findByFolder(
+    folderId: string,
+    userId: string
+  ): Promise<GitHubAccount | null> {
+    const link = await db.query.folderGitHubAccountLinks.findFirst({
+      where: eq(folderGitHubAccountLinks.folderId, folderId),
+    });
+
+    if (!link) return null;
+
+    return this.findByProviderAccountId(link.providerAccountId, userId);
+  }
+
+  async getAccessToken(
+    providerAccountId: string,
+    userId: string
+  ): Promise<string | null> {
+    const account = await db.query.accounts.findFirst({
+      where: and(
+        eq(accounts.userId, userId),
+        eq(accounts.provider, "github"),
+        eq(accounts.providerAccountId, providerAccountId)
+      ),
+    });
+    return decryptSafe(account?.access_token ?? null);
+  }
+
+  async save(account: GitHubAccount): Promise<GitHubAccount> {
+    const data = GitHubAccountMapper.toPersistence(account);
+
+    await db
+      .insert(githubAccountMetadata)
+      .values(data)
+      .onConflictDoUpdate({
+        target: githubAccountMetadata.providerAccountId,
+        set: {
+          login: data.login,
+          displayName: data.displayName,
+          avatarUrl: data.avatarUrl,
+          email: data.email,
+          isDefault: data.isDefault,
+          configDir: data.configDir,
+          updatedAt: new Date(),
+        },
+        // Guard against cross-user overwrite
+        where: eq(githubAccountMetadata.userId, account.userId),
+      });
+
+    // Re-read to get the persisted version
+    const saved = await db.query.githubAccountMetadata.findFirst({
+      where: and(
+        eq(githubAccountMetadata.providerAccountId, account.providerAccountId),
+        eq(githubAccountMetadata.userId, account.userId)
+      ),
+    });
+
+    return saved ? GitHubAccountMapper.toDomain(saved) : account;
+  }
+
+  async delete(providerAccountId: string, userId: string): Promise<boolean> {
+    const result = await db
+      .delete(githubAccountMetadata)
+      .where(
+        and(
+          eq(githubAccountMetadata.providerAccountId, providerAccountId),
+          eq(githubAccountMetadata.userId, userId)
+        )
+      );
+    return (result.rowsAffected ?? 0) > 0;
+  }
+
+  async setDefault(providerAccountId: string, userId: string): Promise<void> {
+    await db.transaction(async (tx) => {
+      // Clear all defaults for this user
+      await tx
+        .update(githubAccountMetadata)
+        .set({ isDefault: false, updatedAt: new Date() })
+        .where(eq(githubAccountMetadata.userId, userId));
+
+      // Set the new default
+      await tx
+        .update(githubAccountMetadata)
+        .set({ isDefault: true, updatedAt: new Date() })
+        .where(
+          and(
+            eq(githubAccountMetadata.providerAccountId, providerAccountId),
+            eq(githubAccountMetadata.userId, userId)
+          )
+        );
+    });
+  }
+
+  async bindFolder(
+    folderId: string,
+    providerAccountId: string
+  ): Promise<void> {
+    await db
+      .insert(folderGitHubAccountLinks)
+      .values({
+        folderId,
+        providerAccountId,
+      })
+      .onConflictDoUpdate({
+        target: folderGitHubAccountLinks.folderId,
+        set: {
+          providerAccountId,
+          createdAt: new Date(),
+        },
+      });
+  }
+
+  async unbindFolder(folderId: string): Promise<void> {
+    await db
+      .delete(folderGitHubAccountLinks)
+      .where(eq(folderGitHubAccountLinks.folderId, folderId));
+  }
+
+  async findFolderBindings(userId: string): Promise<Map<string, string>> {
+    const folders = await db.query.sessionFolders.findMany({
+      where: eq(sessionFolders.userId, userId),
+      columns: { id: true },
+    });
+
+    const folderIds = folders.map((f) => f.id);
+    if (folderIds.length === 0) return new Map();
+
+    const links = await db
+      .select()
+      .from(folderGitHubAccountLinks)
+      .where(inArray(folderGitHubAccountLinks.folderId, folderIds));
+
+    return new Map(links.map((link) => [link.folderId, link.providerAccountId]));
+  }
+
+  async findOwner(providerAccountId: string): Promise<string | null> {
+    const record = await db.query.githubAccountMetadata.findFirst({
+      where: eq(
+        githubAccountMetadata.providerAccountId,
+        providerAccountId
+      ),
+    });
+    return record?.userId ?? null;
+  }
+}

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -99,6 +99,14 @@ export function getReposDir(): string {
 }
 
 /**
+ * Get the gh CLI config directories path.
+ * Each GitHub account gets its own subdirectory with hosts.yml.
+ */
+export function getGhConfigsDir(): string {
+  return join(getDataDir(), "gh-configs");
+}
+
+/**
  * Get the session recordings directory path.
  */
 export function getRecordingsDir(): string {
@@ -124,6 +132,7 @@ export function ensureDataDirectories(): void {
     getProfilesDir(),
     getProjectsDir(),
     getReposDir(),
+    getGhConfigsDir(),
     getRecordingsDir(),
     getServerDir(),
   ];
@@ -160,6 +169,9 @@ export const AppPaths = {
   },
   get reposDir() {
     return getReposDir();
+  },
+  get ghConfigsDir() {
+    return getGhConfigsDir();
   },
   get recordingsDir() {
     return getRecordingsDir();

--- a/src/services/github-account-service.ts
+++ b/src/services/github-account-service.ts
@@ -5,11 +5,12 @@
  * and repository synchronization.
  */
 import { db } from "@/db";
-import { accounts, githubRepositories } from "@/db/schema";
-import { eq, and } from "drizzle-orm";
+import { accounts, githubRepositories, githubAccountMetadata, folderGitHubAccountLinks } from "@/db/schema";
+import { eq, and, inArray } from "drizzle-orm";
 import { existsSync, readdirSync, statSync, rmSync } from "fs";
 import { join } from "path";
 import * as GitHubService from "./github-service";
+import { ghCliConfigGateway } from "@/infrastructure/container";
 
 const GITHUB_API_BASE = "https://api.github.com";
 
@@ -147,7 +148,35 @@ export async function disconnectGitHub(
   userId: string,
   clearCache: boolean = false
 ): Promise<void> {
-  // Delete the OAuth account
+  // Clean up multi-account metadata and gh CLI config dirs
+  const metadataRows = await db.query.githubAccountMetadata.findMany({
+    where: eq(githubAccountMetadata.userId, userId),
+    columns: { providerAccountId: true, configDir: true },
+  });
+
+  // Remove gh CLI config directories
+  for (const row of metadataRows) {
+    await ghCliConfigGateway.removeConfig(row.configDir).catch(() => {});
+  }
+
+  // Remove folder bindings for all accounts being deleted
+  if (metadataRows.length > 0) {
+    await db
+      .delete(folderGitHubAccountLinks)
+      .where(
+        inArray(
+          folderGitHubAccountLinks.providerAccountId,
+          metadataRows.map((r) => r.providerAccountId)
+        )
+      );
+  }
+
+  // Delete all account metadata
+  await db
+    .delete(githubAccountMetadata)
+    .where(eq(githubAccountMetadata.userId, userId));
+
+  // Delete the OAuth account(s)
   await db
     .delete(accounts)
     .where(and(eq(accounts.userId, userId), eq(accounts.provider, "github")));

--- a/src/services/github-service.ts
+++ b/src/services/github-service.ts
@@ -2,7 +2,7 @@
  * GitHubService - Manages GitHub OAuth, repository listing, and cloning
  */
 import { db } from "@/db";
-import { accounts, githubRepositories } from "@/db/schema";
+import { accounts, githubRepositories, githubAccountMetadata } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 import { execFile } from "@/lib/exec";
 import type {
@@ -22,18 +22,54 @@ import { getReposDir } from "@/lib/paths";
 export { GitHubServiceError };
 
 const GITHUB_API_BASE = "https://api.github.com";
-// Use centralized path configuration for cloned repositories
-const getReposCacheDir = () => getReposDir();
 
 /**
  * Get the GitHub access token for a user.
  * Decrypts the token if it was stored encrypted.
+ *
+ * @param userId - User ID
+ * @param providerAccountId - Optional specific account. If omitted, returns the
+ *   default account's token (via github_account_metadata.is_default), or falls
+ *   back to the first account found for backward compatibility.
  */
-export async function getAccessToken(userId: string): Promise<string | null> {
+export async function getAccessToken(
+  userId: string,
+  providerAccountId?: string | null
+): Promise<string | null> {
+  if (providerAccountId) {
+    // Specific account requested
+    const account = await db.query.accounts.findFirst({
+      where: and(
+        eq(accounts.userId, userId),
+        eq(accounts.provider, "github"),
+        eq(accounts.providerAccountId, providerAccountId)
+      ),
+    });
+    return decryptSafe(account?.access_token ?? null);
+  }
+
+  // No specific account: try to find the default via metadata table
+  const defaultMeta = await db.query.githubAccountMetadata.findFirst({
+    where: and(
+      eq(githubAccountMetadata.userId, userId),
+      eq(githubAccountMetadata.isDefault, true)
+    ),
+  });
+  if (defaultMeta) {
+    const account = await db.query.accounts.findFirst({
+      where: and(
+        eq(accounts.userId, userId),
+        eq(accounts.provider, "github"),
+        eq(accounts.providerAccountId, defaultMeta.providerAccountId)
+      ),
+    });
+    if (account) return decryptSafe(account.access_token ?? null);
+  }
+
+  // Fallback: first GitHub account (backward compatibility)
   const account = await db.query.accounts.findFirst({
     where: and(eq(accounts.userId, userId), eq(accounts.provider, "github")),
   });
-  // Decrypt token - handles both encrypted and legacy plaintext
   return decryptSafe(account?.access_token ?? null);
 }
 
@@ -234,10 +270,9 @@ export async function cacheRepository(
 
 /**
  * Get the base directory for cloned repositories.
- * Uses centralized path configuration: ~/.remote-dev/repos/
  */
 export function getReposBaseDir(): string {
-  return getReposCacheDir();
+  return getReposDir();
 }
 
 /**

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -22,6 +22,8 @@ import { getResolvedPreferences, getFolderPreferences, getEnvironmentForSession 
 import { SessionServiceError } from "@/lib/errors";
 import { TerminalTypeRegistry } from "@/lib/terminal-plugins/registry";
 import { initializeBuiltInPlugins } from "@/lib/terminal-plugins/init";
+import { githubAccountRepository } from "@/infrastructure/container";
+import { GitHubAccountEnvironment } from "@/domain/value-objects/GitHubAccountEnvironment";
 
 // Initialize plugins on module load
 initializeBuiltInPlugins();
@@ -262,9 +264,6 @@ export async function createSession(
     // Resolve GitHub account environment for the session's folder binding
     let ghAccountEnv: Record<string, string> | null = null;
     try {
-      const { githubAccountRepository } = await import("@/infrastructure/container");
-      const { GitHubAccountEnvironment } = await import("@/domain/value-objects/GitHubAccountEnvironment");
-
       // Find the GitHub account bound to this folder (or fall back to default)
       const account = input.folderId
         ? await githubAccountRepository.findByFolder(input.folderId, userId)

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -259,12 +259,43 @@ export async function createSession(
       throw error;
     }
 
+    // Resolve GitHub account environment for the session's folder binding
+    let ghAccountEnv: Record<string, string> | null = null;
+    try {
+      const { githubAccountRepository } = await import("@/infrastructure/container");
+      const { GitHubAccountEnvironment } = await import("@/domain/value-objects/GitHubAccountEnvironment");
+
+      // Find the GitHub account bound to this folder (or fall back to default)
+      const account = input.folderId
+        ? await githubAccountRepository.findByFolder(input.folderId, userId)
+        : null;
+      const effectiveAccount = account ?? await githubAccountRepository.findDefault(userId);
+
+      if (effectiveAccount) {
+        const token = await githubAccountRepository.getAccessToken(
+          effectiveAccount.providerAccountId,
+          userId
+        );
+        if (token) {
+          const ghEnv = GitHubAccountEnvironment.create(
+            token,
+            effectiveAccount.configDir,
+            effectiveAccount.login
+          );
+          ghAccountEnv = ghEnv.toEnvironment().toRecord();
+        }
+      }
+    } catch (error) {
+      console.error(`[session:${sessionId}] Failed to resolve GitHub account env:`, error);
+    }
+
     // Persistent session-level environment variables
     // These survive shell exits and are inherited by all new shells in the session
-    // Merge: profileEnv < folderEnv < rdvEnv (later values take precedence)
+    // Merge: profileEnv < folderEnv < ghAccountEnv < rdvEnv (later values take precedence)
     const sessionEnv: Record<string, string> = {
       ...(profileEnv ?? {}),
       ...(folderEnv ?? {}),
+      ...(ghAccountEnv ?? {}),
       ...rdvEnv,
     };
 


### PR DESCRIPTION
## Summary

- Enable linking multiple GitHub accounts (personal, work, etc.) per user
- Per-folder GitHub account binding — sessions in a folder automatically receive the bound account's credentials (`GH_TOKEN`, `GH_CONFIG_DIR`, `GITHUB_USER`)
- Full `gh` CLI auth isolation via per-account `GH_CONFIG_DIR` with `hosts.yml` provisioned at link time
- Explicit default account designation with auto-promotion on unlink
- Clean Architecture: `GitHubAccount` domain entity, 6 use cases, repository port, gh CLI config gateway
- New "Accounts" tab in GitHub Maintenance modal + account selector in folder preferences

## Test plan

- [ ] Link a GitHub account via OAuth flow, verify `github_account_metadata` row created and `gh-configs/{id}/hosts.yml` provisioned
- [ ] Link a second GitHub account, verify first remains default
- [ ] Set second account as default via Accounts tab
- [ ] Bind a folder to a specific account via folder preferences
- [ ] Create a session in that folder, verify `GH_TOKEN`, `GH_CONFIG_DIR`, `GITHUB_USER` env vars are set correctly
- [ ] Unlink the default account, verify another is promoted
- [ ] Run `bun run db:migrate-github-accounts` on existing DB with a single GitHub account
- [ ] Verify `bun run typecheck` and `bun run lint` pass with no new errors

🤖 Generated with [Claude Code](https://claude.ai/code)