### PR TITLE
fix: send carriage return for mobile terminal input

### DIFF
--- a/src/components/terminal/MobileInputBar.tsx
+++ b/src/components/terminal/MobileInputBar.tsx
@@ -52,7 +52,7 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
       const trimmed = value.trim();
       if (!trimmed || disabled) return;
 
-      onSubmit(trimmed + "\n");
+      onSubmit(trimmed + "\r");
       setValue("");
       resetTextareaHeight();
     }, [value, disabled, onSubmit, resetTextareaHeight]);


### PR DESCRIPTION
## Summary
- One-character fix: `\n` → `\r` in MobileInputBar submit handler
- xterm.js sends `\r` (carriage return) on Enter — that's what terminals/PTY/tmux expect
- We were sending `\n` (line feed), which was interpreted as a literal newline, not command submission

## Test plan
- [x] Mobile: Enter key submits command to terminal (confirmed by user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)