### PR TITLE
feat: add loop agent session type with chat-first UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Loop agent session type**: Chat-first, mobile-first UI for long-running AI agent sessions with loop scheduling
+  - New `"loop"` terminal type plugin with conversational and monitoring modes
+  - Stream-JSON output parsing for Claude Code (`--output-format stream-json`) with ANSI text fallback
+  - `useLoopScheduler` hook for interval-based prompt re-fire in monitoring mode
+  - Chat components: `LoopChatPane`, `LoopMessageBubble`, `LoopChatInput`, `LoopStatusBar`
+  - `TerminalDrawer` for toggling raw terminal view (full-screen mobile, resizable desktop)
+  - Session wizard integration with loop config form (type, interval, prompt, agent, profile)
+  - Sidebar `MessageCircle` icon with activity status indicators
+  - 2000-message cap prevents unbounded memory growth in long-running sessions
 - **FCM push notifications for mobile app**: End-to-end push notification delivery from agent hooks to the Flutter mobile app via Firebase Cloud Messaging
   - Server: `PushNotificationGateway` port + `FcmPushGateway` (FCM HTTP v1 API) with `NullPushGateway` graceful degradation
   - New `push_token` DB table and `DrizzlePushTokenRepository` for device token storage

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -63,13 +63,14 @@ export const POST = withApiAuth(async (request, { userId }) => {
       createWorktree?: boolean;
       baseBranch?: string;
       worktreeType?: string;
-      terminalType?: "shell" | "agent" | "file" | "browser";
+      terminalType?: "shell" | "agent" | "file" | "browser" | "loop";
       filePath?: string;
       profileId?: string;
       agentProvider?: string;
       autoLaunchAgent?: boolean;
       agentFlags?: string[];
       parentSessionId?: string;
+      loopConfig?: { loopType?: string; intervalSeconds?: number; promptTemplate?: string; maxIterations?: number; autoRestart?: boolean };
     }>(request);
     if ("error" in result) return result.error;
     const body = result.data;
@@ -97,7 +98,7 @@ export const POST = withApiAuth(async (request, { userId }) => {
       githubRepoId: body.githubRepoId,
       worktreeBranch: body.worktreeBranch,
       folderId: body.folderId,
-      // Terminal type (shell, agent, file, browser)
+      // Terminal type (shell, agent, file, browser, loop)
       terminalType: body.terminalType,
       filePath: validatedFilePath,
       profileId: body.profileId,
@@ -106,6 +107,8 @@ export const POST = withApiAuth(async (request, { userId }) => {
       agentFlags: body.agentFlags,
       // Parent session for team orchestration
       parentSessionId: body.parentSessionId,
+      // Loop agent config
+      loopConfig: body.loopConfig as CreateSessionInput["loopConfig"],
       // Feature session fields
       startupCommand: body.startupCommand,
       featureDescription: body.featureDescription,

--- a/src/components/loop/LoopChatInput.tsx
+++ b/src/components/loop/LoopChatInput.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+/**
+ * LoopChatInput — Mobile-first chat input bar
+ *
+ * Auto-growing textarea that sends on Enter (Shift+Enter for newline).
+ * Anchored to the bottom of the viewport with safe-area support.
+ */
+
+import { useCallback, useRef, useState } from "react";
+import { Send, Settings } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface LoopChatInputProps {
+  onSend: (text: string) => void;
+  onConfigOpen?: () => void;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+export function LoopChatInput({
+  onSend,
+  onConfigOpen,
+  disabled = false,
+  placeholder = "Type a message...",
+}: LoopChatInputProps) {
+  const [value, setValue] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleSend = useCallback(() => {
+    const trimmed = value.trim();
+    if (!trimmed || disabled) return;
+    onSend(trimmed);
+    setValue("");
+    // Reset textarea height
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+    }
+  }, [value, disabled, onSend]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+      }
+    },
+    [handleSend]
+  );
+
+  const handleInput = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setValue(e.target.value);
+      // Auto-grow
+      const el = e.target;
+      el.style.height = "auto";
+      el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+    },
+    []
+  );
+
+  const hasContent = value.trim().length > 0;
+
+  return (
+    <div className="flex-none border-t border-border bg-background/80 backdrop-blur-sm px-3 py-2 pb-safe-bottom">
+      <div className="flex items-end gap-2 max-w-3xl mx-auto">
+        {onConfigOpen && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="flex-shrink-0 h-8 w-8 text-muted-foreground hover:text-foreground"
+            onClick={onConfigOpen}
+          >
+            <Settings className="w-4 h-4" />
+          </Button>
+        )}
+
+        <div className="flex-1 relative">
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={handleInput}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            disabled={disabled}
+            rows={1}
+            className={cn(
+              "w-full resize-none rounded-xl border border-border bg-card px-3 py-2 text-sm",
+              "placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-primary/50",
+              "disabled:opacity-50 disabled:cursor-not-allowed",
+              "max-h-[120px] overflow-y-auto"
+            )}
+          />
+        </div>
+
+        <Button
+          variant={hasContent ? "default" : "ghost"}
+          size="icon"
+          className={cn(
+            "flex-shrink-0 h-8 w-8 rounded-full transition-colors",
+            hasContent
+              ? "bg-primary text-primary-foreground hover:bg-primary/90"
+              : "text-muted-foreground"
+          )}
+          onClick={handleSend}
+          disabled={!hasContent || disabled}
+        >
+          <Send className="w-4 h-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/loop/LoopChatPane.tsx
+++ b/src/components/loop/LoopChatPane.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+/**
+ * LoopChatPane — Main orchestrator for loop agent sessions
+ *
+ * Assembles the chat-first UI for loop sessions:
+ * - Hidden Terminal component maintaining WebSocket/PTY connection
+ * - Output parser converting terminal output to chat messages
+ * - Message list with auto-scroll
+ * - Chat input bar for user messages
+ * - Status bar with agent status and terminal toggle
+ * - Terminal drawer for raw terminal view
+ * - Loop scheduler for monitoring sessions
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Terminal, type TerminalRef } from "@/components/terminal/Terminal";
+import { LoopMessageBubble } from "./LoopMessageBubble";
+import { LoopChatInput } from "./LoopChatInput";
+import { LoopStatusBar } from "./LoopStatusBar";
+import { TerminalDrawer } from "./TerminalDrawer";
+import { useLoopOutputParser } from "@/hooks/useLoopOutputParser";
+import { useLoopScheduler } from "@/hooks/useLoopScheduler";
+import { useSessionContext } from "@/contexts/SessionContext";
+import type { TerminalSession } from "@/types/session";
+import type { ChatMessage, LoopAgentMetadata } from "@/types/loop-agent";
+import type { ConnectionStatus } from "@/types/terminal";
+
+/** Maximum number of messages to keep in the chat — prevents unbounded memory growth for long-running sessions */
+const MAX_MESSAGES = 2000;
+
+function getInputPlaceholder(agentExited: boolean, isMonitoring: boolean): string {
+  if (agentExited) return "Agent has exited — restart to continue";
+  if (isMonitoring) return "Send a message between iterations...";
+  return "Type a message...";
+}
+
+interface LoopChatPaneProps {
+  session: TerminalSession;
+  wsUrl: string;
+  fontSize?: number;
+  fontFamily?: string;
+  scrollback?: number;
+  tmuxHistoryLimit?: number;
+  isActive?: boolean;
+  environmentVars?: Record<string, string> | null;
+  onAgentActivityStatus?: (sessionId: string, status: string) => void;
+  onAgentTodosUpdated?: (sessionId: string) => void;
+  onNotification?: (notification: Record<string, unknown>) => void;
+  onSessionStatus?: (
+    sessionId: string,
+    key: string,
+    indicator: import("@/types/terminal-type").SessionStatusIndicator | null
+  ) => void;
+  onSessionProgress?: (
+    sessionId: string,
+    progress: import("@/types/terminal-type").SessionProgress | null
+  ) => void;
+  onSessionClose?: (sessionId: string) => void;
+  onAgentStateChange?: (
+    sessionId: string,
+    state: "running" | "exited" | "restarting" | "closed"
+  ) => void;
+}
+
+export function LoopChatPane({
+  session,
+  wsUrl,
+  fontSize = 14,
+  fontFamily = "'JetBrainsMono Nerd Font Mono', monospace",
+  scrollback = 10000,
+  tmuxHistoryLimit = 50000,
+  isActive = false,
+  environmentVars,
+  onAgentActivityStatus,
+  onAgentTodosUpdated,
+  onNotification,
+  onSessionStatus,
+  onSessionProgress,
+  onSessionClose,
+  onAgentStateChange,
+}: LoopChatPaneProps) {
+  const { getAgentActivityStatus } = useSessionContext();
+  const activityStatus = getAgentActivityStatus(session.id);
+
+  const terminalRef = useRef<TerminalRef>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
+
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [terminalVisible, setTerminalVisible] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
+  const [currentIteration, setCurrentIteration] = useState(0);
+  const [isUserScrolled, setIsUserScrolled] = useState(false);
+  const [agentExited, setAgentExited] = useState(false);
+  const [hasGreeted, setHasGreeted] = useState(false);
+
+  // Extract loop config from session metadata
+  const metadata = session.typeMetadata as LoopAgentMetadata | null;
+  const loopConfig = metadata?.loopConfig ?? {
+    loopType: "conversational" as const,
+  };
+  const isMonitoring = loopConfig.loopType === "monitoring";
+  const useStreamJson = (session.agentProvider ?? "claude") === "claude";
+
+  // Parse terminal output into chat messages
+  const { handleOutput, reset: resetParser } = useLoopOutputParser({
+    onMessages: useCallback((newMessages: ChatMessage[]) => {
+      setMessages((prev) => {
+        const combined = [...prev, ...newMessages];
+        // Cap message list to prevent unbounded memory growth
+        if (combined.length > MAX_MESSAGES) {
+          return combined.slice(combined.length - MAX_MESSAGES);
+        }
+        return combined;
+      });
+    }, []),
+    useStreamJson,
+  });
+
+  // Send a message to the agent via WebSocket
+  const sendMessage = useCallback(
+    (text: string) => {
+      const ws = terminalRef.current?.getWebSocket();
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: "input", data: `${text}\n` }));
+      }
+    },
+    []
+  );
+
+  // Handle user sending a chat message
+  const handleUserSend = useCallback(
+    (text: string) => {
+      // Add user message optimistically
+      const userMsg: ChatMessage = {
+        id: `user-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+        role: "user",
+        kind: "text",
+        content: text,
+        timestamp: new Date(),
+      };
+      setMessages((prev) => [...prev, userMsg]);
+      setIsUserScrolled(false);
+
+      // Send to agent
+      sendMessage(text);
+    },
+    [sendMessage]
+  );
+
+  // Loop scheduler for monitoring mode
+  useLoopScheduler({
+    enabled: isMonitoring && !isPaused && !agentExited,
+    intervalSeconds: loopConfig.intervalSeconds ?? 300,
+    prompt: loopConfig.promptTemplate ?? "",
+    agentStatus: activityStatus,
+    maxIterations: loopConfig.maxIterations,
+    currentIteration,
+    sendMessage,
+    onPromptFired: useCallback(
+      (iterationNumber: number) => {
+        setCurrentIteration(iterationNumber);
+        // Add iteration marker to chat
+        const marker: ChatMessage = {
+          id: `iter-${iterationNumber}`,
+          role: "system",
+          kind: "iteration_marker",
+          content: `Iteration ${iterationNumber}`,
+          iterationNumber,
+          timestamp: new Date(),
+        };
+        setMessages((prev) => [...prev, marker]);
+      },
+      []
+    ),
+  });
+
+  // Auto-scroll to bottom when new messages arrive
+  useEffect(() => {
+    if (!isUserScrolled && messagesEndRef.current) {
+      messagesEndRef.current.scrollIntoView({ behavior: "instant" });
+    }
+  }, [messages, isUserScrolled]);
+
+  // Track user scroll position
+  const handleScroll = useCallback(() => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    const isAtBottom = scrollHeight - scrollTop - clientHeight < 50;
+    setIsUserScrolled(!isAtBottom);
+  }, []);
+
+  // Handle agent exit
+  const handleAgentExited = useCallback(
+    (exitCode: number | null, exitedAt: string) => {
+      setAgentExited(true);
+      const isSuccess = exitCode === 0;
+      const msg: ChatMessage = {
+        id: `exit-${Date.now()}`,
+        role: "system",
+        kind: isSuccess ? "text" : "error",
+        content: isSuccess
+          ? "Agent completed successfully"
+          : `Agent exited with code ${exitCode ?? "unknown"}`,
+        timestamp: new Date(exitedAt),
+      };
+      setMessages((prev) => [...prev, msg]);
+      onAgentStateChange?.(session.id, "exited");
+    },
+    [session.id, onAgentStateChange]
+  );
+
+  // Handle agent restart
+  const handleRestart = useCallback(() => {
+    setAgentExited(false);
+    resetParser();
+    onAgentStateChange?.(session.id, "restarting");
+    terminalRef.current?.restartAgent();
+  }, [session.id, onAgentStateChange, resetParser]);
+
+  // Handle agent restarted
+  const handleAgentRestarted = useCallback(() => {
+    setAgentExited(false);
+    const msg: ChatMessage = {
+      id: `restart-${Date.now()}`,
+      role: "system",
+      kind: "text",
+      content: "Agent restarted",
+      timestamp: new Date(),
+    };
+    setMessages((prev) => [...prev, msg]);
+    onAgentStateChange?.(session.id, "running");
+  }, [session.id, onAgentStateChange]);
+
+  // Handle terminal connection status for initial greeting
+  const handleStatusChange = useCallback(
+    (status: ConnectionStatus) => {
+      if (status === "connected" && !hasGreeted) {
+        setHasGreeted(true);
+        const greeting: ChatMessage = {
+          id: "greeting",
+          role: "system",
+          kind: "text",
+          content: isMonitoring
+            ? `Monitoring loop started — firing every ${loopConfig.intervalSeconds ?? 300}s`
+            : "Connected — send a message to start",
+          timestamp: new Date(),
+        };
+        setMessages((prev) => [greeting, ...prev]);
+      }
+    },
+    [hasGreeted, isMonitoring, loopConfig.intervalSeconds]
+  );
+
+  return (
+    <div className="flex flex-col h-full w-full bg-background">
+      {/* Status bar */}
+      <LoopStatusBar
+        sessionName={session.name}
+        loopType={loopConfig.loopType ?? "conversational"}
+        activityStatus={activityStatus}
+        currentIteration={currentIteration}
+        terminalVisible={terminalVisible}
+        onToggleTerminal={() => setTerminalVisible((v) => !v)}
+        isPaused={isPaused}
+        onTogglePause={
+          isMonitoring ? () => setIsPaused((v) => !v) : undefined
+        }
+      />
+
+      {/* Chat area */}
+      <div className="flex-1 flex flex-col min-h-0 relative">
+        {/* Message list */}
+        <div
+          ref={messagesContainerRef}
+          className="flex-1 overflow-y-auto px-3 py-3 space-y-3"
+          onScroll={handleScroll}
+        >
+          {messages.length === 0 && (
+            <div className="flex items-center justify-center h-full text-muted-foreground/40 text-sm">
+              {isMonitoring
+                ? "Waiting for first iteration..."
+                : "Send a message to begin"}
+            </div>
+          )}
+          {messages.map((msg) => (
+            <LoopMessageBubble key={msg.id} message={msg} />
+          ))}
+
+          {/* Scroll anchor */}
+          <div ref={messagesEndRef} />
+
+          {/* Typing indicator */}
+          {(activityStatus === "running" ||
+            activityStatus === "compacting") && (
+            <div className="flex items-center gap-2 pl-8">
+              <div className="flex gap-1">
+                <div className="w-1.5 h-1.5 rounded-full bg-muted-foreground/40 animate-bounce [animation-delay:0ms]" />
+                <div className="w-1.5 h-1.5 rounded-full bg-muted-foreground/40 animate-bounce [animation-delay:150ms]" />
+                <div className="w-1.5 h-1.5 rounded-full bg-muted-foreground/40 animate-bounce [animation-delay:300ms]" />
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Terminal drawer */}
+        <TerminalDrawer
+          visible={terminalVisible}
+          onClose={() => setTerminalVisible(false)}
+        >
+          <Terminal
+            ref={terminalRef}
+            sessionId={session.id}
+            tmuxSessionName={session.tmuxSessionName}
+            sessionName={session.name}
+            projectPath={session.projectPath}
+            wsUrl={wsUrl}
+            fontSize={fontSize}
+            fontFamily={fontFamily}
+            scrollback={scrollback}
+            tmuxHistoryLimit={tmuxHistoryLimit}
+            isActive={isActive}
+            environmentVars={environmentVars}
+            terminalType="agent"
+            onStatusChange={handleStatusChange}
+            onOutput={handleOutput}
+            onAgentExited={handleAgentExited}
+            onAgentRestarted={handleAgentRestarted}
+            onAgentActivityStatus={onAgentActivityStatus}
+            onAgentTodosUpdated={onAgentTodosUpdated}
+            onNotification={onNotification}
+            onSessionStatus={onSessionStatus}
+            onSessionProgress={onSessionProgress}
+          />
+        </TerminalDrawer>
+      </div>
+
+      {/* Input bar */}
+      <LoopChatInput
+        onSend={handleUserSend}
+        disabled={agentExited}
+        placeholder={getInputPlaceholder(agentExited, isMonitoring)}
+      />
+
+      {/* Agent exited overlay - restart and close options */}
+      {agentExited && (
+        <div className="absolute bottom-16 left-1/2 -translate-x-1/2 z-20 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleRestart}
+            className="flex items-center gap-2 bg-card border border-border rounded-full px-4 py-2 text-sm shadow-lg hover:bg-card/80 transition-colors"
+          >
+            <span className="text-primary">Restart Agent</span>
+          </button>
+          {onSessionClose && (
+            <button
+              type="button"
+              onClick={() => onSessionClose(session.id)}
+              className="flex items-center gap-2 bg-card border border-border rounded-full px-4 py-2 text-sm shadow-lg hover:bg-card/80 transition-colors"
+            >
+              <span className="text-muted-foreground">Close</span>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/loop/LoopMessageBubble.tsx
+++ b/src/components/loop/LoopMessageBubble.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+/**
+ * LoopMessageBubble — Individual chat message renderer
+ *
+ * Renders user, agent, and system messages with appropriate styling:
+ * - User messages: right-aligned, accent background
+ * - Agent messages: left-aligned, card background, supports markdown
+ * - System messages: centered, muted
+ * - Tool calls: collapsed disclosure with tool name
+ */
+
+import { useState } from "react";
+import { Bot, User, ChevronDown, ChevronRight, Wrench, AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ChatMessage } from "@/types/loop-agent";
+
+interface LoopMessageBubbleProps {
+  message: ChatMessage;
+}
+
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function AgentBubble({ message }: { message: ChatMessage }) {
+  return (
+    <div className="flex items-start gap-2 max-w-[85%]">
+      <div className="flex-shrink-0 w-6 h-6 rounded-full bg-primary/20 flex items-center justify-center mt-1">
+        <Bot className="w-3.5 h-3.5 text-primary" />
+      </div>
+      <div className="flex flex-col gap-0.5">
+        <div className="bg-card border border-border rounded-2xl rounded-tl-sm px-3 py-2 text-sm text-foreground whitespace-pre-wrap break-words">
+          {message.content}
+        </div>
+        <span className="text-[10px] text-muted-foreground/60 pl-1">
+          {formatTime(message.timestamp)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function UserBubble({ message }: { message: ChatMessage }) {
+  return (
+    <div className="flex items-start gap-2 max-w-[85%] ml-auto flex-row-reverse">
+      <div className="flex-shrink-0 w-6 h-6 rounded-full bg-blue-500/20 flex items-center justify-center mt-1">
+        <User className="w-3.5 h-3.5 text-blue-400" />
+      </div>
+      <div className="flex flex-col gap-0.5 items-end">
+        <div className="bg-blue-600/20 border border-blue-500/30 rounded-2xl rounded-tr-sm px-3 py-2 text-sm text-foreground whitespace-pre-wrap break-words">
+          {message.content}
+        </div>
+        <span className="text-[10px] text-muted-foreground/60 pr-1">
+          {formatTime(message.timestamp)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function ToolCallBubble({ message }: { message: ChatMessage }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="flex items-start gap-2 max-w-[85%]">
+      <div className="flex-shrink-0 w-6 h-6 rounded-full bg-amber-500/20 flex items-center justify-center mt-1">
+        <Wrench className="w-3.5 h-3.5 text-amber-400" />
+      </div>
+      <div className="flex flex-col gap-0.5 flex-1 min-w-0">
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="flex items-center gap-1.5 bg-card/50 border border-border/50 rounded-lg px-2.5 py-1.5 text-xs text-muted-foreground hover:bg-card transition-colors text-left"
+        >
+          {expanded ? (
+            <ChevronDown className="w-3 h-3 flex-shrink-0" />
+          ) : (
+            <ChevronRight className="w-3 h-3 flex-shrink-0" />
+          )}
+          <span className="font-mono truncate">
+            {message.toolName ?? "tool"}
+          </span>
+        </button>
+        {expanded && (
+          <div className="bg-card/30 border border-border/30 rounded-lg px-3 py-2 text-xs font-mono text-muted-foreground whitespace-pre-wrap break-all overflow-x-auto max-h-48 overflow-y-auto">
+            {message.content}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SystemBubble({ message }: { message: ChatMessage }) {
+  const isError = message.kind === "error";
+
+  return (
+    <div className="flex justify-center">
+      <div
+        className={cn(
+          "flex items-center gap-1.5 px-3 py-1 rounded-full text-xs",
+          isError
+            ? "bg-red-500/10 text-red-400 border border-red-500/20"
+            : "bg-muted/30 text-muted-foreground"
+        )}
+      >
+        {isError && <AlertCircle className="w-3 h-3" />}
+        {message.content}
+      </div>
+    </div>
+  );
+}
+
+function IterationMarker({ message }: { message: ChatMessage }) {
+  return (
+    <div className="flex items-center gap-3 py-2">
+      <div className="flex-1 h-px bg-border/50" />
+      <span className="text-[10px] font-mono text-muted-foreground/60 uppercase tracking-wider">
+        Iteration {message.iterationNumber}
+      </span>
+      <div className="flex-1 h-px bg-border/50" />
+    </div>
+  );
+}
+
+export function LoopMessageBubble({ message }: LoopMessageBubbleProps) {
+  switch (message.kind) {
+    case "iteration_marker":
+      return <IterationMarker message={message} />;
+
+    case "tool_call":
+    case "tool_result":
+      return <ToolCallBubble message={message} />;
+
+    case "error":
+      return <SystemBubble message={message} />;
+
+    case "text":
+    case "thinking":
+    default: {
+      if (message.role === "system") return <SystemBubble message={message} />;
+      if (message.role === "user") return <UserBubble message={message} />;
+      return <AgentBubble message={message} />;
+    }
+  }
+}

--- a/src/components/loop/LoopStatusBar.tsx
+++ b/src/components/loop/LoopStatusBar.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+/**
+ * LoopStatusBar — Header for loop agent sessions
+ *
+ * Shows session name, agent activity status, loop type indicator,
+ * iteration count, and terminal toggle button.
+ */
+
+import { MessageCircle, Timer, Terminal, Pause, Play } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { AgentActivityStatus } from "@/types/terminal-type";
+import type { LoopType } from "@/types/loop-agent";
+
+interface LoopStatusBarProps {
+  sessionName: string;
+  loopType: LoopType;
+  activityStatus: AgentActivityStatus | string;
+  currentIteration: number;
+  terminalVisible: boolean;
+  onToggleTerminal: () => void;
+  isPaused?: boolean;
+  onTogglePause?: () => void;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  running: "Working",
+  waiting: "Waiting for you",
+  idle: "Idle",
+  error: "Error",
+  compacting: "Thinking",
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  running: "bg-green-500",
+  waiting: "bg-amber-500",
+  idle: "bg-muted-foreground/50",
+  error: "bg-red-500",
+  compacting: "bg-blue-500",
+};
+
+export function LoopStatusBar({
+  sessionName,
+  loopType,
+  activityStatus,
+  currentIteration,
+  terminalVisible,
+  onToggleTerminal,
+  isPaused = false,
+  onTogglePause,
+}: LoopStatusBarProps) {
+  const statusLabel = STATUS_LABELS[activityStatus] ?? activityStatus;
+  const statusColor = STATUS_COLORS[activityStatus] ?? "bg-muted-foreground/50";
+  const isRunning = activityStatus === "running" || activityStatus === "compacting";
+
+  return (
+    <div className="flex-none flex items-center justify-between gap-2 px-3 py-2 border-b border-border bg-background/80 backdrop-blur-sm pt-safe-top">
+      {/* Left: session name + status */}
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        {loopType === "monitoring" ? (
+          <Timer className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+        ) : (
+          <MessageCircle className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+        )}
+        <span className="text-sm font-medium truncate">{sessionName}</span>
+        <div className="flex items-center gap-1.5">
+          <div
+            className={cn(
+              "w-1.5 h-1.5 rounded-full flex-shrink-0",
+              statusColor,
+              isRunning && "animate-pulse"
+            )}
+          />
+          <span className="text-[11px] text-muted-foreground whitespace-nowrap">
+            {statusLabel}
+          </span>
+        </div>
+      </div>
+
+      {/* Right: iteration badge + controls */}
+      <div className="flex items-center gap-1.5">
+        {loopType === "monitoring" && currentIteration > 0 && (
+          <Badge variant="outline" className="text-[10px] px-1.5 py-0 h-5">
+            #{currentIteration}
+          </Badge>
+        )}
+
+        {loopType === "monitoring" && onTogglePause && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={onTogglePause}
+          >
+            {isPaused ? (
+              <Play className="w-3.5 h-3.5" />
+            ) : (
+              <Pause className="w-3.5 h-3.5" />
+            )}
+          </Button>
+        )}
+
+        <Button
+          variant={terminalVisible ? "secondary" : "ghost"}
+          size="icon"
+          className="h-7 w-7"
+          onClick={onToggleTerminal}
+        >
+          <Terminal className="w-3.5 h-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/loop/TerminalDrawer.tsx
+++ b/src/components/loop/TerminalDrawer.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+/**
+ * TerminalDrawer — Toggleable terminal panel for loop sessions
+ *
+ * On mobile: slides up from bottom as a full-height overlay
+ * On desktop: appears as a bottom panel with drag-to-resize handle
+ *
+ * The actual Terminal component is always mounted (maintains PTY connection).
+ * This component only controls visibility and layout.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { X, GripHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useMobile } from "@/hooks/useMobile";
+
+interface TerminalDrawerProps {
+  visible: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+const MIN_HEIGHT = 150;
+const MAX_HEIGHT_RATIO = 0.8;
+const DEFAULT_HEIGHT = 300;
+
+export function TerminalDrawer({
+  visible,
+  onClose,
+  children,
+}: TerminalDrawerProps) {
+  const isMobile = useMobile();
+  const [height, setHeight] = useState(DEFAULT_HEIGHT);
+  const dragging = useRef(false);
+  const startY = useRef(0);
+  const startHeight = useRef(DEFAULT_HEIGHT);
+
+  const handleDragMove = useCallback(
+    (e: PointerEvent) => {
+      if (!dragging.current) return;
+      const delta = startY.current - e.clientY;
+      const maxHeight = window.innerHeight * MAX_HEIGHT_RATIO;
+      const newHeight = Math.max(
+        MIN_HEIGHT,
+        Math.min(maxHeight, startHeight.current + delta)
+      );
+      setHeight(newHeight);
+    },
+    []
+  );
+
+  const handleDragEnd = useCallback(() => {
+    dragging.current = false;
+    document.removeEventListener("pointermove", handleDragMove);
+    document.removeEventListener("pointerup", handleDragEnd);
+  }, [handleDragMove]);
+
+  const handleDragStart = useCallback(
+    (e: React.PointerEvent) => {
+      if (isMobile) return;
+      dragging.current = true;
+      startY.current = e.clientY;
+      startHeight.current = height;
+      document.addEventListener("pointermove", handleDragMove);
+      document.addEventListener("pointerup", handleDragEnd);
+    },
+    [height, isMobile, handleDragMove, handleDragEnd]
+  );
+
+  // Clean up listeners on unmount
+  useEffect(() => {
+    return () => {
+      document.removeEventListener("pointermove", handleDragMove);
+      document.removeEventListener("pointerup", handleDragEnd);
+    };
+  }, [handleDragMove, handleDragEnd]);
+
+  if (!visible) {
+    // Keep children mounted but hidden to maintain WebSocket connection
+    return (
+      <div className="h-0 w-0 overflow-hidden pointer-events-none absolute">
+        {children}
+      </div>
+    );
+  }
+
+  // Mobile: full-screen overlay
+  if (isMobile) {
+    return (
+      <div className="absolute inset-0 z-40 flex flex-col bg-background">
+        <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+          <span className="text-sm font-medium text-muted-foreground">
+            Terminal
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={onClose}
+          >
+            <X className="w-4 h-4" />
+          </Button>
+        </div>
+        <div className="flex-1 relative">{children}</div>
+      </div>
+    );
+  }
+
+  // Desktop: bottom panel with resize handle
+  return (
+    <div
+      className="relative border-t border-border bg-background"
+      style={{ height }}
+    >
+      {/* Resize handle */}
+      <div
+        className={cn(
+          "absolute top-0 left-0 right-0 h-2 -translate-y-1/2 z-10",
+          "flex items-center justify-center cursor-row-resize",
+          "hover:bg-primary/10 transition-colors"
+        )}
+        onPointerDown={handleDragStart}
+      >
+        <GripHorizontal className="w-4 h-4 text-muted-foreground/40" />
+      </div>
+
+      {/* Close button */}
+      <Button
+        variant="ghost"
+        size="icon"
+        className="absolute top-1 right-1 z-10 h-6 w-6"
+        onClick={onClose}
+      >
+        <X className="w-3.5 h-3.5" />
+      </Button>
+
+      {/* Terminal content */}
+      <div className="w-full h-full">{children}</div>
+    </div>
+  );
+}

--- a/src/components/session/NewSessionWizard.tsx
+++ b/src/components/session/NewSessionWizard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Folder, Github, Terminal, ChevronRight, Loader2, Sparkles, GitBranch, FileBox, Clock, Fingerprint } from "lucide-react";
+import { Folder, Github, Terminal, ChevronRight, Loader2, Sparkles, GitBranch, FileBox, Clock, Fingerprint, MessageCircle } from "lucide-react";
 import { PathInput } from "@/components/common";
 import { ProfileSelector } from "@/components/profiles/ProfileSelector";
 import { useProfileContext } from "@/contexts/ProfileContext";
@@ -45,12 +45,14 @@ interface NewSessionWizardProps {
     baseBranch?: string;
     profileId?: string;
     // Terminal type for plugin-based rendering
-    terminalType?: "shell" | "agent" | "file";
+    terminalType?: "shell" | "agent" | "file" | "loop";
     // Agent-aware session fields
     agentProvider?: "claude" | "codex" | "gemini" | "opencode" | "none";
     autoLaunchAgent?: boolean;
     agentFlags?: string[];
     worktreeType?: WorktreeType;
+    // Loop agent session fields
+    loopConfig?: import("@/types/loop-agent").LoopConfig;
   }) => Promise<void>;
   isGitHubConnected: boolean;
 }
@@ -64,8 +66,9 @@ type WizardStep =
   | "feature-form"
   | "feature-confirm"
   | "template-list"
-  | "save-template";
-type SessionType = "simple" | "github" | "folder" | "feature" | "template";
+  | "save-template"
+  | "loop-form";
+type SessionType = "simple" | "github" | "folder" | "feature" | "template" | "loop";
 
 export function NewSessionWizard({
   open,
@@ -106,6 +109,14 @@ export function NewSessionWizard({
   const [featureBaseBranch, setFeatureBaseBranch] = useState("main");
   const [isGitRepoValid, setIsGitRepoValid] = useState<boolean | null>(null);
   const [availableBranches, setAvailableBranches] = useState<string[]>([]);
+
+  // Loop session state
+  const [loopName, setLoopName] = useState("");
+  const [loopProjectPath, setLoopProjectPath] = useState("");
+  const [loopType, setLoopType] = useState<"conversational" | "monitoring">("conversational");
+  const [loopAgent, setLoopAgent] = useState<"claude" | "codex" | "gemini" | "opencode">("claude");
+  const [loopIntervalMinutes, setLoopIntervalMinutes] = useState(5);
+  const [loopPromptTemplate, setLoopPromptTemplate] = useState("");
 
   // Auto-generate branch name from feature description
   useEffect(() => {
@@ -177,6 +188,13 @@ export function NewSessionWizard({
     setIsGitRepoValid(null);
     setAvailableBranches([]);
     setWorktreeType("feature");
+    // Loop session reset
+    setLoopName("");
+    setLoopProjectPath("");
+    setLoopType("conversational");
+    setLoopAgent("claude");
+    setLoopIntervalMinutes(5);
+    setLoopPromptTemplate("");
   };
 
   const handleClose = () => {
@@ -190,6 +208,8 @@ export function NewSessionWizard({
       setStep("simple-form");
     } else if (type === "feature") {
       setStep("feature-form");
+    } else if (type === "loop") {
+      setStep("loop-form");
     } else if (type === "template") {
       setStep("template-list");
     } else {
@@ -384,6 +404,7 @@ export function NewSessionWizard({
             {step === "github-branch" && `Choose a branch for ${selectedRepo?.name}`}
             {step === "github-confirm" && "Review and create your session"}
             {step === "feature-form" && "Configure your feature session"}
+            {step === "loop-form" && "Configure your loop agent session"}
             {step === "feature-confirm" && "Review and create your session"}
             {step === "template-list" && "Select a saved template to use"}
           </DialogDescription>
@@ -418,6 +439,12 @@ export function NewSessionWizard({
                 title="Feature Session"
                 description="Start an AI agent session for a new feature"
                 onClick={() => handleTypeSelect("feature")}
+              />
+              <SessionTypeCard
+                icon={<MessageCircle className="w-5 h-5" />}
+                title="Loop Agent"
+                description="Chat-first agent session with loop scheduling"
+                onClick={() => handleTypeSelect("loop")}
               />
               {templates.length > 0 && (
                 <SessionTypeCard
@@ -866,6 +893,186 @@ export function NewSessionWizard({
                 >
                   Review
                   <ChevronRight className="w-4 h-4 ml-2" />
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Loop Agent Form */}
+          {step === "loop-form" && (
+            <div className="space-y-4">
+              {/* Session Name */}
+              <div className="space-y-2">
+                <Label htmlFor="loop-name" className="text-sm font-medium">Session Name</Label>
+                <Input
+                  id="loop-name"
+                  value={loopName}
+                  onChange={(e) => setLoopName(e.target.value)}
+                  placeholder="My Loop Agent"
+                  className="bg-card/50"
+                />
+              </div>
+
+              {/* Project Path */}
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">Project Directory</Label>
+                <PathInput
+                  value={loopProjectPath}
+                  onChange={setLoopProjectPath}
+                  placeholder="~/projects/my-app"
+                />
+              </div>
+
+              {/* Loop Type */}
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">Loop Type</Label>
+                <div className="grid grid-cols-2 gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setLoopType("conversational")}
+                    className={cn(
+                      "p-3 rounded-lg border text-left text-sm transition-all",
+                      loopType === "conversational"
+                        ? "border-primary bg-primary/10 text-foreground"
+                        : "border-border bg-card/50 text-muted-foreground hover:border-primary/50"
+                    )}
+                  >
+                    <div className="font-medium">Conversational</div>
+                    <div className="text-xs text-muted-foreground mt-0.5">
+                      Long-running chat with the agent
+                    </div>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setLoopType("monitoring")}
+                    className={cn(
+                      "p-3 rounded-lg border text-left text-sm transition-all",
+                      loopType === "monitoring"
+                        ? "border-primary bg-primary/10 text-foreground"
+                        : "border-border bg-card/50 text-muted-foreground hover:border-primary/50"
+                    )}
+                  >
+                    <div className="font-medium">Monitoring</div>
+                    <div className="text-xs text-muted-foreground mt-0.5">
+                      Re-fire a prompt on an interval
+                    </div>
+                  </button>
+                </div>
+              </div>
+
+              {/* Monitoring config (only shown for monitoring type) */}
+              {loopType === "monitoring" && (
+                <div className="space-y-3 p-3 rounded-lg bg-card/30 border border-border/50">
+                  <div className="space-y-2">
+                    <Label htmlFor="loop-interval" className="text-sm font-medium">
+                      Interval (minutes)
+                    </Label>
+                    <Input
+                      id="loop-interval"
+                      type="number"
+                      min={1}
+                      max={1440}
+                      value={loopIntervalMinutes}
+                      onChange={(e) => setLoopIntervalMinutes(Number(e.target.value) || 5)}
+                      className="bg-card/50 w-24"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="loop-prompt" className="text-sm font-medium">
+                      Prompt Template
+                    </Label>
+                    <textarea
+                      id="loop-prompt"
+                      value={loopPromptTemplate}
+                      onChange={(e) => setLoopPromptTemplate(e.target.value)}
+                      placeholder="Check for failing tests and fix them..."
+                      rows={3}
+                      className="w-full rounded-md border border-border bg-card/50 px-3 py-2 text-sm placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-primary/50 resize-none"
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* Agent provider */}
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">Agent</Label>
+                <div className="grid grid-cols-4 gap-2">
+                  {(["claude", "codex", "gemini", "opencode"] as const).map((agent) => (
+                    <button
+                      key={agent}
+                      type="button"
+                      onClick={() => setLoopAgent(agent)}
+                      className={cn(
+                        "px-3 py-2 rounded-lg border text-sm font-medium capitalize transition-all",
+                        loopAgent === agent
+                          ? "border-primary bg-primary/10 text-foreground"
+                          : "border-border bg-card/50 text-muted-foreground hover:border-primary/50"
+                      )}
+                    >
+                      {agent}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Profile selector */}
+              <div className="space-y-2">
+                <Label className="text-sm font-medium flex items-center gap-2">
+                  <Fingerprint className="w-4 h-4 text-primary" />
+                  Profile
+                </Label>
+                <ProfileSelector
+                  value={selectedProfileId}
+                  onChange={setSelectedProfileId}
+                  placeholder="Select a profile (optional)"
+                  showProviderBadge={true}
+                />
+              </div>
+
+              {error && (
+                <p className="text-sm text-red-400">{error}</p>
+              )}
+
+              <div className="flex gap-2 pt-2">
+                <Button variant="outline" onClick={() => setStep("choose-type")} className="flex-1">
+                  Back
+                </Button>
+                <Button
+                  className="flex-1"
+                  disabled={isCreating || !loopName.trim()}
+                  onClick={async () => {
+                    setIsCreating(true);
+                    setError(null);
+                    try {
+                      await onCreate({
+                        name: loopName.trim(),
+                        projectPath: loopProjectPath || undefined,
+                        profileId: selectedProfileId || undefined,
+                        terminalType: "loop",
+                        agentProvider: loopAgent,
+                        autoLaunchAgent: true,
+                        loopConfig: {
+                          loopType,
+                          intervalSeconds: loopType === "monitoring" ? loopIntervalMinutes * 60 : undefined,
+                          promptTemplate: loopType === "monitoring" ? loopPromptTemplate : undefined,
+                        },
+                      });
+                      handleClose();
+                    } catch (err) {
+                      setError(err instanceof Error ? err.message : "Failed to create session");
+                    } finally {
+                      setIsCreating(false);
+                    }
+                  }}
+                >
+                  {isCreating ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      Creating...
+                    </>
+                  ) : (
+                    "Create Loop Session"
+                  )}
                 </Button>
               </div>
             </div>

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -93,6 +93,15 @@ const CodeMirrorEditor = dynamic(
   { ssr: false }
 );
 
+// Dynamically import LoopChatPane for loop-type sessions
+const LoopChatPane = dynamic(
+  () =>
+    import("@/components/loop/LoopChatPane").then(
+      (mod) => mod.LoopChatPane
+    ),
+  { ssr: false }
+);
+
 // Stable subscription functions for useSyncExternalStore (must be outside component)
 // These listen for both cross-tab storage events and same-tab custom events
 function subscribeToSidebarCollapsed(callback: () => void) {
@@ -1739,6 +1748,33 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
                             fileName={String(metadata?.fileName ?? session.name)}
                             fontSize={prefs.fontSize}
                             fontFamily={prefs.fontFamily}
+                          />
+                        </div>
+                      );
+                    }
+
+                    // Loop type uses LoopChatPane for chat-first UI
+                    if (session.terminalType === "loop") {
+                      return (
+                        <div className="absolute inset-0 z-10">
+                          <LoopChatPane
+                            key={session.id}
+                            session={session}
+                            wsUrl={wsUrl}
+                            fontSize={prefs.fontSize}
+                            fontFamily={prefs.fontFamily}
+                            scrollback={userSettings?.xtermScrollback ?? 10000}
+                            tmuxHistoryLimit={userSettings?.tmuxHistoryLimit ?? 50000}
+                            isActive={session.id === activeSessionId}
+                            environmentVars={getEnvironmentWithSecrets(folderId)}
+                            onAgentActivityStatus={handleAgentActivityStatus}
+                            onAgentTodosUpdated={() => debouncedRefresh()}
+                            onNotification={(notification) => {
+                              addNotification(hydrateNotification(notification));
+                            }}
+                            onSessionStatus={setSessionStatusIndicator}
+                            onSessionProgress={setSessionProgress}
+                            onSessionClose={(id) => handleSessionDelete(activeSessions.find(s => s.id === id) ?? session)}
                           />
                         </div>
                       );

--- a/src/components/session/Sidebar.tsx
+++ b/src/components/session/Sidebar.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import {
   X, Plus, Terminal, Settings,
-  Folder, FolderOpen, Pencil, Trash2, Sparkles, GitBranch,
+  Folder, FolderOpen, Pencil, Trash2, Sparkles, GitBranch, MessageCircle,
   PanelLeftClose, PanelLeft,
   SplitSquareHorizontal, SplitSquareVertical, Minus,
   GitPullRequest, CircleDot, Clock, KeyRound, Fingerprint, Network,
@@ -133,7 +133,7 @@ interface SidebarProps {
  * Whether a session type has agent-like behavior (activity status tracking, exit states).
  */
 function hasAgentBehavior(session: TerminalSession): boolean {
-  return session.terminalType === "agent";
+  return session.terminalType === "agent" || session.terminalType === "loop";
 }
 
 /**
@@ -1106,6 +1106,9 @@ export function Sidebar({
                 }
                 if (session.terminalType === "agent") {
                   return <Sparkles className={cn("w-3.5 h-3.5", iconColor)} />;
+                }
+                if (session.terminalType === "loop") {
+                  return <MessageCircle className={cn("w-3.5 h-3.5", iconColor)} />;
                 }
                 return (
                   <span className={cn(

--- a/src/components/session/Sidebar.tsx
+++ b/src/components/session/Sidebar.tsx
@@ -1129,6 +1129,8 @@ export function Sidebar({
                 <GitBranch className="w-3 h-3" />
               ) : session.terminalType === "agent" ? (
                 <Sparkles className="w-3 h-3" />
+              ) : session.terminalType === "loop" ? (
+                <MessageCircle className="w-3 h-3" />
               ) : null}
               <span>{session.name}</span>
             </div>
@@ -1302,6 +1304,9 @@ export function Sidebar({
               }
               if (session.terminalType === "agent") {
                 return <Sparkles className={cn("w-3.5 h-3.5 shrink-0", iconColor)} />;
+              }
+              if (session.terminalType === "loop") {
+                return <MessageCircle className={cn("w-3.5 h-3.5 shrink-0", iconColor)} />;
               }
               return <Terminal className={cn("w-3.5 h-3.5 shrink-0", iconColor)} />;
             })()}

--- a/src/components/terminal/TerminalTypeRenderer.tsx
+++ b/src/components/terminal/TerminalTypeRenderer.tsx
@@ -8,6 +8,7 @@
  * - agent: Terminal with agent exit screen overlay
  * - file: CodeMirrorEditor for file viewing/editing
  * - browser: BrowserPane with screenshot streaming
+ * - loop: LoopChatPane with chat-first UI
  */
 
 import { useState, useRef, useCallback } from "react";
@@ -17,6 +18,7 @@ import { AgentExitScreen } from "./AgentExitScreen";
 import { VoiceMicButton } from "./VoiceMicButton";
 import { CodeMirrorEditor } from "./CodeMirrorEditor";
 import { BrowserPane } from "./BrowserPane";
+import { LoopChatPane } from "@/components/loop/LoopChatPane";
 import type { ConnectionStatus } from "@/types/terminal";
 import type { FileViewerMetadata, SessionStatusIndicator, SessionProgress } from "@/types/terminal-type";
 import { useSessionContext } from "@/contexts/SessionContext";
@@ -193,6 +195,27 @@ export function TerminalTypeRenderer({
 
     case "agent":
       return renderAgentTerminal("agent");
+
+    case "loop":
+      return (
+        <LoopChatPane
+          session={session}
+          wsUrl={wsUrl}
+          fontSize={fontSize}
+          fontFamily={fontFamily}
+          scrollback={scrollback}
+          tmuxHistoryLimit={tmuxHistoryLimit}
+          isActive={isActive}
+          environmentVars={environmentVars}
+          onAgentActivityStatus={onAgentActivityStatus}
+          onAgentTodosUpdated={onAgentTodosUpdated}
+          onNotification={onNotification}
+          onSessionStatus={onSessionStatus}
+          onSessionProgress={onSessionProgress}
+          onSessionClose={onSessionClose}
+          onAgentStateChange={onAgentStateChange}
+        />
+      );
 
     case "browser":
       return <BrowserPane session={session} />;

--- a/src/hooks/useLoopOutputParser.ts
+++ b/src/hooks/useLoopOutputParser.ts
@@ -1,0 +1,258 @@
+/**
+ * useLoopOutputParser — Parses raw terminal output into structured chat messages
+ *
+ * Buffers incoming chunks until complete lines are available.
+ * Attempts JSON.parse() on each line (Claude Code stream-json format).
+ * Falls back to ANSI-stripped text blocks for non-JSON output.
+ *
+ * Used by LoopChatPane to convert hidden terminal output into chat bubbles.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+import type {
+  ChatMessage,
+  ChatMessageRole,
+  StreamJsonEvent,
+} from "@/types/loop-agent";
+
+/** ANSI escape sequence regex — covers CSI, OSC, and single-char escapes */
+const ANSI_REGEX =
+  /(\u009B|\u001B\[)[0-?]*[ -/]*[@-~]|\u001B[@-Z\\-_]|\u001B\][\s\S]*?\u0007|\u001B\(B/g;
+
+/** Strip ANSI escape sequences from a string */
+function stripAnsi(str: string): string {
+  return str.replace(ANSI_REGEX, "");
+}
+
+/** Generate a unique message ID */
+function generateId(): string {
+  return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Extract text content from a stream-json message's content array */
+function extractTextContent(event: StreamJsonEvent): string | null {
+  const text = event.message?.content
+    ?.filter((c) => c.type === "text" && c.text)
+    .map((c) => c.text)
+    .join("\n");
+  return text?.trim() ? text : null;
+}
+
+/**
+ * Parse a stream-json event into a ChatMessage (or null if not displayable)
+ */
+function parseStreamJsonEvent(event: StreamJsonEvent): ChatMessage | null {
+  const now = new Date();
+
+  switch (event.type) {
+    case "assistant": {
+      const text = extractTextContent(event);
+      if (!text) return null;
+      return {
+        id: generateId(),
+        role: "agent",
+        kind: "text",
+        content: text,
+        timestamp: now,
+      };
+    }
+
+    case "tool_use": {
+      return {
+        id: generateId(),
+        role: "agent",
+        kind: "tool_call",
+        content: event.tool_name
+          ? `Using ${event.tool_name}`
+          : "Using tool",
+        toolName: event.tool_name,
+        isCollapsed: true,
+        timestamp: now,
+      };
+    }
+
+    case "tool_result": {
+      return {
+        id: generateId(),
+        role: "agent",
+        kind: "tool_result",
+        content: stripAnsi(event.content ?? ""),
+        toolName: event.tool_name,
+        isCollapsed: true,
+        timestamp: now,
+      };
+    }
+
+    case "user": {
+      // Skip user events — user messages are added optimistically by the chat
+      // input handler. Parsing them here would create duplicates.
+      return null;
+    }
+
+    case "result": {
+      if (!event.result?.trim()) return null;
+      return {
+        id: generateId(),
+        role: "agent",
+        kind: "text",
+        content: event.result,
+        timestamp: now,
+      };
+    }
+
+    case "system": {
+      if (event.subtype === "init") return null;
+      const text = extractTextContent(event);
+      if (!text) return null;
+      return {
+        id: generateId(),
+        role: "system",
+        kind: "text",
+        content: text,
+        timestamp: now,
+      };
+    }
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Try to parse a line as JSON (stream-json format)
+ * Returns a ChatMessage if successful, null otherwise
+ */
+function tryParseJsonLine(line: string): ChatMessage | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("{")) return null;
+
+  try {
+    const event = JSON.parse(trimmed) as StreamJsonEvent;
+    if (!event.type) return null;
+    return parseStreamJsonEvent(event);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create a text message from a raw terminal line
+ */
+function createTextMessage(text: string): ChatMessage | null {
+  const stripped = stripAnsi(text).trim();
+  if (!stripped) return null;
+
+  // Detect user input echoed back (lines starting with ❯ or > prompt)
+  const role: ChatMessageRole = /^[❯>$#]\s/.test(stripped)
+    ? "user"
+    : "agent";
+
+  return {
+    id: generateId(),
+    role,
+    kind: "text",
+    content: stripped,
+    timestamp: new Date(),
+  };
+}
+
+interface UseLoopOutputParserOptions {
+  /** Called when new messages are parsed from output */
+  onMessages: (messages: ChatMessage[]) => void;
+  /** Whether to use stream-json parsing (Claude) or text fallback */
+  useStreamJson?: boolean;
+}
+
+/**
+ * Hook that parses raw terminal output chunks into structured chat messages
+ *
+ * Usage:
+ *   const { handleOutput, reset } = useLoopOutputParser({
+ *     onMessages: (msgs) => setMessages(prev => [...prev, ...msgs]),
+ *   });
+ *
+ *   // In Terminal onOutput callback:
+ *   onOutput={handleOutput}
+ */
+export function useLoopOutputParser({
+  onMessages,
+  useStreamJson = true,
+}: UseLoopOutputParserOptions) {
+  /** Line buffer for incomplete chunks */
+  const lineBufferRef = useRef<string>("");
+  /** Debounce timer for text-mode batching */
+  const textBatchRef = useRef<string[]>([]);
+  const textTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /** Flush accumulated text lines as a single message */
+  const flushTextBatch = useCallback(() => {
+    const batch = textBatchRef.current;
+    textBatchRef.current = [];
+    textTimerRef.current = null;
+
+    if (batch.length === 0) return;
+
+    const combined = batch.join("\n");
+    const msg = createTextMessage(combined);
+    if (msg) {
+      onMessages([msg]);
+    }
+  }, [onMessages]);
+
+  /** Process a raw output chunk from the terminal */
+  const handleOutput = useCallback(
+    (data: string) => {
+      const buffer = lineBufferRef.current + data;
+      const lines = buffer.split("\n");
+
+      // Last element is incomplete (no trailing newline) — keep in buffer
+      lineBufferRef.current = lines.pop() ?? "";
+
+      const messages: ChatMessage[] = [];
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+
+        if (useStreamJson) {
+          // Try JSON parse first
+          const jsonMsg = tryParseJsonLine(line);
+          if (jsonMsg) {
+            messages.push(jsonMsg);
+            continue;
+          }
+        }
+
+        // Text fallback — batch lines and debounce into single messages
+        textBatchRef.current.push(line);
+        if (textTimerRef.current) clearTimeout(textTimerRef.current);
+        textTimerRef.current = setTimeout(flushTextBatch, 100);
+      }
+
+      if (messages.length > 0) {
+        onMessages(messages);
+      }
+    },
+    [onMessages, useStreamJson, flushTextBatch]
+  );
+
+  /** Reset the parser state (e.g., on session restart) */
+  const reset = useCallback(() => {
+    lineBufferRef.current = "";
+    textBatchRef.current = [];
+    if (textTimerRef.current) {
+      clearTimeout(textTimerRef.current);
+      textTimerRef.current = null;
+    }
+  }, []);
+
+  // Clean up pending debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      if (textTimerRef.current) {
+        clearTimeout(textTimerRef.current);
+      }
+    };
+  }, []);
+
+  return { handleOutput, reset };
+}

--- a/src/hooks/useLoopScheduler.ts
+++ b/src/hooks/useLoopScheduler.ts
@@ -1,0 +1,94 @@
+/**
+ * useLoopScheduler — Interval-based prompt scheduler for monitoring loops
+ *
+ * Fires a configured prompt to the agent via WebSocket at regular intervals.
+ * Skips firing when the agent is already running to avoid prompt queuing.
+ * Uses the same WebSocket input channel as keyboard input.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+
+interface UseLoopSchedulerOptions {
+  /** Whether the scheduler is active */
+  enabled: boolean;
+  /** Interval in seconds between prompt fires */
+  intervalSeconds: number;
+  /** The prompt text to send */
+  prompt: string;
+  /** Current agent activity status */
+  agentStatus: string;
+  /** Maximum number of iterations (null = unlimited) */
+  maxIterations?: number | null;
+  /** Current iteration count */
+  currentIteration?: number;
+  /** Send a message to the agent via WebSocket */
+  sendMessage: (text: string) => void;
+  /** Called when a prompt is fired */
+  onPromptFired?: (iterationNumber: number) => void;
+}
+
+/**
+ * Hook that schedules recurring prompts for monitoring loop sessions
+ *
+ * Usage:
+ *   useLoopScheduler({
+ *     enabled: loopConfig.loopType === "monitoring",
+ *     intervalSeconds: loopConfig.intervalSeconds ?? 300,
+ *     prompt: loopConfig.promptTemplate ?? "",
+ *     agentStatus: activityStatus,
+ *     sendMessage: (text) => wsRef.current?.send(JSON.stringify({ type: "input", data: text + "\n" })),
+ *     onPromptFired: (n) => console.log(`Iteration ${n} fired`),
+ *   });
+ */
+export function useLoopScheduler({
+  enabled,
+  intervalSeconds,
+  prompt,
+  agentStatus,
+  maxIterations = null,
+  currentIteration = 0,
+  sendMessage,
+  onPromptFired,
+}: UseLoopSchedulerOptions): void {
+  const iterationRef = useRef(currentIteration);
+  const promptRef = useRef(prompt);
+  const agentStatusRef = useRef(agentStatus);
+
+  // Keep refs in sync without re-running the interval effect
+  useEffect(() => {
+    iterationRef.current = currentIteration;
+    promptRef.current = prompt;
+    agentStatusRef.current = agentStatus;
+  }, [currentIteration, prompt, agentStatus]);
+
+  const firePrompt = useCallback(() => {
+    // Skip if agent is busy (running or compacting)
+    const status = agentStatusRef.current;
+    if (status === "running" || status === "compacting") {
+      return;
+    }
+
+    // Check iteration limit
+    if (maxIterations !== null && iterationRef.current >= maxIterations) {
+      return;
+    }
+
+    const currentPrompt = promptRef.current;
+    if (!currentPrompt.trim()) return;
+
+    const nextIteration = iterationRef.current + 1;
+    iterationRef.current = nextIteration;
+
+    sendMessage(currentPrompt);
+    onPromptFired?.(nextIteration);
+  }, [sendMessage, onPromptFired, maxIterations]);
+
+  useEffect(() => {
+    if (!enabled || intervalSeconds <= 0 || !prompt.trim()) return;
+
+    const intervalMs = intervalSeconds * 1000;
+    const timer = setInterval(firePrompt, intervalMs);
+
+    return () => clearInterval(timer);
+  }, [enabled, intervalSeconds, prompt, firePrompt]);
+}

--- a/src/lib/terminal-plugins/init.ts
+++ b/src/lib/terminal-plugins/init.ts
@@ -10,6 +10,7 @@ import { ShellPlugin } from "./plugins/shell-plugin";
 import { AgentPlugin } from "./plugins/agent-plugin";
 import { FileViewerPlugin } from "./plugins/file-viewer-plugin";
 import { BrowserPlugin } from "./plugins/browser-plugin";
+import { LoopAgentPlugin } from "./plugins/loop-agent-plugin";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("PluginInit");
@@ -36,6 +37,7 @@ export function initializeBuiltInPlugins(): void {
   TerminalTypeRegistry.register(AgentPlugin, { builtIn: true });
   TerminalTypeRegistry.register(FileViewerPlugin, { builtIn: true });
   TerminalTypeRegistry.register(BrowserPlugin, { builtIn: true });
+  TerminalTypeRegistry.register(LoopAgentPlugin, { builtIn: true });
 
   // Set default type to shell
   TerminalTypeRegistry.setDefaultType("shell");

--- a/src/lib/terminal-plugins/plugins/loop-agent-plugin.tsx
+++ b/src/lib/terminal-plugins/plugins/loop-agent-plugin.tsx
@@ -54,13 +54,10 @@ export function createLoopAgentPlugin(): TerminalTypePlugin {
       const agentCommand = buildAgentCommand(provider, flags, false);
 
       // Parse loop config from input metadata or defaults
-      const inputLoopConfig = input.loopConfig;
       const loopConfig: LoopConfig = {
-        loopType: inputLoopConfig?.loopType ?? "conversational",
-        intervalSeconds: inputLoopConfig?.intervalSeconds,
-        promptTemplate: inputLoopConfig?.promptTemplate,
-        maxIterations: inputLoopConfig?.maxIterations,
-        autoRestart: inputLoopConfig?.autoRestart ?? false,
+        loopType: "conversational",
+        autoRestart: false,
+        ...input.loopConfig,
       };
 
       const metadata: LoopAgentMetadata = {

--- a/src/lib/terminal-plugins/plugins/loop-agent-plugin.tsx
+++ b/src/lib/terminal-plugins/plugins/loop-agent-plugin.tsx
@@ -1,0 +1,171 @@
+/**
+ * LoopAgentPlugin — Chat-first agent terminal type with loop scheduling
+ *
+ * Renders a conversational chat UI instead of raw xterm.js terminal.
+ * The agent still runs in tmux via PTY (reusing all existing agent infrastructure),
+ * but output is parsed into structured messages displayed as chat bubbles.
+ *
+ * Supports two modes:
+ * - "conversational": Long-running agent chat with anytime user interrupts
+ * - "monitoring": Recurring prompt fired on an interval
+ */
+
+import { MessageCircle } from "lucide-react";
+import type { ReactNode } from "react";
+import type {
+  TerminalTypePlugin,
+  TerminalRenderProps,
+  SessionConfig,
+  ExitBehavior,
+} from "@/types/terminal-type";
+import type {
+  TerminalSession,
+  CreateSessionInput,
+} from "@/types/session";
+import type { LoopAgentMetadata, LoopConfig } from "@/types/loop-agent";
+import { getProviderConfig, buildAgentCommand } from "../agent-utils";
+
+/**
+ * Create a loop agent plugin instance
+ */
+export function createLoopAgentPlugin(): TerminalTypePlugin {
+  return {
+    type: "loop",
+    displayName: "Loop Agent",
+    description: "Chat-first AI agent with loop scheduling",
+    icon: MessageCircle,
+    priority: 85, // Between agent (90) and browser
+    builtIn: true,
+
+    createSession(input: CreateSessionInput): SessionConfig {
+      const providerId = input.agentProvider ?? "claude";
+      const provider = getProviderConfig(providerId);
+
+      if (!provider || provider.id === "none") {
+        throw new Error(`Invalid agent provider: ${providerId}`);
+      }
+
+      // Build agent command — add stream-json output for Claude
+      const flags = [...(input.agentFlags ?? [])];
+      if (providerId === "claude" && !flags.includes("--output-format")) {
+        flags.push("--output-format", "stream-json");
+      }
+
+      const agentCommand = buildAgentCommand(provider, flags, false);
+
+      // Parse loop config from input metadata or defaults
+      const inputLoopConfig = input.loopConfig;
+      const loopConfig: LoopConfig = {
+        loopType: inputLoopConfig?.loopType ?? "conversational",
+        intervalSeconds: inputLoopConfig?.intervalSeconds,
+        promptTemplate: inputLoopConfig?.promptTemplate,
+        maxIterations: inputLoopConfig?.maxIterations,
+        autoRestart: inputLoopConfig?.autoRestart ?? false,
+      };
+
+      const metadata: LoopAgentMetadata = {
+        agentProvider: providerId,
+        loopConfig,
+        currentIteration: 0,
+        terminalVisible: false,
+      };
+
+      return {
+        shellCommand: agentCommand,
+        shellArgs: [],
+        environment: {
+          TERM: "xterm-256color",
+        },
+        cwd: input.projectPath,
+        useTmux: true,
+        metadata,
+      };
+    },
+
+    onSessionExit(
+      session: TerminalSession,
+      exitCode: number | null
+    ): ExitBehavior {
+      const metadata = session.typeMetadata as LoopAgentMetadata | null;
+      const isMonitoring = metadata?.loopConfig.loopType === "monitoring";
+
+      let exitMessage: string;
+      if (exitCode !== 0) {
+        exitMessage = `Agent exited with code ${exitCode ?? "unknown"}`;
+      } else if (isMonitoring) {
+        exitMessage = "Loop completed";
+      } else {
+        exitMessage = "Agent completed";
+      }
+
+      return {
+        showExitScreen: true,
+        canRestart: true,
+        autoClose: false,
+        exitMessage,
+      };
+    },
+
+    onSessionRestart(session: TerminalSession): SessionConfig | null {
+      const providerId = session.agentProvider ?? "claude";
+      const provider = getProviderConfig(providerId);
+
+      if (!provider || provider.id === "none") {
+        return null;
+      }
+
+      const flags: string[] = [];
+      if (providerId === "claude") {
+        flags.push("--output-format", "stream-json");
+      }
+
+      const agentCommand = buildAgentCommand(provider, flags, false);
+
+      return {
+        shellCommand: agentCommand,
+        shellArgs: [],
+        environment: {
+          TERM: "xterm-256color",
+        },
+        cwd: session.projectPath ?? undefined,
+        useTmux: true,
+      };
+    },
+
+    renderContent(
+      session: TerminalSession,
+      props: TerminalRenderProps
+    ): ReactNode {
+      // Return a marker for TerminalTypeRenderer/SessionManager to interpret
+      return {
+        type: "loop-chat",
+        session,
+        props,
+      } as unknown as ReactNode;
+    },
+
+    validateInput(input: CreateSessionInput): string | null {
+      if (!input.name?.trim()) {
+        return "Session name is required";
+      }
+
+      const providerId = input.agentProvider ?? "claude";
+      const provider = getProviderConfig(providerId);
+
+      if (!provider || provider.id === "none") {
+        return `Invalid agent provider: ${providerId}`;
+      }
+
+      return null;
+    },
+
+    canHandle(session: TerminalSession): boolean {
+      return session.terminalType === "loop";
+    },
+  };
+}
+
+/**
+ * Default loop agent plugin instance
+ */
+export const LoopAgentPlugin = createLoopAgentPlugin();

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -167,7 +167,7 @@ function broadcastToUser(userId: string, data: Record<string, unknown>): void {
 /** Get the current active and agent session counts for drain status reporting. */
 function getSessionCounts(): { activeSessions: number; activeAgentSessions: number } {
   const activeAgentSessions = [...sessions.values()].filter(
-    (s) => s.terminalType === "agent"
+    (s) => s.terminalType === "agent" || s.terminalType === "loop"
   ).length;
   return { activeSessions: sessions.size, activeAgentSessions };
 }
@@ -1394,9 +1394,9 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       log.debug("PTY exited", { sessionId, exitCode, terminalType });
 
       if (ws.readyState === WebSocket.OPEN) {
-        // For agent terminals, send a special agent_exited message
+        // For agent/loop terminals, send a special agent_exited message
         // The frontend will show an exit screen with restart/close options
-        if (terminalType === "agent") {
+        if (terminalType === "agent" || terminalType === "loop") {
           agentLog.info("Agent session exited - sending agent_exited event", { sessionId });
           ws.send(JSON.stringify({
             type: "agent_exited",
@@ -1502,7 +1502,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
             break;
 
           case "restart_agent": {
-            if (terminalType !== "agent") {
+            if (terminalType !== "agent" && terminalType !== "loop") {
               ws.send(JSON.stringify({
                 type: "error",
                 message: "restart_agent is only valid for agent sessions",
@@ -1556,7 +1556,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
           }
 
           case "voice_start": {
-            if (session.terminalType !== "agent") {
+            if (session.terminalType !== "agent" && session.terminalType !== "loop") {
               ws.send(JSON.stringify({ type: "voice_error", message: "Voice mode is only available for agent sessions" }));
               break;
             }

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -164,10 +164,15 @@ function broadcastToUser(userId: string, data: Record<string, unknown>): void {
   }
 }
 
+/** Whether a terminal type has agent-like behavior (exit handling, restart, voice). */
+function isAgentTerminalType(type: string): boolean {
+  return type === "agent" || type === "loop";
+}
+
 /** Get the current active and agent session counts for drain status reporting. */
 function getSessionCounts(): { activeSessions: number; activeAgentSessions: number } {
   const activeAgentSessions = [...sessions.values()].filter(
-    (s) => s.terminalType === "agent" || s.terminalType === "loop"
+    (s) => isAgentTerminalType(s.terminalType)
   ).length;
   return { activeSessions: sessions.size, activeAgentSessions };
 }
@@ -1396,7 +1401,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       if (ws.readyState === WebSocket.OPEN) {
         // For agent/loop terminals, send a special agent_exited message
         // The frontend will show an exit screen with restart/close options
-        if (terminalType === "agent" || terminalType === "loop") {
+        if (isAgentTerminalType(terminalType)) {
           agentLog.info("Agent session exited - sending agent_exited event", { sessionId });
           ws.send(JSON.stringify({
             type: "agent_exited",
@@ -1502,7 +1507,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
             break;
 
           case "restart_agent": {
-            if (terminalType !== "agent" && terminalType !== "loop") {
+            if (!isAgentTerminalType(terminalType)) {
               ws.send(JSON.stringify({
                 type: "error",
                 message: "restart_agent is only valid for agent sessions",
@@ -1556,7 +1561,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
           }
 
           case "voice_start": {
-            if (session.terminalType !== "agent" && session.terminalType !== "loop") {
+            if (!isAgentTerminalType(session.terminalType)) {
               ws.send(JSON.stringify({ type: "voice_error", message: "Voice mode is only available for agent sessions" }));
               break;
             }

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -193,7 +193,12 @@ export async function createSession(
   // wrapper), otherwise fall back to the provider's default command (e.g., `claude`).
   // The agent command replaces any plain startup command to avoid duplication.
   if (input.agentProvider && input.agentProvider !== "none" && input.autoLaunchAgent) {
-    const agentCommand = buildAgentCommand(input.agentProvider, input.agentFlags, startupCommand);
+    // For loop sessions with Claude, add --output-format stream-json for structured output parsing
+    const agentFlags = [...(input.agentFlags ?? [])];
+    if (input.terminalType === "loop" && input.agentProvider === "claude" && !agentFlags.includes("--output-format")) {
+      agentFlags.push("--output-format", "stream-json");
+    }
+    const agentCommand = buildAgentCommand(input.agentProvider, agentFlags, startupCommand);
     if (agentCommand) {
       startupCommand = agentCommand;
     }
@@ -221,7 +226,8 @@ export async function createSession(
   // but may not send agentProvider/autoLaunchAgent separately)
   const isAgentSession =
     (input.agentProvider && input.agentProvider !== "none" && input.autoLaunchAgent) ||
-    input.terminalType === "agent";
+    input.terminalType === "agent" ||
+    input.terminalType === "loop";
   const effectiveAgentProvider = input.agentProvider && input.agentProvider !== "none"
     ? input.agentProvider
     : "claude"; // Default matches DB default on line ~350
@@ -400,6 +406,15 @@ export async function createSession(
   if (terminalType === "file" && input.filePath) {
     const fileName = input.filePath.split("/").pop() ?? input.filePath;
     typeMetadata = JSON.stringify({ filePath: input.filePath, fileName });
+  } else if (terminalType === "loop") {
+    // Loop sessions store their config in typeMetadata
+    const loopConfig = input.loopConfig ?? { loopType: "conversational" };
+    typeMetadata = JSON.stringify({
+      agentProvider: input.agentProvider ?? "claude",
+      loopConfig,
+      currentIteration: 0,
+      terminalVisible: false,
+    });
   }
 
   // Insert the database record - clean up tmux session and worktree if this fails
@@ -422,8 +437,8 @@ export async function createSession(
         terminalType,
         typeMetadata,
         agentProvider: input.agentProvider ?? "claude",
-        // Set agent state for agent terminal type
-        agentExitState: terminalType === "agent" ? "running" : null,
+        // Set agent state for agent/loop terminal types
+        agentExitState: (terminalType === "agent" || terminalType === "loop") ? "running" : null,
         agentExitCode: null,
         agentExitedAt: null,
         agentRestartCount: 0,

--- a/src/types/loop-agent.ts
+++ b/src/types/loop-agent.ts
@@ -1,0 +1,112 @@
+/**
+ * Loop Agent Types — Chat-first agent sessions with loop scheduling
+ *
+ * Loop sessions render a conversational chat UI instead of raw terminal output.
+ * The underlying agent still runs in tmux via PTY, but output is parsed into
+ * structured messages displayed as chat bubbles.
+ *
+ * Two loop modes:
+ * - "conversational": Long-running agent chat with anytime user interrupts
+ * - "monitoring": Recurring prompt fired on an interval (e.g., every 5m)
+ */
+
+import type { AgentProviderType } from "./session";
+
+/**
+ * Loop session type
+ */
+export type LoopType = "conversational" | "monitoring";
+
+/**
+ * Chat message role
+ */
+export type ChatMessageRole = "user" | "agent" | "system";
+
+/**
+ * Chat message kind for rendering differentiation
+ */
+export type ChatMessageKind =
+  | "text"
+  | "tool_call"
+  | "tool_result"
+  | "thinking"
+  | "iteration_marker"
+  | "error";
+
+/**
+ * A structured chat message parsed from agent output
+ */
+export interface ChatMessage {
+  id: string;
+  role: ChatMessageRole;
+  kind: ChatMessageKind;
+  content: string;
+  /** Tool name for tool_call/tool_result kinds */
+  toolName?: string;
+  /** Whether a tool call block is collapsed in the UI */
+  isCollapsed?: boolean;
+  /** Iteration number (for monitoring loops) */
+  iterationNumber?: number;
+  timestamp: Date;
+}
+
+/**
+ * Loop configuration stored in session.typeMetadata
+ */
+export interface LoopConfig {
+  loopType: LoopType;
+  /** Interval in seconds for monitoring loops */
+  intervalSeconds?: number;
+  /** Prompt template to fire on each monitoring iteration */
+  promptTemplate?: string;
+  /** Maximum iterations for monitoring loops (null = unlimited) */
+  maxIterations?: number;
+  /** Whether to auto-restart the agent on exit */
+  autoRestart?: boolean;
+}
+
+/**
+ * Metadata stored with loop sessions in session.typeMetadata
+ */
+export interface LoopAgentMetadata {
+  agentProvider: AgentProviderType;
+  loopConfig: LoopConfig;
+  currentIteration: number;
+  /** Whether the terminal drawer is visible */
+  terminalVisible: boolean;
+}
+
+/**
+ * Stream-JSON event types from Claude Code --output-format stream-json
+ */
+export type StreamJsonEventType =
+  | "system"
+  | "assistant"
+  | "user"
+  | "tool_use"
+  | "tool_result"
+  | "result";
+
+/**
+ * A parsed event from Claude Code's stream-json output
+ */
+export interface StreamJsonEvent {
+  type: StreamJsonEventType;
+  /** For assistant/system: the text content */
+  message?: {
+    content?: Array<{
+      type: "text" | "tool_use" | "tool_result" | "thinking";
+      text?: string;
+      name?: string;
+      input?: Record<string, unknown>;
+    }>;
+  };
+  /** For tool_use events */
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+  /** For tool_result events */
+  content?: string;
+  /** For result events */
+  result?: string;
+  subtype?: string;
+}

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -88,6 +88,8 @@ export interface CreateSessionInput {
   createWorktree?: boolean;     // Whether to create worktree
   baseBranch?: string;          // Base branch for new worktree
   worktreeType?: WorktreeType;  // Branch prefix type (feature, fix, etc.)
+  // Loop agent session fields
+  loopConfig?: import("./loop-agent").LoopConfig;
 }
 
 /**

--- a/src/types/terminal-type.ts
+++ b/src/types/terminal-type.ts
@@ -21,7 +21,7 @@ export type TerminalType = "shell" | "agent" | "file" | "browser" | string;
 /**
  * Built-in terminal types (cannot be unregistered)
  */
-export const BUILT_IN_TERMINAL_TYPES: TerminalType[] = ["shell", "agent", "file", "browser"];
+export const BUILT_IN_TERMINAL_TYPES: TerminalType[] = ["shell", "agent", "file", "browser", "loop"];
 
 /**
  * Session exit behavior determines what happens when the main process exits
@@ -52,7 +52,7 @@ export interface SessionConfig {
   /** Whether to create a tmux session (false for file viewer) */
   useTmux: boolean;
   /** Additional metadata stored with session */
-  metadata?: AgentSessionMetadata | FileViewerMetadata | BrowserSessionMetadata | Record<string, unknown>;
+  metadata?: AgentSessionMetadata | FileViewerMetadata | BrowserSessionMetadata | import("./loop-agent").LoopAgentMetadata | Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add new `"loop"` terminal type plugin with a **chat-first, mobile-first UI** instead of raw xterm.js
- Two loop modes: **conversational** (long-running chat with anytime user interrupts) and **monitoring** (recurring prompt fired on interval)
- Agent still runs in tmux/PTY — output is parsed into structured chat messages via Claude Code's `--output-format stream-json`
- Full integration: session wizard, sidebar icons with activity status, terminal server lifecycle, split pane support

## Key Decisions
- **Hidden Terminal pattern**: xterm.js Terminal component stays mounted but hidden (`display:none`) to maintain the WebSocket/PTY connection. No server changes needed.
- **Client-side output parsing**: `useLoopOutputParser` hook parses stream-json lines from Claude Code. Falls back to ANSI-stripped text for non-Claude agents.
- **Message cap at 2000**: Prevents unbounded memory growth for long-running monitoring sessions.
- **Type-safe `loopConfig`**: Added to `CreateSessionInput` to avoid unsafe casts throughout the codebase.

## New Files (9)
| File | Purpose |
|------|---------|
| `src/types/loop-agent.ts` | Types: ChatMessage, LoopConfig, LoopAgentMetadata, StreamJsonEvent |
| `src/hooks/useLoopOutputParser.ts` | Parses PTY output → structured chat messages |
| `src/hooks/useLoopScheduler.ts` | Interval-based prompt scheduler for monitoring loops |
| `src/lib/terminal-plugins/plugins/loop-agent-plugin.tsx` | Loop terminal type plugin |
| `src/components/loop/LoopMessageBubble.tsx` | Chat bubbles (user/agent/system/tool/iteration) |
| `src/components/loop/LoopChatInput.tsx` | Mobile-first input bar with auto-grow |
| `src/components/loop/LoopStatusBar.tsx` | Header with status badge, iteration count, terminal toggle |
| `src/components/loop/TerminalDrawer.tsx` | Toggleable terminal panel (full-screen mobile, resizable desktop) |
| `src/components/loop/LoopChatPane.tsx` | Main orchestrator assembling all components |

## Modified Files (9)
- `src/types/terminal-type.ts` — Added `"loop"` to built-in types
- `src/types/session.ts` — Added `loopConfig` to `CreateSessionInput`
- `src/lib/terminal-plugins/init.ts` — Registered LoopAgentPlugin
- `src/components/session/SessionManager.tsx` — Loop rendering branch
- `src/components/session/NewSessionWizard.tsx` — Loop Agent creation form
- `src/components/session/Sidebar.tsx` — MessageCircle icon + activity status
- `src/components/terminal/TerminalTypeRenderer.tsx` — Loop case for split panes
- `src/server/terminal.ts` — Loop treated as agent for exit/restart/voice
- `src/services/session-service.ts` — Loop metadata, stream-json flags, isAgentSession

## Test Plan
- [ ] Create a conversational loop session via wizard → verify chat UI renders
- [ ] Send messages via chat input → verify they appear as user bubbles and agent responds
- [ ] Toggle terminal drawer → verify raw terminal output is visible
- [ ] Create a monitoring loop session with 1-minute interval → verify prompt fires on schedule
- [ ] Test on mobile viewport → verify mobile-first layout (bottom input, safe areas)
- [ ] Agent exit → verify restart button works, exit message appears in chat
- [ ] Sidebar → verify MessageCircle icon with correct activity status colors
- [ ] Split pane → verify loop session renders correctly in split layout
- [ ] Build passes: `bun run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)