### PR TITLE
fix: dismiss toast when session is selected

### DIFF
--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -64,6 +64,7 @@ import type { AgentActivityStatus } from "@/types/terminal-type";
 import { useAgentNotifications } from "@/hooks/useAgentNotifications";
 import { NotificationPanel } from "@/components/notifications/NotificationPanel";
 import { useNotificationContext, hydrateNotification } from "@/contexts/NotificationContext";
+import { dismissToastsForSession } from "@/lib/notification-toast";
 
 // Dynamically import TerminalWithKeyboard to avoid SSR issues with xterm
 const TerminalWithKeyboard = dynamic(
@@ -345,7 +346,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
   const { getRepositoryById } = useGitHubStats();
 
   const { refreshTasks } = useTaskContext();
-  const { addNotification, registerJumpHandler } = useNotificationContext();
+  const { addNotification, registerJumpHandler, notifications, markRead } = useNotificationContext();
 
   // Notification panel state
   const [notificationPanelOpen, setNotificationPanelOpen] = useState(false);
@@ -1388,6 +1389,22 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
     registerJumpHandler(setActiveSession);
     return () => registerJumpHandler(null);
   }, [registerJumpHandler, setActiveSession]);
+
+  // Dismiss toasts and mark notifications read when a session is selected
+  const markSessionNotificationsRead = useEffectEvent((sessionId: string) => {
+    dismissToastsForSession(sessionId);
+    const unreadIds = notifications
+      .filter((n) => !n.readAt && n.sessionId === sessionId)
+      .map((n) => n.id);
+    if (unreadIds.length > 0) {
+      markRead(unreadIds);
+    }
+  });
+
+  useEffect(() => {
+    if (!activeSessionId) return;
+    markSessionNotificationsRead(activeSessionId);
+  }, [activeSessionId]);
 
   /** Close a session in a split pane */
   const handlePaneSessionExit = useCallback(async (sessionId: string) => {

--- a/src/lib/notification-toast.ts
+++ b/src/lib/notification-toast.ts
@@ -13,6 +13,28 @@ const TYPE_TO_VARIANT: Record<NotificationType, ToastVariant> = {
   info: "default",
 };
 
+/** Maps sessionId → active toast IDs so they can be dismissed when the session is selected */
+const sessionToastIds = new Map<string, Set<string | number>>();
+
+/** Dismiss all active toasts for a given session */
+export function dismissToastsForSession(sessionId: string): void {
+  const toastIds = sessionToastIds.get(sessionId);
+  if (!toastIds) return;
+  for (const id of toastIds) {
+    toast.dismiss(id);
+  }
+  sessionToastIds.delete(sessionId);
+}
+
+function trackToast(sessionId: string, toastId: string | number): void {
+  let ids = sessionToastIds.get(sessionId);
+  if (!ids) {
+    ids = new Set();
+    sessionToastIds.set(sessionId, ids);
+  }
+  ids.add(toastId);
+}
+
 export function fireNotificationToast(
   notification: NotificationEvent,
   onJumpToSession: ((sessionId: string) => void) | null,
@@ -33,19 +55,39 @@ export function fireNotificationToast(
         }
       : undefined;
 
-  const options = { description, action, duration: 5000 };
+  const options = {
+    description,
+    action,
+    duration: 5000,
+    onDismiss: () => {
+      // Clean up tracking when toast is dismissed (auto or manual)
+      if (notification.sessionId) {
+        const ids = sessionToastIds.get(notification.sessionId);
+        if (ids) {
+          ids.delete(toastId);
+          if (ids.size === 0) sessionToastIds.delete(notification.sessionId);
+        }
+      }
+    },
+  };
+
+  let toastId: string | number;
 
   switch (variant) {
     case "error":
-      toast.error(notification.title, options);
+      toastId = toast.error(notification.title, options);
       break;
     case "success":
-      toast.success(notification.title, options);
+      toastId = toast.success(notification.title, options);
       break;
     case "warning":
-      toast.warning(notification.title, options);
+      toastId = toast.warning(notification.title, options);
       break;
     default:
-      toast(notification.title, options);
+      toastId = toast(notification.title, options);
+  }
+
+  if (notification.sessionId) {
+    trackToast(notification.sessionId, toastId);
   }
 }


### PR DESCRIPTION
## Summary
- Dismiss active toast notifications when the associated session is selected/activated
- Mark corresponding notifications as read automatically on session selection
- Track toast IDs per session in `notification-toast.ts` for programmatic dismissal

## Test plan
- [ ] Trigger an agent notification (e.g., agent waiting/error) and verify toast appears
- [ ] Select the session via sidebar — toast should dismiss and notification badge should update
- [ ] Select the session via "View session" toast action — toast should dismiss
- [ ] Verify toasts for other sessions are not affected
- [ ] Verify auto-dismiss still works after 5 seconds if session is not selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)