### PR TITLE
feat: toast notifications, clear notifications, glassmorphism panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Clear Notifications**: Per-item dismiss (X button on hover) and "Clear all" button in notification panel header. Hard deletes notifications from the database.
 - **Notification Panel Glassmorphism**: Upgraded notification panel to frosted glass style (`bg-popover/95 backdrop-blur-xl`) matching the rest of the app's modal/panel aesthetic.
 - **Clear all tasks**: Bulk delete tasks from the right sidebar with "Clear completed" and "Clear all" options, available for both Tasks and Agent Tasks sections
-
 - **rdv CLI (Rust)**: New CLI at `crates/rdv/` for agent interaction with the terminal server
   - Commands: session, worktree, agent, task, folder, status, context
   - Auto-discovery via `RDV_SESSION_ID`, `RDV_TERMINAL_SOCKET`, `RDV_TERMINAL_PORT` env vars

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Toast Notifications**: Real-time toast notifications for agent events (waiting, error, complete, exited) via sonner, positioned bottom-center with glassmorphism styling. Toasts are clickable to jump directly to the related session.
+- **Clear Notifications**: Per-item dismiss (X button on hover) and "Clear all" button in notification panel header. Hard deletes notifications from the database.
+- **Notification Panel Glassmorphism**: Upgraded notification panel to frosted glass style (`bg-popover/95 backdrop-blur-xl`) matching the rest of the app's modal/panel aesthetic.
 - **Clear all tasks**: Bulk delete tasks from the right sidebar with "Clear completed" and "Clear all" options, available for both Tasks and Agent Tasks sections
 
 - **rdv CLI (Rust)**: New CLI at `crates/rdv/` for agent interaction with the terminal server

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,7 @@ Located in `src/services/`:
 | `AgentConfigTemplateService` | Templates for agent config files (CLAUDE.md, AGENTS.md, etc.) |
 | `ClaudeSessionService` | Discover resumable Claude Code sessions from `.jsonl` files |
 | `TaskService` | Project task CRUD, folder-scoped queries |
+| `NotificationService` | Notification CRUD, debounced creation, read/delete management |
 
 **Security**: All shell commands use `execFile` with array arguments (no shell interpolation).
 
@@ -415,6 +416,7 @@ React Contexts in `src/contexts/`:
 | `PortContext` | Port allocations, framework detection, monitoring |
 | `GitHubAccountContext` | Multi-GitHub account state with folder bindings |
 | `TaskContext` | Project tasks state with folder-scoped CRUD |
+| `NotificationContext` | Notification state with toast integration and delete operations |
 
 **Preference Inheritance**: Default → User Settings → Folder Preferences
 
@@ -559,6 +561,11 @@ React Contexts in `src/contexts/`:
 - `GET /api/profiles/:id/appearance` - Get profile appearance settings
 - `PUT /api/profiles/:id/appearance` - Update profile appearance (mode, schemes, terminal settings)
 - `DELETE /api/profiles/:id/appearance` - Reset profile appearance to defaults
+
+### Notifications
+- `GET /api/notifications` - List notifications with unread count
+- `PATCH /api/notifications` - Mark notifications read (by ids or all)
+- `DELETE /api/notifications` - Delete notifications (by ids or all)
 
 ### Tasks
 - `GET /api/tasks` - List tasks (optional `?folderId=` filter)

--- a/bun.lock
+++ b/bun.lock
@@ -70,6 +70,7 @@
         "react-markdown": "^10.1.0",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "ws": "^8.18.3",
         "zod": "^4.2.1",
@@ -2965,6 +2966,8 @@
     "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
 
     "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
 

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "ws": "^8.18.3",
     "zod": "^4.2.1"

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -30,10 +30,33 @@ export const PATCH = withApiAuth(async (request, { userId }) => {
       await NotificationService.markAllRead(userId);
     } else if (ids?.length) {
       await NotificationService.markRead(userId, ids);
+    } else {
+      return errorResponse("Must provide ids or all=true", 400);
     }
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Error marking notifications read:", error);
     return errorResponse("Failed to update notifications", 500);
+  }
+});
+
+// DELETE /api/notifications - hard delete one or all
+export const DELETE = withApiAuth(async (request, { userId }) => {
+  try {
+    const result = await parseJsonBody<{ ids?: string[]; all?: boolean }>(request);
+    if ("error" in result) return result.error;
+    const { ids, all } = result.data;
+
+    if (all) {
+      await NotificationService.deleteAllNotifications(userId);
+    } else if (ids?.length) {
+      await NotificationService.deleteNotifications(userId, ids);
+    } else {
+      return errorResponse("Must provide ids or all=true", 400);
+    }
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting notifications:", error);
+    return errorResponse("Failed to delete notifications", 500);
   }
 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { SessionProvider } from "next-auth/react";
 import { AppearanceProvider } from "@/contexts/AppearanceContext";
 import { ServiceWorkerRegistration } from "@/components/pwa/ServiceWorkerRegistration";
+import { Toaster } from "sonner";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -58,6 +59,21 @@ export default function RootLayout({
         <SessionProvider>
           <AppearanceProvider>{children}</AppearanceProvider>
         </SessionProvider>
+        <Toaster
+          position="bottom-center"
+          theme="dark"
+          toastOptions={{
+            classNames: {
+              toast:
+                "bg-popover/95 backdrop-blur-xl border border-border shadow-2xl text-popover-foreground",
+              title: "font-medium text-sm",
+              description: "text-xs text-muted-foreground",
+              actionButton:
+                "bg-primary text-primary-foreground text-xs px-2 py-1 rounded-md",
+              closeButton: "text-muted-foreground hover:text-foreground",
+            },
+          }}
+        />
         <ServiceWorkerRegistration />
       </body>
     </html>

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -2,7 +2,7 @@
 
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, CheckCheck } from "lucide-react";
+import { ExternalLink, CheckCheck, Trash2, X } from "lucide-react";
 import { useNotificationContext } from "@/contexts/NotificationContext";
 import { cn, formatRelativeTime } from "@/lib/utils";
 import type { NotificationEvent } from "@/types/notification";
@@ -14,7 +14,14 @@ interface NotificationPanelProps {
 }
 
 export function NotificationPanel({ open, onOpenChange, onJumpToSession }: NotificationPanelProps) {
-  const { notifications, markRead, markAllRead, unreadCount } = useNotificationContext();
+  const {
+    notifications,
+    markRead,
+    markAllRead,
+    deleteNotification,
+    deleteAllNotifications,
+    unreadCount,
+  } = useNotificationContext();
 
   const handleJump = (notification: NotificationEvent) => {
     if (notification.sessionId) {
@@ -28,43 +35,88 @@ export function NotificationPanel({ open, onOpenChange, onJumpToSession }: Notif
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-[380px] sm:w-[420px] p-0">
-        <SheetHeader className="flex flex-row items-center justify-between p-6 pb-2">
-          <SheetTitle>Notifications</SheetTitle>
-          {unreadCount > 0 && (
-            <Button variant="ghost" size="sm" onClick={() => markAllRead()} className="text-xs">
-              <CheckCheck className="w-3 h-3 mr-1" />
-              Mark all read
-            </Button>
-          )}
+      <SheetContent
+        side="right"
+        className="w-[380px] sm:w-[420px] p-0 bg-popover/95 backdrop-blur-xl border-l border-border"
+      >
+        <SheetHeader className="flex flex-row items-center justify-between p-4 pb-2 border-b border-border/50">
+          <SheetTitle className="text-sm font-semibold">Notifications</SheetTitle>
+          <div className="flex items-center gap-1">
+            {unreadCount > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => markAllRead()}
+                className="h-7 text-xs text-muted-foreground hover:text-foreground"
+              >
+                <CheckCheck className="w-3 h-3 mr-1" />
+                Mark all read
+              </Button>
+            )}
+            {notifications.length > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => deleteAllNotifications()}
+                className="h-7 text-xs text-destructive/70 hover:text-destructive hover:bg-destructive/10"
+              >
+                <Trash2 className="w-3 h-3 mr-1" />
+                Clear all
+              </Button>
+            )}
+          </div>
         </SheetHeader>
-        <div className="px-4 pb-4 space-y-1 overflow-y-auto max-h-[calc(100vh-120px)]">
+
+        <div className="px-3 py-2 space-y-0.5 overflow-y-auto max-h-[calc(100vh-80px)]">
           {notifications.length === 0 ? (
-            <p className="text-sm text-muted-foreground text-center py-8">No notifications yet</p>
+            <p className="text-sm text-muted-foreground text-center py-8">
+              No notifications
+            </p>
           ) : (
             notifications.map((n) => (
               <div
                 key={n.id}
                 className={cn(
-                  "flex items-start gap-2 p-2 rounded-md hover:bg-muted/50 transition-colors",
+                  "group flex items-start gap-2 p-2 rounded-md hover:bg-muted/50 transition-colors",
                   !n.readAt && "border-l-2 border-blue-400 bg-blue-400/5"
                 )}
               >
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium truncate">{n.title}</p>
-                  {n.body && <p className="text-xs text-muted-foreground truncate">{n.body}</p>}
+                  {n.body && (
+                    <p className="text-xs text-muted-foreground truncate">{n.body}</p>
+                  )}
                   <div className="flex items-center gap-2 mt-0.5">
                     {n.sessionName && (
-                      <span className="text-[10px] text-muted-foreground/60">{n.sessionName}</span>
+                      <span className="text-[10px] text-muted-foreground/60">
+                        {n.sessionName}
+                      </span>
                     )}
-                    <span className="text-[10px] text-muted-foreground/40">{formatRelativeTime(n.createdAt.toISOString())}</span>
+                    <span className="text-[10px] text-muted-foreground/40">
+                      {formatRelativeTime(n.createdAt.toISOString())}
+                    </span>
                   </div>
                 </div>
-                {n.sessionId && (
-                  <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={() => handleJump(n)}>
-                    <ExternalLink className="w-3 h-3" />
+                <div className="flex items-center gap-0.5 shrink-0">
+                  {n.sessionId && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+                      onClick={() => handleJump(n)}
+                    >
+                      <ExternalLink className="w-3 h-3" />
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-destructive"
+                    onClick={() => deleteNotification(n.id)}
+                  >
+                    <X className="w-3 h-3" />
                   </Button>
-                )}
+                </div>
               </div>
             ))
           )}

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -349,7 +349,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
   const { getRepositoryById } = useGitHubStats();
 
   const { refreshTasks } = useTaskContext();
-  const { addNotification } = useNotificationContext();
+  const { addNotification, registerJumpHandler } = useNotificationContext();
 
   // Notification panel state
   const [notificationPanelOpen, setNotificationPanelOpen] = useState(false);
@@ -1400,6 +1400,12 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
     window.addEventListener("notification-panel-toggle", handleToggle);
     return () => window.removeEventListener("notification-panel-toggle", handleToggle);
   }, []);
+
+  // Register session jump handler for toast "View session" actions
+  useEffect(() => {
+    registerJumpHandler(setActiveSession);
+    return () => registerJumpHandler(null);
+  }, [registerJumpHandler, setActiveSession]);
 
   /** Close a session in a split pane */
   const handlePaneSessionExit = useCallback(async (sessionId: string) => {

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -7,17 +7,19 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   type ReactNode,
 } from "react";
 import type { NotificationEvent } from "@/types/notification";
+import { fireNotificationToast } from "@/lib/notification-toast";
 
 /** Hydrate date strings from API response into Date objects */
 export function hydrateNotification(raw: Record<string, unknown>): NotificationEvent {
   return {
-    ...(raw as unknown as NotificationEvent),
+    ...raw,
     createdAt: new Date(raw.createdAt as string),
     readAt: raw.readAt ? new Date(raw.readAt as string) : null,
-  };
+  } as NotificationEvent;
 }
 
 interface NotificationContextValue {
@@ -28,6 +30,9 @@ interface NotificationContextValue {
   markAllRead: () => Promise<void>;
   refresh: () => Promise<void>;
   addNotification: (notification: NotificationEvent) => void;
+  deleteNotification: (id: string) => Promise<void>;
+  deleteAllNotifications: () => Promise<void>;
+  registerJumpHandler: (fn: ((sessionId: string) => void) | null) => void;
 }
 
 const NotificationContext = createContext<NotificationContextValue | null>(null);
@@ -82,8 +87,18 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
     refresh();
   }, [refresh]);
 
+  // Ref for session jump handler — registered by SessionManager, no re-render on change
+  const jumpHandlerRef = useRef<((sessionId: string) => void) | null>(null);
+
+  const registerJumpHandler = useCallback((fn: ((sessionId: string) => void) | null) => {
+    jumpHandlerRef.current = fn;
+  }, []);
+
+  const markReadRef = useRef<((ids: string[]) => void) | null>(null);
+
   const addNotification = useCallback((notification: NotificationEvent) => {
     setNotifications((prev) => [notification, ...prev].slice(0, MAX_NOTIFICATIONS));
+    fireNotificationToast(notification, jumpHandlerRef.current, markReadRef.current);
   }, []);
 
   const markRead = useCallback(
@@ -113,6 +128,9 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
     [refresh]
   );
 
+  // Keep markRead ref in sync for toast action callbacks
+  markReadRef.current = markRead;
+
   const markAllRead = useCallback(async () => {
     // Optimistic update
     setNotifications((prev) =>
@@ -134,6 +152,39 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
     }
   }, [refresh]);
 
+  const deleteNotification = useCallback(
+    async (id: string) => {
+      setNotifications((prev) => prev.filter((n) => n.id !== id));
+      try {
+        const response = await fetch("/api/notifications", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: [id] }),
+        });
+        if (!response.ok) throw new Error("Failed to delete notification");
+      } catch (err) {
+        console.error("Error deleting notification:", err);
+        await refresh();
+      }
+    },
+    [refresh]
+  );
+
+  const deleteAllNotifications = useCallback(async () => {
+    setNotifications([]);
+    try {
+      const response = await fetch("/api/notifications", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ all: true }),
+      });
+      if (!response.ok) throw new Error("Failed to delete all notifications");
+    } catch (err) {
+      console.error("Error deleting all notifications:", err);
+      await refresh();
+    }
+  }, [refresh]);
+
   const value = useMemo(
     () => ({
       notifications,
@@ -143,8 +194,11 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
       markAllRead,
       refresh,
       addNotification,
+      deleteNotification,
+      deleteAllNotifications,
+      registerJumpHandler,
     }),
-    [notifications, unreadCount, loading, markRead, markAllRead, refresh, addNotification]
+    [notifications, unreadCount, loading, markRead, markAllRead, refresh, addNotification, deleteNotification, deleteAllNotifications, registerJumpHandler]
   );
 
   return (

--- a/src/lib/notification-toast.ts
+++ b/src/lib/notification-toast.ts
@@ -1,0 +1,51 @@
+import { toast } from "sonner";
+import type { NotificationEvent, NotificationType } from "@/types/notification";
+
+type ToastVariant = "default" | "error" | "success" | "warning";
+
+const TYPE_TO_VARIANT: Record<NotificationType, ToastVariant> = {
+  agent_error: "error",
+  build_fail: "error",
+  agent_complete: "success",
+  agent_exited: "default",
+  agent_waiting: "warning",
+  session_closed: "default",
+  info: "default",
+};
+
+export function fireNotificationToast(
+  notification: NotificationEvent,
+  onJumpToSession: ((sessionId: string) => void) | null,
+  onMarkRead: ((ids: string[]) => void) | null
+): void {
+  const variant = TYPE_TO_VARIANT[notification.type];
+  const description = notification.body ?? notification.sessionName ?? undefined;
+  const action =
+    notification.sessionId && onJumpToSession
+      ? {
+          label: "View session",
+          onClick: () => {
+            onJumpToSession(notification.sessionId!);
+            if (!notification.readAt) {
+              onMarkRead?.([notification.id]);
+            }
+          },
+        }
+      : undefined;
+
+  const options = { description, action, duration: 5000 };
+
+  switch (variant) {
+    case "error":
+      toast.error(notification.title, options);
+      break;
+    case "success":
+      toast.success(notification.title, options);
+      break;
+    case "warning":
+      toast.warning(notification.title, options);
+      break;
+    default:
+      toast(notification.title, options);
+  }
+}

--- a/src/services/notification-service.ts
+++ b/src/services/notification-service.ts
@@ -1,6 +1,6 @@
 import { db } from "@/db";
 import { notificationEvents } from "@/db/schema";
-import { eq, and, desc, isNull, inArray, sql } from "drizzle-orm";
+import { eq, and, desc, isNull, inArray, count } from "drizzle-orm";
 import type { NotificationEvent, CreateNotificationInput } from "@/types/notification";
 
 // Debounce: prevent duplicate notifications per (userId, sessionId, type) within 5s window
@@ -76,14 +76,27 @@ export async function markAllRead(userId: string): Promise<void> {
     ));
 }
 
+export async function deleteNotifications(userId: string, ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  await db
+    .delete(notificationEvents)
+    .where(and(eq(notificationEvents.userId, userId), inArray(notificationEvents.id, ids)));
+}
+
+export async function deleteAllNotifications(userId: string): Promise<void> {
+  await db
+    .delete(notificationEvents)
+    .where(eq(notificationEvents.userId, userId));
+}
+
 export async function getUnreadCount(userId: string): Promise<number> {
-  const result = await db.select({ count: sql<number>`count(*)` })
+  const [row] = await db.select({ count: count() })
     .from(notificationEvents)
     .where(and(
       eq(notificationEvents.userId, userId),
       isNull(notificationEvents.readAt)
     ));
-  return result[0]?.count ?? 0;
+  return row?.count ?? 0;
 }
 
 function mapRow(row: typeof notificationEvents.$inferSelect): NotificationEvent {
@@ -95,7 +108,7 @@ function mapRow(row: typeof notificationEvents.$inferSelect): NotificationEvent 
     type: row.type as NotificationEvent["type"],
     title: row.title,
     body: row.body,
-    readAt: row.readAt ? new Date(row.readAt) : null,
-    createdAt: new Date(row.createdAt),
+    readAt: row.readAt,
+    createdAt: row.createdAt,
   };
 }


### PR DESCRIPTION
## Summary

- **Toast notifications**: Real-time toasts for agent events (waiting, error, complete, exited) via sonner, positioned bottom-center with glassmorphism styling. Type-mapped variants (error=red, success=green, warning=yellow). Clickable "View session" action navigates directly to the related session.
- **Clear notifications**: Per-item dismiss (X button on hover) and "Clear all" button in notification panel header. Hard deletes from database with optimistic UI updates and rollback on failure.
- **Glassmorphism panel**: Upgraded notification panel from solid `bg-background` to frosted glass `bg-popover/95 backdrop-blur-xl`, matching the app's modal/popover aesthetic.

### Files changed
| File | Change |
|------|--------|
| `src/lib/notification-toast.ts` | **New** — Toast bridge with notification type → variant mapping |
| `src/services/notification-service.ts` | +`deleteNotifications`, `deleteAllNotifications`; `count()` fix |
| `src/app/api/notifications/route.ts` | +`DELETE` handler |
| `src/contexts/NotificationContext.tsx` | +delete ops, toast integration, jump handler registration |
| `src/components/notifications/NotificationPanel.tsx` | Glassmorphism, clear all, per-item dismiss |
| `src/components/session/SessionManager.tsx` | Register jump handler for toast actions |
| `src/app/layout.tsx` | Mount `<Toaster>` with glassmorphism config |
| `CHANGELOG.md` | Document changes |

## Test plan

- [ ] Verify toasts appear for real-time agent events (start an agent session, wait for status changes)
- [ ] Verify toasts do NOT appear on page load/refresh
- [ ] Verify "View session" toast action navigates to the correct session
- [ ] Verify per-item X button dismisses individual notifications
- [ ] Verify "Clear all" button removes all notifications
- [ ] Verify optimistic updates revert on network failure
- [ ] Verify notification panel has glassmorphism styling
- [ ] Verify `bun run typecheck` passes
- [ ] Verify `bun run lint` has no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)