### PR TITLE
fix: worktree cleanup with merge verification and branch deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Worktree cleanup**: New `rdv worktree cleanup` command for agents to trigger full worktree lifecycle cleanup from inside a worktree
+  - Merge verification: requires branch is merged into main/master before removal (use `--force` to skip)
+  - Removes worktree directory via server-side git commands (solves the CWD-inside-worktree problem)
+  - Deletes local and remote branches after merge verification
+  - Closes the session automatically
+- **Worktree service functions**: `getDefaultBranch()`, `isBranchMerged()`, `deleteBranch()`, `cleanupWorktree()` for reusable git branch lifecycle operations
+- **Session cleanup mode**: `DELETE /api/sessions/:id?cleanup=true&force=false` for full worktree cleanup via API
+
+### Fixed
+
+- **rdv worktree remove**: Fixed broken field names (`repoPath`/`branch` → `projectPath`/`worktreePath`) that caused 400 errors when calling the API
 - **Structured Logging System**: Complete logging overhaul replacing all `console.*` calls with structured, leveled logging
   - 5 log levels: error, warn, info, debug, trace (controlled via `LOG_LEVEL` env var)
   - Separate SQLite database at `~/.remote-dev/logs/logs.db` for log persistence

--- a/crates/rdv/src/commands/worktree.rs
+++ b/crates/rdv/src/commands/worktree.rs
@@ -27,14 +27,24 @@ enum WorktreeCommand {
         #[arg(long)]
         repo: String,
     },
-    /// Remove a worktree
+    /// Remove a worktree (directory only, no branch cleanup)
     Remove {
-        /// Repository path
+        /// Path to the worktree directory to remove
         #[arg(long)]
-        repo: String,
-        /// Branch name of the worktree to remove
+        worktree_path: String,
+        /// Path to the main repository (or any path within it)
         #[arg(long)]
-        branch: String,
+        project_path: String,
+        /// Force removal even with uncommitted changes
+        #[arg(long, default_value_t = false)]
+        force: bool,
+    },
+    /// Full cleanup: verify merge, remove worktree, delete branches, close session.
+    /// Uses RDV_SESSION_ID from environment to identify the session.
+    Cleanup {
+        /// Force cleanup even if branch is not merged
+        #[arg(long, default_value_t = false)]
+        force: bool,
     },
 }
 
@@ -76,12 +86,29 @@ pub async fn run(args: WorktreeArgs, client: &Client, human: bool) -> Result<(),
                 println!("{}", serde_json::to_string_pretty(&result)?);
             }
         }
-        WorktreeCommand::Remove { repo, branch } => {
+        WorktreeCommand::Remove { worktree_path, project_path, force } => {
             let body = json!({
-                "repoPath": repo,
-                "branch": branch,
+                "projectPath": project_path,
+                "worktreePath": worktree_path,
+                "force": force,
             });
             let result = client.delete_with_body("/api/github/worktrees", &body).await?;
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        }
+        WorktreeCommand::Cleanup { force } => {
+            let session_id = client.session_id()
+                .ok_or("RDV_SESSION_ID is not set. This command must be run from within an agent session.")?;
+            // Validate session ID format (UUID) to prevent path injection
+            if session_id.len() != 36
+                || !session_id.chars().all(|c| c.is_ascii_hexdigit() || c == '-')
+            {
+                return Err("RDV_SESSION_ID is not a valid session ID".into());
+            }
+            let path = format!(
+                "/api/sessions/{}?cleanup=true&force={}",
+                session_id, force
+            );
+            let result: serde_json::Value = client.delete(&path).await?;
             println!("{}", serde_json::to_string_pretty(&result)?);
         }
     }

--- a/skills/rdv/SKILL.md
+++ b/skills/rdv/SKILL.md
@@ -59,9 +59,33 @@ rdv worktree create --repo /path/to/repo --branch feature/my-branch
 # List worktrees
 rdv worktree list --repo /path/to/repo
 
-# Remove a worktree
-rdv worktree remove --repo /path/to/repo --branch feature/my-branch
+# Remove a worktree (directory only, no branch cleanup)
+rdv worktree remove --worktree-path /path/to/worktree --project-path /path/to/repo [--force]
+
+# Full cleanup: verify merge, remove worktree, delete branches, close session
+# This is the preferred way to clean up when you're done with a worktree.
+# It works even when your CWD is inside the worktree being removed.
+rdv worktree cleanup [--force]
 ```
+
+### Worktree Cleanup Flow
+
+When you finish work in a worktree (commits pushed, PR merged), use `rdv worktree cleanup`:
+
+1. **Merge verification**: Checks that your branch is merged into main/master. Returns an error if not merged (use `--force` to skip).
+2. **Worktree removal**: Removes the worktree directory via server-side git commands (CWD-safe).
+3. **Branch deletion**: Deletes both the local and remote branch.
+4. **Session close**: Kills the tmux session and marks the session as closed.
+
+```bash
+# After your PR is merged, clean up everything:
+rdv worktree cleanup
+
+# If you want to discard unmerged work:
+rdv worktree cleanup --force
+```
+
+**Note**: `rdv worktree cleanup` requires `RDV_SESSION_ID` to be set (automatically set in agent sessions). It uses the session's metadata to find the worktree path and branch.
 
 ## Task Management
 
@@ -212,7 +236,18 @@ rdv worktree create --repo . --branch feature/experiment
 rdv session create --name "experiment" --working-dir /path/to/worktree
 ```
 
-### 4. Orchestrate parallel agents with children
+### 4. Complete work in a worktree and clean up
+```bash
+# Do your work, commit, push, create/merge PR
+git add . && git commit -m "feat: my changes"
+git push origin feature/my-branch
+gh pr create --fill && gh pr merge --auto
+
+# Clean up worktree, branches, and session
+rdv worktree cleanup
+```
+
+### 5. Orchestrate parallel agents with children
 ```bash
 rdv session spawn <my-session-id> --agent-provider claude --name "backend-work"
 rdv session spawn <my-session-id> --agent-provider claude --name "frontend-work"

--- a/src/app/api/sessions/[id]/route.ts
+++ b/src/app/api/sessions/[id]/route.ts
@@ -76,17 +76,42 @@ export const PATCH = withAuth(async (request, { userId, params }) => {
 });
 
 /**
+ * Resolve the main repository path for a worktree session.
+ * Tries GitHub repo record first, then folder preferences.
+ */
+async function resolveMainRepoPath(
+  session: { githubRepoId?: string | null; folderId?: string | null },
+  userId: string
+): Promise<string | null> {
+  if (session.githubRepoId) {
+    const repo = await GitHubService.getRepository(session.githubRepoId, userId);
+    if (repo?.localPath) return repo.localPath;
+  }
+
+  if (session.folderId) {
+    const folderPrefs = await getFolderPreferences(session.folderId, userId);
+    if (folderPrefs?.localRepoPath) return folderPrefs.localRepoPath;
+  }
+
+  return null;
+}
+
+/**
  * DELETE /api/sessions/:id - Close a session
  *
  * Query params:
  * - deleteWorktree=true: Also delete the git worktree from disk
  * - trash=true: Move worktree to trash instead of permanent close
+ * - cleanup=true: Full worktree cleanup (merge check, remove worktree, delete branches, close session)
+ * - force=true: Skip merge verification when using cleanup mode
  */
 export const DELETE = withAuth(async (request, { userId, params }) => {
   const id = params!.id;
   const { searchParams } = new URL(request.url);
   const deleteWorktree = searchParams.get("deleteWorktree") === "true";
   const shouldTrash = searchParams.get("trash") === "true";
+  const shouldCleanup = searchParams.get("cleanup") === "true";
+  const force = searchParams.get("force") === "true";
 
   try {
     // Get session details for worktree operations
@@ -105,27 +130,44 @@ export const DELETE = withAuth(async (request, { userId, params }) => {
       return NextResponse.json({ success: true, trashItemId: trashItem.id });
     }
 
+    // Handle full worktree cleanup (merge check + remove worktree + delete branches + close)
+    if (shouldCleanup && terminalSession?.worktreeBranch && terminalSession?.projectPath) {
+      const mainRepoPath = await resolveMainRepoPath(terminalSession, userId);
+      if (!mainRepoPath) {
+        return errorResponse(
+          "Cannot resolve main repository path for cleanup",
+          400,
+          "NO_REPO_PATH"
+        );
+      }
+
+      // cleanupWorktree may throw BRANCH_NOT_MERGED (should not close session)
+      // or REMOVE_FAILED. For other partial failures (e.g., worktree removed
+      // but branch delete failed), cleanupWorktree handles them internally
+      // and returns a result. We always close the session after a successful cleanup.
+      const cleanupResult = await WorktreeService.cleanupWorktree(
+        mainRepoPath,
+        terminalSession.projectPath,
+        terminalSession.worktreeBranch,
+        force
+      );
+      log.info("Worktree cleanup completed", {
+        sessionId: id,
+        branch: terminalSession.worktreeBranch,
+        message: cleanupResult.message,
+      });
+
+      // Close the session after successful cleanup.
+      // If this fails, the worktree/branches are already cleaned up
+      // but the session record remains — acceptable since a stale session
+      // can be manually closed later.
+      await SessionService.closeSession(id, userId);
+      return NextResponse.json({ success: true, cleanup: cleanupResult });
+    }
+
     // If deleteWorktree is requested, handle worktree cleanup first
     if (deleteWorktree && terminalSession?.worktreeBranch && terminalSession?.projectPath) {
-      let mainRepoPath: string | null = null;
-
-      // Try to get the main repo path from GitHub repository
-      if (terminalSession.githubRepoId) {
-        const repo = await GitHubService.getRepository(
-          terminalSession.githubRepoId,
-          userId
-        );
-        mainRepoPath = repo?.localPath ?? null;
-      }
-
-      // Fall back to folder preferences for local repo path
-      if (!mainRepoPath && terminalSession.folderId) {
-        const folderPrefs = await getFolderPreferences(
-          terminalSession.folderId,
-          userId
-        );
-        mainRepoPath = folderPrefs?.localRepoPath ?? null;
-      }
+      const mainRepoPath = await resolveMainRepoPath(terminalSession, userId);
 
       if (mainRepoPath) {
         try {
@@ -173,6 +215,14 @@ export const DELETE = withAuth(async (request, { userId, params }) => {
 
     if (error instanceof TrashService.TrashServiceError) {
       return errorResponse(error.message, 400, error.code);
+    }
+
+    if (error instanceof WorktreeService.WorktreeServiceError) {
+      const status = error.code === "BRANCH_NOT_MERGED" ? 409 : 400;
+      return NextResponse.json(
+        { error: error.message, code: error.code, details: error.details },
+        { status }
+      );
     }
 
     throw error;

--- a/src/app/api/sessions/[id]/route.ts
+++ b/src/app/api/sessions/[id]/route.ts
@@ -157,6 +157,19 @@ export const DELETE = withAuth(async (request, { userId, params }) => {
         message: cleanupResult.message,
       });
 
+      // Disable any scheduled commands for this session
+      try {
+        const disabledCount = await ScheduleService.disableSessionSchedules(id);
+        if (disabledCount > 0) {
+          notifySessionJobsRemoved(id).catch((err) =>
+            log.warn("Failed to notify scheduler of session job removal", { error: String(err) })
+          );
+          log.info("Disabled schedules for session", { disabledCount, sessionId: id });
+        }
+      } catch (scheduleError) {
+        log.error("Failed to disable schedules", { error: String(scheduleError) });
+      }
+
       // Close the session after successful cleanup.
       // If this fails, the worktree/branches are already cleaned up
       // but the session record remains — acceptable since a stale session

--- a/src/services/worktree-service.ts
+++ b/src/services/worktree-service.ts
@@ -678,6 +678,226 @@ export async function getWorktreeStatus(
 }
 
 /**
+ * Result of a merge verification check
+ */
+export interface MergeVerificationResult {
+  isMerged: boolean;
+  targetBranch: string;
+  branchExists: boolean;
+}
+
+/**
+ * Result of a branch deletion operation
+ */
+export interface DeleteBranchResult {
+  deletedLocal: boolean;
+  deletedRemote: boolean;
+}
+
+/**
+ * Result of a full worktree cleanup operation
+ */
+export interface CleanupWorktreeResult {
+  worktreeRemoved: boolean;
+  localBranchDeleted: boolean;
+  remoteBranchDeleted: boolean;
+  mergeVerification: MergeVerificationResult;
+  message: string;
+}
+
+/**
+ * Detect the default branch (main/master) of a repository.
+ * Tries origin/HEAD first, then falls back to checking main/master locally.
+ */
+export async function getDefaultBranch(repoPath: string): Promise<string> {
+  // Strategy 1: Check origin/HEAD symbolic ref
+  const originHead = await execFileNoThrow("git", [
+    "-C", repoPath,
+    "symbolic-ref", "--short", "refs/remotes/origin/HEAD",
+  ]);
+  if (originHead.exitCode === 0 && originHead.stdout) {
+    return originHead.stdout.replace("origin/", "");
+  }
+
+  // Strategy 2: Check if 'main' exists locally or on remote
+  const mainCheck = await execFileNoThrow("git", [
+    "-C", repoPath,
+    "rev-parse", "--verify", "refs/heads/main",
+  ]);
+  if (mainCheck.exitCode === 0) return "main";
+
+  const mainRemote = await execFileNoThrow("git", [
+    "-C", repoPath,
+    "rev-parse", "--verify", "refs/remotes/origin/main",
+  ]);
+  if (mainRemote.exitCode === 0) return "main";
+
+  // Strategy 3: Check if 'master' exists locally or on remote
+  const masterCheck = await execFileNoThrow("git", [
+    "-C", repoPath,
+    "rev-parse", "--verify", "refs/heads/master",
+  ]);
+  if (masterCheck.exitCode === 0) return "master";
+
+  const masterRemote = await execFileNoThrow("git", [
+    "-C", repoPath,
+    "rev-parse", "--verify", "refs/remotes/origin/master",
+  ]);
+  if (masterRemote.exitCode === 0) return "master";
+
+  // Last resort: assume 'main' (most common modern default)
+  return "main";
+}
+
+/**
+ * Check if a branch has been merged into a target branch.
+ * Fetches remote first to ensure up-to-date state.
+ *
+ * Uses `git merge-base --is-ancestor` which checks if the branch tip
+ * is reachable from the target branch.
+ */
+export async function isBranchMerged(
+  repoPath: string,
+  branch: string,
+  targetBranch?: string
+): Promise<MergeVerificationResult> {
+  // Fetch latest state (non-fatal if offline)
+  await fetchRemoteRefs(repoPath);
+
+  const target = targetBranch ?? await getDefaultBranch(repoPath);
+
+  // Check if branch exists
+  const branchCheck = await execFileNoThrow("git", [
+    "-C", repoPath,
+    "rev-parse", "--verify", `refs/heads/${branch}`,
+  ]);
+  if (branchCheck.exitCode !== 0) {
+    // Branch doesn't exist locally — check if it was already deleted
+    return { isMerged: true, targetBranch: target, branchExists: false };
+  }
+
+  // Check if branch is an ancestor of the target branch.
+  // Use origin/<target> to compare against the up-to-date remote ref,
+  // since the local ref may be stale or non-existent.
+  const remoteTarget = `origin/${target}`;
+  const hasRemoteTarget = await execFileNoThrow("git", [
+    "-C", repoPath,
+    "rev-parse", "--verify", remoteTarget,
+  ]);
+  const mergeTarget = hasRemoteTarget.exitCode === 0 ? remoteTarget : target;
+
+  const mergeCheck = await execFileNoThrow("git", [
+    "-C", repoPath,
+    "merge-base", "--is-ancestor", branch, mergeTarget,
+  ]);
+
+  return {
+    isMerged: mergeCheck.exitCode === 0,
+    targetBranch: target,
+    branchExists: true,
+  };
+}
+
+/**
+ * Delete a git branch, optionally also deleting the remote tracking branch.
+ * Remote deletion is best-effort (logged but not fatal).
+ *
+ * @param repoPath - Path to the main repository
+ * @param branch - Branch name to delete
+ * @param options - deleteRemote: also delete on origin; force: use -D instead of -d
+ */
+export async function deleteBranch(
+  repoPath: string,
+  branch: string,
+  options: { deleteRemote?: boolean; force?: boolean } = {}
+): Promise<DeleteBranchResult> {
+  const { deleteRemote = true, force = false } = options;
+
+  // Delete local branch
+  const localResult = await execFileNoThrow("git", [
+    "-C", repoPath,
+    "branch", force ? "-D" : "-d", branch,
+  ]);
+  const deletedLocal = localResult.exitCode === 0;
+  if (!deletedLocal) {
+    log.warn("Failed to delete local branch", { branch, error: localResult.stderr });
+  }
+
+  // Delete remote branch (best-effort)
+  let deletedRemote = false;
+  if (deleteRemote) {
+    const remoteResult = await execFileNoThrow("git", [
+      "-C", repoPath,
+      "push", "origin", "--delete", branch,
+    ]);
+    deletedRemote = remoteResult.exitCode === 0;
+    if (!deletedRemote) {
+      log.warn("Failed to delete remote branch (non-fatal)", { branch, error: remoteResult.stderr });
+    }
+  }
+
+  return { deletedLocal, deletedRemote };
+}
+
+/**
+ * Full worktree cleanup: verify merge, remove worktree, delete branches.
+ *
+ * This is the orchestrator for the complete cleanup flow. It runs all
+ * git commands using `-C repoPath` so the caller's CWD is irrelevant,
+ * solving the problem of agents running inside the worktree they want removed.
+ *
+ * @param repoPath - Path to the main repository (NOT the worktree)
+ * @param worktreePath - Path to the worktree directory
+ * @param branch - Branch name checked out in the worktree
+ * @param force - Skip merge verification and force all deletions
+ * @throws WorktreeServiceError with code BRANCH_NOT_MERGED if not merged and not forced
+ */
+export async function cleanupWorktree(
+  repoPath: string,
+  worktreePath: string,
+  branch: string,
+  force = false
+): Promise<CleanupWorktreeResult> {
+  // Step 1: Verify branch is merged (unless forced)
+  const mergeResult = await isBranchMerged(repoPath, branch);
+
+  if (!force && !mergeResult.isMerged) {
+    throw new WorktreeServiceError(
+      `Branch '${branch}' has not been merged into '${mergeResult.targetBranch}'`,
+      "BRANCH_NOT_MERGED",
+      `Merge or push your changes first, or use --force to proceed anyway`
+    );
+  }
+
+  // Step 2: Remove the worktree directory
+  const removeResult = await removeWorktree(repoPath, worktreePath, true);
+
+  // Step 3: Delete local and remote branches
+  // Use -D (force) since we already verified merge status above
+  const branchResult = await deleteBranch(repoPath, branch, {
+    deleteRemote: true,
+    force: true,
+  });
+
+  const messages: string[] = [];
+  if (removeResult.alreadyRemoved) {
+    messages.push("worktree was already removed");
+  } else {
+    messages.push("worktree removed");
+  }
+  if (branchResult.deletedLocal) messages.push("local branch deleted");
+  if (branchResult.deletedRemote) messages.push("remote branch deleted");
+
+  return {
+    worktreeRemoved: !removeResult.alreadyRemoved,
+    localBranchDeleted: branchResult.deletedLocal,
+    remoteBranchDeleted: branchResult.deletedRemote,
+    mergeVerification: mergeResult,
+    message: messages.join(", "),
+  };
+}
+
+/**
  * Result of copying env files to a worktree
  */
 export interface CopyEnvFilesResult {


### PR DESCRIPTION
## Summary

- Add `rdv worktree cleanup` command for agents to trigger full server-side worktree cleanup from inside a worktree
- Merge verification: requires branch is merged into main/master before removal (`--force` to skip)
- Removes worktree directory, deletes local+remote branches, and closes the session
- Solves the CWD-inside-worktree problem where agents couldn't run `git worktree remove`
- Fix `rdv worktree remove` broken field names (`repoPath`/`branch` → `projectPath`/`worktreePath`)

## Test plan

- [ ] Test `rdv worktree cleanup` from inside an agent session with a merged branch
- [ ] Test `rdv worktree cleanup` with an unmerged branch (should return 409)
- [ ] Test `rdv worktree cleanup --force` with an unmerged branch (should succeed)
- [ ] Test `rdv worktree remove` with corrected field names
- [ ] Verify session is closed after cleanup
- [ ] Verify local and remote branches are deleted

🤖 Generated with [Claude Code](https://claude.ai/code)