### PR TITLE
feat: add rdv hook subcommand for lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Produces `remote-dev-{version}-{platform}.tar.gz` with SHA-256 checksums
   - Triggered on version tags (`v*`)
   - `scripts/pack-release.sh`: builds Next.js, terminal server, and Rust CLI, then packages into distributable tarball
+- **rdv Hook Commands**: `rdv hook stop|notify|session-end` for Claude Code lifecycle hook integration (stop reporting, lifecycle notifications, session-end handling).
+- **POST /api/notifications**: New endpoint to create notifications programmatically via API.
 - **Local CLI Credentials**: Auto-provisioned API key at `~/.remote-dev/rdv/.local-key` so `rdv` CLI authenticates without manual `RDV_API_KEY` setup. Key is created at server startup with 0600 permissions.
 - **rdv Dual-Server Routing**: CLI now routes `/api/*` to Next.js and `/internal/*` to the terminal server, with Unix socket and TCP support for both.
 - **rdv Browser Commands**: `rdv browser navigate|screenshot|snapshot|click|type|evaluate|back|forward` for headless browser automation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,9 @@ Rust CLI for agent interaction with the terminal server. Agents use `rdv` comman
 | `rdv browser type` | Type text in browser |
 | `rdv browser evaluate` | Evaluate JavaScript |
 | `rdv session git-status` | Get git status for session |
+| `rdv hook stop` | Handle Stop hook: report idle, check tasks, notify |
+| `rdv hook notify <event>` | Send notification for lifecycle event |
+| `rdv hook session-end` | Handle SessionEnd hook: report ended status |
 | `rdv status` | System dashboard |
 | `rdv context` | Show current session context |
 

--- a/crates/rdv/src/commands/hook.rs
+++ b/crates/rdv/src/commands/hook.rs
@@ -1,0 +1,127 @@
+use clap::{Args, Subcommand};
+use serde_json::json;
+
+use crate::client::Client;
+
+#[derive(Args)]
+pub struct HookArgs {
+    #[command(subcommand)]
+    command: HookCommand,
+}
+
+#[derive(Subcommand)]
+enum HookCommand {
+    /// Handle Stop hook: report idle status, check tasks, create notification
+    Stop {
+        /// Agent provider name (e.g. "claude", "codex")
+        #[arg(long)]
+        agent: Option<String>,
+        /// Reason the agent stopped
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Send a notification for a lifecycle event
+    Notify {
+        /// Event name (e.g. "task_complete", "error", "stalled")
+        event: String,
+        /// Optional message body
+        #[arg(long)]
+        message: Option<String>,
+    },
+    /// Handle SessionEnd hook: report session ended, optionally trigger learning
+    SessionEnd {
+        /// Skip learning/analysis extraction
+        #[arg(long)]
+        skip_learn: bool,
+    },
+}
+
+pub async fn run(args: HookArgs, client: &Client, _human: bool) -> Result<(), Box<dyn std::error::Error>> {
+    match args.command {
+        HookCommand::Stop { agent, reason } => {
+            let sid = match client.session_id() {
+                Some(s) => s,
+                None => return Ok(()),
+            };
+
+            // Report idle status and check tasks concurrently (same as `task check`)
+            let idle_query = [("sessionId", sid), ("status", "idle")];
+            let check_query = [("sessionId", sid)];
+            let (idle_result, check_result) = tokio::join!(
+                client.post_empty_with_query("/internal/agent-status", &idle_query),
+                client.post_empty_with_query("/internal/agent-stop-check", &check_query)
+            );
+            if let Err(e) = idle_result {
+                eprintln!("warning: failed to report idle status: {e}");
+            }
+
+            // Create a notification about the stop event
+            let title = match &agent {
+                Some(a) => format!("Agent stopped: {a}"),
+                None => "Agent stopped".to_string(),
+            };
+            let message = reason.unwrap_or_else(|| "Session ended normally".to_string());
+            let body = json!({
+                "sessionId": sid,
+                "type": "agent_stop",
+                "title": title,
+                "message": message,
+            });
+            // Best-effort notification — don't fail the hook if this errors
+            let _ = client.post_json("/api/notifications", &body).await;
+
+            // Output task check message (blocks stop if tasks remain)
+            match check_result {
+                Ok(val) => {
+                    if let Some(msg) = val.get("message").and_then(|v| v.as_str()) {
+                        if !msg.is_empty() {
+                            println!("{msg}");
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("warning: failed to check tasks: {e}");
+                    println!("Unable to verify task completion — please check your rdv task list before stopping.");
+                }
+            }
+        }
+        HookCommand::Notify { event, message } => {
+            let sid = match client.session_id() {
+                Some(s) => s,
+                None => return Ok(()),
+            };
+
+            let body = json!({
+                "sessionId": sid,
+                "type": format!("hook_{event}"),
+                "title": event,
+                "message": message.unwrap_or_default(),
+            });
+            let _ = client.post_json("/api/notifications", &body).await;
+        }
+        HookCommand::SessionEnd { skip_learn } => {
+            let sid = match client.session_id() {
+                Some(s) => s,
+                None => return Ok(()),
+            };
+
+            // Report ended status
+            let query = [("sessionId", sid), ("status", "ended")];
+            if let Err(e) = client.post_empty_with_query("/internal/agent-status", &query).await {
+                eprintln!("warning: failed to report ended status: {e}");
+            }
+
+            if !skip_learn {
+                // Create a notification suggesting learning extraction
+                let body = json!({
+                    "sessionId": sid,
+                    "type": "session_end",
+                    "title": "Session ended",
+                    "message": "Consider running `rdv learn analyze` to extract learnings.",
+                });
+                let _ = client.post_json("/api/notifications", &body).await;
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/rdv/src/commands/hook.rs
+++ b/crates/rdv/src/commands/hook.rs
@@ -26,7 +26,7 @@ enum HookCommand {
         event: String,
         /// Optional message body
         #[arg(long)]
-        message: Option<String>,
+        body: Option<String>,
     },
     /// Handle SessionEnd hook: report session ended, optionally trigger learning
     SessionEnd {
@@ -55,49 +55,52 @@ pub async fn run(args: HookArgs, client: &Client, _human: bool) -> Result<(), Bo
                 eprintln!("warning: failed to report idle status: {e}");
             }
 
-            // Create a notification about the stop event
-            let title = match &agent {
-                Some(a) => format!("Agent stopped: {a}"),
-                None => "Agent stopped".to_string(),
-            };
-            let message = reason.unwrap_or_else(|| "Session ended normally".to_string());
-            let body = json!({
-                "sessionId": sid,
-                "type": "agent_stop",
-                "title": title,
-                "message": message,
-            });
-            // Best-effort notification — don't fail the hook if this errors
-            let _ = client.post_json("/api/notifications", &body).await;
-
-            // Output task check message (blocks stop if tasks remain)
-            match check_result {
+            // Output task check message first (blocks stop if tasks remain)
+            let stop_blocked = match &check_result {
                 Ok(val) => {
-                    if let Some(msg) = val.get("message").and_then(|v| v.as_str()) {
-                        if !msg.is_empty() {
-                            println!("{msg}");
-                        }
+                    let msg = val.get("message").and_then(|v| v.as_str()).unwrap_or("");
+                    if !msg.is_empty() {
+                        println!("{msg}");
+                        true
+                    } else {
+                        false
                     }
                 }
                 Err(e) => {
                     eprintln!("warning: failed to check tasks: {e}");
                     println!("Unable to verify task completion — please check your rdv task list before stopping.");
+                    true
                 }
+            };
+
+            // Only send "Agent stopped" notification if the stop is actually proceeding
+            if !stop_blocked {
+                let title = match &agent {
+                    Some(a) => format!("Agent stopped: {a}"),
+                    None => "Agent stopped".to_string(),
+                };
+                let body = json!({
+                    "sessionId": sid,
+                    "type": "agent_complete",
+                    "title": title,
+                    "body": reason.unwrap_or_else(|| "Session ended normally".to_string()),
+                });
+                let _ = client.post_json("/api/notifications", &body).await;
             }
         }
-        HookCommand::Notify { event, message } => {
+        HookCommand::Notify { event, body } => {
             let sid = match client.session_id() {
                 Some(s) => s,
                 None => return Ok(()),
             };
 
-            let body = json!({
+            let payload = json!({
                 "sessionId": sid,
-                "type": format!("hook_{event}"),
+                "type": "info",
                 "title": event,
-                "message": message.unwrap_or_default(),
+                "body": body.unwrap_or_default(),
             });
-            let _ = client.post_json("/api/notifications", &body).await;
+            let _ = client.post_json("/api/notifications", &payload).await;
         }
         HookCommand::SessionEnd { skip_learn } => {
             let sid = match client.session_id() {
@@ -112,14 +115,13 @@ pub async fn run(args: HookArgs, client: &Client, _human: bool) -> Result<(), Bo
             }
 
             if !skip_learn {
-                // Create a notification suggesting learning extraction
-                let body = json!({
+                let payload = json!({
                     "sessionId": sid,
-                    "type": "session_end",
+                    "type": "info",
                     "title": "Session ended",
-                    "message": "Consider running `rdv learn analyze` to extract learnings.",
+                    "body": "Consider running `rdv learn analyze` to extract learnings.",
                 });
-                let _ = client.post_json("/api/notifications", &body).await;
+                let _ = client.post_json("/api/notifications", &payload).await;
             }
         }
     }

--- a/crates/rdv/src/commands/mod.rs
+++ b/crates/rdv/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod browser;
 pub mod context;
 pub mod folder;
+pub mod hook;
 pub mod notification;
 pub mod session;
 pub mod status;

--- a/crates/rdv/src/main.rs
+++ b/crates/rdv/src/main.rs
@@ -3,7 +3,7 @@ mod commands;
 mod config;
 
 use clap::Parser;
-use commands::{agent, browser, context, folder, notification, session, status, system, task, worktree};
+use commands::{agent, browser, context, folder, hook, notification, session, status, system, task, worktree};
 
 #[derive(Parser)]
 #[command(name = "rdv", version, about = "CLI for Remote Dev terminal server")]
@@ -28,6 +28,8 @@ enum Command {
     Task(task::TaskArgs),
     /// Manage folders
     Folder(folder::FolderArgs),
+    /// Handle Claude Code lifecycle hooks (stop, notify, session-end)
+    Hook(hook::HookArgs),
     /// Show dashboard status or report agent status
     Status(status::StatusArgs),
     /// System management (updates, service control)
@@ -52,6 +54,7 @@ async fn main() {
         Command::Agent(args) => agent::run(args, &client, cli.human).await,
         Command::Task(args) => task::run(args, &client, cli.human).await,
         Command::Folder(args) => folder::run(args, &client, cli.human).await,
+        Command::Hook(args) => hook::run(args, &client, cli.human).await,
         Command::Status(args) => status::run(args, &client, cli.human).await,
         Command::System(args) => system::run(args, &client, cli.human).await,
         Command::Context => context::run(&client, cli.human).await,

--- a/skills/rdv/SKILL.md
+++ b/skills/rdv/SKILL.md
@@ -152,6 +152,23 @@ rdv session spawn <parent-id> --folder-id <fid> --project-path /path/to/project
 rdv session git-status <session-id>
 ```
 
+## Lifecycle Hooks
+
+Commands designed for Claude Code hook integration:
+
+```bash
+# Stop hook: report idle, check tasks, notify (used by Stop hook)
+rdv hook stop --agent claude --reason "task complete"
+
+# Notify about a lifecycle event (used by Stop/PostToolUse hooks)
+rdv hook notify task_complete
+rdv hook notify error --message "Build failed"
+
+# Session end: report ended status, optionally skip learning (used by SessionEnd hook)
+rdv hook session-end
+rdv hook session-end --skip-learn
+```
+
 ## System Status
 
 ```bash

--- a/skills/rdv/SKILL.md
+++ b/skills/rdv/SKILL.md
@@ -160,9 +160,9 @@ Commands designed for Claude Code hook integration:
 # Stop hook: report idle, check tasks, notify (used by Stop hook)
 rdv hook stop --agent claude --reason "task complete"
 
-# Notify about a lifecycle event (used by Stop/PostToolUse hooks)
+# Notify about a lifecycle event
 rdv hook notify task_complete
-rdv hook notify error --message "Build failed"
+rdv hook notify error --body "Build failed"
 
 # Session end: report ended status, optionally skip learning (used by SessionEnd hook)
 rdv hook session-end

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -2,6 +2,36 @@ import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
 import * as NotificationService from "@/services/notification-service";
 
+// POST /api/notifications - create notification
+export const POST = withApiAuth(async (request, { userId }) => {
+  try {
+    const result = await parseJsonBody<{
+      sessionId?: string;
+      type?: string;
+      title?: string;
+      body?: string;
+    }>(request);
+    if ("error" in result) return result.error;
+    const { sessionId, type, title, body } = result.data;
+
+    if (!title) {
+      return errorResponse("title is required", 400);
+    }
+
+    const notification = await NotificationService.createNotification({
+      userId,
+      sessionId: sessionId ?? undefined,
+      type: (type ?? "info") as import("@/types/notification").NotificationType,
+      title,
+      body: body ?? undefined,
+    });
+    return NextResponse.json(notification ?? { debounced: true });
+  } catch (error) {
+    console.error("Error creating notification:", error);
+    return errorResponse("Failed to create notification", 500);
+  }
+});
+
 // GET /api/notifications?limit=50&unreadOnly=false
 export const GET = withApiAuth(async (request, { userId }) => {
   try {


### PR DESCRIPTION
## Summary
- Adds `rdv hook` subcommand with `stop`, `notify`, and `session-end` sub-commands
- Fixes "unrecognized subcommand 'hook'" errors from `~/.claude/settings.local.json` Stop/SessionEnd hooks
- Documents lifecycle hooks in `skills/rdv/SKILL.md`

## Test plan
- [x] `cargo build` succeeds
- [x] `rdv hook --help` shows all three sub-commands
- [x] `rdv hook stop --help` shows `--agent` and `--reason` options
- [ ] Verify Stop hook no longer errors on session end
- [ ] Verify SessionEnd hook reports status correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)