### PR TITLE
feat: mobile-optimized terminal with native text input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Cross-channel notification sync: `/internal/notification-dismissed` WebSocket broadcast
   - Flutter: `PushNotificationService` with FCM lifecycle, token refresh, and deep link to session on tap
   - Android notification channel via `AndroidManifest.xml` metadata
+- **Mobile-optimized terminal with native text input**: On mobile devices, replaces xterm.js canvas with a native text input bar and ANSI-to-HTML output panel
+  - `MobileTerminalView`: scrollable output panel with theme-aware ANSI color rendering
+  - `MobileInputBar`: native `<textarea>` with autocorrect, predictive text, and voice dictation
+  - `useTerminalWebSocket`: shared WebSocket hook with auth, reconnect, and message dispatch
+  - All session types (shell, agent) get native text input on mobile; desktop path unchanged
 - **Mobile worktree creation**: Create git worktrees from the Flutter mobile app's session creation sheet
   - Worktree type picker (feature/fix/chore/refactor/docs/release)
   - Branch name auto-suggestion from session name

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,7 +439,9 @@ bun run test:coverage  # Run tests with coverage
 | Component | Purpose |
 |-----------|---------|
 | `Terminal.tsx` | xterm.js wrapper with WebSocket and recording support |
-| `TerminalWithKeyboard.tsx` | Terminal with mobile keyboard support |
+| `TerminalWithKeyboard.tsx` | Terminal with mobile keyboard support (routes to MobileTerminalView on mobile) |
+| `MobileTerminalView.tsx` | Mobile-optimized terminal: ANSI output panel + native text input + special keys |
+| `MobileInputBar.tsx` | Native textarea with autocorrect, voice dictation, and predictive text |
 | `SplitPane.tsx` | In-session split pane container (multiple terminals in one session) |
 | `SplitPaneLayout.tsx` | Cross-session split layout (multiple sessions side-by-side) |
 | `ResizeHandle.tsx` | Draggable resize handle for split panes |

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
+        "ansi-to-html": "0.7.2",
         "better-sqlite3": "^12.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1302,6 +1303,8 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "ansi-to-html": ["ansi-to-html@0.7.2", "", { "dependencies": { "entities": "^2.2.0" }, "bin": { "ansi-to-html": "bin/ansi-to-html" } }, "sha512-v6MqmEpNlxF+POuyhKkidusCHWWkaLcGRURzivcU3I9tv7k4JVhFcnukrM5Rlk2rUywdZuzYAZ+kbZqWCnfN3g=="],
+
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
@@ -1719,6 +1722,8 @@
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.18.4", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q=="],
+
+    "entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "env-editor": ["env-editor@0.4.2", "", {}, "sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA=="],
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
+    "ansi-to-html": "0.7.2",
     "better-sqlite3": "^12.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/terminal/MobileInputBar.tsx
+++ b/src/components/terminal/MobileInputBar.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState, useCallback, forwardRef } from "react";
+import { Send } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface MobileInputBarProps {
+  onSubmit: (text: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+}
+
+/**
+ * Native text input bar for mobile terminal sessions.
+ *
+ * Enables autocorrect, autocomplete, predictive text, and voice dictation
+ * by using a standard HTML textarea instead of xterm.js's internal textarea
+ * (which disables all of these to prevent duplication bugs).
+ *
+ * - Enter: submit text and clear
+ * - Shift+Enter: insert literal newline
+ * - Auto-expands height with content (max 8rem)
+ */
+export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProps>(
+  function MobileInputBar(
+    {
+      onSubmit,
+      disabled = false,
+      placeholder = "Type a message...",
+      className,
+    },
+    ref
+  ) {
+    const [value, setValue] = useState("");
+
+    const handleSubmit = useCallback(() => {
+      // Trim prevents submitting whitespace-only input. Leading/trailing
+      // spaces are stripped intentionally — mobile text entry rarely needs
+      // them, and autocorrect often inserts trailing spaces.
+      const trimmed = value.trim();
+      if (!trimmed || disabled) return;
+
+      onSubmit(trimmed + "\n");
+      setValue("");
+    }, [value, disabled, onSubmit]);
+
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          handleSubmit();
+        }
+      },
+      [handleSubmit]
+    );
+
+    const handleInput = useCallback((e: React.FormEvent<HTMLTextAreaElement>) => {
+      const textarea = e.currentTarget;
+      textarea.style.height = "auto";
+      textarea.style.height = `${textarea.scrollHeight}px`;
+    }, []);
+
+    return (
+      <div
+        className={cn(
+          "flex items-end gap-1.5 px-2 py-1.5 bg-popover/95 backdrop-blur-sm border-t border-border",
+          className
+        )}
+      >
+        {/* Native text input with autocorrect/voice enabled */}
+        <textarea
+          ref={ref}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onInput={handleInput}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={1}
+          autoComplete="on"
+          autoCorrect="on"
+          autoCapitalize="sentences"
+          spellCheck
+          enterKeyHint="send"
+          className={cn(
+            "flex-1 min-h-[2.25rem] max-h-32 resize-none rounded-lg px-3 py-2",
+            "bg-muted/50 text-foreground text-sm leading-snug",
+            "placeholder:text-muted-foreground/60",
+            "focus:outline-none focus:ring-1 focus:ring-primary/50",
+            "overflow-y-auto",
+            disabled && "opacity-50 cursor-not-allowed"
+          )}
+        />
+
+        {/* Send button */}
+        <button
+          onClick={handleSubmit}
+          disabled={disabled || !value.trim()}
+          className={cn(
+            "p-2 rounded-md shrink-0 touch-manipulation",
+            "transition-colors duration-100",
+            value.trim() && !disabled
+              ? "text-primary active:bg-primary/20"
+              : "text-muted-foreground/40"
+          )}
+          aria-label="Send"
+        >
+          <Send className="w-4 h-4" />
+        </button>
+      </div>
+    );
+  }
+);

--- a/src/components/terminal/MobileTerminalView.tsx
+++ b/src/components/terminal/MobileTerminalView.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import { useRef, useCallback, useState, useEffect, forwardRef, useImperativeHandle } from "react";
+import AnsiToHtml from "ansi-to-html";
+import { MobileInputBar } from "./MobileInputBar";
+import { MobileKeyboard } from "./MobileKeyboard";
+import { VoiceMicButton } from "./VoiceMicButton";
+import { AgentExitScreen } from "./AgentExitScreen";
+import { AuthErrorOverlay } from "./AuthErrorOverlay";
+import { useTerminalWebSocket } from "@/hooks/useTerminalWebSocket";
+import { useTerminalTheme } from "@/contexts/AppearanceContext";
+import { useSessionContext } from "@/contexts/SessionContext";
+import { sendImageToTerminal } from "@/lib/image-upload";
+import { cn } from "@/lib/utils";
+import type { TerminalSession } from "@/types/session";
+import type { ConnectionStatus } from "@/types/terminal";
+import type { SessionStatusIndicator, SessionProgress } from "@/types/terminal-type";
+
+// ─── Types ─────────────────────────────────────────────────────────────────────
+
+export interface MobileTerminalViewRef {
+  focus: () => void;
+}
+
+interface MobileTerminalViewProps {
+  sessionId: string;
+  tmuxSessionName: string;
+  sessionName?: string;
+  projectPath?: string | null;
+  session?: TerminalSession;
+  wsUrl?: string;
+  tmuxHistoryLimit?: number;
+  notificationsEnabled?: boolean;
+  isRecording?: boolean;
+  environmentVars?: Record<string, string> | null;
+  onStatusChange?: (status: ConnectionStatus) => void;
+  onWebSocketReady?: (ws: WebSocket | null) => void;
+  onSessionExit?: (exitCode: number) => void;
+  onOutput?: (data: string) => void;
+  onSessionDelete?: (deleteWorktree?: boolean) => Promise<void>;
+  onAgentActivityStatus?: (sessionId: string, status: string) => void;
+  onAgentTodosUpdated?: (sessionId: string) => void;
+  onNotification?: (notification: Record<string, unknown>) => void;
+  onSessionStatus?: (sessionId: string, key: string, indicator: SessionStatusIndicator | null) => void;
+  onSessionProgress?: (sessionId: string, progress: SessionProgress | null) => void;
+}
+
+// ─── Types & Constants ──────────────────────────────────────────────────────────
+
+interface OutputEntry {
+  id: number;
+  html: string;
+}
+
+const MAX_OUTPUT_ENTRIES = 2000;
+const MOBILE_COLS = 120;
+const MOBILE_ROWS = 24;
+
+function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+/** Build the 16-color ANSI palette from theme values. */
+function getAnsiColors(theme: ReturnType<typeof useTerminalTheme>): string[] {
+  return [
+    theme.black, theme.red, theme.green, theme.yellow,
+    theme.blue, theme.magenta, theme.cyan, theme.white,
+    theme.brightBlack, theme.brightRed, theme.brightGreen, theme.brightYellow,
+    theme.brightBlue, theme.brightMagenta, theme.brightCyan, theme.brightWhite,
+  ];
+}
+
+/** Create an AnsiToHtml converter in stream mode with the given theme. */
+function createAnsiConverter(theme: ReturnType<typeof useTerminalTheme>): AnsiToHtml {
+  return new AnsiToHtml({
+    fg: theme.foreground,
+    bg: "transparent",
+    colors: getAnsiColors(theme),
+    escapeXML: true,
+    stream: true,
+  });
+}
+
+/** Map connection status to a badge CSS class. */
+function getStatusColor(status: ConnectionStatus): string {
+  switch (status) {
+    case "connected": return "bg-green-500";
+    case "connecting":
+    case "reconnecting": return "bg-yellow-500 animate-pulse";
+    case "error": return "bg-red-500";
+    default: return "bg-muted-foreground/50";
+  }
+}
+
+/** Map connection status to a human-readable label. */
+function getStatusLabel(status: ConnectionStatus, sessionName?: string): string {
+  switch (status) {
+    case "connected": return sessionName || "Terminal";
+    case "connecting": return "Connecting...";
+    case "reconnecting": return "Reconnecting...";
+    case "error": return "Connection error";
+    default: return "Disconnected";
+  }
+}
+
+// ─── Component ─────────────────────────────────────────────────────────────────
+
+export const MobileTerminalView = forwardRef<MobileTerminalViewRef, MobileTerminalViewProps>(
+  function MobileTerminalView(
+    {
+      sessionId,
+      tmuxSessionName,
+      sessionName,
+      projectPath,
+      session,
+      wsUrl = "ws://localhost:3001",
+      tmuxHistoryLimit = 50000,
+      notificationsEnabled = true,
+      isRecording = false,
+      environmentVars,
+      onStatusChange,
+      onWebSocketReady,
+      onSessionExit,
+      onOutput,
+      onSessionDelete,
+      onAgentActivityStatus,
+      onAgentTodosUpdated,
+      onNotification,
+      onSessionStatus,
+      onSessionProgress,
+    },
+    ref
+  ) {
+    // ── Refs ──────────────────────────────────────────────────────────────────
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const anchorRef = useRef<HTMLDivElement>(null);
+    const inputBarRef = useRef<HTMLTextAreaElement>(null);
+    const converterRef = useRef<AnsiToHtml | null>(null);
+    const lineIdRef = useRef(0);
+    const userScrolledUpRef = useRef(false);
+
+    // ── State ─────────────────────────────────────────────────────────────────
+    const [outputEntries, setOutputEntries] = useState<OutputEntry[]>([]);
+    const [agentExitInfo, setAgentExitInfo] = useState<{
+      exitCode: number | null;
+      exitedAt: string;
+    } | null>(null);
+    const [isRestarting, setIsRestarting] = useState(false);
+
+    // ── Theme ─────────────────────────────────────────────────────────────────
+    const terminalTheme = useTerminalTheme();
+    const { getAgentActivityStatus } = useSessionContext();
+    const activityStatus = session ? getAgentActivityStatus(session.id) : "idle";
+    const needsAttention = activityStatus === "waiting" || activityStatus === "error";
+
+    // ── ANSI converter (stream mode for cross-chunk state continuity) ─────────
+    // Initialize on first render and rebuild when theme changes
+    if (converterRef.current == null) {
+      converterRef.current = createAnsiConverter(terminalTheme);
+    }
+
+    useEffect(() => {
+      converterRef.current = createAnsiConverter(terminalTheme);
+    }, [terminalTheme]);
+
+    // ── Shared output append helper ───────────────────────────────────────────
+    const appendAnsiOutput = useCallback((ansi: string) => {
+      const converter = converterRef.current;
+      if (!converter) return;
+      const html = converter.toHtml(ansi);
+      if (!html) return;
+      setOutputEntries(prev => {
+        const newEntry: OutputEntry = { id: lineIdRef.current++, html };
+        const updated = [...prev, newEntry];
+        return updated.length > MAX_OUTPUT_ENTRIES
+          ? updated.slice(-MAX_OUTPUT_ENTRIES)
+          : updated;
+      });
+    }, []);
+
+    const handleOutput = useCallback((data: string) => {
+      appendAnsiOutput(data);
+      onOutput?.(data);
+    }, [appendAnsiOutput, onOutput]);
+
+    const handleStatusMessage = useCallback((message: string) => {
+      appendAnsiOutput("\r\n" + message + "\r\n");
+    }, [appendAnsiOutput]);
+
+    // ── Agent lifecycle callbacks ─────────────────────────────────────────────
+    // onAgentActivityStatus is already called by useTerminalWebSocket for agent_exited
+    const handleAgentExited = useCallback((exitCode: number | null, exitedAt: string) => {
+      setAgentExitInfo({ exitCode, exitedAt });
+    }, []);
+
+    const handleAgentRestarted = useCallback(() => {
+      setAgentExitInfo(null);
+      setIsRestarting(false);
+      setOutputEntries([]);
+      lineIdRef.current = 0;
+      converterRef.current = createAnsiConverter(terminalTheme);
+    }, [terminalTheme]);
+
+    // ── WebSocket connection ─────────────────────────────────────────────────
+    const {
+      wsRef,
+      status,
+      authError,
+      sendInput,
+      sendRestartAgent,
+    } = useTerminalWebSocket({
+      sessionId,
+      tmuxSessionName,
+      projectPath,
+      wsUrl,
+      terminalType: session?.terminalType ?? "shell",
+      tmuxHistoryLimit,
+      environmentVars,
+      initialCols: MOBILE_COLS,
+      initialRows: MOBILE_ROWS,
+      notificationsEnabled,
+      sessionName,
+      onOutput: handleOutput,
+      onStatusChange,
+      onWebSocketReady,
+      onSessionExit,
+      onAgentExited: handleAgentExited,
+      onAgentRestarted: handleAgentRestarted,
+      onAgentActivityStatus,
+      onAgentTodosUpdated,
+      onNotification,
+      onSessionStatus,
+      onSessionProgress,
+      onStatusMessage: handleStatusMessage,
+    });
+
+    // ── Expose ref ────────────────────────────────────────────────────────────
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        inputBarRef.current?.focus();
+      },
+    }), []);
+
+    // ── Auto-scroll ──────────────────────────────────────────────────────────
+    useEffect(() => {
+      if (userScrolledUpRef.current) return;
+      anchorRef.current?.scrollIntoView({ behavior: "instant" as ScrollBehavior });
+    }, [outputEntries]);
+
+    const handleScroll = useCallback(() => {
+      const el = scrollRef.current;
+      if (!el) return;
+      // User scrolled up if they're more than 50px from the bottom
+      const isAtBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 50;
+      userScrolledUpRef.current = !isAtBottom;
+    }, []);
+
+    // ── Input handlers ───────────────────────────────────────────────────────
+    const handleMobileKeyPress = useCallback(
+      (key: string, modifiers?: { ctrl?: boolean; alt?: boolean }) => {
+        let data = key;
+        if (modifiers?.ctrl && key.length === 1) {
+          const charCode = key.toUpperCase().charCodeAt(0);
+          if (charCode >= 65 && charCode <= 90) {
+            data = String.fromCharCode(charCode - 64);
+          }
+        }
+        if (modifiers?.alt) {
+          data = "\x1b" + data;
+        }
+        sendInput(data);
+      },
+      [sendInput]
+    );
+
+    const handleImageUpload = useCallback(
+      async (file: File) => {
+        await sendImageToTerminal(file, wsRef.current);
+      },
+      [wsRef]
+    );
+
+    // ── Agent restart / close ────────────────────────────────────────────────
+    const handleAgentRestart = useCallback(() => {
+      setIsRestarting(true);
+      sendRestartAgent();
+    }, [sendRestartAgent]);
+
+    const handleAgentClose = useCallback(async () => {
+      if (onSessionDelete) {
+        await onSessionDelete();
+      } else {
+        onSessionExit?.(agentExitInfo?.exitCode ?? 0);
+      }
+    }, [onSessionDelete, onSessionExit, agentExitInfo]);
+
+    // ── Background styling to match terminal theme ──────────────────────────
+    const bgOpacity = terminalTheme.opacity / 100;
+    const outputBg = bgOpacity < 1
+      ? hexToRgba(terminalTheme.background, bgOpacity)
+      : terminalTheme.background;
+
+    return (
+      <div className={cn("flex flex-col h-full relative", needsAttention && "notification-ring")}>
+        {/* Connection status indicator */}
+        <div className="flex items-center gap-1.5 px-2 py-1 bg-popover/80 border-b border-border text-xs text-muted-foreground">
+          <div className={cn("w-1.5 h-1.5 rounded-full shrink-0", getStatusColor(status))} />
+          <span className="truncate">{getStatusLabel(status, sessionName)}</span>
+          {isRecording && (
+            <span className="ml-auto flex items-center gap-1 text-red-400">
+              <span className="w-1.5 h-1.5 rounded-full bg-red-400 animate-pulse" />
+              REC
+            </span>
+          )}
+        </div>
+
+        {/* Output panel */}
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden"
+          style={{
+            backgroundColor: outputBg,
+            backdropFilter: terminalTheme.blur > 0 ? `blur(${terminalTheme.blur}px)` : undefined,
+            color: terminalTheme.foreground,
+          }}
+        >
+          <pre
+            className="p-2 text-xs leading-relaxed font-mono whitespace-pre-wrap break-words min-h-full"
+            style={{ fontFamily: "'JetBrainsMono Nerd Font Mono', monospace" }}
+          >
+            {outputEntries.map(entry => (
+              <span
+                key={entry.id}
+                dangerouslySetInnerHTML={{ __html: entry.html }}
+              />
+            ))}
+            <span ref={anchorRef} />
+          </pre>
+        </div>
+
+        {/* Voice mic button for agent sessions */}
+        {session?.terminalType === "agent" && (
+          <div className="absolute top-8 left-2 z-50">
+            <VoiceMicButton getWebSocket={() => wsRef.current} />
+          </div>
+        )}
+
+        {/* Text input bar (camera button lives in MobileKeyboard to avoid duplication) */}
+        <MobileInputBar
+          ref={inputBarRef}
+          onSubmit={sendInput}
+          disabled={status !== "connected"}
+          placeholder={session?.terminalType === "agent" ? "Ask the agent..." : "Type a command..."}
+        />
+
+        {/* Special keys toolbar */}
+        <MobileKeyboard
+          onKeyPress={handleMobileKeyPress}
+          onImageUpload={handleImageUpload}
+        />
+
+        {/* Agent exit screen overlay */}
+        {agentExitInfo && session && (
+          <AgentExitScreen
+            sessionId={session.id}
+            sessionName={session.name}
+            exitCode={agentExitInfo.exitCode}
+            exitedAt={agentExitInfo.exitedAt}
+            restartCount={session.agentRestartCount ?? 0}
+            onRestart={handleAgentRestart}
+            onClose={handleAgentClose}
+            isRestarting={isRestarting}
+          />
+        )}
+
+        {/* Auth error overlay */}
+        {authError && <AuthErrorOverlay message={authError} />}
+      </div>
+    );
+  }
+);

--- a/src/components/terminal/MobileTerminalView.tsx
+++ b/src/components/terminal/MobileTerminalView.tsx
@@ -16,7 +16,7 @@ import type { TerminalSession } from "@/types/session";
 import type { ConnectionStatus } from "@/types/terminal";
 import type { SessionStatusIndicator, SessionProgress } from "@/types/terminal-type";
 
-// ─── Types ─────────────────────────────────────────────────────────────────────
+// ─── Types & Constants ──────────────────────────────────────────────────────────
 
 export interface MobileTerminalViewRef {
   focus: () => void;
@@ -44,8 +44,6 @@ interface MobileTerminalViewProps {
   onSessionStatus?: (sessionId: string, key: string, indicator: SessionStatusIndicator | null) => void;
   onSessionProgress?: (sessionId: string, progress: SessionProgress | null) => void;
 }
-
-// ─── Types & Constants ──────────────────────────────────────────────────────────
 
 interface OutputEntry {
   id: number;

--- a/src/components/terminal/TerminalWithKeyboard.tsx
+++ b/src/components/terminal/TerminalWithKeyboard.tsx
@@ -3,13 +3,13 @@
 import { useRef, useCallback, useState, forwardRef, useImperativeHandle } from "react";
 import { Terminal, type TerminalRef } from "./Terminal";
 import { VoiceMicButton } from "./VoiceMicButton";
-import { MobileKeyboard } from "./MobileKeyboard";
+import { MobileTerminalView, type MobileTerminalViewRef } from "./MobileTerminalView";
 import { SessionEndedOverlay } from "./SessionEndedOverlay";
 import { ErrorBoundary } from "@/components/common/ErrorBoundary";
 import { useMobile } from "@/hooks/useMobile";
-import { sendImageToTerminal } from "@/lib/image-upload";
 import type { ConnectionStatus } from "@/types/terminal";
 import type { TerminalSession } from "@/types/session";
+import type { SessionStatusIndicator, SessionProgress } from "@/types/terminal-type";
 
 export interface TerminalWithKeyboardRef {
   focus: () => void;
@@ -46,9 +46,9 @@ interface TerminalWithKeyboardProps {
   /** Called when a notification is broadcast from the terminal server */
   onNotification?: (notification: Record<string, unknown>) => void;
   /** Called when a session status indicator is set or cleared */
-  onSessionStatus?: (sessionId: string, key: string, indicator: import("@/types/terminal-type").SessionStatusIndicator | null) => void;
+  onSessionStatus?: (sessionId: string, key: string, indicator: SessionStatusIndicator | null) => void;
   /** Called when session progress is updated or cleared */
-  onSessionProgress?: (sessionId: string, progress: import("@/types/terminal-type").SessionProgress | null) => void;
+  onSessionProgress?: (sessionId: string, progress: SessionProgress | null) => void;
 }
 
 export const TerminalWithKeyboard = forwardRef<TerminalWithKeyboardRef, TerminalWithKeyboardProps>(function TerminalWithKeyboard({
@@ -80,6 +80,7 @@ export const TerminalWithKeyboard = forwardRef<TerminalWithKeyboardRef, Terminal
 }, ref) {
   const wsRef = useRef<WebSocket | null>(null);
   const terminalRef = useRef<TerminalRef>(null);
+  const mobileViewRef = useRef<MobileTerminalViewRef>(null);
   const [sessionEnded, setSessionEnded] = useState(false);
   const [exitCode, setExitCode] = useState(0);
   const isMobile = useMobile();
@@ -87,9 +88,13 @@ export const TerminalWithKeyboard = forwardRef<TerminalWithKeyboardRef, Terminal
   // Expose focus method to parent components
   useImperativeHandle(ref, () => ({
     focus: () => {
-      terminalRef.current?.focus();
+      if (isMobile) {
+        mobileViewRef.current?.focus();
+      } else {
+        terminalRef.current?.focus();
+      }
     },
-  }), []);
+  }), [isMobile]);
 
   const handleWebSocketReady = useCallback((ws: WebSocket | null) => {
     wsRef.current = ws;
@@ -98,58 +103,60 @@ export const TerminalWithKeyboard = forwardRef<TerminalWithKeyboardRef, Terminal
   const handleSessionExit = useCallback((code: number) => {
     setExitCode(code);
     setSessionEnded(true);
-    // Don't call onSessionExit immediately - wait for user action
   }, []);
 
   const handleRestart = useCallback(async () => {
-    if (onSessionRestart) {
-      await onSessionRestart();
-    }
+    await onSessionRestart?.();
   }, [onSessionRestart]);
 
   const handleDelete = useCallback(async (deleteWorktree?: boolean) => {
     if (onSessionDelete) {
       await onSessionDelete(deleteWorktree);
     } else {
-      // Fallback to just calling onSessionExit if no delete handler
       onSessionExit?.(exitCode);
     }
   }, [onSessionDelete, onSessionExit, exitCode]);
 
-  const handleMobileKeyPress = useCallback(
-    (key: string, modifiers?: { ctrl?: boolean; alt?: boolean }) => {
-      if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
-        return;
-      }
+  // ── Mobile path: MobileTerminalView with native text input ─────────────
+  if (isMobile) {
+    return (
+      <div className="flex flex-col h-full relative">
+        <MobileTerminalView
+          ref={mobileViewRef}
+          sessionId={sessionId}
+          tmuxSessionName={tmuxSessionName}
+          sessionName={sessionName}
+          projectPath={projectPath}
+          session={session}
+          wsUrl={wsUrl}
+          tmuxHistoryLimit={tmuxHistoryLimit}
+          notificationsEnabled={notificationsEnabled}
+          isRecording={isRecording}
+          environmentVars={environmentVars}
+          onStatusChange={onStatusChange}
+          onWebSocketReady={handleWebSocketReady}
+          onSessionExit={handleSessionExit}
+          onOutput={onOutput}
+          onSessionDelete={onSessionDelete}
+          onAgentActivityStatus={onAgentActivityStatus}
+          onAgentTodosUpdated={onAgentTodosUpdated}
+          onNotification={onNotification}
+          onSessionStatus={onSessionStatus}
+          onSessionProgress={onSessionProgress}
+        />
+        {sessionEnded && session && (
+          <SessionEndedOverlay
+            session={session}
+            exitCode={exitCode}
+            onRestart={handleRestart}
+            onDelete={handleDelete}
+          />
+        )}
+      </div>
+    );
+  }
 
-      let data = key;
-
-      // Handle Ctrl modifier - convert to control character
-      if (modifiers?.ctrl && key.length === 1) {
-        const charCode = key.toUpperCase().charCodeAt(0);
-        if (charCode >= 65 && charCode <= 90) {
-          // A-Z -> Ctrl codes (1-26)
-          data = String.fromCharCode(charCode - 64);
-        }
-      }
-
-      // Handle Alt modifier - send escape prefix
-      if (modifiers?.alt) {
-        data = "\x1b" + data;
-      }
-
-      wsRef.current.send(JSON.stringify({ type: "input", data }));
-    },
-    []
-  );
-
-  const handleImageUpload = useCallback(
-    async (file: File) => {
-      await sendImageToTerminal(file, wsRef.current);
-    },
-    []
-  );
-
+  // ── Desktop path: xterm.js Terminal ──────────────────────────────────────
   return (
     <div className="flex flex-col h-full relative">
       <div className="flex-1 min-h-0 relative">
@@ -187,12 +194,6 @@ export const TerminalWithKeyboard = forwardRef<TerminalWithKeyboardRef, Terminal
           </div>
         )}
       </div>
-      {isMobile && (
-        <MobileKeyboard
-          onKeyPress={handleMobileKeyPress}
-          onImageUpload={handleImageUpload}
-        />
-      )}
 
       {sessionEnded && session && (
         <SessionEndedOverlay

--- a/src/hooks/useTerminalWebSocket.ts
+++ b/src/hooks/useTerminalWebSocket.ts
@@ -1,0 +1,390 @@
+"use client";
+
+import { useEffect, useRef, useCallback, useState } from "react";
+import type { ConnectionStatus } from "@/types/terminal";
+import type { SessionStatusIndicator, SessionProgress } from "@/types/terminal-type";
+import { useNotifications } from "@/hooks/useNotifications";
+
+// ─── Options ───────────────────────────────────────────────────────────────────
+
+export interface UseTerminalWebSocketOptions {
+  sessionId: string;
+  tmuxSessionName: string;
+  projectPath?: string | null;
+  wsUrl?: string;
+  terminalType?: string;
+  tmuxHistoryLimit?: number;
+  environmentVars?: Record<string, string> | null;
+  /** Initial terminal dimensions sent in the WebSocket URL */
+  initialCols: number;
+  initialRows: number;
+  notificationsEnabled?: boolean;
+  sessionName?: string;
+  /** Required — caller owns rendering of output data */
+  onOutput: (data: string) => void;
+  onStatusChange?: (status: ConnectionStatus) => void;
+  onWebSocketReady?: (ws: WebSocket | null) => void;
+  onSessionExit?: (exitCode: number) => void;
+  onAgentExited?: (exitCode: number | null, exitedAt: string) => void;
+  onAgentRestarted?: () => void;
+  onAgentActivityStatus?: (sessionId: string, status: string) => void;
+  onAgentTodosUpdated?: (sessionId: string) => void;
+  onNotification?: (notification: Record<string, unknown>) => void;
+  onSessionStatus?: (sessionId: string, key: string, indicator: SessionStatusIndicator | null) => void;
+  onSessionProgress?: (sessionId: string, progress: SessionProgress | null) => void;
+  /** Called for non-output status messages (e.g. "Reconnecting 1/5...") */
+  onStatusMessage?: (message: string) => void;
+}
+
+// ─── Return value ──────────────────────────────────────────────────────────────
+
+export interface UseTerminalWebSocketReturn {
+  wsRef: React.RefObject<WebSocket | null>;
+  status: ConnectionStatus;
+  authError: string | null;
+  sendInput: (data: string) => void;
+  sendResize: (cols: number, rows: number) => void;
+  sendRestartAgent: () => void;
+  markIntentionalExit: () => void;
+}
+
+// ─── Constants ─────────────────────────────────────────────────────────────────
+
+const MAX_RECONNECT_ATTEMPTS = 5;
+const RECONNECT_DELAY_MS = 3000;
+const AUTH_ERROR_MESSAGES = ["Authentication required", "Invalid or expired token", "Unauthorized"];
+
+// ─── Hook ──────────────────────────────────────────────────────────────────────
+
+export function useTerminalWebSocket({
+  sessionId,
+  tmuxSessionName,
+  projectPath,
+  wsUrl = "ws://localhost:3001",
+  terminalType = "shell",
+  tmuxHistoryLimit = 50000,
+  environmentVars,
+  initialCols,
+  initialRows,
+  notificationsEnabled = true,
+  sessionName = "Terminal",
+  onOutput,
+  onStatusChange,
+  onWebSocketReady,
+  onSessionExit,
+  onAgentExited,
+  onAgentRestarted,
+  onAgentActivityStatus,
+  onAgentTodosUpdated,
+  onNotification,
+  onSessionStatus,
+  onSessionProgress,
+  onStatusMessage,
+}: UseTerminalWebSocketOptions): UseTerminalWebSocketReturn {
+  const wsRef = useRef<WebSocket | null>(null);
+  const [status, setStatus] = useState<ConnectionStatus>("disconnected");
+  const [authError, setAuthError] = useState<string | null>(null);
+
+  // Reconnect state
+  const isUnmountingRef = useRef(false);
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const intentionalExitRef = useRef(false);
+
+  // Notifications hook for command completion
+  const { recordActivity } = useNotifications({
+    enabled: notificationsEnabled,
+    sessionName,
+    inactivityDelay: 3000,
+  });
+
+  // ── Ref-stabilize all callbacks to avoid re-running the connection effect ──
+  const onOutputRef = useRef(onOutput);
+  const onStatusChangeRef = useRef(onStatusChange);
+  const onWebSocketReadyRef = useRef(onWebSocketReady);
+  const onSessionExitRef = useRef(onSessionExit);
+  const onAgentExitedRef = useRef(onAgentExited);
+  const onAgentRestartedRef = useRef(onAgentRestarted);
+  const onAgentActivityStatusRef = useRef(onAgentActivityStatus);
+  const onAgentTodosUpdatedRef = useRef(onAgentTodosUpdated);
+  const onNotificationRef = useRef(onNotification);
+  const onSessionStatusRef = useRef(onSessionStatus);
+  const onSessionProgressRef = useRef(onSessionProgress);
+  const onStatusMessageRef = useRef(onStatusMessage);
+  const recordActivityRef = useRef(recordActivity);
+  const tmuxHistoryLimitRef = useRef(tmuxHistoryLimit);
+  const environmentVarsRef = useRef(environmentVars);
+
+  useEffect(() => {
+    onOutputRef.current = onOutput;
+    onStatusChangeRef.current = onStatusChange;
+    onWebSocketReadyRef.current = onWebSocketReady;
+    onSessionExitRef.current = onSessionExit;
+    onAgentExitedRef.current = onAgentExited;
+    onAgentRestartedRef.current = onAgentRestarted;
+    onAgentActivityStatusRef.current = onAgentActivityStatus;
+    onAgentTodosUpdatedRef.current = onAgentTodosUpdated;
+    onNotificationRef.current = onNotification;
+    onSessionStatusRef.current = onSessionStatus;
+    onSessionProgressRef.current = onSessionProgress;
+    onStatusMessageRef.current = onStatusMessage;
+    recordActivityRef.current = recordActivity;
+    tmuxHistoryLimitRef.current = tmuxHistoryLimit;
+    environmentVarsRef.current = environmentVars;
+  }, [
+    onOutput, onStatusChange, onWebSocketReady, onSessionExit,
+    onAgentExited, onAgentRestarted, onAgentActivityStatus, onAgentTodosUpdated,
+    onNotification, onSessionStatus, onSessionProgress, onStatusMessage,
+    recordActivity, tmuxHistoryLimit, environmentVars,
+  ]);
+
+  // ── Intentional exit helper ────────────────────────────────────────────────
+
+  const markIntentionalExit = useCallback(() => {
+    intentionalExitRef.current = true;
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+    reconnectAttemptsRef.current = 0;
+  }, []);
+
+  // ── Stable status updater ─────────────────────────────────────────────────
+
+  const updateStatus = useCallback((newStatus: ConnectionStatus) => {
+    setStatus(newStatus);
+    onStatusChangeRef.current?.(newStatus);
+  }, []);
+
+  // ── Public send helpers ────────────────────────────────────────────────────
+
+  const sendJSON = useCallback((payload: Record<string, unknown>) => {
+    const ws = wsRef.current;
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(payload));
+    }
+  }, []);
+
+  const sendInput = useCallback((data: string) => {
+    sendJSON({ type: "input", data });
+  }, [sendJSON]);
+
+  const sendResize = useCallback((cols: number, rows: number) => {
+    sendJSON({ type: "resize", cols, rows });
+  }, [sendJSON]);
+
+  const sendRestartAgent = useCallback(() => {
+    sendJSON({ type: "restart_agent" });
+  }, [sendJSON]);
+
+  // ── Connection effect ──────────────────────────────────────────────────────
+
+  useEffect(() => {
+    let mounted = true;
+    isUnmountingRef.current = false;
+    intentionalExitRef.current = false;
+
+    async function connect() {
+      if (wsRef.current?.readyState === WebSocket.OPEN) return;
+
+      updateStatus("connecting");
+
+      // Fetch auth token
+      let token: string;
+      try {
+        const tokenResponse = await fetch(`/api/sessions/${sessionId}/token`);
+        if (!tokenResponse.ok) {
+          throw new Error("Failed to get auth token");
+        }
+        const tokenData = await tokenResponse.json();
+        token = tokenData.token;
+      } catch {
+        setAuthError("Your session may have expired. Please refresh the page to re-authenticate.");
+        updateStatus("error");
+        onStatusMessageRef.current?.("\x1b[31mError: Failed to authenticate\x1b[0m");
+        return;
+      }
+
+      // Build WebSocket URL with params
+      const params = new URLSearchParams({
+        token,
+        sessionId,
+        tmuxSession: tmuxSessionName,
+        cols: String(initialCols),
+        rows: String(initialRows),
+        tmuxHistoryLimit: String(tmuxHistoryLimitRef.current),
+        terminalType,
+      });
+      if (projectPath) {
+        params.set("cwd", projectPath);
+      }
+      const envVars = environmentVarsRef.current;
+      if (envVars && Object.keys(envVars).length > 0) {
+        params.set("environmentVars", encodeURIComponent(JSON.stringify(envVars)));
+      }
+
+      const ws = new WebSocket(`${wsUrl}?${params.toString()}`);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        if (isUnmountingRef.current) {
+          ws.close();
+          return;
+        }
+        updateStatus("connected");
+        reconnectAttemptsRef.current = 0;
+        onWebSocketReadyRef.current?.(ws);
+      };
+
+      ws.onmessage = (event) => {
+        // Skip binary frames (voice audio)
+        if (typeof event.data !== "string") return;
+
+        try {
+          const msg = JSON.parse(event.data);
+          switch (msg.type) {
+            case "output":
+              onOutputRef.current?.(msg.data);
+              recordActivityRef.current?.();
+              break;
+
+            case "ready":
+              break;
+
+            case "session_created":
+              break;
+
+            case "session_attached":
+              break;
+
+            case "exit":
+              markIntentionalExit();
+              onStatusMessageRef.current?.(`\x1b[33mSession ended (exit code ${msg.code})\x1b[0m`);
+              onSessionExitRef.current?.(msg.code);
+              break;
+
+            case "agent_exited":
+              markIntentionalExit();
+              onAgentActivityStatusRef.current?.(
+                msg.sessionId ?? sessionId,
+                msg.exitCode != null && msg.exitCode !== 0 ? "error" : "idle"
+              );
+              onStatusMessageRef.current?.(`\x1b[33mAgent exited (exit code ${msg.exitCode ?? "unknown"})\x1b[0m`);
+              onAgentExitedRef.current?.(msg.exitCode, msg.exitedAt);
+              break;
+
+            case "agent_restarted":
+              intentionalExitRef.current = false;
+              onAgentActivityStatusRef.current?.(sessionId, "running");
+              onStatusMessageRef.current?.("\x1b[32mAgent restarted\x1b[0m");
+              onAgentRestartedRef.current?.();
+              break;
+
+            case "agent_activity_status":
+              onAgentActivityStatusRef.current?.(msg.sessionId, msg.status);
+              break;
+
+            case "agent_todos_updated":
+              onAgentTodosUpdatedRef.current?.(msg.sessionId);
+              break;
+
+            case "notification":
+              if (msg.notification) {
+                onNotificationRef.current?.(msg.notification as Record<string, unknown>);
+              }
+              break;
+
+            case "session_status_update":
+              onSessionStatusRef.current?.(msg.sessionId, msg.key, msg.indicator);
+              break;
+
+            case "session_status_cleared":
+              onSessionStatusRef.current?.(msg.sessionId, msg.key, null);
+              break;
+
+            case "session_progress_update":
+              onSessionProgressRef.current?.(msg.sessionId, {
+                value: msg.value,
+                label: msg.label,
+                updatedAt: msg.updatedAt || new Date().toISOString(),
+              });
+              break;
+
+            case "session_progress_cleared":
+              onSessionProgressRef.current?.(msg.sessionId, null);
+              break;
+
+            case "voice_ready":
+              break;
+
+            case "voice_error":
+              console.error(`[Voice] Error: ${msg.message}`);
+              break;
+
+            case "error": {
+              onStatusMessageRef.current?.(`\x1b[31mError: ${msg.message}\x1b[0m`);
+              if (AUTH_ERROR_MESSAGES.some(m => msg.message?.includes(m))) {
+                setAuthError(msg.message);
+                updateStatus("error");
+              }
+              break;
+            }
+          }
+        } catch {
+          // Non-JSON data — treat as raw output
+          onOutputRef.current?.(event.data);
+          recordActivityRef.current?.();
+        }
+      };
+
+      ws.onclose = () => {
+        if (isUnmountingRef.current) return;
+
+        updateStatus("disconnected");
+        onWebSocketReadyRef.current?.(null);
+
+        if (intentionalExitRef.current) return;
+
+        if (reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
+          updateStatus("reconnecting");
+          reconnectAttemptsRef.current++;
+          onStatusMessageRef.current?.(
+            `\x1b[33mReconnecting (attempt ${reconnectAttemptsRef.current}/${MAX_RECONNECT_ATTEMPTS})...\x1b[0m`
+          );
+          reconnectTimeoutRef.current = setTimeout(() => {
+            if (mounted) connect();
+          }, RECONNECT_DELAY_MS);
+        } else {
+          onStatusMessageRef.current?.("\x1b[31mConnection lost. Refresh to reconnect.\x1b[0m");
+          updateStatus("error");
+        }
+      };
+
+      ws.onerror = () => {
+        console.error("WebSocket error");
+      };
+    }
+
+    connect();
+
+    return () => {
+      mounted = false;
+      isUnmountingRef.current = true;
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+      }
+      wsRef.current?.close();
+      wsRef.current = null;
+    };
+  }, [sessionId, tmuxSessionName, projectPath, wsUrl, terminalType, initialCols, initialRows, updateStatus, markIntentionalExit]);
+
+  return {
+    wsRef,
+    status,
+    authError,
+    sendInput,
+    sendResize,
+    sendRestartAgent,
+    markIntentionalExit,
+  };
+}


### PR DESCRIPTION
## Summary

- **Problem**: On mobile, xterm.js disables autocorrect, predictive text, and voice dictation to prevent input duplication bugs — making typing natural language prompts painful
- **Solution**: On mobile devices, replace the xterm.js canvas with a native text input bar and scrollable ANSI-to-HTML output panel, preserving the special keys toolbar
- **Scope**: All session types (shell, agent, file, browser) on mobile get the native text input. Desktop path is completely unchanged — Terminal.tsx is not modified

### New files
| File | Purpose |
|------|---------|
| `src/hooks/useTerminalWebSocket.ts` | Shared WebSocket hook with auth, reconnect, and 14+ message dispatch |
| `src/components/terminal/MobileInputBar.tsx` | Native textarea with autocorrect/voice/autocomplete (forwardRef) |
| `src/components/terminal/MobileTerminalView.tsx` | Mobile output panel + input bar + keyboard + agent lifecycle |

### Modified files
| File | Change |
|------|--------|
| `src/components/terminal/TerminalWithKeyboard.tsx` | `isMobile` branch renders `MobileTerminalView` instead of `Terminal` |
| `package.json` | Added `ansi-to-html@0.7.2` for ANSI-to-HTML conversion |

### Key decisions
- **Approach B (Clean Separation)**: Shared `useTerminalWebSocket` hook extracts connection logic for reuse
- **WebSocket PTY write** for text delivery (not tmux send-keys) — real-time, no HTTP roundtrip
- **ANSI stream mode** preserves color state across chunked WebSocket messages
- **Camera button** only in MobileKeyboard (not duplicated in input bar)
- **Theme-reactive**: ANSI converter rebuilds when terminal theme changes

## Test plan
- [ ] Test on iOS Safari: verify autocorrect, predictive text, and voice dictation work
- [ ] Test on Android Chrome: verify same native keyboard features
- [ ] Verify agent sessions show VoiceMicButton and AgentExitScreen overlay
- [ ] Verify shell sessions show SessionEndedOverlay on exit
- [ ] Verify reconnect behavior (kill terminal server, observe reconnect messages)
- [ ] Verify desktop path is completely unaffected (no isMobile detection on desktop)
- [ ] Verify image upload via MobileKeyboard camera button works
- [ ] Run `bun run typecheck` and `bun run lint` (only pre-existing login/page.tsx error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)