### PR TITLE
fix: allow Unix socket connections in localhost check

### DIFF
--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -306,6 +306,8 @@ async function readRequestBody(req: IncomingMessage): Promise<string> {
 
 function isLocalhostRequest(req: IncomingMessage): boolean {
   const addr = req.socket.remoteAddress;
+  // Unix domain socket connections have no remoteAddress — they are inherently local
+  if (!addr) return true;
   return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
 }
 


### PR DESCRIPTION
## Summary
- `isLocalhostRequest()` in the terminal server only checked for IP loopback addresses (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`)
- Unix domain socket connections have `remoteAddress === undefined`, causing all rdv CLI requests via auto-detected sockets (`~/.remote-dev/run/terminal.sock`) to fail with HTTP 403 on internal endpoints (`/internal/agent-todos`, `/internal/agent-stop-check`, etc.)
- Fix: treat undefined `remoteAddress` as local, since Unix sockets are inherently local (require filesystem access)

## Test plan
- [ ] Restart terminal server to pick up the change
- [ ] Verify `rdv task sync` works via Unix socket: `echo '{}' | RDV_SESSION_ID=test rdv task sync`
- [ ] Verify `rdv task check` works via Unix socket
- [ ] Confirm Claude Code PostToolUse hooks (TaskCreate/TaskUpdate/TodoWrite) no longer produce 403 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)