### PR TITLE
feat: poll-based auto-update for multi-server deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Poll-based auto-update system**: Multi-server deployment support replacing GitHub webhook dependency
+  - Each server independently polls GitHub Releases for pre-built artifacts
+  - AutoUpdateOrchestrator coordinates lifecycle: detect → schedule → drain → apply → restart
+  - Graceful session draining with configurable timeout (broadcasts `update_pending` to connected clients)
+  - Durable deployment state persisted to SQLite, recovers pending timers on restart
+  - New domain objects: `DeploymentStage`, `UpdatePolicy`, `UpdateDeployment` entity
+  - New use cases: `ScheduleAutoUpdateUseCase`, `DrainSessionsUseCase`
+  - New API actions: `POST /api/system/update { action: "cancel" }` to cancel pending updates
+  - `GET /api/system/update` now includes deployment lifecycle stage info
+  - Configurable via `AUTO_UPDATE_ENABLED`, `AUTO_UPDATE_DELAY_MINUTES`, `AUTO_UPDATE_DRAIN_TIMEOUT_SECONDS`
+
+### Deprecated
+
+- **Webhook deploy endpoint**: `POST /api/deploy` returns 410 when `AUTO_UPDATE_ENABLED=true`, guiding migration to poll-based updates
+
+### Added
+
 - **Worktree cleanup**: New `rdv worktree cleanup` command for agents to trigger full worktree lifecycle cleanup from inside a worktree
   - Merge verification: requires branch is merged into main/master before removal (use `--force` to skip)
   - Removes worktree directory via server-side git commands (solves the CWD-inside-worktree problem)

--- a/src/app/api/deploy/route.ts
+++ b/src/app/api/deploy/route.ts
@@ -55,6 +55,19 @@ function verifySignature(
 }
 
 export async function POST(request: Request) {
+  // Deprecation gate: when auto-update is enabled, the webhook deploy path
+  // is disabled in favor of poll-based auto-updates from GitHub Releases.
+  if (process.env.AUTO_UPDATE_ENABLED === "true") {
+    log.warn("Webhook deploy rejected: auto-update is enabled");
+    return NextResponse.json(
+      {
+        error: "Webhook deploy is deprecated when auto-update is enabled. Each server polls GitHub Releases for updates.",
+        code: "WEBHOOK_DEPRECATED",
+      },
+      { status: 410 }
+    );
+  }
+
   const webhookSecret = process.env.DEPLOY_WEBHOOK_SECRET;
   if (!webhookSecret) {
     log.error("DEPLOY_WEBHOOK_SECRET not configured");

--- a/src/app/api/system/update/route.ts
+++ b/src/app/api/system/update/route.ts
@@ -92,8 +92,15 @@ export const POST = withApiAuth(async (request) => {
   }
 
   if (action === "cancel") {
-    await autoUpdateOrchestrator.cancelPendingUpdate();
-    return NextResponse.json({ status: "cancelled", message: "Pending auto-update cancelled." });
+    try {
+      await autoUpdateOrchestrator.cancelPendingUpdate();
+      return NextResponse.json({ status: "cancelled", message: "Pending auto-update cancelled." });
+    } catch (error) {
+      if (error instanceof DeploymentAlreadyActiveError) {
+        return errorResponse(error.message, 409, error.code);
+      }
+      throw error;
+    }
   }
 
   return errorResponse(

--- a/src/app/api/system/update/route.ts
+++ b/src/app/api/system/update/route.ts
@@ -2,7 +2,7 @@
  * System Update API
  *
  * GET  /api/system/update  - Get current update status
- * POST /api/system/update  - Perform update action (check or apply)
+ * POST /api/system/update  - Perform update action (check, apply, cancel)
  */
 
 import { NextResponse } from "next/server";
@@ -11,33 +11,49 @@ import {
   getUpdateStatusUseCase,
   checkForUpdatesUseCase,
   applyUpdateUseCase,
+  autoUpdateOrchestrator,
+  deploymentRepository,
 } from "@/infrastructure/container";
 import {
   toUpdateStatusResponse,
   toCheckResultResponse,
+  toDeploymentInfo,
 } from "@/interface/presenters/UpdatePresenter";
 import {
   UpdateInProgressError,
   NoUpdateAvailableError,
+  DeploymentAlreadyActiveError,
 } from "@/domain/errors/UpdateError";
 
 /**
  * GET /api/system/update
  *
- * Returns the current update status including version info and available updates.
+ * Returns the current update status including version info, available updates,
+ * and auto-update deployment lifecycle state.
  */
 export const GET = withApiAuth(async () => {
-  const status = await getUpdateStatusUseCase.execute();
-  return NextResponse.json(toUpdateStatusResponse(status));
+  const [status, deployment] = await Promise.all([
+    getUpdateStatusUseCase.execute(),
+    deploymentRepository.getCurrent(),
+  ]);
+
+  const response = toUpdateStatusResponse(status);
+
+  if (deployment) {
+    response.deployment = toDeploymentInfo(deployment);
+  }
+
+  return NextResponse.json(response);
 });
 
 /**
  * POST /api/system/update
  *
- * Body: { action: "check" | "apply" }
+ * Body: { action: "check" | "apply" | "cancel" }
  *
  * - "check": Force-check GitHub for new releases
  * - "apply": Download, install, and restart with the cached release
+ * - "cancel": Cancel a pending scheduled auto-update
  */
 export const POST = withApiAuth(async (request) => {
   const result = await parseJsonBody<{ action: string }>(request);
@@ -68,12 +84,20 @@ export const POST = withApiAuth(async (request) => {
       if (error instanceof NoUpdateAvailableError) {
         return errorResponse(error.message, 404, error.code);
       }
+      if (error instanceof DeploymentAlreadyActiveError) {
+        return errorResponse(error.message, 409, error.code);
+      }
       throw error;
     }
   }
 
+  if (action === "cancel") {
+    await autoUpdateOrchestrator.cancelPendingUpdate();
+    return NextResponse.json({ status: "cancelled", message: "Pending auto-update cancelled." });
+  }
+
   return errorResponse(
-    "Invalid action. Must be 'check' or 'apply'.",
+    "Invalid action. Must be 'check', 'apply', or 'cancel'.",
     400,
     "INVALID_ACTION"
   );

--- a/src/application/ports/DeploymentRepository.ts
+++ b/src/application/ports/DeploymentRepository.ts
@@ -1,0 +1,27 @@
+/**
+ * DeploymentRepository - Port interface for persisting auto-update deployment state.
+ *
+ * Stores the current deployment lifecycle state as a singleton row.
+ * Used by the auto-update orchestrator to track and recover deployment progress.
+ */
+
+import type { UpdateDeployment } from "@/domain/entities/UpdateDeployment";
+
+export interface DeploymentRepository {
+  /**
+   * Get the current deployment state, or null if no deployment is tracked.
+   */
+  getCurrent(): Promise<UpdateDeployment | null>;
+
+  /**
+   * Save the current deployment state.
+   * Upserts — creates if not present, updates if exists.
+   */
+  save(deployment: UpdateDeployment): Promise<void>;
+
+  /**
+   * Clear the current deployment state.
+   * Called after a deployment completes (success or terminal failure).
+   */
+  clear(): Promise<void>;
+}

--- a/src/application/ports/SessionDrainGateway.ts
+++ b/src/application/ports/SessionDrainGateway.ts
@@ -1,0 +1,28 @@
+/**
+ * SessionDrainGateway - Port interface for notifying connected clients
+ * of a pending update and querying active session count.
+ *
+ * The implementation communicates with the terminal server process
+ * to broadcast drain warnings and read session state.
+ */
+
+export interface DrainStatus {
+  activeSessions: number;
+  activeAgentSessions: number;
+}
+
+export interface SessionDrainGateway {
+  /**
+   * Notify all connected terminal clients that a restart is imminent.
+   * Returns the current active session and agent session counts.
+   *
+   * @param countdownSeconds - Seconds until the restart will occur
+   * @param version - Version being deployed
+   */
+  notifyDrain(countdownSeconds: number, version: string): Promise<DrainStatus>;
+
+  /**
+   * Query the current active session count without broadcasting.
+   */
+  getActiveSessionCount(): Promise<DrainStatus>;
+}

--- a/src/application/use-cases/update/DrainSessionsUseCase.ts
+++ b/src/application/use-cases/update/DrainSessionsUseCase.ts
@@ -1,0 +1,130 @@
+/**
+ * DrainSessionsUseCase - Notifies connected clients of a pending restart
+ * and waits for active sessions to drain.
+ *
+ * The drain is advisory, not blocking. After the configured timeout,
+ * the use case resolves regardless of remaining active sessions.
+ * Agent tmux sessions survive server restarts, so interrupted agents
+ * can be resumed post-update.
+ */
+
+import type { SessionDrainGateway, DrainStatus } from "@/application/ports/SessionDrainGateway";
+import type { DeploymentRepository } from "@/application/ports/DeploymentRepository";
+import type { UpdateDeployment } from "@/domain/entities/UpdateDeployment";
+import type { UpdatePolicy } from "@/domain/value-objects/UpdatePolicy";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("DrainSessions");
+
+export interface DrainSessionsInput {
+  deployment: UpdateDeployment;
+  policy: UpdatePolicy;
+}
+
+export interface DrainSessionsOutput {
+  drained: boolean;
+  remainingSessions: number;
+  remainingAgentSessions: number;
+  elapsedSeconds: number;
+}
+
+export class DrainSessionsUseCase {
+  constructor(
+    private readonly sessionDrainGateway: SessionDrainGateway,
+    private readonly deploymentRepository: DeploymentRepository
+  ) {}
+
+  async execute(input: DrainSessionsInput): Promise<DrainSessionsOutput> {
+    const { deployment, policy } = input;
+    const startTime = Date.now();
+
+    // Transition to draining stage
+    const drainingDeployment = deployment.startDrain();
+    await this.deploymentRepository.save(drainingDeployment);
+
+    log.info("Starting session drain", {
+      version: deployment.version,
+      timeoutSeconds: policy.drainTimeoutSeconds,
+    });
+
+    // Initial drain notification
+    let status: DrainStatus;
+    // Intentional fail-open: if the terminal server is unreachable,
+    // we cannot query session count but should not block the update.
+    // Agent tmux sessions survive restarts, so interrupted agents resume.
+    try {
+      status = await this.sessionDrainGateway.notifyDrain(
+        policy.drainTimeoutSeconds,
+        deployment.version
+      );
+    } catch (error) {
+      log.warn("Terminal server unreachable, skipping drain", { error: String(error) });
+      return {
+        drained: false,
+        remainingSessions: 0,
+        remainingAgentSessions: 0,
+        elapsedSeconds: 0,
+      };
+    }
+
+    if (status.activeSessions === 0) {
+      log.info("No active sessions, drain complete immediately");
+      return {
+        drained: true,
+        remainingSessions: 0,
+        remainingAgentSessions: 0,
+        elapsedSeconds: 0,
+      };
+    }
+
+    log.info("Waiting for sessions to drain", {
+      activeSessions: status.activeSessions,
+      activeAgentSessions: status.activeAgentSessions,
+    });
+
+    // Poll until drained or timeout.
+    // Use getActiveSessionCount for subsequent polls to avoid re-broadcasting
+    // the drain warning to all clients on every poll cycle.
+    const deadline = startTime + policy.drainTimeoutMs;
+    while (Date.now() < deadline) {
+      await sleep(Math.min(policy.drainPollIntervalMs, deadline - Date.now()));
+
+      try {
+        status = await this.sessionDrainGateway.getActiveSessionCount();
+      } catch (error) {
+        log.warn("Drain poll failed, proceeding", { error: String(error) });
+        break;
+      }
+
+      if (status.activeSessions === 0) {
+        const elapsed = (Date.now() - startTime) / 1000;
+        log.info("All sessions drained", { elapsedSeconds: elapsed });
+        return {
+          drained: true,
+          remainingSessions: 0,
+          remainingAgentSessions: 0,
+          elapsedSeconds: elapsed,
+        };
+      }
+    }
+
+    // Timeout — proceed anyway
+    const elapsed = (Date.now() - startTime) / 1000;
+    log.warn("Drain timeout reached, proceeding with update", {
+      remainingSessions: status.activeSessions,
+      remainingAgentSessions: status.activeAgentSessions,
+      elapsedSeconds: elapsed,
+    });
+
+    return {
+      drained: false,
+      remainingSessions: status.activeSessions,
+      remainingAgentSessions: status.activeAgentSessions,
+      elapsedSeconds: elapsed,
+    };
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/application/use-cases/update/ScheduleAutoUpdateUseCase.ts
+++ b/src/application/use-cases/update/ScheduleAutoUpdateUseCase.ts
@@ -1,0 +1,52 @@
+/**
+ * ScheduleAutoUpdateUseCase - Creates and persists a deployment record
+ * when an update is detected, computing the scheduled apply time.
+ *
+ * Called by the AutoUpdateOrchestrator when CheckForUpdatesUseCase
+ * returns an available update and auto-update is enabled.
+ */
+
+import { UpdateDeployment } from "@/domain/entities/UpdateDeployment";
+import type { DeploymentRepository } from "@/application/ports/DeploymentRepository";
+import type { UpdatePolicy } from "@/domain/value-objects/UpdatePolicy";
+import { DeploymentAlreadyActiveError } from "@/domain/errors/UpdateError";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("ScheduleAutoUpdate");
+
+export interface ScheduleAutoUpdateInput {
+  version: string;
+  policy: UpdatePolicy;
+}
+
+export interface ScheduleAutoUpdateOutput {
+  deployment: UpdateDeployment;
+}
+
+export class ScheduleAutoUpdateUseCase {
+  constructor(
+    private readonly deploymentRepository: DeploymentRepository
+  ) {}
+
+  async execute(input: ScheduleAutoUpdateInput): Promise<ScheduleAutoUpdateOutput> {
+    const { version, policy } = input;
+
+    const existing = await this.deploymentRepository.getCurrent();
+    if (existing && !existing.stage.isTerminal()) {
+      throw new DeploymentAlreadyActiveError(existing.stageTag);
+    }
+
+    const scheduledFor = new Date(Date.now() + policy.delayMs);
+    const deployment = UpdateDeployment.detected(version).schedule(scheduledFor);
+
+    await this.deploymentRepository.save(deployment);
+
+    log.info("Auto-update scheduled", {
+      version,
+      scheduledFor: scheduledFor.toISOString(),
+      delayMinutes: policy.delayMinutes,
+    });
+
+    return { deployment };
+  }
+}

--- a/src/application/use-cases/update/index.ts
+++ b/src/application/use-cases/update/index.ts
@@ -5,3 +5,9 @@ export { ApplyUpdateUseCase } from "./ApplyUpdateUseCase";
 
 export { GetUpdateStatusUseCase } from "./GetUpdateStatusUseCase";
 export type { UpdateStatusOutput } from "./GetUpdateStatusUseCase";
+
+export { ScheduleAutoUpdateUseCase } from "./ScheduleAutoUpdateUseCase";
+export type { ScheduleAutoUpdateInput, ScheduleAutoUpdateOutput } from "./ScheduleAutoUpdateUseCase";
+
+export { DrainSessionsUseCase } from "./DrainSessionsUseCase";
+export type { DrainSessionsInput, DrainSessionsOutput } from "./DrainSessionsUseCase";

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1603,6 +1603,7 @@ export const systemUpdateCache = sqliteTable("system_update_cache", {
   id: text("id").primaryKey().default("singleton"),
   lastChecked: integer("last_checked", { mode: "timestamp_ms" }),
   cachedReleaseJson: text("cached_release_json"),
+  deploymentStateJson: text("deployment_state_json"),
   updatedAt: integer("updated_at", { mode: "timestamp_ms" })
     .notNull()
     .$defaultFn(() => new Date()),

--- a/src/domain/entities/UpdateDeployment.ts
+++ b/src/domain/entities/UpdateDeployment.ts
@@ -1,0 +1,195 @@
+/**
+ * UpdateDeployment - Entity representing an in-progress auto-update deployment.
+ *
+ * Tracks the lifecycle of an update from detection through application.
+ * Persisted as a singleton row in the database so state survives restarts.
+ * Immutable — state changes return new instances.
+ */
+
+import { DeploymentStage } from "../value-objects/DeploymentStage";
+import type { DeploymentStageTag, DeploymentStagePlain } from "../value-objects/DeploymentStage";
+
+/** Serialized form for persistence (Dates as epoch ms). */
+export interface UpdateDeploymentPlain {
+  stage: DeploymentStagePlain;
+  version: string;
+  detectedAt: number;
+  scheduledFor: number | null;
+  drainStartedAt: number | null;
+  appliedAt: number | null;
+  failedAt: number | null;
+  failureReason: string | null;
+}
+
+export interface UpdateDeploymentProps {
+  stage: DeploymentStage;
+  version: string;
+  detectedAt: Date;
+  scheduledFor: Date | null;
+  drainStartedAt: Date | null;
+  appliedAt: Date | null;
+  failedAt: Date | null;
+  failureReason: string | null;
+}
+
+export class UpdateDeployment {
+  private constructor(private readonly props: UpdateDeploymentProps) {}
+
+  /**
+   * Create a new deployment when an update is first detected.
+   */
+  static detected(version: string): UpdateDeployment {
+    return new UpdateDeployment({
+      stage: DeploymentStage.detected(),
+      version,
+      detectedAt: new Date(),
+      scheduledFor: null,
+      drainStartedAt: null,
+      appliedAt: null,
+      failedAt: null,
+      failureReason: null,
+    });
+  }
+
+  /**
+   * Reconstitute from persisted data.
+   */
+  static reconstitute(props: UpdateDeploymentProps): UpdateDeployment {
+    return new UpdateDeployment(props);
+  }
+
+  get stage(): DeploymentStage {
+    return this.props.stage;
+  }
+
+  get stageTag(): DeploymentStageTag {
+    return this.props.stage.tag;
+  }
+
+  get version(): string {
+    return this.props.version;
+  }
+
+  get detectedAt(): Date {
+    return this.props.detectedAt;
+  }
+
+  get scheduledFor(): Date | null {
+    return this.props.scheduledFor;
+  }
+
+  get drainStartedAt(): Date | null {
+    return this.props.drainStartedAt;
+  }
+
+  get appliedAt(): Date | null {
+    return this.props.appliedAt;
+  }
+
+  get failedAt(): Date | null {
+    return this.props.failedAt;
+  }
+
+  get failureReason(): string | null {
+    return this.props.failureReason;
+  }
+
+  /**
+   * Transition to scheduled stage with a target apply time.
+   */
+  schedule(scheduledFor: Date): UpdateDeployment {
+    return new UpdateDeployment({
+      ...this.props,
+      stage: DeploymentStage.scheduled(scheduledFor),
+      scheduledFor,
+    });
+  }
+
+  /**
+   * Transition to draining stage.
+   */
+  startDrain(): UpdateDeployment {
+    return new UpdateDeployment({
+      ...this.props,
+      stage: DeploymentStage.draining(),
+      drainStartedAt: new Date(),
+    });
+  }
+
+  /**
+   * Transition to applying stage.
+   */
+  startApply(): UpdateDeployment {
+    return new UpdateDeployment({
+      ...this.props,
+      stage: DeploymentStage.applying(),
+    });
+  }
+
+  /**
+   * Transition to applied stage.
+   */
+  markApplied(): UpdateDeployment {
+    return new UpdateDeployment({
+      ...this.props,
+      stage: DeploymentStage.applied(),
+      appliedAt: new Date(),
+    });
+  }
+
+  /**
+   * Transition to failed stage.
+   */
+  markFailed(reason: string): UpdateDeployment {
+    return new UpdateDeployment({
+      ...this.props,
+      stage: DeploymentStage.failed(reason),
+      failedAt: new Date(),
+      failureReason: reason,
+    });
+  }
+
+  /**
+   * Transition to rolled back stage.
+   */
+  markRolledBack(): UpdateDeployment {
+    return new UpdateDeployment({
+      ...this.props,
+      stage: DeploymentStage.rolledBack(),
+      failedAt: new Date(),
+      failureReason: this.props.failureReason,
+    });
+  }
+
+  /**
+   * Serialize to a plain object for persistence.
+   */
+  toPlainObject(): UpdateDeploymentPlain {
+    return {
+      stage: this.props.stage.toPlainObject(),
+      version: this.props.version,
+      detectedAt: this.props.detectedAt.getTime(),
+      scheduledFor: this.props.scheduledFor?.getTime() ?? null,
+      drainStartedAt: this.props.drainStartedAt?.getTime() ?? null,
+      appliedAt: this.props.appliedAt?.getTime() ?? null,
+      failedAt: this.props.failedAt?.getTime() ?? null,
+      failureReason: this.props.failureReason,
+    };
+  }
+
+  /**
+   * Reconstitute from a plain object.
+   */
+  static fromPlainObject(obj: UpdateDeploymentPlain): UpdateDeployment {
+    return UpdateDeployment.reconstitute({
+      stage: DeploymentStage.fromPlainObject(obj.stage),
+      version: obj.version,
+      detectedAt: new Date(obj.detectedAt),
+      scheduledFor: obj.scheduledFor ? new Date(obj.scheduledFor) : null,
+      drainStartedAt: obj.drainStartedAt ? new Date(obj.drainStartedAt) : null,
+      appliedAt: obj.appliedAt ? new Date(obj.appliedAt) : null,
+      failedAt: obj.failedAt ? new Date(obj.failedAt) : null,
+      failureReason: obj.failureReason,
+    });
+  }
+}

--- a/src/domain/errors/UpdateError.ts
+++ b/src/domain/errors/UpdateError.ts
@@ -66,18 +66,6 @@ export class NoUpdateAvailableError extends UpdateError {
   }
 }
 
-export class DrainTimeoutError extends UpdateError {
-  constructor(
-    public readonly remainingSessionCount: number,
-    public readonly timeoutSeconds: number
-  ) {
-    super(
-      `Session drain timed out after ${timeoutSeconds}s with ${remainingSessionCount} active sessions`,
-      "DRAIN_TIMEOUT"
-    );
-  }
-}
-
 export class DeploymentAlreadyActiveError extends UpdateError {
   constructor(
     public readonly currentStage: string

--- a/src/domain/errors/UpdateError.ts
+++ b/src/domain/errors/UpdateError.ts
@@ -4,11 +4,7 @@
 
 import { DomainError } from "./DomainError";
 
-export class UpdateError extends DomainError {
-  constructor(message: string, code: string) {
-    super(message, code);
-  }
-}
+export class UpdateError extends DomainError {}
 
 export class NetworkError extends UpdateError {
   constructor(
@@ -66,6 +62,29 @@ export class NoUpdateAvailableError extends UpdateError {
     super(
       "No update is available to apply",
       "NO_UPDATE_AVAILABLE"
+    );
+  }
+}
+
+export class DrainTimeoutError extends UpdateError {
+  constructor(
+    public readonly remainingSessionCount: number,
+    public readonly timeoutSeconds: number
+  ) {
+    super(
+      `Session drain timed out after ${timeoutSeconds}s with ${remainingSessionCount} active sessions`,
+      "DRAIN_TIMEOUT"
+    );
+  }
+}
+
+export class DeploymentAlreadyActiveError extends UpdateError {
+  constructor(
+    public readonly currentStage: string
+  ) {
+    super(
+      `A deployment is already active in stage '${currentStage}'`,
+      "DEPLOYMENT_ALREADY_ACTIVE"
     );
   }
 }

--- a/src/domain/value-objects/DeploymentStage.ts
+++ b/src/domain/value-objects/DeploymentStage.ts
@@ -1,0 +1,136 @@
+/**
+ * DeploymentStage - Value object representing the lifecycle stage of an auto-update deployment.
+ *
+ * Stages:
+ *   detected → scheduled → draining → applying → applied
+ *                                    └─► failed
+ *                                    └─► rolledBack
+ *
+ * Each stage variant carries only the data relevant to it.
+ */
+
+export type DeploymentStageTag =
+  | "detected"
+  | "scheduled"
+  | "draining"
+  | "applying"
+  | "applied"
+  | "failed"
+  | "rolled_back";
+
+export type DeploymentStageVariant =
+  | { tag: "detected" }
+  | { tag: "scheduled"; scheduledFor: Date }
+  | { tag: "draining" }
+  | { tag: "applying" }
+  | { tag: "applied" }
+  | { tag: "failed"; reason: string }
+  | { tag: "rolled_back" };
+
+/** Serialized form for persistence (Dates as epoch ms). */
+export interface DeploymentStagePlain {
+  tag: DeploymentStageTag;
+  scheduledFor?: number;
+  reason?: string;
+}
+
+export class DeploymentStage {
+  private constructor(private readonly variant: DeploymentStageVariant) {}
+
+  static detected(): DeploymentStage {
+    return new DeploymentStage({ tag: "detected" });
+  }
+
+  static scheduled(scheduledFor: Date): DeploymentStage {
+    return new DeploymentStage({ tag: "scheduled", scheduledFor });
+  }
+
+  static draining(): DeploymentStage {
+    return new DeploymentStage({ tag: "draining" });
+  }
+
+  static applying(): DeploymentStage {
+    return new DeploymentStage({ tag: "applying" });
+  }
+
+  static applied(): DeploymentStage {
+    return new DeploymentStage({ tag: "applied" });
+  }
+
+  static failed(reason: string): DeploymentStage {
+    return new DeploymentStage({ tag: "failed", reason });
+  }
+
+  static rolledBack(): DeploymentStage {
+    return new DeploymentStage({ tag: "rolled_back" });
+  }
+
+  get tag(): DeploymentStageTag {
+    return this.variant.tag;
+  }
+
+  get scheduledFor(): Date | null {
+    return this.variant.tag === "scheduled" ? this.variant.scheduledFor : null;
+  }
+
+  get failureReason(): string | null {
+    return this.variant.tag === "failed" ? this.variant.reason : null;
+  }
+
+  isTerminal(): boolean {
+    return this.variant.tag === "applied" || this.variant.tag === "failed" || this.variant.tag === "rolled_back";
+  }
+
+  isPending(): boolean {
+    return this.variant.tag === "detected" || this.variant.tag === "scheduled";
+  }
+
+  isActive(): boolean {
+    return this.variant.tag === "draining" || this.variant.tag === "applying";
+  }
+
+  equals(other: DeploymentStage): boolean {
+    if (this.variant.tag !== other.variant.tag) return false;
+    if (this.variant.tag === "scheduled" && other.variant.tag === "scheduled") {
+      return this.variant.scheduledFor.getTime() === other.variant.scheduledFor.getTime();
+    }
+    if (this.variant.tag === "failed" && other.variant.tag === "failed") {
+      return this.variant.reason === other.variant.reason;
+    }
+    return true;
+  }
+
+  /**
+   * Serialize to a plain object for persistence.
+   */
+  toPlainObject(): DeploymentStagePlain {
+    const v = this.variant;
+    switch (v.tag) {
+      case "scheduled":
+        return { tag: v.tag, scheduledFor: v.scheduledFor.getTime() };
+      case "failed":
+        return { tag: v.tag, reason: v.reason };
+      default:
+        return { tag: v.tag };
+    }
+  }
+
+  /**
+   * Reconstitute from persisted data.
+   */
+  static fromPlainObject(obj: DeploymentStagePlain): DeploymentStage {
+    switch (obj.tag) {
+      case "detected": return DeploymentStage.detected();
+      case "scheduled": return DeploymentStage.scheduled(new Date(obj.scheduledFor ?? 0));
+      case "draining": return DeploymentStage.draining();
+      case "applying": return DeploymentStage.applying();
+      case "applied": return DeploymentStage.applied();
+      case "failed": return DeploymentStage.failed(obj.reason ?? "Unknown error");
+      case "rolled_back": return DeploymentStage.rolledBack();
+    }
+  }
+
+  toString(): string {
+    return this.variant.tag;
+  }
+}

--- a/src/domain/value-objects/UpdatePolicy.ts
+++ b/src/domain/value-objects/UpdatePolicy.ts
@@ -1,0 +1,95 @@
+/**
+ * UpdatePolicy - Value object encapsulating auto-update configuration.
+ *
+ * Reads from environment variables with sensible defaults.
+ * Immutable after construction.
+ */
+
+export interface UpdatePolicyProps {
+  enabled: boolean;
+  delayMinutes: number;
+  drainTimeoutSeconds: number;
+  drainPollIntervalSeconds: number;
+}
+
+const DEFAULT_DELAY_MINUTES = 5;
+const DEFAULT_DRAIN_TIMEOUT_SECONDS = 60;
+const DEFAULT_DRAIN_POLL_INTERVAL_SECONDS = 10;
+
+export class UpdatePolicy {
+  private constructor(private readonly props: UpdatePolicyProps) {}
+
+  /**
+   * Create an UpdatePolicy from environment variables.
+   *
+   * - AUTO_UPDATE_ENABLED: "true" to enable auto-updates (default: false)
+   * - AUTO_UPDATE_DELAY_MINUTES: minutes to wait after detection before applying (default: 5)
+   * - AUTO_UPDATE_DRAIN_TIMEOUT_SECONDS: max seconds to wait for sessions to drain (default: 60)
+   */
+  static fromEnv(env: Record<string, string | undefined> = process.env): UpdatePolicy {
+    const enabled = env.AUTO_UPDATE_ENABLED === "true";
+
+    const delayMinutes = parseInt(env.AUTO_UPDATE_DELAY_MINUTES ?? "", 10);
+    const drainTimeout = parseInt(env.AUTO_UPDATE_DRAIN_TIMEOUT_SECONDS ?? "", 10);
+
+    return new UpdatePolicy({
+      enabled,
+      delayMinutes: isNaN(delayMinutes) || delayMinutes < 0 ? DEFAULT_DELAY_MINUTES : delayMinutes,
+      drainTimeoutSeconds: isNaN(drainTimeout) || drainTimeout < 0 ? DEFAULT_DRAIN_TIMEOUT_SECONDS : drainTimeout,
+      drainPollIntervalSeconds: DEFAULT_DRAIN_POLL_INTERVAL_SECONDS,
+    });
+  }
+
+  /**
+   * Create an UpdatePolicy with explicit values (for testing).
+   */
+  static create(props: Partial<UpdatePolicyProps> = {}): UpdatePolicy {
+    return new UpdatePolicy({
+      enabled: props.enabled ?? false,
+      delayMinutes: props.delayMinutes ?? DEFAULT_DELAY_MINUTES,
+      drainTimeoutSeconds: props.drainTimeoutSeconds ?? DEFAULT_DRAIN_TIMEOUT_SECONDS,
+      drainPollIntervalSeconds: props.drainPollIntervalSeconds ?? DEFAULT_DRAIN_POLL_INTERVAL_SECONDS,
+    });
+  }
+
+  get enabled(): boolean {
+    return this.props.enabled;
+  }
+
+  get delayMinutes(): number {
+    return this.props.delayMinutes;
+  }
+
+  get delayMs(): number {
+    return this.props.delayMinutes * 60 * 1000;
+  }
+
+  get drainTimeoutSeconds(): number {
+    return this.props.drainTimeoutSeconds;
+  }
+
+  get drainTimeoutMs(): number {
+    return this.props.drainTimeoutSeconds * 1000;
+  }
+
+  get drainPollIntervalSeconds(): number {
+    return this.props.drainPollIntervalSeconds;
+  }
+
+  get drainPollIntervalMs(): number {
+    return this.props.drainPollIntervalSeconds * 1000;
+  }
+
+  equals(other: UpdatePolicy): boolean {
+    return (
+      this.props.enabled === other.props.enabled &&
+      this.props.delayMinutes === other.props.delayMinutes &&
+      this.props.drainTimeoutSeconds === other.props.drainTimeoutSeconds &&
+      this.props.drainPollIntervalSeconds === other.props.drainPollIntervalSeconds
+    );
+  }
+
+  toString(): string {
+    return `UpdatePolicy(enabled=${this.props.enabled}, delay=${this.props.delayMinutes}m, drain=${this.props.drainTimeoutSeconds}s)`;
+  }
+}

--- a/src/infrastructure/container.ts
+++ b/src/infrastructure/container.ts
@@ -73,18 +73,25 @@ import { RestartAgentUseCase } from "@/application/use-cases/session/RestartAgen
 
 // Update System
 import { DrizzleReleaseRepository } from "./persistence/repositories/DrizzleReleaseRepository";
+import { DrizzleDeploymentRepository } from "./persistence/repositories/DrizzleDeploymentRepository";
 import { GitHubReleaseGatewayImpl } from "./external/update/GitHubReleaseGateway";
+import { TerminalServerDrainGateway } from "./external/update/TerminalServerDrainGateway";
 import { ProcessServiceRestarter } from "./external/update/ProcessServiceRestarter";
 import { TarballInstallerImpl } from "./external/update/TarballInstallerImpl";
 import type { ReleaseRepository } from "@/application/ports/ReleaseRepository";
 import type { ReleaseGateway } from "@/application/ports/ReleaseGateway";
 import type { ServiceRestarter } from "@/application/ports/ServiceRestarter";
 import type { TarballInstaller } from "@/application/ports/TarballInstaller";
+import type { DeploymentRepository } from "@/application/ports/DeploymentRepository";
+import type { SessionDrainGateway } from "@/application/ports/SessionDrainGateway";
 import {
   CheckForUpdatesUseCase,
   ApplyUpdateUseCase,
   GetUpdateStatusUseCase,
+  ScheduleAutoUpdateUseCase,
+  DrainSessionsUseCase,
 } from "@/application/use-cases/update";
+import { AutoUpdateOrchestrator } from "@/services/auto-update-orchestrator";
 import { AppVersion } from "@/domain/value-objects/AppVersion";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -393,6 +400,27 @@ export const getUpdateStatusUseCase = new GetUpdateStatusUseCase(
   currentAppVersion
 );
 
+// Auto-Update System
+export const deploymentRepository: DeploymentRepository = new DrizzleDeploymentRepository();
+
+export const sessionDrainGateway: SessionDrainGateway = new TerminalServerDrainGateway();
+
+export const scheduleAutoUpdateUseCase = new ScheduleAutoUpdateUseCase(
+  deploymentRepository
+);
+
+export const drainSessionsUseCase = new DrainSessionsUseCase(
+  sessionDrainGateway,
+  deploymentRepository
+);
+
+export const autoUpdateOrchestrator = new AutoUpdateOrchestrator(
+  scheduleAutoUpdateUseCase,
+  drainSessionsUseCase,
+  applyUpdateUseCase,
+  deploymentRepository
+);
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Test Helpers
 // ─────────────────────────────────────────────────────────────────────────────
@@ -416,6 +444,8 @@ export interface Container {
   releaseGateway: ReleaseGateway;
   serviceRestarter: ServiceRestarter;
   tarballInstaller: TarballInstaller;
+  deploymentRepository: DeploymentRepository;
+  sessionDrainGateway: SessionDrainGateway;
 }
 
 /**
@@ -436,6 +466,8 @@ export const defaultContainer: Container = {
   releaseGateway,
   serviceRestarter,
   tarballInstaller,
+  deploymentRepository,
+  sessionDrainGateway,
 };
 
 /**

--- a/src/infrastructure/external/update/TerminalServerDrainGateway.ts
+++ b/src/infrastructure/external/update/TerminalServerDrainGateway.ts
@@ -1,0 +1,116 @@
+/**
+ * TerminalServerDrainGateway - Communicates with the terminal server's
+ * internal HTTP API to broadcast drain warnings and query session counts.
+ *
+ * Uses the same server discovery pattern as the rdv CLI:
+ * RDV_TERMINAL_SOCKET > RDV_TERMINAL_PORT > fallback to 6002.
+ */
+
+import type { SessionDrainGateway, DrainStatus } from "@/application/ports/SessionDrainGateway";
+import http from "node:http";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("TerminalServerDrainGateway");
+
+const DEFAULT_TERMINAL_PORT = 6002;
+
+export class TerminalServerDrainGateway implements SessionDrainGateway {
+  private cachedConnectionOptions: { socketPath?: string; hostname?: string; port?: number } | null = null;
+
+  private getConnectionOptions(): { socketPath?: string; hostname?: string; port?: number } {
+    if (this.cachedConnectionOptions) return this.cachedConnectionOptions;
+
+    const result = this.resolveConnectionOptions();
+    this.cachedConnectionOptions = result;
+    return result;
+  }
+
+  private resolveConnectionOptions(): { socketPath?: string; hostname?: string; port?: number } {
+    // Priority 1: explicit socket path
+    const socketEnv = process.env.RDV_TERMINAL_SOCKET;
+    if (socketEnv) {
+      return { socketPath: socketEnv };
+    }
+
+    // Priority 2: explicit port
+    const portEnv = process.env.RDV_TERMINAL_PORT;
+    if (portEnv) {
+      const port = parseInt(portEnv, 10);
+      if (!isNaN(port)) {
+        return { hostname: "127.0.0.1", port };
+      }
+    }
+
+    // Priority 3: auto-detect socket
+    const dataDir = process.env.RDV_DATA_DIR || join(homedir(), ".remote-dev");
+    const socketPath = join(dataDir, "run", "terminal.sock");
+    if (existsSync(socketPath)) {
+      return { socketPath };
+    }
+
+    // Priority 4: fallback TCP
+    return { hostname: "127.0.0.1", port: DEFAULT_TERMINAL_PORT };
+  }
+
+  async notifyDrain(countdownSeconds: number, version: string): Promise<DrainStatus> {
+    const body = JSON.stringify({ countdownSeconds, version });
+    return this.postInternal("/internal/drain", body);
+  }
+
+  async getActiveSessionCount(): Promise<DrainStatus> {
+    return this.postInternal("/internal/drain-status", "{}");
+  }
+
+  private postInternal(path: string, body: string): Promise<DrainStatus> {
+    const connOpts = this.getConnectionOptions();
+
+    return new Promise((resolve, reject) => {
+      const req = http.request(
+        {
+          ...connOpts,
+          method: "POST",
+          path,
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(body),
+            host: "localhost",
+          },
+        },
+        (res) => {
+          let responseBody = "";
+          res.on("data", (chunk: Buffer) => {
+            responseBody += chunk.toString();
+          });
+          res.on("end", () => {
+            try {
+              const data = JSON.parse(responseBody);
+              resolve({
+                activeSessions: data.activeSessions ?? 0,
+                activeAgentSessions: data.activeAgentSessions ?? 0,
+              });
+            } catch {
+              log.warn("Invalid JSON from terminal server", { path, responseBody });
+              resolve({ activeSessions: 0, activeAgentSessions: 0 });
+            }
+          });
+        }
+      );
+
+      req.setTimeout(5_000, () => {
+        req.destroy();
+        reject(new Error(`Timeout connecting to terminal server at ${path}`));
+      });
+
+      req.on("error", (err) => {
+        log.warn("Failed to reach terminal server", { path, error: err.message });
+        reject(err);
+      });
+
+      req.write(body);
+      req.end();
+    });
+  }
+}

--- a/src/infrastructure/persistence/repositories/DrizzleDeploymentRepository.ts
+++ b/src/infrastructure/persistence/repositories/DrizzleDeploymentRepository.ts
@@ -1,0 +1,66 @@
+/**
+ * DrizzleDeploymentRepository - SQLite-backed implementation of DeploymentRepository.
+ *
+ * Stores deployment lifecycle state as a JSON blob in the deploymentStateJson
+ * column of the existing system_update_cache singleton row.
+ */
+
+import { db } from "@/db";
+import { systemUpdateCache } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { UpdateDeployment } from "@/domain/entities/UpdateDeployment";
+import type { DeploymentRepository } from "@/application/ports/DeploymentRepository";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("DrizzleDeploymentRepository");
+
+const SINGLETON_ID = "singleton";
+
+export class DrizzleDeploymentRepository implements DeploymentRepository {
+  async getCurrent(): Promise<UpdateDeployment | null> {
+    const row = await db.query.systemUpdateCache.findFirst({
+      where: eq(systemUpdateCache.id, SINGLETON_ID),
+    });
+
+    if (!row?.deploymentStateJson) {
+      return null;
+    }
+
+    try {
+      const json = JSON.parse(row.deploymentStateJson);
+      return UpdateDeployment.fromPlainObject(json);
+    } catch (error) {
+      log.error("Failed to parse deployment state", { error: String(error) });
+      return null;
+    }
+  }
+
+  async save(deployment: UpdateDeployment): Promise<void> {
+    const json = JSON.stringify(deployment.toPlainObject());
+
+    await db
+      .insert(systemUpdateCache)
+      .values({
+        id: SINGLETON_ID,
+        deploymentStateJson: json,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: systemUpdateCache.id,
+        set: {
+          deploymentStateJson: json,
+          updatedAt: new Date(),
+        },
+      });
+  }
+
+  async clear(): Promise<void> {
+    await db
+      .update(systemUpdateCache)
+      .set({
+        deploymentStateJson: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(systemUpdateCache.id, SINGLETON_ID));
+  }
+}

--- a/src/interface/presenters/UpdatePresenter.ts
+++ b/src/interface/presenters/UpdatePresenter.ts
@@ -9,11 +9,23 @@ import type { UpdateStatusOutput } from "@/application/use-cases/update/GetUpdat
 import type { CheckForUpdatesOutput } from "@/application/use-cases/update/CheckForUpdatesUseCase";
 import type { Release } from "@/domain/entities/Release";
 import type { UpdateState, UpdateStateTag } from "@/domain/value-objects/UpdateState";
+import type { DeploymentStageTag } from "@/domain/value-objects/DeploymentStage";
 
 export interface DeployInfo {
   activeSlot: string;
   activeCommit: string;
   deployedAt: string;
+}
+
+export interface DeploymentInfo {
+  stage: DeploymentStageTag;
+  version: string;
+  detectedAt: string;
+  scheduledFor: string | null;
+  drainStartedAt: string | null;
+  appliedAt: string | null;
+  failedAt: string | null;
+  failureReason: string | null;
 }
 
 export interface UpdateStatusResponse {
@@ -27,6 +39,7 @@ export interface UpdateStatusResponse {
   publishedAt: string | null;
   errorMessage: string | null;
   deploy: DeployInfo | null;
+  deployment?: DeploymentInfo | null;
 }
 
 function readDeployInfo(): DeployInfo | null {
@@ -83,4 +96,29 @@ export function toCheckResultResponse(output: CheckForUpdatesOutput): UpdateStat
     new Date().toISOString(),
     output.release,
   );
+}
+
+/**
+ * Transform an UpdateDeployment entity into a DeploymentInfo response shape.
+ */
+export function toDeploymentInfo(deployment: {
+  stageTag: DeploymentStageTag;
+  version: string;
+  detectedAt: Date;
+  scheduledFor: Date | null;
+  drainStartedAt: Date | null;
+  appliedAt: Date | null;
+  failedAt: Date | null;
+  failureReason: string | null;
+}): DeploymentInfo {
+  return {
+    stage: deployment.stageTag,
+    version: deployment.version,
+    detectedAt: deployment.detectedAt.toISOString(),
+    scheduledFor: deployment.scheduledFor?.toISOString() ?? null,
+    drainStartedAt: deployment.drainStartedAt?.toISOString() ?? null,
+    appliedAt: deployment.appliedAt?.toISOString() ?? null,
+    failedAt: deployment.failedAt?.toISOString() ?? null,
+    failureReason: deployment.failureReason,
+  };
 }

--- a/src/lib/notification-toast.ts
+++ b/src/lib/notification-toast.ts
@@ -10,6 +10,8 @@ const TYPE_TO_VARIANT: Record<NotificationType, ToastVariant> = {
   agent_exited: "default",
   agent_waiting: "warning",
   session_closed: "default",
+  update_pending: "warning",
+  update_applied: "success",
   info: "default",
 };
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -15,6 +15,7 @@ import { config } from "dotenv";
 import { createTerminalServer } from "./terminal.js";
 import { schedulerOrchestrator } from "../services/scheduler-orchestrator.js";
 import { updateScheduler } from "../services/update-scheduler.js";
+import { autoUpdateOrchestrator } from "../infrastructure/container.js";
 import { execFile } from "../lib/exec.js";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -75,10 +76,19 @@ async function startServer(): Promise<void> {
     log.error("Failed to start update scheduler", { error: String(error) });
   }
 
+  // Start auto-update orchestrator (recovers pending deployments, handles scheduled updates)
+  try {
+    await autoUpdateOrchestrator.start();
+    log.info("Auto-update orchestrator started");
+  } catch (error) {
+    log.error("Failed to start auto-update orchestrator", { error: String(error) });
+  }
+
   async function shutdown(signal: string): Promise<void> {
     log.info("Shutdown signal received", { signal });
 
     updateScheduler.stop();
+    autoUpdateOrchestrator.stop();
 
     try {
       await schedulerOrchestrator.stop();

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -154,6 +154,14 @@ function broadcastToClients(data: Record<string, unknown>): void {
   }
 }
 
+/** Get the current active and agent session counts for drain status reporting. */
+function getSessionCounts(): { activeSessions: number; activeAgentSessions: number } {
+  const activeAgentSessions = [...sessions.values()].filter(
+    (s) => s.terminalType === "agent"
+  ).length;
+  return { activeSessions: sessions.size, activeAgentSessions };
+}
+
 /** Broadcast a JSON message to clients connected to a specific session */
 function broadcastToSession(sessionId: string, data: Record<string, unknown>): void {
   const message = JSON.stringify(data);
@@ -395,6 +403,31 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
 
   if (pathname === "/health" && req.method === "GET") {
     sendJson(res, 200, { status: "ok", scheduler: schedulerOrchestrator.isStarted() });
+    return true;
+  }
+
+  // Session drain notification for auto-update system
+  // Called by AutoUpdateOrchestrator: POST /internal/drain
+  if (pathname === "/internal/drain" && req.method === "POST") {
+    const payload = await parseRequestJson(req, res);
+    if (!payload) return true;
+    const { countdownSeconds, version } = payload;
+
+    internalLog.info("Drain notification received", { countdownSeconds, version });
+    broadcastToClients({
+      type: "update_pending",
+      countdownSeconds: countdownSeconds ?? 0,
+      version: version ?? "unknown",
+    });
+
+    sendJson(res, 200, getSessionCounts());
+    return true;
+  }
+
+  // Session drain status query (no broadcast)
+  // Called by AutoUpdateOrchestrator: POST /internal/drain-status
+  if (pathname === "/internal/drain-status" && req.method === "POST") {
+    sendJson(res, 200, getSessionCounts());
     return true;
   }
 

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -406,6 +406,14 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
     return true;
   }
 
+  // --- Localhost restriction for drain endpoints ---
+  if (pathname === "/internal/drain" || pathname === "/internal/drain-status") {
+    if (!isLocalhostRequest(req)) {
+      sendJson(res, 403, { error: "Forbidden: localhost only" });
+      return true;
+    }
+  }
+
   // Session drain notification for auto-update system
   // Called by AutoUpdateOrchestrator: POST /internal/drain
   if (pathname === "/internal/drain" && req.method === "POST") {

--- a/src/services/auto-update-orchestrator.ts
+++ b/src/services/auto-update-orchestrator.ts
@@ -1,0 +1,255 @@
+/**
+ * AutoUpdateOrchestrator - Coordinates the full auto-update lifecycle.
+ *
+ * Lifecycle: detect → schedule (delay) → drain → apply → restart
+ *
+ * Started alongside the UpdateScheduler in the terminal server process.
+ * Recovers in-progress deployments on restart by reading persisted state.
+ */
+
+import type { ScheduleAutoUpdateUseCase } from "@/application/use-cases/update/ScheduleAutoUpdateUseCase";
+import type { DrainSessionsUseCase } from "@/application/use-cases/update/DrainSessionsUseCase";
+import type { ApplyUpdateUseCase } from "@/application/use-cases/update/ApplyUpdateUseCase";
+import type { DeploymentRepository } from "@/application/ports/DeploymentRepository";
+import { UpdatePolicy } from "@/domain/value-objects/UpdatePolicy";
+import { DeploymentAlreadyActiveError } from "@/domain/errors/UpdateError";
+import type { DeploymentStageTag } from "@/domain/value-objects/DeploymentStage";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("AutoUpdateOrchestrator");
+
+export class AutoUpdateOrchestrator {
+  private policy: UpdatePolicy;
+  private applyTimer: ReturnType<typeof setTimeout> | null = null;
+  private running = false;
+
+  constructor(
+    private readonly scheduleUseCase: ScheduleAutoUpdateUseCase,
+    private readonly drainUseCase: DrainSessionsUseCase,
+    private readonly applyUseCase: ApplyUpdateUseCase,
+    private readonly deploymentRepository: DeploymentRepository
+  ) {
+    this.policy = UpdatePolicy.fromEnv();
+  }
+
+  /**
+   * Start the orchestrator. Recovers pending deployments from the database.
+   */
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+
+    log.info("Started", { policy: this.policy.toString() });
+
+    if (!this.policy.enabled) {
+      log.info("Auto-update is disabled (set AUTO_UPDATE_ENABLED=true to enable)");
+      return;
+    }
+
+    // Recover any in-progress deployment from a previous server instance
+    await this.recoverPendingDeployment();
+  }
+
+  /**
+   * Stop the orchestrator and cancel any pending timers.
+   */
+  stop(): void {
+    this.running = false;
+    if (this.applyTimer) {
+      clearTimeout(this.applyTimer);
+      this.applyTimer = null;
+    }
+    log.info("Stopped");
+  }
+
+  /**
+   * Called by UpdateScheduler when a new release is detected.
+   */
+  async onUpdateDetected(version: string): Promise<void> {
+    if (!this.policy.enabled) {
+      log.debug("Auto-update disabled, ignoring detected update", { version });
+      return;
+    }
+
+    if (this.applyTimer) {
+      log.debug("Auto-update already scheduled, ignoring", { version });
+      return;
+    }
+
+    try {
+      const result = await this.scheduleUseCase.execute({
+        version,
+        policy: this.policy,
+      });
+
+      const scheduledFor = result.deployment.scheduledFor;
+      if (!scheduledFor) return;
+
+      const delayMs = Math.max(0, scheduledFor.getTime() - Date.now());
+      this.armTimer(delayMs, version);
+
+      log.info("Auto-update armed", {
+        version,
+        delayMinutes: this.policy.delayMinutes,
+        scheduledFor: scheduledFor.toISOString(),
+      });
+    } catch (error) {
+      if (error instanceof DeploymentAlreadyActiveError) {
+        log.debug("Deployment already active, skipping schedule", {
+          currentStage: error.currentStage,
+        });
+        return;
+      }
+      log.error("Failed to schedule auto-update", { error: String(error) });
+    }
+  }
+
+  /**
+   * Cancel a pending scheduled update.
+   * Cannot cancel a deployment that has already started draining or applying.
+   */
+  async cancelPendingUpdate(): Promise<void> {
+    const existing = await this.deploymentRepository.getCurrent();
+    if (existing && existing.stage.isActive()) {
+      log.warn("Cannot cancel active deployment", { stage: existing.stageTag });
+      throw new DeploymentAlreadyActiveError(existing.stageTag);
+    }
+
+    if (this.applyTimer) {
+      clearTimeout(this.applyTimer);
+      this.applyTimer = null;
+    }
+
+    await this.deploymentRepository.clear();
+    log.info("Pending auto-update cancelled");
+  }
+
+  /**
+   * Get the current deployment stage for status reporting.
+   */
+  async getDeploymentStage(): Promise<DeploymentStageTag | null> {
+    const deployment = await this.deploymentRepository.getCurrent();
+    return deployment?.stageTag ?? null;
+  }
+
+  private armTimer(delayMs: number, version: string): void {
+    if (this.applyTimer) {
+      clearTimeout(this.applyTimer);
+    }
+
+    this.applyTimer = setTimeout(async () => {
+      this.applyTimer = null;
+      await this.executeUpdate(version);
+    }, delayMs);
+  }
+
+  private async executeUpdate(version: string): Promise<void> {
+    log.info("Starting auto-update", { version });
+
+    try {
+      let deployment = await this.deploymentRepository.getCurrent();
+      if (!deployment) {
+        log.warn("No deployment record found, aborting auto-update");
+        return;
+      }
+
+      const drainResult = await this.drainUseCase.execute({
+        deployment,
+        policy: this.policy,
+      });
+
+      log.info("Drain complete", {
+        drained: drainResult.drained,
+        remainingSessions: drainResult.remainingSessions,
+        elapsedSeconds: drainResult.elapsedSeconds,
+      });
+
+      // Re-read deployment (drain use case may have updated it)
+      deployment = await this.deploymentRepository.getCurrent();
+      if (!deployment) {
+        log.warn("Deployment record lost during drain, aborting");
+        return;
+      }
+
+      const applyingDeployment = deployment.startApply();
+      await this.deploymentRepository.save(applyingDeployment);
+
+      await this.applyUseCase.execute();
+
+      // Mark applied (may not execute if restart happens first)
+      const appliedDeployment = applyingDeployment.markApplied();
+      await this.deploymentRepository.save(appliedDeployment);
+
+      log.info("Auto-update applied successfully", { version });
+    } catch (error) {
+      log.error("Auto-update failed", { version, error: String(error) });
+
+      // Record failure
+      try {
+        const deployment = await this.deploymentRepository.getCurrent();
+        if (deployment) {
+          const failedDeployment = deployment.markFailed(String(error));
+          await this.deploymentRepository.save(failedDeployment);
+        }
+      } catch (saveError) {
+        log.error("Failed to record deployment failure", { error: String(saveError) });
+      }
+    }
+  }
+
+  /**
+   * On startup, check if there's a pending deployment from a previous instance.
+   * If the scheduled time is in the past, apply immediately.
+   * If in the future, re-arm the timer for the remaining delay.
+   */
+  private async recoverPendingDeployment(): Promise<void> {
+    const deployment = await this.deploymentRepository.getCurrent();
+    if (!deployment) return;
+
+    const stage = deployment.stageTag;
+
+    // Terminal stages — clear stale state
+    if (deployment.stage.isTerminal()) {
+      log.debug("Clearing terminal deployment state", { stage });
+      await this.deploymentRepository.clear();
+      return;
+    }
+
+    // If scheduled, re-arm timer
+    if (stage === "scheduled" && deployment.scheduledFor) {
+      const remainingMs = deployment.scheduledFor.getTime() - Date.now();
+      if (remainingMs > 0) {
+        log.info("Recovering scheduled deployment", {
+          version: deployment.version,
+          remainingMinutes: Math.ceil(remainingMs / 60_000),
+        });
+        this.armTimer(remainingMs, deployment.version);
+      } else {
+        log.info("Scheduled deployment overdue, applying now", {
+          version: deployment.version,
+        });
+        this.armTimer(0, deployment.version);
+      }
+      return;
+    }
+
+    // If draining or applying, the previous instance was interrupted mid-update.
+    // Clear the state and let the next poll cycle detect the update again.
+    if (stage === "draining" || stage === "applying") {
+      log.warn("Previous deployment was interrupted, clearing state", {
+        stage,
+        version: deployment.version,
+      });
+      await this.deploymentRepository.clear();
+      return;
+    }
+
+    // Detected but not yet scheduled — schedule now
+    if (stage === "detected") {
+      log.info("Recovering detected deployment, scheduling", {
+        version: deployment.version,
+      });
+      await this.onUpdateDetected(deployment.version);
+    }
+  }
+}

--- a/src/services/auto-update-orchestrator.ts
+++ b/src/services/auto-update-orchestrator.ts
@@ -244,11 +244,14 @@ export class AutoUpdateOrchestrator {
       return;
     }
 
-    // Detected but not yet scheduled — schedule now
+    // Detected but not yet scheduled — clear stale record and re-schedule.
+    // Cannot call onUpdateDetected() because ScheduleAutoUpdateUseCase would
+    // see the existing non-terminal record and throw DeploymentAlreadyActiveError.
     if (stage === "detected") {
-      log.info("Recovering detected deployment, scheduling", {
+      log.info("Recovering detected deployment, clearing and re-scheduling", {
         version: deployment.version,
       });
+      await this.deploymentRepository.clear();
       await this.onUpdateDetected(deployment.version);
     }
   }

--- a/src/services/update-scheduler.ts
+++ b/src/services/update-scheduler.ts
@@ -3,9 +3,12 @@
  *
  * Periodically checks for new releases from GitHub.
  * Configurable via UPDATE_CHECK_INTERVAL_HOURS env var (default: 4 hours).
+ *
+ * When auto-update is enabled, notifies the AutoUpdateOrchestrator
+ * when a new version is detected so it can schedule the update.
  */
 
-import { checkForUpdatesUseCase } from "@/infrastructure/container";
+import { checkForUpdatesUseCase, autoUpdateOrchestrator } from "@/infrastructure/container";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("UpdateScheduler");
@@ -56,8 +59,11 @@ class UpdateScheduler {
   private async check(): Promise<void> {
     try {
       const result = await checkForUpdatesUseCase.execute({ force: false });
-      if (result.state.isAvailable()) {
-        log.info(`Update available: v${result.latestVersion}`);
+      if (result.state.isAvailable() && result.latestVersion) {
+        log.info("Update available", { version: result.latestVersion });
+
+        // Notify the auto-update orchestrator (no-op if auto-update is disabled)
+        await autoUpdateOrchestrator.onUpdateDetected(result.latestVersion);
       }
     } catch (error) {
       log.error("Check failed", { error: String(error) });

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -9,6 +9,8 @@ export type NotificationType =
   | "agent_exited"
   | "build_fail"
   | "session_closed"
+  | "update_pending"
+  | "update_applied"
   | "info";
 
 export interface NotificationEvent {


### PR DESCRIPTION
## Summary
- Replace GitHub webhook dependency with poll-based auto-update system for independent multi-server installations
- Each server polls GitHub Releases for pre-built artifacts and self-updates with graceful session draining
- Full Clean Architecture implementation: domain objects, ports, use cases, infrastructure, orchestrator
- Webhook deploy path gradually deprecated (returns 410 when `AUTO_UPDATE_ENABLED=true`)

## Architecture
```
UpdateScheduler (every 4h)
  → CheckForUpdatesUseCase
  → AutoUpdateOrchestrator.onUpdateDetected()
    → ScheduleAutoUpdateUseCase (persist + delay)
    → DrainSessionsUseCase (notify clients, poll until idle or timeout)
    → ApplyUpdateUseCase (download, verify, install, restart)
```

## New env vars
| Variable | Default | Description |
|----------|---------|-------------|
| `AUTO_UPDATE_ENABLED` | `false` | Enable poll-based auto-updates |
| `AUTO_UPDATE_DELAY_MINUTES` | `5` | Delay after detection before applying |
| `AUTO_UPDATE_DRAIN_TIMEOUT_SECONDS` | `60` | Max wait for sessions to drain |

## Key design decisions
- **Fail-open drain**: If terminal server unreachable, update proceeds (agent tmux sessions survive restarts)
- **Durable state**: Deployment lifecycle persisted to SQLite, recovers pending timers on restart
- **Cancel guard**: Cannot cancel deployment already in draining/applying stage

## Files changed
- 10 new files (domain, ports, use cases, infra, orchestrator)
- 12 modified files (schema, container, API routes, terminal server, scheduler)

## Test plan
- [ ] Set `AUTO_UPDATE_ENABLED=true` and verify UpdateScheduler triggers orchestrator on detection
- [ ] Verify drain broadcasts `update_pending` WebSocket message to connected clients
- [ ] Verify `POST /api/system/update { action: "cancel" }` cancels pending updates
- [ ] Verify `POST /api/deploy` returns 410 when `AUTO_UPDATE_ENABLED=true`
- [ ] Verify deployment state persists and recovers across server restarts
- [ ] Verify `GET /api/system/update` includes deployment lifecycle info

🤖 Generated with [Claude Code](https://claude.com/claude-code)