### PR TITLE
feat: add worktree creation to mobile app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Mobile worktree creation**: Create git worktrees from the Flutter mobile app's session creation sheet
+  - Worktree type picker (feature/fix/chore/refactor/docs/release)
+  - Branch name auto-suggestion from session name
+  - Async base branch picker fetched from server
+  - New Clean Architecture ports: GitGateway, FolderPreferencesGateway
+
 ## [0.3.0] - 2026-03-20
 
 ### Added

--- a/mobile/lib/application/ports/folder_preferences_gateway.dart
+++ b/mobile/lib/application/ports/folder_preferences_gateway.dart
@@ -1,0 +1,27 @@
+import 'package:remote_dev/domain/errors/app_error.dart';
+
+/// Per-folder preferences relevant to worktree and git operations.
+class FolderPreferences {
+  const FolderPreferences({
+    this.localRepoPath,
+    this.githubRepoId,
+    this.defaultWorkingDirectory,
+  });
+
+  final String? localRepoPath;
+  final String? githubRepoId;
+  final String? defaultWorkingDirectory;
+
+  /// Whether this folder has a linked git repository.
+  bool get hasGitRepo => localRepoPath != null || githubRepoId != null;
+
+  /// The best available path for git operations.
+  /// Prefers [localRepoPath], falls back to [defaultWorkingDirectory].
+  String? get gitPath => localRepoPath ?? defaultWorkingDirectory;
+}
+
+/// Abstract gateway for folder preference operations.
+abstract interface class FolderPreferencesGateway {
+  /// Returns preferences keyed by folder ID.
+  Future<Result<Map<String, FolderPreferences>>> getAllFolderPreferences();
+}

--- a/mobile/lib/application/ports/folder_preferences_gateway.dart
+++ b/mobile/lib/application/ports/folder_preferences_gateway.dart
@@ -12,12 +12,14 @@ class FolderPreferences {
   final String? githubRepoId;
   final String? defaultWorkingDirectory;
 
-  /// Whether this folder has a linked git repository.
-  bool get hasGitRepo => localRepoPath != null || githubRepoId != null;
-
   /// The best available path for git operations.
   /// Prefers [localRepoPath], falls back to [defaultWorkingDirectory].
   String? get gitPath => localRepoPath ?? defaultWorkingDirectory;
+
+  /// Whether this folder has a usable git repository path.
+  /// Only true when [gitPath] is non-null, ensuring the worktree toggle
+  /// is only enabled when branch fetching can actually succeed.
+  bool get hasGitRepo => gitPath != null;
 }
 
 /// Abstract gateway for folder preference operations.

--- a/mobile/lib/application/ports/git_gateway.dart
+++ b/mobile/lib/application/ports/git_gateway.dart
@@ -1,0 +1,21 @@
+import 'package:remote_dev/domain/errors/app_error.dart';
+
+/// Result of validating a filesystem path as a git repository.
+class GitValidationResult {
+  const GitValidationResult({
+    required this.isGitRepo,
+    required this.branches,
+  });
+
+  final bool isGitRepo;
+  final List<String> branches;
+}
+
+/// Abstract gateway for git-related server queries.
+///
+/// Read-only operations (not CRUD persistence), following the
+/// [AppearanceGateway] pattern for lightweight gateways.
+abstract interface class GitGateway {
+  /// Validates a path as a git repo and returns its local branches.
+  Future<Result<GitValidationResult>> validateAndListBranches(String path);
+}

--- a/mobile/lib/domain/repositories/session_repository.dart
+++ b/mobile/lib/domain/repositories/session_repository.dart
@@ -14,6 +14,12 @@ class CreateSessionInput {
   final String? startupCommand;
   final String? parentSessionId;
 
+  // Worktree fields
+  final bool createWorktree;
+  final String? worktreeType;
+  final String? baseBranch;
+  final String? featureDescription;
+
   const CreateSessionInput({
     required this.name,
     this.projectPath,
@@ -25,6 +31,10 @@ class CreateSessionInput {
     this.agentFlags,
     this.startupCommand,
     this.parentSessionId,
+    this.createWorktree = false,
+    this.worktreeType,
+    this.baseBranch,
+    this.featureDescription,
   });
 }
 

--- a/mobile/lib/domain/value_objects/worktree_type.dart
+++ b/mobile/lib/domain/value_objects/worktree_type.dart
@@ -1,0 +1,25 @@
+/// Worktree branch type determining the branch prefix.
+///
+/// Matches the server's `WORKTREE_TYPES` from `src/types/session.ts`.
+enum WorktreeType {
+  feature('feature', 'Feature'),
+  fix('fix', 'Fix'),
+  chore('chore', 'Chore'),
+  refactor('refactor', 'Refactor'),
+  docs('docs', 'Docs'),
+  release('release', 'Release');
+
+  const WorktreeType(this.value, this.displayName);
+  final String value;
+  final String displayName;
+
+  static WorktreeType fromString(String? value) => switch (value) {
+        'feature' => WorktreeType.feature,
+        'fix' => WorktreeType.fix,
+        'chore' => WorktreeType.chore,
+        'refactor' => WorktreeType.refactor,
+        'docs' => WorktreeType.docs,
+        'release' => WorktreeType.release,
+        _ => WorktreeType.feature,
+      };
+}

--- a/mobile/lib/infrastructure/api/gateways/api_folder_preferences_gateway.dart
+++ b/mobile/lib/infrastructure/api/gateways/api_folder_preferences_gateway.dart
@@ -1,0 +1,47 @@
+import 'package:remote_dev/application/ports/folder_preferences_gateway.dart';
+import 'package:remote_dev/domain/errors/app_error.dart';
+import 'package:remote_dev/infrastructure/api/remote_dev_client.dart';
+
+/// API-backed implementation of [FolderPreferencesGateway].
+///
+/// Reuses the existing `GET /api/preferences` endpoint and extracts
+/// the `folderPreferences` map from the response.
+class ApiFolderPreferencesGateway implements FolderPreferencesGateway {
+  ApiFolderPreferencesGateway({required RemoteDevClient client})
+      : _client = client;
+  final RemoteDevClient _client;
+
+  @override
+  Future<Result<Map<String, FolderPreferences>>>
+      getAllFolderPreferences() async {
+    try {
+      final data = await _client.getPreferences();
+      // Server returns folderPreferences as an array of objects,
+      // each containing a folderId field.
+      final rawList = data['folderPreferences'] as List? ?? [];
+      final result = <String, FolderPreferences>{};
+      for (final item in rawList) {
+        final prefs = item as Map<String, dynamic>;
+        final folderId = prefs['folderId'] as String?;
+        if (folderId == null || folderId.isEmpty) continue;
+        result[folderId] = FolderPreferences(
+          localRepoPath: prefs['localRepoPath'] as String?,
+          githubRepoId: prefs['githubRepoId'] as String?,
+          defaultWorkingDirectory:
+              prefs['defaultWorkingDirectory'] as String?,
+        );
+      }
+      return Success(result);
+    } on AppError catch (e) {
+      return Failure(e);
+    } on Object catch (e) {
+      return Failure(
+        ApiError(
+          'Failed to parse folder preferences: $e',
+          code: 'PARSE_ERROR',
+          statusCode: 0,
+        ),
+      );
+    }
+  }
+}

--- a/mobile/lib/infrastructure/api/gateways/api_git_gateway.dart
+++ b/mobile/lib/infrastructure/api/gateways/api_git_gateway.dart
@@ -1,0 +1,34 @@
+import 'package:remote_dev/application/ports/git_gateway.dart';
+import 'package:remote_dev/domain/errors/app_error.dart';
+import 'package:remote_dev/infrastructure/api/remote_dev_client.dart';
+
+/// API-backed implementation of [GitGateway].
+class ApiGitGateway implements GitGateway {
+  ApiGitGateway({required RemoteDevClient client}) : _client = client;
+  final RemoteDevClient _client;
+
+  @override
+  Future<Result<GitValidationResult>> validateAndListBranches(
+    String path,
+  ) async {
+    try {
+      final data = await _client.validateGitPath(path);
+      return Success(
+        GitValidationResult(
+          isGitRepo: data['isGitRepo'] as bool? ?? false,
+          branches: (data['branches'] as List?)?.cast<String>() ?? [],
+        ),
+      );
+    } on AppError catch (e) {
+      return Failure(e);
+    } on Object catch (e) {
+      return Failure(
+        ApiError(
+          'Failed to validate git path: $e',
+          code: 'PARSE_ERROR',
+          statusCode: 0,
+        ),
+      );
+    }
+  }
+}

--- a/mobile/lib/infrastructure/api/remote_dev_client.dart
+++ b/mobile/lib/infrastructure/api/remote_dev_client.dart
@@ -169,6 +169,19 @@ class RemoteDevClient {
     );
   }
 
+  // ── Git ──────────────────────────────────────────────────────────────
+
+  /// Validates a filesystem path as a git repository and returns local branches.
+  /// Returns { isGitRepo: bool, branches: List<String> }.
+  Future<Map<String, dynamic>> validateGitPath(String path) async {
+    return _request(
+      () => _dio.get(
+        '/api/git/validate',
+        queryParameters: {'path': path},
+      ),
+    );
+  }
+
   // ── Splits ────────────────────────────────────────────────────────────
 
   Future<List<Map<String, dynamic>>> listSplits() async {

--- a/mobile/lib/infrastructure/api/repositories/api_session_repository.dart
+++ b/mobile/lib/infrastructure/api/repositories/api_session_repository.dart
@@ -49,6 +49,11 @@ class ApiSessionRepository implements SessionRepository {
         if (input.agentFlags != null) 'agentFlags': input.agentFlags,
         if (input.startupCommand != null) 'startupCommand': input.startupCommand,
         if (input.parentSessionId != null) 'parentSessionId': input.parentSessionId,
+        if (input.createWorktree) 'createWorktree': true,
+        if (input.worktreeType != null) 'worktreeType': input.worktreeType,
+        if (input.baseBranch != null) 'baseBranch': input.baseBranch,
+        if (input.featureDescription != null)
+          'featureDescription': input.featureDescription,
       });
       return Success(_mapSession(data));
     } on AppError catch (e) {

--- a/mobile/lib/presentation/providers/git_providers.dart
+++ b/mobile/lib/presentation/providers/git_providers.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:remote_dev/application/ports/folder_preferences_gateway.dart';
+import 'package:remote_dev/application/ports/git_gateway.dart';
+import 'package:remote_dev/infrastructure/api/gateways/api_folder_preferences_gateway.dart';
+import 'package:remote_dev/infrastructure/api/gateways/api_git_gateway.dart';
+import 'package:remote_dev/presentation/providers/server_config_providers.dart';
+
+// ── Gateway instances ────────────────────────────────────────────────
+
+/// Git gateway instance. Null when unauthenticated.
+final gitGatewayProvider = Provider<GitGateway?>((ref) {
+  final client = ref.watch(remoteDevClientProvider);
+  if (client == null) return null;
+  return ApiGitGateway(client: client);
+});
+
+/// Folder preferences gateway instance. Null when unauthenticated.
+final folderPreferencesGatewayProvider =
+    Provider<FolderPreferencesGateway?>((ref) {
+  final client = ref.watch(remoteDevClientProvider);
+  if (client == null) return null;
+  return ApiFolderPreferencesGateway(client: client);
+});
+
+// ── Folder preferences ───────────────────────────────────────────────
+
+/// Async folder preferences map: folderId → FolderPreferences.
+class FolderPreferencesNotifier
+    extends AsyncNotifier<Map<String, FolderPreferences>> {
+  @override
+  Future<Map<String, FolderPreferences>> build() async {
+    final gateway = ref.watch(folderPreferencesGatewayProvider);
+    if (gateway == null) return {};
+    final result = await gateway.getAllFolderPreferences();
+    return result.valueOrThrow;
+  }
+
+  Future<void> refresh() async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() => build());
+  }
+}
+
+final folderPreferencesProvider = AsyncNotifierProvider<
+    FolderPreferencesNotifier, Map<String, FolderPreferences>>(
+  FolderPreferencesNotifier.new,
+);
+
+/// Derived: preferences for a specific folder.
+final folderPreferenceForIdProvider =
+    Provider.family<FolderPreferences?, String?>((ref, folderId) {
+  if (folderId == null) return null;
+  return ref.watch(folderPreferencesProvider).valueOrNull?[folderId];
+});
+
+// ── Branch listing ───────────────────────────────────────────────────
+
+/// One-shot branch fetch, keyed by git repo path. Lazy — only triggered
+/// when the create session sheet needs branch data.
+class BranchListNotifier extends FamilyAsyncNotifier<List<String>, String> {
+  @override
+  Future<List<String>> build(String path) async {
+    final gateway = ref.watch(gitGatewayProvider);
+    if (gateway == null) return [];
+    final result = await gateway.validateAndListBranches(path);
+    return result.valueOrThrow.branches;
+  }
+}
+
+final branchListProvider =
+    AsyncNotifierProvider.family<BranchListNotifier, List<String>, String>(
+  BranchListNotifier.new,
+);

--- a/mobile/lib/presentation/providers/providers.dart
+++ b/mobile/lib/presentation/providers/providers.dart
@@ -1,6 +1,7 @@
 export 'appearance_providers.dart';
 export 'auth_providers.dart';
 export 'folder_providers.dart';
+export 'git_providers.dart';
 export 'server_config_providers.dart';
 export 'session_providers.dart';
 export 'terminal_providers.dart';

--- a/mobile/lib/presentation/widgets/session/create_session_sheet.dart
+++ b/mobile/lib/presentation/widgets/session/create_session_sheet.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:remote_dev/domain/repositories/session_repository.dart';
 import 'package:remote_dev/domain/value_objects/agent_provider.dart';
 import 'package:remote_dev/domain/value_objects/terminal_type.dart';
+import 'package:remote_dev/domain/value_objects/worktree_type.dart';
 import 'package:remote_dev/presentation/providers/providers.dart';
 
 class CreateSessionSheet extends ConsumerStatefulWidget {
@@ -19,23 +20,70 @@ class CreateSessionSheet extends ConsumerStatefulWidget {
 
 class _CreateSessionSheetState extends ConsumerState<CreateSessionSheet> {
   final _nameController = TextEditingController(text: 'New Session');
+  final _branchNameController = TextEditingController();
   TerminalType _terminalType = TerminalType.shell;
   AgentProvider _agentProvider = AgentProvider.claude;
   bool _isCreating = false;
 
+  // Worktree state
+  bool _createWorktree = false;
+  WorktreeType _worktreeType = WorktreeType.feature;
+  String? _baseBranch;
+
+  /// Track the last auto-generated branch name so manual edits are preserved.
+  String _lastAutoName = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController.addListener(_autoPopulateBranchName);
+  }
+
   @override
   void dispose() {
+    _nameController.removeListener(_autoPopulateBranchName);
     _nameController.dispose();
+    _branchNameController.dispose();
     super.dispose();
+  }
+
+  void _autoPopulateBranchName() {
+    if (!_createWorktree) return;
+    final current = _branchNameController.text;
+    // Only auto-populate if the field is empty or matches last auto-generated value
+    if (current.isNotEmpty && current != _lastAutoName) return;
+    final slug = _slugify(_nameController.text.trim());
+    _lastAutoName = slug;
+    _branchNameController.text = slug;
+  }
+
+  String _slugify(String input) {
+    return input
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^a-z0-9]+'), '-')
+        .replaceAll(RegExp(r'-+'), '-')
+        .replaceAll(RegExp(r'^-|-$'), '');
+  }
+
+  /// Select the best default branch from a list, preferring main > master.
+  static String _pickDefaultBranch(List<String> branches) {
+    if (branches.contains('main')) return 'main';
+    if (branches.contains('master')) return 'master';
+    return branches.first;
   }
 
   Future<void> _create() async {
     final name = _nameController.text.trim();
     if (name.isEmpty) return;
+    if (_createWorktree && _branchNameController.text.trim().isEmpty) return;
 
     setState(() => _isCreating = true);
 
     try {
+      final branchName = _createWorktree
+          ? _branchNameController.text.trim()
+          : null;
+
       final session =
           await ref.read(sessionListProvider.notifier).createSession(
                 CreateSessionInput(
@@ -46,6 +94,11 @@ class _CreateSessionSheetState extends ConsumerState<CreateSessionSheet> {
                       ? _agentProvider.value
                       : null,
                   autoLaunchAgent: _terminalType == TerminalType.agent,
+                  createWorktree: _createWorktree,
+                  worktreeType:
+                      _createWorktree ? _worktreeType.value : null,
+                  baseBranch: _createWorktree ? _baseBranch : null,
+                  featureDescription: _createWorktree ? branchName : null,
                 ),
               );
 
@@ -66,6 +119,29 @@ class _CreateSessionSheetState extends ConsumerState<CreateSessionSheet> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
+    final folderPrefs =
+        ref.watch(folderPreferenceForIdProvider(widget.folderId));
+    final canUseWorktree = folderPrefs?.hasGitRepo ?? false;
+    final gitPath = folderPrefs?.gitPath;
+
+    // Reset worktree toggle if folder lost its repo
+    ref.listen(folderPreferenceForIdProvider(widget.folderId),
+        (previous, next) {
+      if (_createWorktree && !(next?.hasGitRepo ?? false)) {
+        setState(() => _createWorktree = false);
+      }
+    });
+
+    // Auto-select base branch when branch data loads
+    if (_createWorktree && gitPath != null) {
+      ref.listen(branchListProvider(gitPath), (previous, next) {
+        final branches = next.valueOrNull;
+        if (branches == null || branches.isEmpty) return;
+        if (_baseBranch != null && branches.contains(_baseBranch)) return;
+        setState(() => _baseBranch = _pickDefaultBranch(branches));
+      });
+    }
+
     return Padding(
       padding: EdgeInsets.fromLTRB(
         24,
@@ -73,92 +149,263 @@ class _CreateSessionSheetState extends ConsumerState<CreateSessionSheet> {
         24,
         MediaQuery.of(context).viewInsets.bottom + 24,
       ),
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.height * 0.85,
+        ),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'New Session',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 20),
+
+              TextField(
+                controller: _nameController,
+                decoration: const InputDecoration(
+                  labelText: 'Session Name',
+                  prefixIcon: Icon(Icons.label_outline),
+                ),
+                autofocus: true,
+                textCapitalization: TextCapitalization.words,
+              ),
+              const SizedBox(height: 20),
+
+              SegmentedButton<TerminalType>(
+                segments: const [
+                  ButtonSegment(
+                    value: TerminalType.shell,
+                    label: Text('Shell'),
+                    icon: Icon(Icons.terminal),
+                  ),
+                  ButtonSegment(
+                    value: TerminalType.agent,
+                    label: Text('Agent'),
+                    icon: Icon(Icons.smart_toy_outlined),
+                  ),
+                ],
+                selected: {_terminalType},
+                onSelectionChanged: (selected) {
+                  setState(() => _terminalType = selected.first);
+                },
+              ),
+              const SizedBox(height: 20),
+
+              // Agent provider dropdown
+              AnimatedSize(
+                duration: const Duration(milliseconds: 200),
+                curve: Curves.easeInOut,
+                alignment: Alignment.topCenter,
+                child: _terminalType == TerminalType.agent
+                    ? Padding(
+                        padding: const EdgeInsets.only(bottom: 20),
+                        child: DropdownMenu<AgentProvider>(
+                          initialSelection: _agentProvider,
+                          label: const Text('Agent Provider'),
+                          leadingIcon:
+                              const Icon(Icons.smart_toy_outlined),
+                          expandedInsets: EdgeInsets.zero,
+                          onSelected: (value) {
+                            if (value != null) {
+                              setState(() => _agentProvider = value);
+                            }
+                          },
+                          dropdownMenuEntries: AgentProvider.values
+                              .where((p) => p.isAgent)
+                              .map(
+                                (provider) => DropdownMenuEntry(
+                                  value: provider,
+                                  label: provider.displayName,
+                                ),
+                              )
+                              .toList(),
+                        ),
+                      )
+                    : const SizedBox.shrink(),
+              ),
+
+              // Worktree toggle
+              if (widget.folderId != null)
+                SwitchListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Create Worktree'),
+                  subtitle: Text(
+                    canUseWorktree
+                        ? 'Isolated branch directory'
+                        : 'Link a git repo in folder settings',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  secondary: Icon(
+                    Icons.account_tree_outlined,
+                    color: canUseWorktree
+                        ? theme.colorScheme.primary
+                        : theme.colorScheme.onSurfaceVariant,
+                  ),
+                  value: _createWorktree,
+                  onChanged: canUseWorktree
+                      ? (value) {
+                          setState(() => _createWorktree = value);
+                          if (value) _autoPopulateBranchName();
+                        }
+                      : null,
+                ),
+
+              // Worktree options (expanded when toggle is on)
+              AnimatedSize(
+                duration: const Duration(milliseconds: 200),
+                curve: Curves.easeInOut,
+                alignment: Alignment.topCenter,
+                child: _createWorktree
+                    ? _buildWorktreeOptions(theme, gitPath)
+                    : const SizedBox.shrink(),
+              ),
+
+              FilledButton(
+                onPressed: _isCreating ||
+                        (_createWorktree &&
+                            _branchNameController.text.trim().isEmpty)
+                    ? null
+                    : _create,
+                child: _isCreating
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child:
+                            CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Create Session'),
+              ),
+              const SizedBox(height: 8),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWorktreeOptions(ThemeData theme, String? gitPath) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
       child: Column(
-        mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Text(
-            'New Session',
-            style: theme.textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          const SizedBox(height: 20),
-
-          TextField(
-            controller: _nameController,
-            decoration: const InputDecoration(
-              labelText: 'Session Name',
-              prefixIcon: Icon(Icons.label_outline),
-            ),
-            autofocus: true,
-            textCapitalization: TextCapitalization.words,
-          ),
-          const SizedBox(height: 20),
-
-          SegmentedButton<TerminalType>(
-            segments: const [
-              ButtonSegment(
-                value: TerminalType.shell,
-                label: Text('Shell'),
-                icon: Icon(Icons.terminal),
-              ),
-              ButtonSegment(
-                value: TerminalType.agent,
-                label: Text('Agent'),
-                icon: Icon(Icons.smart_toy_outlined),
-              ),
-            ],
-            selected: {_terminalType},
-            onSelectionChanged: (selected) {
-              setState(() => _terminalType = selected.first);
-            },
-          ),
-          const SizedBox(height: 20),
-
-          AnimatedSize(
-            duration: const Duration(milliseconds: 200),
-            curve: Curves.easeInOut,
-            alignment: Alignment.topCenter,
-            child: _terminalType == TerminalType.agent
-                ? Padding(
-                    padding: const EdgeInsets.only(bottom: 20),
-                    child: DropdownMenu<AgentProvider>(
-                      initialSelection: _agentProvider,
-                      label: const Text('Agent Provider'),
-                      leadingIcon: const Icon(Icons.smart_toy_outlined),
-                      expandedInsets: EdgeInsets.zero,
-                      onSelected: (value) {
-                        if (value != null) {
-                          setState(() => _agentProvider = value);
-                        }
-                      },
-                      dropdownMenuEntries: AgentProvider.values
-                          .where((p) => p.isAgent)
-                          .map(
-                            (provider) => DropdownMenuEntry(
-                              value: provider,
-                              label: provider.displayName,
-                            ),
-                          )
-                          .toList(),
-                    ),
-                  )
-                : const SizedBox.shrink(),
-          ),
-
-          FilledButton(
-            onPressed: _isCreating ? null : _create,
-            child: _isCreating
-                ? const SizedBox(
-                    height: 20,
-                    width: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Text('Create Session'),
-          ),
           const SizedBox(height: 8),
+
+          // Worktree type selector
+          DropdownMenu<WorktreeType>(
+            initialSelection: _worktreeType,
+            label: const Text('Type'),
+            leadingIcon: const Icon(Icons.category_outlined),
+            expandedInsets: EdgeInsets.zero,
+            onSelected: (value) {
+              if (value != null) {
+                setState(() => _worktreeType = value);
+              }
+            },
+            dropdownMenuEntries: WorktreeType.values
+                .map(
+                  (type) => DropdownMenuEntry(
+                    value: type,
+                    label: type.displayName,
+                  ),
+                )
+                .toList(),
+          ),
+          const SizedBox(height: 16),
+
+          // Branch name input
+          TextField(
+            controller: _branchNameController,
+            decoration: InputDecoration(
+              labelText: 'Branch Name',
+              prefixIcon:
+                  const Icon(Icons.account_tree_outlined),
+              helperText: _branchNameController.text.trim().isNotEmpty
+                  ? '${_worktreeType.value}/${_branchNameController.text.trim()}'
+                  : null,
+              helperStyle: TextStyle(
+                fontFamily: 'monospace',
+                color: theme.colorScheme.primary,
+                fontSize: 12,
+              ),
+            ),
+            onChanged: (_) => setState(() {}),
+          ),
+          const SizedBox(height: 16),
+
+          // Base branch picker
+          if (gitPath != null)
+            _buildBaseBranchPicker(theme, gitPath)
+          else
+            Text(
+              'Base branch: default (no local path configured)',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildBaseBranchPicker(ThemeData theme, String gitPath) {
+    final branchesAsync = ref.watch(branchListProvider(gitPath));
+
+    return branchesAsync.when(
+      data: (branches) {
+        if (branches.isEmpty) {
+          return Text(
+            'No branches found',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          );
+        }
+
+        return DropdownMenu<String>(
+          initialSelection: _baseBranch,
+          label: const Text('Base Branch'),
+          leadingIcon: const Icon(Icons.merge_type_outlined),
+          expandedInsets: EdgeInsets.zero,
+          onSelected: (value) {
+            if (value != null) {
+              setState(() => _baseBranch = value);
+            }
+          },
+          dropdownMenuEntries: branches
+              .map(
+                (branch) => DropdownMenuEntry(
+                  value: branch,
+                  label: branch,
+                ),
+              )
+              .toList(),
+        );
+      },
+      loading: () => const Row(
+        children: [
+          SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          SizedBox(width: 12),
+          Text('Loading branches...'),
+        ],
+      ),
+      error: (_, __) => Text(
+        'Could not load branches',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.error,
+        ),
       ),
     );
   }

--- a/src/app/api/git/validate/route.ts
+++ b/src/app/api/git/validate/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { withAuth, errorResponse } from "@/lib/api";
+import { withApiAuth, errorResponse } from "@/lib/api";
 import { isGitRepo, getBranches } from "@/services/worktree-service";
 
 /**
@@ -10,7 +10,7 @@ import { isGitRepo, getBranches } from "@/services/worktree-service";
  *   - isGitRepo: boolean
  *   - branches: string[] (local branch names, if it's a git repo)
  */
-export const GET = withAuth(async (request) => {
+export const GET = withApiAuth(async (request) => {
   const { searchParams } = new URL(request.url);
   const path = searchParams.get("path");
 


### PR DESCRIPTION
## Summary
- Adds worktree creation UI to the Flutter mobile app's existing session creation sheet
- When a folder has a linked git repo, users can toggle "Create Worktree" to create isolated branch directories
- Supports worktree type selection (feature/fix/chore/refactor/docs/release), branch name auto-suggestion, and async base branch picker
- Follows Clean Architecture with new domain ports, infrastructure gateways, and Riverpod providers

## Test plan
- [ ] Open mobile app, navigate to a folder with a linked git repo
- [ ] Tap "+" to create a new session — verify "Create Worktree" toggle appears
- [ ] Toggle on — verify type picker, branch name field, and base branch dropdown appear
- [ ] Verify branch name auto-populates from session name as a slug
- [ ] Verify base branch dropdown loads branches from server
- [ ] Create a worktree session — verify it appears with the correct branch name
- [ ] Verify folders without a linked git repo do NOT show the worktree toggle
- [ ] Run `flutter analyze` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)