### PR TITLE
fix: refresh task list on page visibility change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Task list stale after sleep/tab switch**: Task list now automatically refreshes when the page regains visibility (e.g. returning from sleep, switching tabs) instead of requiring a manual reload. Also added fetch cancellation via AbortController to prevent race conditions from concurrent refreshes.
 - **Task session scoping**: Tasks sidebar now shows only the active session's tasks instead of all folder tasks, matching the schedule scoping pattern. New tasks and linked GitHub issues are automatically associated with the active session.
 - **Schedule session scoping**: Schedules sidebar now shows only the active session's schedules instead of all schedules, and schedule creation auto-detects the active session instead of showing a session picker
 

--- a/src/contexts/TaskContext.tsx
+++ b/src/contexts/TaskContext.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   useCallback,
   useEffect,
+  useRef,
   useMemo,
   type ReactNode,
 } from "react";
@@ -78,17 +79,25 @@ export function TaskProvider({ children }: TaskProviderProps) {
   const activeFolderId = activeProject.folderId;
   const { activeSessionId } = useSessionContext();
 
+  const abortRef = useRef<AbortController | null>(null);
+
   const refreshTasks = useCallback(async () => {
+    abortRef.current?.abort();
+
     if (!activeFolderId) {
       setAllTasks([]);
       return;
     }
 
+    const controller = new AbortController();
+    abortRef.current = controller;
+
     try {
       setLoading(true);
       setError(null);
       const response = await fetch(
-        `/api/tasks?folderId=${encodeURIComponent(activeFolderId)}`
+        `/api/tasks?folderId=${encodeURIComponent(activeFolderId)}`,
+        { signal: controller.signal }
       );
       if (!response.ok) {
         throw new Error("Failed to fetch tasks");
@@ -96,19 +105,26 @@ export function TaskProvider({ children }: TaskProviderProps) {
       const data = await response.json();
       setAllTasks(data.map(hydrateTask));
     } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);
     }
   }, [activeFolderId]);
 
-  // Fetch tasks when active folder changes and refresh on visibility restore
+  // Reload when active folder changes
   useEffect(() => {
     refreshTasks();
+  }, [refreshTasks]);
 
+  // Refresh tasks when page becomes visible again (e.g. after sleep, tab switch)
+  const refreshRef = useRef(refreshTasks);
+  refreshRef.current = refreshTasks;
+
+  useEffect(() => {
     function handleVisibilityChange(): void {
       if (!document.hidden) {
-        refreshTasks();
+        refreshRef.current();
       }
     }
 
@@ -116,7 +132,7 @@ export function TaskProvider({ children }: TaskProviderProps) {
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [refreshTasks]);
+  }, []);
 
   const createTask = useCallback(
     async (input: CreateTaskInput): Promise<ProjectTask | null> => {

--- a/src/contexts/TaskContext.tsx
+++ b/src/contexts/TaskContext.tsx
@@ -102,9 +102,20 @@ export function TaskProvider({ children }: TaskProviderProps) {
     }
   }, [activeFolderId]);
 
-  // Reload when active folder changes
+  // Fetch tasks when active folder changes and refresh on visibility restore
   useEffect(() => {
     refreshTasks();
+
+    function handleVisibilityChange(): void {
+      if (!document.hidden) {
+        refreshTasks();
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
   }, [refreshTasks]);
 
   const createTask = useCallback(


### PR DESCRIPTION
## Summary
- Add `visibilitychange` event listener to `TaskContext` so tasks refresh automatically when the page regains visibility
- Fixes stale task list when returning from sleep, tab switch, or window restore — previously required a manual page reload

## Test plan
- [ ] Open app with task sidebar visible
- [ ] Switch to another tab, wait, switch back — tasks should refresh
- [ ] Close laptop lid, reopen — tasks should refresh
- [ ] Verify no duplicate fetches on normal folder switching

🤖 Generated with [Claude Code](https://claude.ai/claude-code)