### PR TITLE
Fix agent hooks not firing with HOME override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Worktree Icon Priority**: Fix missing worktree icon for agent+worktree sessions in expanded sidebar and tooltip by checking `worktreeBranch` before `terminalType`
+- **Agent Hooks with HOME Override**: Fix agent activity hooks not firing when startup command overrides HOME (e.g., `jclaude` alias with `HOME=/Users/joyfulhouse`). Server now resolves the effective HOME from inline assignments and shell aliases, installing hooks at both the profile config dir and the agent's actual HOME.
 - **Session Type Fixes**: Fix missing `worktreeType` and `agentActivityStatus` fields in server-side session mapping and API presenter
 - **CodeMirror Deduplication**: Add overrides to resolve duplicate `@codemirror/language` versions causing build type errors
 - **Agent Tasks Per Session**: Agent tasks in the Task Sidebar are now scoped to the active session instead of showing all agent tasks for the folder

--- a/src/services/agent-profile-service.ts
+++ b/src/services/agent-profile-service.ts
@@ -24,7 +24,7 @@ import { homedir } from "os";
 import { createSecretsProvider, isProviderSupported } from "./secrets";
 import { encrypt, decryptSafe } from "@/lib/encryption";
 import { AgentProfileServiceError } from "@/lib/errors";
-import { execFile } from "@/lib/exec";
+import { execFile, execFileNoThrow } from "@/lib/exec";
 import { safeJsonParse } from "@/lib/utils";
 import { getProfilesDir } from "@/lib/paths";
 import { ProfileIsolation } from "@/domain/value-objects/ProfileIsolation";
@@ -575,6 +575,66 @@ function mapDbToProfile(record: typeof agentProfiles.$inferSelect): AgentProfile
     createdAt: new Date(record.createdAt),
     updatedAt: new Date(record.updatedAt),
   };
+}
+
+// ============================================================================
+// Startup Command HOME Resolution
+// ============================================================================
+
+/** Only allow safe alias names: alphanumeric, hyphens, underscores */
+const SAFE_ALIAS_NAME = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * Resolve the effective HOME directory from a startup command.
+ *
+ * Handles two patterns:
+ * 1. Inline `HOME=/path cmd ...` — extracts /path directly
+ * 2. Shell aliases (e.g. `jclaude`) — resolves via the user's shell
+ *    and extracts HOME= from the alias definition
+ *
+ * Returns the HOME path if a HOME override is detected, null otherwise.
+ */
+export async function resolveEffectiveHome(
+  startupCommand: string
+): Promise<string | null> {
+  const trimmed = startupCommand.trim();
+
+  // Pattern 1: Inline HOME=/path at the start of the command
+  // Matches: HOME=/Users/foo claude ... or HOME="/Users/foo" claude ...
+  const inlineMatch = trimmed.match(/^HOME=["']?([^\s"']+)["']?\s/);
+  if (inlineMatch) {
+    return inlineMatch[1];
+  }
+
+  // Pattern 2: Single-word command that could be a shell alias
+  const firstWord = trimmed.split(/\s/)[0];
+  if (!firstWord || !SAFE_ALIAS_NAME.test(firstWord)) {
+    return null;
+  }
+
+  try {
+    // Use user's login shell (fall back to zsh) with -ic to load aliases
+    const shell = process.env.SHELL || "zsh";
+    const result = await execFileNoThrow(
+      shell,
+      ["-ic", `type ${firstWord}`],
+      { timeout: 3000 }
+    );
+
+    if (result.exitCode !== 0 || !result.stdout) {
+      return null;
+    }
+
+    // Shell output: "jclaude is an alias for HOME=/Users/joyfulhouse claude ..."
+    const aliasMatch = result.stdout.match(/HOME=["']?([^\s"']+)["']?/);
+    if (aliasMatch) {
+      return aliasMatch[1];
+    }
+  } catch {
+    // Alias resolution failed — not critical
+  }
+
+  return null;
 }
 
 // ============================================================================

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -239,7 +239,8 @@ export async function createSession(
   if (isAgentSession) {
     const configDir = profile?.configDir ?? process.env.HOME;
     if (configDir) {
-      await ensureAgentConfig(configDir, effectiveAgentProvider, userId, sessionId);
+      const configDirs = await resolveAgentConfigDirs(configDir, startupCommand, sessionId);
+      await ensureAgentConfig(configDirs, effectiveAgentProvider, userId, sessionId);
     }
   }
 
@@ -769,7 +770,8 @@ export async function resumeSession(
       : process.env.HOME;
 
     if (configDir && agentProvider !== "none") {
-      await ensureAgentConfig(configDir, agentProvider, userId, sessionId);
+      // On resume, hooks were installed at create time — just refresh the primary configDir
+      await ensureAgentConfig(new Set([configDir]), agentProvider, userId, sessionId);
     }
 
     // Refresh RDV + GitHub account env vars on resume (may be missing on older
@@ -944,29 +946,52 @@ function buildAgentCommand(provider: AgentProviderType, flags?: string[]): strin
 }
 
 /**
+ * Resolve all config directories where agent hooks/MCP config should be installed.
+ * Includes the primary configDir plus any HOME override detected in the startup command.
+ */
+async function resolveAgentConfigDirs(
+  configDir: string,
+  startupCommand: string | undefined,
+  sessionId: string
+): Promise<Set<string>> {
+  const dirs = new Set<string>([configDir]);
+  if (!startupCommand) return dirs;
+
+  try {
+    const effectiveHome = await AgentProfileService.resolveEffectiveHome(startupCommand);
+    if (effectiveHome) {
+      console.log(`[session:${sessionId}] Detected HOME override: ${effectiveHome} (configDir: ${configDir})`);
+      dirs.add(effectiveHome);
+    }
+  } catch (error) {
+    console.warn(`[session:${sessionId}] Failed to resolve effective HOME:`, error);
+  }
+
+  return dirs;
+}
+
+/**
  * Install agent activity hooks and register the MCP server in the agent's config.
  * Used by both createSession and resumeSession to keep agent config current.
  * Failures are logged but do not block session creation/resume.
+ * Installs to all provided config directories in parallel.
  */
 async function ensureAgentConfig(
-  configDir: string,
+  configDirs: Set<string>,
   provider: Exclude<AgentProviderType, "none">,
   userId: string,
   sessionId: string
 ): Promise<void> {
-  if (provider === "claude") {
-    try {
-      await AgentProfileService.installAgentHooks(configDir, provider);
-    } catch (error) {
-      console.error(`[session:${sessionId}] Failed to install agent hooks:`, error);
-    }
-  }
+  const tasks = [...configDirs].flatMap((dir) => [
+    ...(provider === "claude"
+      ? [AgentProfileService.installAgentHooks(dir, provider)
+          .catch((e) => console.error(`[session:${sessionId}] Failed to install agent hooks at ${dir}:`, e))]
+      : []),
+    AgentProfileService.registerMCPServer(dir, provider, userId)
+      .catch((e) => console.error(`[session:${sessionId}] Failed to register MCP server at ${dir}:`, e)),
+  ]);
 
-  try {
-    await AgentProfileService.registerMCPServer(configDir, provider, userId);
-  } catch (error) {
-    console.error(`[session:${sessionId}] Failed to register MCP server:`, error);
-  }
+  await Promise.all(tasks);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix agent activity hooks (running/waiting/idle status) not firing when a session's startup command overrides `HOME` (e.g., the `jclaude` alias which sets `HOME=/Users/joyfulhouse`)
- Server now resolves the effective HOME from inline `HOME=/path` assignments and shell alias resolution, installing hooks at both the profile config dir and the agent's actual HOME
- Includes command injection protection via strict alias name allowlist and parallel hook installation

## Test plan
- [ ] Create a session using the `jclaude` alias — verify `/Users/joyfulhouse/.claude/settings.json` gets hooks installed
- [ ] Create a session with inline `HOME=/path claude` startup command — verify hooks installed at `/path`
- [ ] Create a regular agent session (no HOME override) — verify behavior unchanged
- [ ] Verify activity status indicators update in the sidebar for all session types

🤖 Generated with [Claude Code](https://claude.com/claude-code)