### PR TITLE
fix: add read:org scope to GitHub OAuth

### DIFF
--- a/src/app/api/auth/github/link/route.ts
+++ b/src/app/api/auth/github/link/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { withAuth, errorResponse } from "@/lib/api";
 import { createSignedState } from "@/lib/oauth-state";
+import { GITHUB_SCOPE_STRING } from "@/lib/github-scopes";
 
 export const GET = withAuth(async (_request, { userId }) => {
   // Redirect to GitHub OAuth with state parameter to indicate this is an account link
@@ -10,15 +11,14 @@ export const GET = withAuth(async (_request, { userId }) => {
   }
 
   const redirectUri = `${process.env.NEXTAUTH_URL || "http://localhost:3000"}/api/auth/github/callback`;
-  const scope = "read:user user:email repo";
-  
+
   // Use HMAC-signed state to prevent CSRF attacks
   const state = createSignedState(userId, "link");
 
   const githubAuthUrl = new URL("https://github.com/login/oauth/authorize");
   githubAuthUrl.searchParams.set("client_id", clientId);
   githubAuthUrl.searchParams.set("redirect_uri", redirectUri);
-  githubAuthUrl.searchParams.set("scope", scope);
+  githubAuthUrl.searchParams.set("scope", GITHUB_SCOPE_STRING);
   githubAuthUrl.searchParams.set("state", state);
   // Force GitHub to show the account picker instead of silently re-authing
   githubAuthUrl.searchParams.set("prompt", "select_account");

--- a/src/app/api/github/accounts/route.ts
+++ b/src/app/api/github/accounts/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { withAuth, errorResponse } from "@/lib/api";
-import { listGitHubAccountsUseCase } from "@/infrastructure/container";
+import { listGitHubAccountsUseCase, githubAccountRepository } from "@/infrastructure/container";
 import { createLogger } from "@/lib/logger";
+import { isMissingRequiredScopes } from "@/lib/github-scopes";
 
 const log = createLogger("api/github");
 
@@ -11,14 +12,20 @@ const log = createLogger("api/github");
  */
 export const GET = withAuth(async (_request, { userId }) => {
   try {
-    const result = await listGitHubAccountsUseCase.execute(userId);
+    const [result, scopeMap] = await Promise.all([
+      listGitHubAccountsUseCase.execute(userId),
+      githubAccountRepository.getAccountScopes(userId),
+    ]);
 
     return NextResponse.json({
       accounts: result.accounts.map((a) => {
         // Strip configDir (server-side path) from client response
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { configDir, ...rest } = a.toPlainObject();
-        return rest;
+        const needsReauth = isMissingRequiredScopes(
+          scopeMap.get(a.providerAccountId) ?? null
+        );
+        return { ...rest, needsReauth };
       }),
       folderBindings: Object.fromEntries(result.folderBindings),
     });

--- a/src/application/ports/GitHubAccountRepository.ts
+++ b/src/application/ports/GitHubAccountRepository.ts
@@ -34,4 +34,7 @@ export interface GitHubAccountRepository {
 
   /** Returns the userId that owns this account, or null. */
   findOwner(providerAccountId: string): Promise<string | null>;
+
+  /** Returns a map of providerAccountId -> scope string from the OAuth accounts table. */
+  getAccountScopes(userId: string): Promise<Map<string, string | null>>;
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -8,6 +8,7 @@ import { db } from "@/db";
 import { users, accounts, sessions, verificationTokens, authorizedUsers } from "@/db/schema";
 import { encrypt, decryptSafe } from "@/lib/encryption";
 import { createLogger } from "@/lib/logger";
+import { GITHUB_SCOPE_STRING } from "@/lib/github-scopes";
 import type { Adapter, AdapterAccount } from "next-auth/adapters";
 
 const log = createLogger("Auth");
@@ -87,8 +88,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       clientSecret: process.env.GITHUB_CLIENT_SECRET,
       authorization: {
         params: {
-          // Request full repo access for cloning private repos and managing worktrees
-          scope: "read:user user:email repo",
+          scope: GITHUB_SCOPE_STRING,
         },
       },
     }),

--- a/src/components/github/AccountSwitcher.tsx
+++ b/src/components/github/AccountSwitcher.tsx
@@ -19,6 +19,7 @@ import {
   Loader2,
   ExternalLink,
   AlertCircle,
+  RefreshCw,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -131,6 +132,11 @@ export function AccountSwitcher() {
                           Default
                         </Badge>
                       )}
+                      {account.needsReauth && (
+                        <Badge variant="outline" className="text-xs shrink-0 border-amber-500/50 text-amber-500">
+                          Missing scopes
+                        </Badge>
+                      )}
                     </div>
                     <p className="text-sm text-muted-foreground truncate">
                       @{account.login}
@@ -139,6 +145,22 @@ export function AccountSwitcher() {
                   </div>
 
                   <div className="flex items-center gap-1 shrink-0">
+                    {account.needsReauth && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8 text-amber-500 hover:text-amber-400"
+                            onClick={addAccount}
+                          >
+                            <RefreshCw className="w-4 h-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Re-authorize to grant missing scopes</TooltipContent>
+                      </Tooltip>
+                    )}
+
                     {!account.isDefault && (
                       <Tooltip>
                         <TooltipTrigger asChild>

--- a/src/contexts/GitHubAccountContext.tsx
+++ b/src/contexts/GitHubAccountContext.tsx
@@ -28,6 +28,7 @@ export interface LinkedGitHubAccount {
   avatarUrl: string;
   email: string | null;
   isDefault: boolean;
+  needsReauth: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/infrastructure/persistence/repositories/DrizzleGitHubAccountRepository.ts
+++ b/src/infrastructure/persistence/repositories/DrizzleGitHubAccountRepository.ts
@@ -211,4 +211,18 @@ export class DrizzleGitHubAccountRepository implements GitHubAccountRepository {
     });
     return record?.userId ?? null;
   }
+
+  async getAccountScopes(userId: string): Promise<Map<string, string | null>> {
+    const rows = await db
+      .select({
+        providerAccountId: accounts.providerAccountId,
+        scope: accounts.scope,
+      })
+      .from(accounts)
+      .where(
+        and(eq(accounts.userId, userId), eq(accounts.provider, "github"))
+      );
+
+    return new Map(rows.map((r) => [r.providerAccountId, r.scope]));
+  }
 }

--- a/src/lib/github-scopes.ts
+++ b/src/lib/github-scopes.ts
@@ -1,0 +1,21 @@
+/**
+ * Required GitHub OAuth scopes for full functionality.
+ * Accounts missing any of these scopes will be flagged for re-authorization.
+ */
+export const REQUIRED_GITHUB_SCOPES = [
+  "read:user",
+  "user:email",
+  "repo",
+  "read:org",
+] as const;
+
+export const GITHUB_SCOPE_STRING = REQUIRED_GITHUB_SCOPES.join(" ");
+
+/**
+ * Check whether a stored scope string is missing any required scopes.
+ * Returns true if the account should be re-authorized.
+ */
+export function isMissingRequiredScopes(storedScope: string | null): boolean {
+  const granted = (storedScope ?? "").split(/[,\s]+/).filter(Boolean);
+  return REQUIRED_GITHUB_SCOPES.some((s) => !granted.includes(s));
+}


### PR DESCRIPTION
## Summary
- Add `read:org` to GitHub OAuth scope requests (both NextAuth provider and manual link flow)
- Centralize required scopes in `src/lib/github-scopes.ts` as single source of truth
- Detect existing accounts with missing scopes via `getAccountScopes()` repository method
- Surface `needsReauth` flag in the accounts API response
- Show "Missing scopes" badge and re-authorize button in AccountSwitcher UI

## Test plan
- [ ] Link a new GitHub account — verify token includes `read:org` scope
- [ ] Check existing accounts — verify "Missing scopes" badge appears for accounts without `read:org`
- [ ] Click re-authorize button — verify it redirects through OAuth flow with updated scopes
- [ ] After re-auth — verify badge disappears and `gh auth status` shows no missing scopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)