### PR TITLE
fix: mobile terminal send button and output resize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ next-env.d.ts
 # MCP config (machine-specific paths)
 .mcp.json
 
+# worktrees
+.worktrees/
+
 # worktree trash
 .trash/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mobile terminal send button**: Wrapped `MobileInputBar` in a `<form>` so the mobile keyboard's `enterKeyHint="send"` properly triggers submission instead of inserting a newline
+- **Mobile terminal output resize**: Output panel now scrolls to bottom when the input textarea auto-expands with multi-line content
+- **Mobile terminal ANSI garbage**: Added stateful `AnsiStripper` that strips non-SGR terminal control sequences (cursor movement, screen clearing, tmux status bar, character set selection) before rendering, handling sequences split across WebSocket chunks
+
 ## [0.3.1] - 2026-03-21
 
 ### Added

--- a/src/components/terminal/MobileInputBar.tsx
+++ b/src/components/terminal/MobileInputBar.tsx
@@ -37,7 +37,7 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
     const [value, setValue] = useState("");
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-    useImperativeHandle(ref, () => textareaRef.current as HTMLTextAreaElement);
+    useImperativeHandle(ref, () => textareaRef.current!, []);
 
     const resetTextareaHeight = useCallback(() => {
       const textarea = textareaRef.current;
@@ -47,7 +47,8 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
       onHeightChange?.();
     }, [onHeightChange]);
 
-    const handleSubmit = useCallback(() => {
+    const handleSubmit = useCallback((e?: React.FormEvent) => {
+      e?.preventDefault();
       const trimmed = value.trim();
       if (!trimmed || disabled) return;
 
@@ -55,14 +56,6 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
       setValue("");
       resetTextareaHeight();
     }, [value, disabled, onSubmit, resetTextareaHeight]);
-
-    const handleFormSubmit = useCallback(
-      (e: React.FormEvent) => {
-        e.preventDefault();
-        handleSubmit();
-      },
-      [handleSubmit]
-    );
 
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -83,7 +76,7 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
 
     return (
       <form
-        onSubmit={handleFormSubmit}
+        onSubmit={handleSubmit}
         className={cn(
           "flex items-end gap-1.5 px-2 py-1.5 bg-popover/95 backdrop-blur-sm border-t border-border",
           className

--- a/src/components/terminal/MobileInputBar.tsx
+++ b/src/components/terminal/MobileInputBar.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, useCallback, forwardRef } from "react";
+import { useState, useCallback, useRef, forwardRef, useImperativeHandle } from "react";
 import { Send } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface MobileInputBarProps {
   onSubmit: (text: string) => void;
+  onHeightChange?: () => void;
   disabled?: boolean;
   placeholder?: string;
   className?: string;
@@ -18,7 +19,7 @@ interface MobileInputBarProps {
  * by using a standard HTML textarea instead of xterm.js's internal textarea
  * (which disables all of these to prevent duplication bugs).
  *
- * - Enter: submit text and clear
+ * - Enter / Send button: submit text and clear
  * - Shift+Enter: insert literal newline
  * - Auto-expands height with content (max 8rem)
  */
@@ -26,6 +27,7 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
   function MobileInputBar(
     {
       onSubmit,
+      onHeightChange,
       disabled = false,
       placeholder = "Type a message...",
       className,
@@ -33,17 +35,34 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
     ref
   ) {
     const [value, setValue] = useState("");
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    useImperativeHandle(ref, () => textareaRef.current as HTMLTextAreaElement);
+
+    const resetTextareaHeight = useCallback(() => {
+      const textarea = textareaRef.current;
+      if (textarea) {
+        textarea.style.height = "auto";
+      }
+      onHeightChange?.();
+    }, [onHeightChange]);
 
     const handleSubmit = useCallback(() => {
-      // Trim prevents submitting whitespace-only input. Leading/trailing
-      // spaces are stripped intentionally — mobile text entry rarely needs
-      // them, and autocorrect often inserts trailing spaces.
       const trimmed = value.trim();
       if (!trimmed || disabled) return;
 
       onSubmit(trimmed + "\n");
       setValue("");
-    }, [value, disabled, onSubmit]);
+      resetTextareaHeight();
+    }, [value, disabled, onSubmit, resetTextareaHeight]);
+
+    const handleFormSubmit = useCallback(
+      (e: React.FormEvent) => {
+        e.preventDefault();
+        handleSubmit();
+      },
+      [handleSubmit]
+    );
 
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -59,18 +78,19 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
       const textarea = e.currentTarget;
       textarea.style.height = "auto";
       textarea.style.height = `${textarea.scrollHeight}px`;
-    }, []);
+      onHeightChange?.();
+    }, [onHeightChange]);
 
     return (
-      <div
+      <form
+        onSubmit={handleFormSubmit}
         className={cn(
           "flex items-end gap-1.5 px-2 py-1.5 bg-popover/95 backdrop-blur-sm border-t border-border",
           className
         )}
       >
-        {/* Native text input with autocorrect/voice enabled */}
         <textarea
-          ref={ref}
+          ref={textareaRef}
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}
@@ -93,9 +113,8 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
           )}
         />
 
-        {/* Send button */}
         <button
-          onClick={handleSubmit}
+          type="submit"
           disabled={disabled || !value.trim()}
           className={cn(
             "p-2 rounded-md shrink-0 touch-manipulation",
@@ -108,7 +127,7 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
         >
           <Send className="w-4 h-4" />
         </button>
-      </div>
+      </form>
     );
   }
 );

--- a/src/components/terminal/MobileTerminalView.tsx
+++ b/src/components/terminal/MobileTerminalView.tsx
@@ -54,6 +54,59 @@ const MAX_OUTPUT_ENTRIES = 2000;
 const MOBILE_COLS = 120;
 const MOBILE_ROWS = 24;
 
+/**
+ * Stateful terminal escape sequence stripper.
+ *
+ * Handles sequences split across WebSocket chunks by buffering incomplete
+ * escapes. Keeps SGR (colors/styles ending in 'm') for ansi-to-html.
+ * Strips everything else: cursor movement, screen clearing, tmux status
+ * bar rendering, character set selection, OSC, DCS, etc.
+ */
+class AnsiStripper {
+  private pending = "";
+
+  process(data: string): string {
+    // Prepend any buffered partial sequence from previous chunk
+    let input = this.pending + data;
+    this.pending = "";
+
+    // If input ends with an incomplete escape, buffer it for next chunk
+    const lastEsc = input.lastIndexOf("\x1b");
+    if (lastEsc !== -1) {
+      const tail = input.slice(lastEsc);
+      // Check if tail is a complete sequence or still accumulating
+      // A complete CSI ends with a letter; a complete OSC ends with BEL or ST
+      const isCompleteCsi = /^\x1b\[[0-9;?]*[A-Za-z]/.test(tail);
+      const isCompleteSgr = /^\x1b\[[0-9;]*m/.test(tail);
+      const isCompleteOsc = /^\x1b\].*(?:\x07|\x1b\\)/.test(tail);
+      const isSingleChar = /^\x1b[^[\]()]/.test(tail) && tail.length >= 2;
+      const isCharSet = /^\x1b[()]./.test(tail);
+
+      if (!isCompleteCsi && !isCompleteSgr && !isCompleteOsc && !isSingleChar && !isCharSet) {
+        // Incomplete sequence — buffer it
+        this.pending = tail;
+        input = input.slice(0, lastEsc);
+      }
+    }
+
+    return input
+      // Remove CSI sequences that are NOT SGR (ending in a-l, n-z, A-Z except m)
+      .replace(/\x1b\[[0-9;?]*[A-HJ-Za-lp-z]/g, "")
+      // Remove OSC sequences: \x1b] ... (terminated by BEL or ST)
+      .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
+      // Remove DCS/PM/APC sequences
+      .replace(/\x1b[PX^_][^\x1b]*\x1b\\/g, "")
+      // Remove character set selection: \x1b(B, \x1b)0, etc.
+      .replace(/\x1b[()][A-Z0-9]/g, "")
+      // Remove single-character escapes (\x1b=, \x1b>, \x1bM, etc.)
+      .replace(/\x1b[^\[(\])]/g, "")
+      // Remove \r not followed by \n (in-line overwrites from progress bars)
+      .replace(/\r(?!\n)/g, "")
+      // Remove stray lone \x1b that might remain
+      .replace(/\x1b(?![[\](])/g, "");
+  }
+}
+
 function hexToRgba(hex: string, alpha: number): string {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);
@@ -137,6 +190,7 @@ export const MobileTerminalView = forwardRef<MobileTerminalViewRef, MobileTermin
     const anchorRef = useRef<HTMLDivElement>(null);
     const inputBarRef = useRef<HTMLTextAreaElement>(null);
     const converterRef = useRef<AnsiToHtml | null>(null);
+    const stripperRef = useRef(new AnsiStripper());
     const lineIdRef = useRef(0);
     const userScrolledUpRef = useRef(false);
 
@@ -168,7 +222,10 @@ export const MobileTerminalView = forwardRef<MobileTerminalViewRef, MobileTermin
     const appendAnsiOutput = useCallback((ansi: string) => {
       const converter = converterRef.current;
       if (!converter) return;
-      const html = converter.toHtml(ansi);
+      // Strip non-SGR control sequences before color conversion
+      const cleaned = stripperRef.current.process(ansi);
+      if (!cleaned) return;
+      const html = converter.toHtml(cleaned);
       if (!html) return;
       setOutputEntries(prev => {
         const newEntry: OutputEntry = { id: lineIdRef.current++, html };

--- a/src/components/terminal/MobileTerminalView.tsx
+++ b/src/components/terminal/MobileTerminalView.tsx
@@ -64,27 +64,30 @@ const MOBILE_ROWS = 24;
  */
 class AnsiStripper {
   private pending = "";
+  private static readonly MAX_PENDING = 64;
+
+  reset(): void {
+    this.pending = "";
+  }
 
   process(data: string): string {
-    // Prepend any buffered partial sequence from previous chunk
     let input = this.pending + data;
     this.pending = "";
 
-    // If input ends with an incomplete escape, buffer it for next chunk
+    // Buffer incomplete escape sequence at end of chunk for next call.
+    // Only buffer from the last \x1b if it's incomplete — complete
+    // sequences before it are kept for regex processing below.
     const lastEsc = input.lastIndexOf("\x1b");
     if (lastEsc !== -1) {
       const tail = input.slice(lastEsc);
-      // Check if tail is a complete sequence or still accumulating
-      // A complete CSI ends with a letter; a complete OSC ends with BEL or ST
-      const isCompleteCsi = /^\x1b\[[0-9;?]*[A-Za-z]/.test(tail);
-      const isCompleteSgr = /^\x1b\[[0-9;]*m/.test(tail);
-      const isCompleteOsc = /^\x1b\].*(?:\x07|\x1b\\)/.test(tail);
-      const isSingleChar = /^\x1b[^[\]()]/.test(tail) && tail.length >= 2;
-      const isCharSet = /^\x1b[()]./.test(tail);
+      const isComplete =
+        /^\x1b\[[0-9;?]*[A-Za-z]/.test(tail) ||  // CSI (including SGR)
+        /^\x1b\].*(?:\x07|\x1b\\)/.test(tail) ||  // OSC
+        (/^\x1b[^[\]()]/.test(tail) && tail.length >= 2) ||  // Single-char
+        /^\x1b[()]./.test(tail);  // Character set
 
-      if (!isCompleteCsi && !isCompleteSgr && !isCompleteOsc && !isSingleChar && !isCharSet) {
-        // Incomplete sequence — buffer it
-        this.pending = tail;
+      if (!isComplete) {
+        this.pending = tail.length <= AnsiStripper.MAX_PENDING ? tail : "";
         input = input.slice(0, lastEsc);
       }
     }
@@ -99,11 +102,11 @@ class AnsiStripper {
       // Remove character set selection: \x1b(B, \x1b)0, etc.
       .replace(/\x1b[()][A-Z0-9]/g, "")
       // Remove single-character escapes (\x1b=, \x1b>, \x1bM, etc.)
-      .replace(/\x1b[^\[(\])]/g, "")
+      .replace(/\x1b(?![\[(\])])[^\x1b]/g, "")
       // Remove \r not followed by \n (in-line overwrites from progress bars)
       .replace(/\r(?!\n)/g, "")
       // Remove stray lone \x1b that might remain
-      .replace(/\x1b(?![[\](])/g, "");
+      .replace(/\x1b(?![\[(\]()])/g, "");
   }
 }
 
@@ -257,6 +260,7 @@ export const MobileTerminalView = forwardRef<MobileTerminalViewRef, MobileTermin
       setOutputEntries([]);
       lineIdRef.current = 0;
       converterRef.current = createAnsiConverter(terminalTheme);
+      stripperRef.current.reset();
     }, [terminalTheme]);
 
     // ── WebSocket connection ─────────────────────────────────────────────────
@@ -315,11 +319,6 @@ export const MobileTerminalView = forwardRef<MobileTerminalViewRef, MobileTermin
       const isAtBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 50;
       userScrolledUpRef.current = !isAtBottom;
     }, []);
-
-    // Re-scroll when input bar height changes (textarea expand/collapse)
-    const handleInputHeightChange = useCallback(() => {
-      scrollToBottom();
-    }, [scrollToBottom]);
 
     // ── Input handlers ───────────────────────────────────────────────────────
     const handleMobileKeyPress = useCallback(
@@ -416,7 +415,7 @@ export const MobileTerminalView = forwardRef<MobileTerminalViewRef, MobileTermin
         <MobileInputBar
           ref={inputBarRef}
           onSubmit={sendInput}
-          onHeightChange={handleInputHeightChange}
+          onHeightChange={scrollToBottom}
           disabled={status !== "connected"}
           placeholder={session?.terminalType === "agent" ? "Ask the agent..." : "Type a command..."}
         />

--- a/src/components/terminal/MobileTerminalView.tsx
+++ b/src/components/terminal/MobileTerminalView.tsx
@@ -243,18 +243,26 @@ export const MobileTerminalView = forwardRef<MobileTerminalViewRef, MobileTermin
     }), []);
 
     // ── Auto-scroll ──────────────────────────────────────────────────────────
-    useEffect(() => {
+    const scrollToBottom = useCallback(() => {
       if (userScrolledUpRef.current) return;
       anchorRef.current?.scrollIntoView({ behavior: "instant" as ScrollBehavior });
-    }, [outputEntries]);
+    }, []);
+
+    useEffect(() => {
+      scrollToBottom();
+    }, [outputEntries, scrollToBottom]);
 
     const handleScroll = useCallback(() => {
       const el = scrollRef.current;
       if (!el) return;
-      // User scrolled up if they're more than 50px from the bottom
       const isAtBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 50;
       userScrolledUpRef.current = !isAtBottom;
     }, []);
+
+    // Re-scroll when input bar height changes (textarea expand/collapse)
+    const handleInputHeightChange = useCallback(() => {
+      scrollToBottom();
+    }, [scrollToBottom]);
 
     // ── Input handlers ───────────────────────────────────────────────────────
     const handleMobileKeyPress = useCallback(
@@ -351,6 +359,7 @@ export const MobileTerminalView = forwardRef<MobileTerminalViewRef, MobileTermin
         <MobileInputBar
           ref={inputBarRef}
           onSubmit={sendInput}
+          onHeightChange={handleInputHeightChange}
           disabled={status !== "connected"}
           placeholder={session?.terminalType === "agent" ? "Ask the agent..." : "Type a command..."}
         />


### PR DESCRIPTION
## Summary
- **Send button fix**: Wrapped MobileInputBar in a `<form>` with `onSubmit` so the mobile keyboard's `enterKeyHint="send"` triggers form submission instead of inserting a newline. Button changed to `type="submit"`.
- **Output resize fix**: Added `onHeightChange` callback from MobileInputBar → MobileTerminalView that triggers `scrollToBottom()` when the textarea auto-expands, keeping the latest output visible.
- Textarea height resets to single-line after submit.

## Test plan
- [ ] On iOS Safari: type text and tap the keyboard's "Send" button — should submit, not insert newline
- [ ] On Android Chrome: same test with soft keyboard send action
- [ ] Type multiple lines (Shift+Enter) — textarea should expand, output should stay scrolled to bottom
- [ ] Submit multi-line text — textarea should collapse back to single line
- [ ] Desktop browser: Enter still submits, Shift+Enter still inserts newline

🤖 Generated with [Claude Code](https://claude.com/claude-code)