### PR TITLE
Fix MCP discovery by correcting bun --cwd flag position

### DIFF
--- a/src/services/agent-profile-service.ts
+++ b/src/services/agent-profile-service.ts
@@ -725,7 +725,7 @@ export async function registerMCPServer(
   const bunPath = await getBunPath();
   const mcpEntry: MCPEntry = {
     command: bunPath,
-    args: ["--cwd", RDV_PROJECT_ROOT, "run", "mcp"],
+    args: ["run", "--cwd", RDV_PROJECT_ROOT, "mcp"],
     env: { MCP_USER_ID: userId },
   };
 


### PR DESCRIPTION
## Summary
- `--cwd` is a `bun run` subcommand flag, not a global bun flag
- `bun --cwd /path run mcp` silently exits 0 (shows help), causing MCP discovery to fail with 0 tools
- Fixed to `bun run --cwd /path mcp`

## Test plan
- [x] Verified `bun run --cwd /path mcp` responds to MCP initialize request
- [x] Verified MCP discovery succeeds in Claude Code with 39 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)