### PR TITLE
feat: stop hook checks agent tasks and auto-appends quality gates

### DIFF
--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -358,6 +358,32 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
     return true;
   }
 
+  // Handle agent stop task check from Claude Code Stop hook
+  // Called by hooks: POST /internal/agent-stop-check?sessionId=xxx
+  // Returns incomplete tasks as text (agent should continue) or empty (agent can stop)
+  if (pathname === "/internal/agent-stop-check" && req.method === "POST") {
+    const sessionId = query.sessionId as string;
+
+    if (!sessionId) {
+      sendJson(res, 400, { error: "Missing sessionId parameter" });
+      return true;
+    }
+
+    try {
+      const { checkTasksOnStop } = await import("@/services/agent-todo-sync");
+      const message = await checkTasksOnStop(sessionId);
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(message ?? "");
+    } catch (error) {
+      console.error("[Agent Stop Check] Error:", error);
+      // On error, allow the agent to stop (don't block on failures)
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("");
+    }
+
+    return true;
+  }
+
   // Handle agent task sync from Claude Code PostToolUse hooks
   // Called by hooks: POST /internal/agent-todos?sessionId=xxx
   // Body: Claude Code PostToolUse stdin JSON (TaskCreate/TaskUpdate/TodoWrite)

--- a/src/services/agent-profile-service.ts
+++ b/src/services/agent-profile-service.ts
@@ -696,16 +696,22 @@ export async function installAgentHooks(
   // to resolve session ID and connection info. This is more robust than relying
   // on inherited process env because the tmux server doesn't propagate the
   // client's env to spawned shells.
-  const curlForStatus = (status: string) =>
+  const envPreamble =
     '_RDV_SN=$(tmux display-message -p "#{session_name}" 2>/dev/null); ' +
     '[ -z "$_RDV_SN" ] && exit 0; ' +
     'eval "$(tmux show-environment -t "$_RDV_SN" 2>/dev/null | grep "^RDV_")" 2>/dev/null; ' +
-    '[ -z "$RDV_SESSION_ID" ] && exit 0; ' +
+    '[ -z "$RDV_SESSION_ID" ] && exit 0; ';
+
+  /** Build a curl command that hits an internal endpoint via socket or port */
+  const curlCmd = (path: string, opts = "") =>
     'if [ -n "$RDV_TERMINAL_SOCKET" ]; then ' +
-    `curl --unix-socket "$RDV_TERMINAL_SOCKET" -s -X POST "http://localhost/internal/agent-status?sessionId=\${RDV_SESSION_ID}&status=${status}"; ` +
+    `curl --unix-socket "$RDV_TERMINAL_SOCKET" -s -X POST ${opts} "http://localhost${path}"; ` +
     'else ' +
-    `curl -s -X POST "http://localhost:\${RDV_TERMINAL_PORT}/internal/agent-status?sessionId=\${RDV_SESSION_ID}&status=${status}"; ` +
-    'fi || true';
+    `curl -s -X POST ${opts} "http://localhost:\${RDV_TERMINAL_PORT}${path}"; ` +
+    'fi';
+
+  const curlForStatus = (status: string) =>
+    envPreamble + curlCmd(`/internal/agent-status?sessionId=\${RDV_SESSION_ID}&status=${status}`) + ' || true';
 
   const preToolUseHook = {
     matcher: "",
@@ -722,18 +728,21 @@ export async function installAgentHooks(
     hooks: [{ type: "command", command: curlForStatus("waiting"), timeout: 5 }],
   };
 
+  // Stop hook: report idle status (fire-and-forget, backgrounded) AND check
+  // if all tasks are completed. Non-empty output tells Claude Code to continue.
+  const stopCheckCommand = envPreamble +
+    curlCmd('/internal/agent-status?sessionId=${RDV_SESSION_ID}&status=idle', '>/dev/null 2>&1') + ' & ' +
+    'TASK_MSG=$(' + curlCmd('/internal/agent-stop-check?sessionId=${RDV_SESSION_ID}') + '); ' +
+    '[ -n "$TASK_MSG" ] && printf "%s" "$TASK_MSG"';
+
   const stopHook = {
-    hooks: [{ type: "command", command: curlForStatus("idle"), timeout: 5 }],
+    hooks: [{ type: "command", command: stopCheckCommand, timeout: 15 }],
   };
 
   // Task sync hook: reads PostToolUse JSON from stdin, POSTs to /internal/agent-todos
   // Matches TaskCreate, TaskUpdate (v2.1.69+), and legacy TodoWrite
   const todoSyncCommand =
-    'INPUT=$(cat); ' +
-    '_RDV_SN=$(tmux display-message -p "#{session_name}" 2>/dev/null); ' +
-    '[ -z "$_RDV_SN" ] && exit 0; ' +
-    'eval "$(tmux show-environment -t "$_RDV_SN" 2>/dev/null | grep "^RDV_")" 2>/dev/null; ' +
-    '[ -z "$RDV_SESSION_ID" ] && exit 0; ' +
+    'INPUT=$(cat); ' + envPreamble +
     'if [ -n "$RDV_TERMINAL_SOCKET" ]; then ' +
     'printf \'%s\' "$INPUT" | curl --unix-socket "$RDV_TERMINAL_SOCKET" -s -X POST -H "Content-Type: application/json" -d @- "http://localhost/internal/agent-todos?sessionId=${RDV_SESSION_ID}"; ' +
     'else ' +

--- a/src/services/agent-profile-service.ts
+++ b/src/services/agent-profile-service.ts
@@ -705,9 +705,9 @@ export async function installAgentHooks(
   /** Build a curl command that hits an internal endpoint via socket or port */
   const curlCmd = (path: string, opts = "") =>
     'if [ -n "$RDV_TERMINAL_SOCKET" ]; then ' +
-    `curl --unix-socket "$RDV_TERMINAL_SOCKET" -s -X POST ${opts} "http://localhost${path}"; ` +
+    `curl --unix-socket "$RDV_TERMINAL_SOCKET" -s -X POST "http://localhost${path}" ${opts}; ` +
     'else ' +
-    `curl -s -X POST ${opts} "http://localhost:\${RDV_TERMINAL_PORT}${path}"; ` +
+    `curl -s -X POST "http://localhost:\${RDV_TERMINAL_PORT}${path}" ${opts}; ` +
     'fi';
 
   const curlForStatus = (status: string) =>

--- a/src/services/agent-todo-sync-pure.ts
+++ b/src/services/agent-todo-sync-pure.ts
@@ -5,7 +5,7 @@
  * from Claude Code v2.1.69+.
  */
 
-import type { TaskStatus } from "@/types/task";
+import type { TaskStatus, TaskPriority } from "@/types/task";
 
 /** PostToolUse hook stdin payload from Claude Code */
 export interface PostToolUsePayload {
@@ -16,8 +16,17 @@ export interface PostToolUsePayload {
 
 /** Parsed agent task operation */
 export type AgentTaskOp =
-  | { type: "create"; agentTaskId: string; subject: string; description?: string; status: TaskStatus }
-  | { type: "update"; agentTaskId: string; status?: TaskStatus; subject?: string };
+  | { type: "create"; agentTaskId: string; subject: string; description?: string; status: TaskStatus; priority?: TaskPriority }
+  | { type: "update"; agentTaskId: string; status?: TaskStatus; subject?: string; priority?: TaskPriority };
+
+const VALID_PRIORITIES = new Set<string>(["critical", "high", "medium", "low"]);
+
+/** Map Claude Code task priority to remote-dev TaskPriority */
+export function mapAgentTaskPriority(priority: string | undefined): TaskPriority | undefined {
+  if (!priority) return undefined;
+  const normalized = priority.toLowerCase();
+  return VALID_PRIORITIES.has(normalized) ? (normalized as TaskPriority) : undefined;
+}
 
 /** Map Claude Code task status to remote-dev TaskStatus */
 export function mapAgentTaskStatus(status: string): TaskStatus {
@@ -55,6 +64,7 @@ export function parsePostToolUsePayload(payload: PostToolUsePayload): AgentTaskO
       subject,
       description: tool_input.description as string | undefined,
       status: "open",
+      priority: mapAgentTaskPriority(tool_input.priority as string | undefined),
     }];
   }
 
@@ -67,6 +77,9 @@ export function parsePostToolUsePayload(payload: PostToolUsePayload): AgentTaskO
     }
     if (tool_input.subject) {
       op.subject = tool_input.subject as string;
+    }
+    if (tool_input.priority) {
+      op.priority = mapAgentTaskPriority(tool_input.priority as string);
     }
     return [op];
   }

--- a/src/services/agent-todo-sync.ts
+++ b/src/services/agent-todo-sync.ts
@@ -13,7 +13,7 @@ import { terminalSessions } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import * as TaskService from "./task-service";
 import { parsePostToolUsePayload, type PostToolUsePayload } from "./agent-todo-sync-pure";
-import type { TaskStatus } from "@/types/task";
+import type { TaskStatus, TaskPriority } from "@/types/task";
 
 const MARKER_PREFIX = "agent-task:";
 
@@ -86,15 +86,18 @@ export async function syncAgentTodos(
       const existingTask = existingByMarker.get(marker);
 
       if (existingTask) {
-        // Upsert: update if status or title changed
+        // Upsert: update if status, title, or priority changed
         const needsUpdate =
           existingTask.status !== op.status ||
-          existingTask.title !== op.subject;
+          existingTask.title !== op.subject ||
+          (op.priority && existingTask.priority !== op.priority);
         if (needsUpdate) {
-          await TaskService.updateTask(existingTask.id, userId, {
+          const updates: { status?: TaskStatus; title?: string; priority?: TaskPriority } = {
             status: op.status,
             title: op.subject,
-          });
+          };
+          if (op.priority) updates.priority = op.priority;
+          await TaskService.updateTask(existingTask.id, userId, updates);
           updated++;
         }
         continue;
@@ -108,6 +111,7 @@ export async function syncAgentTodos(
           ? `${marker}\n${op.description}`
           : marker,
         status: op.status,
+        priority: op.priority,
         source: "agent",
         sortOrder: existing.length + created,
       });
@@ -119,10 +123,11 @@ export async function syncAgentTodos(
 
       if (!isNaN(taskIndex) && taskIndex >= 0 && taskIndex < agentTasks.length) {
         const target = agentTasks[taskIndex];
-        if (op.status || op.subject) {
-          const updates: { status?: TaskStatus; title?: string } = {};
+        if (op.status || op.subject || op.priority) {
+          const updates: { status?: TaskStatus; title?: string; priority?: TaskPriority } = {};
           if (op.status) updates.status = op.status;
           if (op.subject) updates.title = op.subject;
+          if (op.priority) updates.priority = op.priority;
           await TaskService.updateTask(target.id, userId, updates);
           updated++;
         }
@@ -131,6 +136,69 @@ export async function syncAgentTodos(
   }
 
   return { created, updated };
+}
+
+/**
+ * Post-task titles that get appended after all user ToDo tasks.
+ * These are quality-gate tasks the agent must run before stopping.
+ */
+const POST_TASKS = ["Code Simplifier", "Code Review"] as const;
+
+/**
+ * Check agent tasks on stop and enforce completion.
+ *
+ * Called by the Stop hook endpoint. This function:
+ * 1. Appends "Code Simplifier" and "Code Review" tasks if they don't exist yet
+ * 2. Checks if all agent tasks (including the appended ones) are completed
+ * 3. Returns null if all done (agent can stop), or a message listing
+ *    incomplete tasks (agent should continue)
+ */
+export async function checkTasksOnStop(
+  sessionId: string
+): Promise<string | null> {
+  const session = await getSessionById(sessionId);
+  if (!session) return null; // session not found, allow stop
+
+  const { userId, folderId } = session;
+  const tasks = await TaskService.getTasksBySession(sessionId, userId);
+
+  // Append post-tasks if they don't already exist
+  const newTasks = [];
+  for (let i = 0; i < POST_TASKS.length; i++) {
+    const postTaskTitle = POST_TASKS[i];
+    const exists = tasks.some((t) => t.title === postTaskTitle);
+    if (!exists) {
+      const newTask = await TaskService.createTask(userId, {
+        folderId,
+        sessionId,
+        title: postTaskTitle,
+        status: "open",
+        priority: "low",
+        source: "agent",
+        sortOrder: tasks.length + i,
+      });
+      newTasks.push(newTask);
+    }
+  }
+
+  // Check for incomplete tasks (anything not done or cancelled)
+  const allTasks = [...tasks, ...newTasks];
+  const incomplete = allTasks.filter(
+    (t) => t.status !== "done" && t.status !== "cancelled"
+  );
+
+  if (incomplete.length === 0) return null; // all done, agent can stop
+
+  // Build a message for the agent listing what's left
+  const lines = incomplete.map(
+    (t) => `- [${t.status}] ${t.title}${t.priority !== "medium" ? ` (${t.priority})` : ""}`
+  );
+  return [
+    `You have ${incomplete.length} incomplete task(s). Please complete them before stopping:`,
+    ...lines,
+    "",
+    'Mark each task as completed using TaskUpdate when done. For "Code Simplifier", run /simplify. For "Code Review", run /code-review.',
+  ].join("\n");
 }
 
 /**

--- a/src/services/agent-todo-sync.ts
+++ b/src/services/agent-todo-sync.ts
@@ -143,6 +143,7 @@ export async function syncAgentTodos(
  * These are quality-gate tasks the agent must run before stopping.
  */
 const POST_TASKS = ["Code Simplifier", "Code Review"] as const;
+const POST_TASK_MARKER_PREFIX = "post-task:";
 
 /**
  * Check agent tasks on stop and enforce completion.
@@ -152,6 +153,8 @@ const POST_TASKS = ["Code Simplifier", "Code Review"] as const;
  * 2. Checks if all agent tasks (including the appended ones) are completed
  * 3. Returns null if all done (agent can stop), or a message listing
  *    incomplete tasks (agent should continue)
+ *
+ * Only checks agent-sourced tasks (manual tasks are excluded).
  */
 export async function checkTasksOnStop(
   sessionId: string
@@ -160,30 +163,46 @@ export async function checkTasksOnStop(
   if (!session) return null; // session not found, allow stop
 
   const { userId, folderId } = session;
-  const tasks = await TaskService.getTasksBySession(sessionId, userId);
+  let tasks = await TaskService.getTasksBySession(sessionId, userId);
 
-  // Append post-tasks if they don't already exist
-  const newTasks = [];
+  // Append post-tasks if they don't already exist (uses marker-based dedup
+  // to prevent duplicates from concurrent stop hook invocations)
+  let created = false;
   for (let i = 0; i < POST_TASKS.length; i++) {
     const postTaskTitle = POST_TASKS[i];
-    const exists = tasks.some((t) => t.title === postTaskTitle);
+    const marker = `${POST_TASK_MARKER_PREFIX}${postTaskTitle}`;
+    const exists = tasks.some((t) => t.description?.startsWith(marker));
     if (!exists) {
-      const newTask = await TaskService.createTask(userId, {
+      await TaskService.createTask(userId, {
         folderId,
         sessionId,
         title: postTaskTitle,
+        description: marker,
         status: "open",
         priority: "low",
         source: "agent",
         sortOrder: tasks.length + i,
       });
-      newTasks.push(newTask);
+      created = true;
     }
   }
 
+  // Re-fetch after creation to get authoritative list (handles race conditions
+  // where concurrent calls may have also created post-tasks)
+  if (created) {
+    tasks = await TaskService.getTasksBySession(sessionId, userId);
+  }
+
+  // Deduplicate by title (keeps earliest by sort order, handles race-created dupes)
+  const seen = new Set<string>();
+  const dedupedTasks = tasks.filter((t) => {
+    if (seen.has(t.title)) return false;
+    seen.add(t.title);
+    return true;
+  });
+
   // Check for incomplete tasks (anything not done or cancelled)
-  const allTasks = [...tasks, ...newTasks];
-  const incomplete = allTasks.filter(
+  const incomplete = dedupedTasks.filter(
     (t) => t.status !== "done" && t.status !== "cancelled"
   );
 


### PR DESCRIPTION
## Summary
- Stop hook now verifies all agent tasks are completed before allowing the agent to stop. If incomplete tasks remain, their list is output to the agent so it continues working.
- Auto-appends **"Code Simplifier"** and **"Code Review"** tasks (priority: low) on first stop, acting as quality gates the agent must run before finishing.
- Adds **priority support** to task sync — `TaskCreate` and `TaskUpdate` payloads now carry priority through to the DB instead of defaulting everything to "medium".
- Extracts shell preamble (`envPreamble`) and curl helper (`curlCmd`) to eliminate 3x duplication across hook commands.
- New `/internal/agent-stop-check` endpoint returns plain text for the Stop hook.
- Idle status update runs backgrounded (`&`) so the task check starts immediately.

## Test plan
- [ ] Create an agent session and verify tasks sync with correct priority
- [ ] Stop the agent with incomplete tasks — verify it receives the incomplete task list and continues
- [ ] Verify "Code Simplifier" and "Code Review" tasks are auto-created on first stop
- [ ] Complete all tasks including post-tasks, stop again — verify agent stops cleanly
- [ ] Verify stop hook doesn't block if terminal server is unreachable (graceful fallback)
- [ ] Verify existing PreToolUse/PostToolUse/Notification hooks still work after preamble refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)