### PR TITLE
feat: mobile app redesign with M3 glassmorphism + multi-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Mobile app multi-server support**: Save and switch between multiple remote-dev server instances with per-server credential isolation via `ServerScopedStorage`
+- **QR code server onboarding**: Scan a QR code from the web dashboard for zero-typing server setup using `mobile_scanner`
+- **Edge drawer navigation**: Swipe from left edge for instant session switching (1 gesture vs 2-3 taps), with floating status pill and quick actions panel
+- **Glassmorphism UI**: `GlassmorphicContainer` widget with frosted glass `BackdropFilter` surfaces on drawer, bottom sheets, and dialogs
+- **Smart input widgets**: Port stepper `[-][6001][+]`, protocol dropdown (http/https), host input with recent history autocomplete
+- **Credential auto-migration**: Existing single-server credentials automatically migrated to multi-server format on first launch
+
 ### Changed
 
 - **Mobile terminal rendering**: Replaced ANSI-to-HTML renderer (`MobileTerminalView`) with xterm.js + native input overlay. xterm.js handles all rendering (colors, cursor, tmux, scrollback) while `MobileInputBar` provides native text input with autocorrect, voice dictation, and predictive text. Special keys toolbar (ESC, TAB, CTRL, arrows) renders below the input bar.
+- **GoRouter**: Migrated to `ShellRoute` with `refreshListenable` for stable navigation (no more router recreation on state changes)
+- **Theme**: Transparent drawer/dialog/sheet backgrounds for glassmorphism, replaced manual color mixing with `Color.lerp`
 
 ## [0.3.1] - 2026-03-21
 

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -4,20 +4,41 @@ import 'package:go_router/go_router.dart';
 
 import 'package:remote_dev/presentation/providers/providers.dart';
 import 'package:remote_dev/presentation/providers/push_notification_providers.dart';
+import 'package:remote_dev/presentation/providers/server_config_providers.dart';
 import 'package:remote_dev/presentation/screens/auth/login_screen.dart';
-import 'package:remote_dev/presentation/screens/home/home_screen.dart';
+import 'package:remote_dev/presentation/screens/home/terminal_home_screen.dart';
+import 'package:remote_dev/presentation/screens/server/add_server_screen.dart';
 import 'package:remote_dev/presentation/screens/session/terminal_screen.dart';
 import 'package:remote_dev/presentation/screens/settings/settings_screen.dart';
 import 'package:remote_dev/presentation/theme/app_theme.dart';
 
-/// GoRouter configuration with auth-based redirects.
+/// Listenable that notifies GoRouter to re-evaluate redirects
+/// without rebuilding the entire router instance.
+class _RouterRefreshNotifier extends ChangeNotifier {
+  void notify() => notifyListeners();
+}
+
+/// Single GoRouter instance — persists across state changes.
+/// Uses refreshListenable to re-evaluate redirects reactively.
 final routerProvider = Provider<GoRouter>((ref) {
-  final authState = ref.watch(authNotifierProvider);
+  final refreshNotifier = _RouterRefreshNotifier();
+
+  // Listen to auth and server changes, trigger redirect re-evaluation
+  ref.listen(authNotifierProvider, (_, __) => refreshNotifier.notify());
+  ref.listen(serverListProvider, (_, __) => refreshNotifier.notify());
 
   return GoRouter(
-    initialLocation: '/login',
+    initialLocation: '/sessions',
+    refreshListenable: refreshNotifier,
     redirect: (context, state) {
-      final isOnLogin = state.matchedLocation == '/login';
+      final authState = ref.read(authNotifierProvider);
+      final hasServers = ref.read(serverListProvider).isNotEmpty;
+      final location = state.matchedLocation;
+      final isOnLogin = location == '/login';
+      final isOnSetup = location == '/servers/add';
+
+      if (!hasServers && !isOnSetup) return '/servers/add';
+      if (isOnSetup) return null;
 
       return switch (authState) {
         AuthLoading() => null,
@@ -31,17 +52,30 @@ final routerProvider = Provider<GoRouter>((ref) {
         builder: (context, state) => const LoginScreen(),
       ),
       GoRoute(
-        path: '/sessions',
-        builder: (context, state) => const HomeScreen(),
+        path: '/servers/add',
+        builder: (context, state) => const AddServerScreen(),
       ),
-      GoRoute(
-        path: '/sessions/:id',
-        builder: (context, state) => TerminalScreen(
-          sessionId: state.pathParameters['id']!,
-        ),
+      ShellRoute(
+        builder: (context, state, child) => TerminalHomeScreen(child: child),
+        routes: [
+          GoRoute(
+            path: '/sessions',
+            builder: (context, state) => const SizedBox.shrink(),
+          ),
+          GoRoute(
+            path: '/sessions/:id',
+            builder: (context, state) => TerminalScreen(
+              sessionId: state.pathParameters['id']!,
+            ),
+          ),
+        ],
       ),
       GoRoute(
         path: '/settings',
+        builder: (context, state) => const SettingsScreen(),
+      ),
+      GoRoute(
+        path: '/servers',
         builder: (context, state) => const SettingsScreen(),
       ),
     ],
@@ -56,7 +90,6 @@ class RemoteDevApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final palette = ref.watch(terminalPaletteProvider);
     final router = ref.watch(routerProvider);
-    // Watch push registration so it actually runs when authenticated
     ref.watch(pushRegistrationProvider);
 
     return MaterialApp.router(

--- a/mobile/lib/domain/entities/server_config.dart
+++ b/mobile/lib/domain/entities/server_config.dart
@@ -1,0 +1,94 @@
+import 'package:remote_dev/domain/value_objects/auth_method.dart';
+
+/// A saved remote-dev server configuration.
+///
+/// Each server has its own URL, auth method, and credentials.
+/// Credentials (API key, CF token) are stored separately in
+/// [ServerScopedStorage], keyed by [id].
+class ServerConfig {
+  final String id;
+  final String nickname;
+  final String serverUrl;
+  final String terminalPort;
+  final AuthMethod authMethod;
+  final DateTime createdAt;
+  final DateTime lastConnectedAt;
+  final int sortOrder;
+
+  const ServerConfig({
+    required this.id,
+    required this.nickname,
+    required this.serverUrl,
+    this.terminalPort = '6002',
+    required this.authMethod,
+    required this.createdAt,
+    required this.lastConnectedAt,
+    this.sortOrder = 0,
+  });
+
+  /// Display name: nickname if set, otherwise extracted hostname.
+  String get displayName {
+    if (nickname.isNotEmpty) return nickname;
+    final uri = Uri.tryParse(serverUrl);
+    return uri?.host ?? serverUrl;
+  }
+
+  /// Whether this server uses Cloudflare Access (port is irrelevant).
+  bool get isCfAccess => authMethod is CfAccessAuth;
+
+  /// WebSocket URL for the terminal server.
+  String get wsUrl {
+    final uri = Uri.parse(serverUrl);
+    final wsScheme = uri.scheme == 'https' ? 'wss' : 'ws';
+    // For CF Access, terminal goes through the same host (reverse proxy).
+    // For direct connections, use the terminal port.
+    if (isCfAccess) {
+      return '$wsScheme://${uri.host}/ws';
+    }
+    return '$wsScheme://${uri.host}:$terminalPort/ws';
+  }
+
+  ServerConfig copyWith({
+    String? nickname,
+    String? serverUrl,
+    String? terminalPort,
+    AuthMethod? authMethod,
+    DateTime? lastConnectedAt,
+    int? sortOrder,
+  }) {
+    return ServerConfig(
+      id: id,
+      nickname: nickname ?? this.nickname,
+      serverUrl: serverUrl ?? this.serverUrl,
+      terminalPort: terminalPort ?? this.terminalPort,
+      authMethod: authMethod ?? this.authMethod,
+      createdAt: createdAt,
+      lastConnectedAt: lastConnectedAt ?? this.lastConnectedAt,
+      sortOrder: sortOrder ?? this.sortOrder,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'nickname': nickname,
+        'serverUrl': serverUrl,
+        'terminalPort': terminalPort,
+        'authMethod': authMethod.toJson(),
+        'createdAt': createdAt.toIso8601String(),
+        'lastConnectedAt': lastConnectedAt.toIso8601String(),
+        'sortOrder': sortOrder,
+      };
+
+  factory ServerConfig.fromJson(Map<String, dynamic> json) => ServerConfig(
+        id: json['id'] as String,
+        nickname: json['nickname'] as String? ?? '',
+        serverUrl: json['serverUrl'] as String,
+        terminalPort: json['terminalPort'] as String? ?? '6002',
+        authMethod: AuthMethod.fromJson(
+          json['authMethod'] as Map<String, dynamic>,
+        ),
+        createdAt: DateTime.parse(json['createdAt'] as String),
+        lastConnectedAt: DateTime.parse(json['lastConnectedAt'] as String),
+        sortOrder: json['sortOrder'] as int? ?? 0,
+      );
+}

--- a/mobile/lib/domain/value_objects/auth_method.dart
+++ b/mobile/lib/domain/value_objects/auth_method.dart
@@ -1,0 +1,69 @@
+/// How the user authenticates to a remote-dev server.
+///
+/// Credentials (API key, CF token) are stored in secure storage,
+/// keyed by server ID. This sealed class only tracks the _method_,
+/// not the credentials themselves.
+sealed class AuthMethod {
+  const AuthMethod();
+
+  String get type;
+
+  Map<String, dynamic> toJson();
+
+  factory AuthMethod.fromJson(Map<String, dynamic> json) {
+    return switch (json['type'] as String) {
+      'cfAccess' => const CfAccessAuth(),
+      'apiKey' => const ApiKeyAuth(),
+      'qrScanned' => QrScannedAuth(
+          scannedAt: DateTime.parse(json['scannedAt'] as String),
+        ),
+      _ => const ApiKeyAuth(),
+    };
+  }
+}
+
+/// Cloudflare Access authentication.
+///
+/// The user authenticates via browser → CF Access login → deep link callback.
+/// Terminal port is irrelevant since everything goes through the CF tunnel.
+final class CfAccessAuth extends AuthMethod {
+  const CfAccessAuth();
+
+  @override
+  String get type => 'cfAccess';
+
+  @override
+  Map<String, dynamic> toJson() => {'type': type};
+}
+
+/// Direct API key authentication.
+///
+/// User manually enters the API key. Requires server URL and terminal port.
+final class ApiKeyAuth extends AuthMethod {
+  const ApiKeyAuth();
+
+  @override
+  String get type => 'apiKey';
+
+  @override
+  Map<String, dynamic> toJson() => {'type': type};
+}
+
+/// QR code scanned authentication.
+///
+/// Tracks when the QR was scanned for audit/display purposes.
+/// The QR payload contains server URL + API key.
+final class QrScannedAuth extends AuthMethod {
+  const QrScannedAuth({required this.scannedAt});
+
+  final DateTime scannedAt;
+
+  @override
+  String get type => 'qrScanned';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'type': type,
+        'scannedAt': scannedAt.toIso8601String(),
+      };
+}

--- a/mobile/lib/infrastructure/storage/secure_storage_service.dart
+++ b/mobile/lib/infrastructure/storage/secure_storage_service.dart
@@ -16,6 +16,12 @@ class SecureStorageService {
 
   final FlutterSecureStorage _storage;
 
+  // Generic key-value operations (used by ServerScopedStorage)
+  Future<String?> read(String key) => _storage.read(key: key);
+  Future<void> write(String key, String value) =>
+      _storage.write(key: key, value: value);
+  Future<void> delete(String key) => _storage.delete(key: key);
+
   // Storage keys
   static const _apiKeyKey = 'rdv_api_key';
   static const _serverUrlKey = 'rdv_server_url';
@@ -91,9 +97,6 @@ class SecureStorageService {
   Future<void> clearAll() => _storage.deleteAll();
 
   /// Check if credentials exist (does not validate them).
-  Future<bool> hasCredentials() async {
-    final key = await getApiKey();
-    final url = await getServerUrl();
-    return key != null && url != null;
-  }
+  Future<bool> hasCredentials() async =>
+      await getApiKey() != null && await getServerUrl() != null;
 }

--- a/mobile/lib/infrastructure/storage/server_config_store.dart
+++ b/mobile/lib/infrastructure/storage/server_config_store.dart
@@ -1,0 +1,88 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:remote_dev/domain/entities/server_config.dart';
+
+/// Local persistence for server configurations using SharedPreferences.
+///
+/// Stores server configs as a JSON list. Credentials (API keys, tokens)
+/// are stored separately in [ServerScopedStorage] via flutter_secure_storage.
+///
+/// Caches the decoded list to avoid repeated JSON parsing on every read.
+class ServerConfigStore {
+  ServerConfigStore(this._prefs);
+
+  final SharedPreferences _prefs;
+  List<ServerConfig>? _cache;
+
+  static const _serversKey = 'rdv_servers';
+  static const _activeServerKey = 'rdv_active_server_id';
+
+  /// Load all saved server configurations. Returns cached list if available.
+  List<ServerConfig> loadAll() {
+    if (_cache != null) return _cache!;
+
+    final json = _prefs.getString(_serversKey);
+    if (json == null) return _cache = [];
+
+    final list = jsonDecode(json) as List<dynamic>;
+    return _cache = list
+        .map((e) => ServerConfig.fromJson(e as Map<String, dynamic>))
+        .toList()
+      ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+  }
+
+  /// Save a server configuration (create or update).
+  Future<void> save(ServerConfig config) async {
+    final servers = List<ServerConfig>.of(loadAll());
+    final index = servers.indexWhere((s) => s.id == config.id);
+    if (index >= 0) {
+      servers[index] = config;
+    } else {
+      servers.add(config);
+    }
+    await _persist(servers);
+  }
+
+  /// Delete a server configuration by ID.
+  Future<void> delete(String id) async {
+    final servers = List<ServerConfig>.of(loadAll())
+      ..removeWhere((s) => s.id == id);
+    await _persist(servers);
+
+    if (getActiveServerId() == id) {
+      await setActiveServerId(servers.isNotEmpty ? servers.first.id : null);
+    }
+  }
+
+  /// Reorder servers by providing ordered IDs.
+  Future<void> reorder(List<String> orderedIds) async {
+    final servers = loadAll();
+    final reordered = <ServerConfig>[];
+    for (var i = 0; i < orderedIds.length; i++) {
+      final server = servers.firstWhere(
+        (s) => s.id == orderedIds[i],
+        orElse: () => throw StateError('Server not found: ${orderedIds[i]}'),
+      );
+      reordered.add(server.copyWith(sortOrder: i));
+    }
+    await _persist(reordered);
+  }
+
+  String? getActiveServerId() => _prefs.getString(_activeServerKey);
+
+  Future<void> setActiveServerId(String? id) async {
+    if (id == null) {
+      await _prefs.remove(_activeServerKey);
+    } else {
+      await _prefs.setString(_activeServerKey, id);
+    }
+  }
+
+  Future<void> _persist(List<ServerConfig> servers) async {
+    _cache = List.of(servers);
+    final json = jsonEncode(servers.map((s) => s.toJson()).toList());
+    await _prefs.setString(_serversKey, json);
+  }
+}

--- a/mobile/lib/infrastructure/storage/server_scoped_storage.dart
+++ b/mobile/lib/infrastructure/storage/server_scoped_storage.dart
@@ -1,0 +1,65 @@
+import 'package:remote_dev/infrastructure/storage/secure_storage_service.dart';
+
+/// Wraps [SecureStorageService] to scope keys by server ID.
+///
+/// Each server's credentials are stored with a unique prefix,
+/// preventing collision when switching between servers.
+///
+/// Keys follow the pattern: `rdv_{serverId}_{key}`
+class ServerScopedStorage {
+  ServerScopedStorage({
+    required SecureStorageService storage,
+    required String serverId,
+  })  : _storage = storage,
+        _prefix = 'rdv_${serverId}_';
+
+  final SecureStorageService _storage;
+  final String _prefix;
+
+  String get _apiKeyKey => '${_prefix}api_key';
+  String get _cfTokenKey => '${_prefix}cf_token';
+  String get _userIdKey => '${_prefix}user_id';
+  String get _userEmailKey => '${_prefix}user_email';
+
+  Future<String?> getApiKey() => _storage.read(_apiKeyKey);
+  Future<void> setApiKey(String value) => _storage.write(_apiKeyKey, value);
+
+  Future<String?> getCfToken() => _storage.read(_cfTokenKey);
+  Future<void> setCfToken(String value) => _storage.write(_cfTokenKey, value);
+
+  Future<String?> getUserId() => _storage.read(_userIdKey);
+  Future<void> setUserId(String value) => _storage.write(_userIdKey, value);
+
+  Future<String?> getUserEmail() => _storage.read(_userEmailKey);
+  Future<void> setUserEmail(String value) =>
+      _storage.write(_userEmailKey, value);
+
+  /// Store all credentials at once after successful login.
+  Future<void> storeCredentials({
+    required String apiKey,
+    required String userId,
+    required String email,
+    String? cfToken,
+  }) async {
+    await Future.wait([
+      setApiKey(apiKey),
+      setUserId(userId),
+      setUserEmail(email),
+      if (cfToken != null) setCfToken(cfToken),
+    ]);
+  }
+
+  /// Clear all credentials for this server.
+  Future<void> clearAll() async {
+    await Future.wait([
+      _storage.delete(_apiKeyKey),
+      _storage.delete(_cfTokenKey),
+      _storage.delete(_userIdKey),
+      _storage.delete(_userEmailKey),
+    ]);
+  }
+
+  /// Check if credentials exist for this server.
+  Future<bool> hasCredentials() async =>
+      await getApiKey() != null;
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -3,19 +3,31 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
 
 import 'package:remote_dev/app.dart';
+import 'package:remote_dev/domain/entities/server_config.dart';
+import 'package:remote_dev/domain/value_objects/auth_method.dart';
 import 'package:remote_dev/firebase_options.dart';
 import 'package:remote_dev/infrastructure/push/push_notification_service.dart';
+import 'package:remote_dev/infrastructure/storage/secure_storage_service.dart';
+import 'package:remote_dev/infrastructure/storage/server_config_store.dart';
+import 'package:remote_dev/infrastructure/storage/server_scoped_storage.dart';
+import 'package:remote_dev/presentation/providers/server_config_providers.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Initialize Firebase for push notifications
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  final results = await Future.wait([
+    Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform),
+    SharedPreferences.getInstance(),
+  ]);
+  final prefs = results[1] as SharedPreferences;
+
   FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
+
+  await _migrateToMultiServer(prefs);
 
   SystemChrome.setSystemUIOverlayStyle(
     const SystemUiOverlayStyle(
@@ -27,8 +39,60 @@ Future<void> main() async {
   );
 
   runApp(
-    const ProviderScope(
-      child: RemoteDevApp(),
+    ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+      ],
+      child: const RemoteDevApp(),
     ),
+  );
+}
+
+/// Migrates existing single-server credentials to multi-server format.
+///
+/// If old-style credentials exist (rdv_api_key, rdv_server_url) but no
+/// server configs are saved, creates a "default" server config and copies
+/// credentials to server-scoped keys.
+Future<void> _migrateToMultiServer(SharedPreferences prefs) async {
+  final store = ServerConfigStore(prefs);
+  final existing = store.loadAll();
+  if (existing.isNotEmpty) return;
+
+  final storage = SecureStorageService();
+  final hasOldCredentials = await storage.hasCredentials();
+  if (!hasOldCredentials) return;
+
+  final serverUrl = await storage.getServerUrl();
+  final terminalPort = await storage.getTerminalPort();
+  final apiKey = await storage.getApiKey();
+  final userId = await storage.getUserId();
+  final email = await storage.getUserEmail();
+  final cfToken = await storage.getCfToken();
+
+  if (serverUrl == null || apiKey == null) return;
+
+  final serverId = const Uuid().v4();
+  final config = ServerConfig(
+    id: serverId,
+    nickname: '',
+    serverUrl: serverUrl,
+    terminalPort: terminalPort ?? '6002',
+    authMethod: cfToken != null ? const CfAccessAuth() : const ApiKeyAuth(),
+    createdAt: DateTime.now(),
+    lastConnectedAt: DateTime.now(),
+  );
+
+  await store.save(config);
+  await store.setActiveServerId(serverId);
+
+  final scopedStorage = ServerScopedStorage(
+    storage: storage,
+    serverId: serverId,
+  );
+  await scopedStorage.storeCredentials(
+    apiKey: apiKey,
+    userId: userId ?? '',
+    email: email ?? '',
+    cfToken: cfToken,
   );
 }

--- a/mobile/lib/presentation/providers/auth_providers.dart
+++ b/mobile/lib/presentation/providers/auth_providers.dart
@@ -22,7 +22,11 @@ final class Unauthenticated extends AuthState {
   const Unauthenticated();
 }
 
-/// Manages authentication state by checking secure storage for credentials.
+/// Manages authentication state scoped to the active server.
+///
+/// Checks the active server's scoped storage for credentials.
+/// When no server is configured, transitions to Unauthenticated
+/// (the router then redirects to server setup).
 class AuthNotifier extends StateNotifier<AuthState> {
   AuthNotifier(this._ref) : super(const AuthLoading()) {
     checkStoredCredentials();
@@ -30,17 +34,27 @@ class AuthNotifier extends StateNotifier<AuthState> {
 
   final Ref _ref;
 
-  /// Check if valid credentials exist in secure storage.
+  /// Check if valid credentials exist for the active server.
   Future<void> checkStoredCredentials() async {
     state = const AuthLoading();
-    final storage = _ref.read(secureStorageProvider);
-    final hasCredentials = await storage.hasCredentials();
 
+    final config = _ref.read(activeServerConfigProvider);
+    if (config == null) {
+      state = const Unauthenticated();
+      return;
+    }
+
+    final scopedStorage = _ref.read(serverScopedStorageProvider);
+    if (scopedStorage == null) {
+      state = const Unauthenticated();
+      return;
+    }
+
+    final hasCredentials = await scopedStorage.hasCredentials();
     if (hasCredentials) {
-      final serverUrl = await storage.getServerUrl();
-      final email = await storage.getUserEmail();
+      final email = await scopedStorage.getUserEmail();
       state = Authenticated(
-        serverUrl: serverUrl ?? '',
+        serverUrl: config.serverUrl,
         email: email,
       );
     } else {
@@ -50,21 +64,20 @@ class AuthNotifier extends StateNotifier<AuthState> {
 
   /// Called after successful login to transition to authenticated state.
   Future<void> loginCompleted() async {
-    // Invalidate server config so it re-reads from storage
     _ref.invalidate(serverConfigProvider);
+    _ref.invalidate(serverListProvider);
     await checkStoredCredentials();
-    // Trigger push notification registration after credentials are available
     _ref.invalidate(pushRegistrationProvider);
   }
 
-  /// Sign out: clear storage and transition to unauthenticated.
+  /// Sign out from the active server only.
   Future<void> signOut() async {
-    // Unregister push token before clearing credentials
     final pushService = _ref.read(pushNotificationServiceProvider);
     await pushService?.unregister();
 
-    final storage = _ref.read(secureStorageProvider);
-    await storage.clearAll();
+    final scopedStorage = _ref.read(serverScopedStorageProvider);
+    await scopedStorage?.clearAll();
+
     _ref.invalidate(serverConfigProvider);
     state = const Unauthenticated();
   }

--- a/mobile/lib/presentation/providers/server_config_providers.dart
+++ b/mobile/lib/presentation/providers/server_config_providers.dart
@@ -1,81 +1,123 @@
+import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:remote_dev/domain/entities/server_config.dart';
 import 'package:remote_dev/infrastructure/api/remote_dev_client.dart';
 import 'package:remote_dev/infrastructure/storage/secure_storage_service.dart';
+import 'package:remote_dev/infrastructure/storage/server_config_store.dart';
+import 'package:remote_dev/infrastructure/storage/server_scoped_storage.dart';
 
-/// Server connection configuration resolved from secure storage.
-class ServerConfig {
-  final String serverUrl;
-  final String terminalPort;
-  final String apiKey;
-  final String? userId;
-  final String? email;
-
-  const ServerConfig({
-    required this.serverUrl,
-    required this.terminalPort,
-    required this.apiKey,
-    this.userId,
-    this.email,
-  });
-
-  /// WebSocket URL derived from the server URL.
-  /// Local dev: ws://localhost:6002 (direct to terminal server port).
-  /// Remote/tunnel: wss://hostname/ws (cloudflared routes to terminal server).
-  String get wsUrl {
-    final uri = Uri.parse(serverUrl);
-    final wsScheme = uri.scheme == 'https' ? 'wss' : 'ws';
-    final isLocal = uri.host == 'localhost' ||
-        uri.host == '127.0.0.1' ||
-        uri.host == '10.0.2.2';
-    if (isLocal) {
-      return '$wsScheme://${uri.host}:$terminalPort';
-    }
-    // Remote: use /ws path (cloudflared routes to terminal server)
-    final port = uri.port != 0 && uri.port != 443 && uri.port != 80
-        ? ':${uri.port}'
-        : '';
-    return '$wsScheme://${uri.host}$port/ws';
-  }
-}
+/// SharedPreferences instance. Must be initialized in main.dart.
+final sharedPreferencesProvider = Provider<SharedPreferences>((ref) {
+  throw UnimplementedError(
+    'sharedPreferencesProvider must be overridden at app startup',
+  );
+});
 
 /// Singleton secure storage instance.
 final secureStorageProvider = Provider<SecureStorageService>((ref) {
   return SecureStorageService();
 });
 
-/// Loads server config from secure storage. Refreshed after login/logout.
-final serverConfigProvider = FutureProvider<ServerConfig?>((ref) async {
-  final storage = ref.watch(secureStorageProvider);
-  final hasCredentials = await storage.hasCredentials();
-  if (!hasCredentials) return null;
-
-  final serverUrl = await storage.getServerUrl();
-  final terminalPort = await storage.getTerminalPort();
-  final apiKey = await storage.getApiKey();
-  final userId = await storage.getUserId();
-  final email = await storage.getUserEmail();
-
-  if (serverUrl == null || apiKey == null) return null;
-
-  return ServerConfig(
-    serverUrl: serverUrl,
-    terminalPort: terminalPort ?? '6002',
-    apiKey: apiKey,
-    userId: userId,
-    email: email,
-  );
+/// Server config store (local persistence for server list).
+final serverConfigStoreProvider = Provider<ServerConfigStore>((ref) {
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return ServerConfigStore(prefs);
 });
 
-/// HTTP client for the Remote Dev API. Only available when authenticated.
+/// All saved server configurations.
+/// Call ref.invalidate(serverListProvider) after adding/removing servers.
+final serverListProvider = Provider<List<ServerConfig>>((ref) {
+  final store = ref.watch(serverConfigStoreProvider);
+  return store.loadAll();
+});
+
+/// Currently active server ID. Persisted in SharedPreferences.
+final activeServerIdProvider = StateProvider<String?>((ref) {
+  final store = ref.watch(serverConfigStoreProvider);
+  return store.getActiveServerId();
+});
+
+/// The active server's configuration. Null when no server selected.
+final activeServerConfigProvider = Provider<ServerConfig?>((ref) {
+  final serverId = ref.watch(activeServerIdProvider);
+  if (serverId == null) return null;
+  final servers = ref.watch(serverListProvider);
+  final match = servers.firstWhereOrNull((s) => s.id == serverId);
+  if (match != null) return match;
+  // Stale ID (server was deleted) — return null so router redirects to setup
+  return null;
+});
+
+/// Secure storage scoped to the active server.
+/// Returns null when no server is active.
+final serverScopedStorageProvider = Provider<ServerScopedStorage?>((ref) {
+  final config = ref.watch(activeServerConfigProvider);
+  if (config == null) return null;
+  final storage = ref.watch(secureStorageProvider);
+  return ServerScopedStorage(storage: storage, serverId: config.id);
+});
+
+/// HTTP client for the active server's REST API.
+/// Only available when a server is selected.
 final remoteDevClientProvider = Provider<RemoteDevClient?>((ref) {
-  final configAsync = ref.watch(serverConfigProvider);
-  final config = configAsync.valueOrNull;
+  final config = ref.watch(activeServerConfigProvider);
   if (config == null) return null;
 
   final storage = ref.watch(secureStorageProvider);
   return RemoteDevClient(
     storage: storage,
     baseUrl: config.serverUrl,
+  );
+});
+
+// --- Legacy compatibility ---
+
+/// Legacy ServerConfig shape used by existing code.
+/// Bridges old single-server code to new multi-server architecture.
+class ServerConfigLegacy {
+  final String serverUrl;
+  final String terminalPort;
+  final String apiKey;
+  final String? userId;
+  final String? email;
+  final ServerConfig _source;
+
+  ServerConfigLegacy._({
+    required this.serverUrl,
+    required this.terminalPort,
+    required this.apiKey,
+    this.userId,
+    this.email,
+    required ServerConfig source,
+  }) : _source = source;
+
+  /// Delegates to the canonical ServerConfig.wsUrl implementation.
+  String get wsUrl => _source.wsUrl;
+}
+
+/// Legacy provider that returns the old ServerConfig shape.
+/// Existing code can continue using this until migrated.
+final serverConfigProvider = FutureProvider<ServerConfigLegacy?>((ref) async {
+  final config = ref.watch(activeServerConfigProvider);
+  if (config == null) return null;
+
+  final scopedStorage = ref.watch(serverScopedStorageProvider);
+  if (scopedStorage == null) return null;
+
+  final apiKey = await scopedStorage.getApiKey();
+  if (apiKey == null) return null;
+
+  final userId = await scopedStorage.getUserId();
+  final email = await scopedStorage.getUserEmail();
+
+  return ServerConfigLegacy._(
+    serverUrl: config.serverUrl,
+    terminalPort: config.terminalPort,
+    apiKey: apiKey,
+    userId: userId,
+    email: email,
+    source: config,
   );
 });

--- a/mobile/lib/presentation/screens/home/terminal_home_screen.dart
+++ b/mobile/lib/presentation/screens/home/terminal_home_screen.dart
@@ -1,0 +1,533 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:remote_dev/domain/entities/session.dart';
+import 'package:remote_dev/presentation/providers/providers.dart';
+import 'package:remote_dev/presentation/widgets/common/glassmorphic_container.dart';
+import 'package:remote_dev/presentation/widgets/session/create_session_sheet.dart';
+
+/// Terminal-first home screen with edge drawer navigation.
+///
+/// The terminal takes full viewport. UI chrome lives at the edges:
+/// - Swipe from left edge → session drawer (frosted glass)
+/// - Swipe from right edge → quick actions panel
+/// - Floating status pill at top shows current session
+/// - MobileInputBar + KeyboardToolbar at bottom
+class TerminalHomeScreen extends ConsumerStatefulWidget {
+  const TerminalHomeScreen({super.key, this.child});
+
+  /// Terminal screen content (from GoRouter shell route).
+  final Widget? child;
+
+  @override
+  ConsumerState<TerminalHomeScreen> createState() =>
+      _TerminalHomeScreenState();
+}
+
+class _TerminalHomeScreenState extends ConsumerState<TerminalHomeScreen> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey();
+  bool _showQuickActions = false;
+
+  void _openSessionDrawer() {
+    HapticFeedback.lightImpact();
+    _scaffoldKey.currentState?.openDrawer();
+  }
+
+  void _onCreateSession() {
+    setState(() => _showQuickActions = false);
+    final folderId = ref.read(activeFolderIdProvider);
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => GlassmorphicContainer.sheet(
+        child: CreateSessionSheet(folderId: folderId),
+      ),
+    );
+  }
+
+  void _onSessionTap(Session session) {
+    ref.read(activeSessionIdProvider.notifier).state = session.id;
+    Navigator.of(context).maybePop(); // Close drawer
+    HapticFeedback.selectionClick();
+    context.go('/sessions/${session.id}');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final sessions = ref.watch(filteredSessionsProvider);
+    final activeSessionId = ref.watch(activeSessionIdProvider);
+    final activeServer = ref.watch(activeServerConfigProvider);
+
+    return Scaffold(
+      key: _scaffoldKey,
+      backgroundColor: colorScheme.surface,
+      drawer: _SessionDrawer(
+        sessions: sessions,
+        activeSessionId: activeSessionId,
+        serverName: activeServer?.displayName,
+        onSessionTap: _onSessionTap,
+        onCreateSession: _onCreateSession,
+        onServerTap: () {
+          Navigator.of(context).maybePop();
+          context.push('/servers');
+        },
+      ),
+      drawerEdgeDragWidth: 40,
+      drawerEnableOpenDragGesture: true,
+      body: Stack(
+        children: [
+          widget.child ??
+              _EmptyState(
+                onCreateSession: _onCreateSession,
+                onOpenDrawer: _openSessionDrawer,
+              ),
+
+          if (activeSessionId != null)
+            Positioned(
+              top: MediaQuery.of(context).padding.top + 8,
+              left: 0,
+              right: 0,
+              child: Center(
+                child: _StatusPill(
+                  onTap: _openSessionDrawer,
+                ),
+              ),
+            ),
+
+          if (_showQuickActions)
+            Positioned(
+              right: 0,
+              top: 0,
+              bottom: 0,
+              child: GestureDetector(
+                onHorizontalDragEnd: (details) {
+                  if (details.primaryVelocity != null &&
+                      details.primaryVelocity! > 0) {
+                    setState(() => _showQuickActions = false);
+                  }
+                },
+                child: _QuickActionsPanel(
+                  onCreateSession: _onCreateSession,
+                  onSettings: () {
+                    setState(() => _showQuickActions = false);
+                    context.push('/settings');
+                  },
+                  onServers: () {
+                    setState(() => _showQuickActions = false);
+                    context.push('/servers');
+                  },
+                  onClose: () => setState(() => _showQuickActions = false),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Session drawer with frosted glass surface.
+class _SessionDrawer extends StatelessWidget {
+  const _SessionDrawer({
+    required this.sessions,
+    required this.activeSessionId,
+    required this.serverName,
+    required this.onSessionTap,
+    required this.onCreateSession,
+    required this.onServerTap,
+  });
+
+  final List<Session> sessions;
+  final String? activeSessionId;
+  final String? serverName;
+  final void Function(Session) onSessionTap;
+  final VoidCallback onCreateSession;
+  final VoidCallback onServerTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final drawerWidth = MediaQuery.of(context).size.width * 0.80;
+
+    return SizedBox(
+      width: drawerWidth.clamp(280, 360).toDouble(),
+      child: Drawer(
+        child: GlassmorphicContainer.drawer(
+          child: SafeArea(
+            child: Column(
+              children: [
+                // Server indicator
+                InkWell(
+                  onTap: onServerTap,
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 8,
+                          height: 8,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: colorScheme.primary,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            serverName ?? 'No server',
+                            style: theme.textTheme.labelLarge?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        Icon(
+                          Icons.swap_horiz_rounded,
+                          size: 18,
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+                Divider(color: colorScheme.outlineVariant),
+
+                // New session button
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 4,
+                  ),
+                  child: FilledButton.icon(
+                    onPressed: onCreateSession,
+                    icon: const Icon(Icons.add_rounded, size: 18),
+                    label: const Text('New Session'),
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size.fromHeight(40),
+                    ),
+                  ),
+                ),
+
+                const SizedBox(height: 4),
+
+                // Session list
+                Expanded(
+                  child: sessions.isEmpty
+                      ? Center(
+                          child: Text(
+                            'No sessions yet',
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        )
+                      : ListView.builder(
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
+                          itemCount: sessions.length,
+                          itemBuilder: (context, index) {
+                            final session = sessions[index];
+                            final isActive = session.id == activeSessionId;
+
+                            return _SessionTile(
+                              session: session,
+                              isActive: isActive,
+                              onTap: () => onSessionTap(session),
+                            );
+                          },
+                        ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A single session tile in the drawer.
+class _SessionTile extends StatelessWidget {
+  const _SessionTile({
+    required this.session,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  final Session session;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  Color _statusColor(ColorScheme colorScheme) {
+    if (session.isAgent) {
+      if (session.agentNeedsAttention) return colorScheme.error;
+      if (session.agentIsWaiting) return Colors.amber;
+      return colorScheme.primary;
+    }
+    if (session.isActive) return colorScheme.primary;
+    return colorScheme.outlineVariant;
+  }
+
+  IconData get _typeIcon {
+    if (session.isAgent) return Icons.smart_toy_rounded;
+    return Icons.terminal_rounded;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 1),
+      child: ListTile(
+        dense: true,
+        visualDensity: VisualDensity.compact,
+        selected: isActive,
+        selectedColor: colorScheme.primary,
+        selectedTileColor: colorScheme.primary.withValues(alpha: 0.12),
+        leading: Icon(_typeIcon, size: 18),
+        title: Text(
+          session.name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontWeight: isActive ? FontWeight.w600 : FontWeight.w400,
+          ),
+        ),
+        trailing: Container(
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: _statusColor(colorScheme),
+          ),
+        ),
+        onTap: onTap,
+      ),
+    );
+  }
+}
+
+/// Floating status pill showing current session info.
+class _StatusPill extends ConsumerWidget {
+  const _StatusPill({
+    required this.onTap,
+  });
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final session = ref.watch(activeSessionProvider);
+
+    if (session == null) return const SizedBox.shrink();
+
+    return GestureDetector(
+      onTap: onTap,
+      child: GlassmorphicContainer.statusBar(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              session.isAgent
+                  ? Icons.smart_toy_rounded
+                  : Icons.terminal_rounded,
+              size: 14,
+              color: colorScheme.onSurface.withValues(alpha: 0.7),
+            ),
+            const SizedBox(width: 6),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 160),
+              child: Text(
+                session.name,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: colorScheme.onSurface.withValues(alpha: 0.8),
+                  fontWeight: FontWeight.w500,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            const SizedBox(width: 4),
+            Icon(
+              Icons.keyboard_arrow_down_rounded,
+              size: 14,
+              color: colorScheme.onSurface.withValues(alpha: 0.5),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Quick actions panel (right edge).
+class _QuickActionsPanel extends StatelessWidget {
+  const _QuickActionsPanel({
+    required this.onCreateSession,
+    required this.onSettings,
+    required this.onServers,
+    required this.onClose,
+  });
+
+  final VoidCallback onCreateSession;
+  final VoidCallback onSettings;
+  final VoidCallback onServers;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return GlassmorphicContainer.panel(
+      width: 200,
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Row(
+                  children: [
+                    Text(
+                      'Quick Actions',
+                      style: theme.textTheme.labelLarge?.copyWith(
+                        color: colorScheme.onSurface.withValues(alpha: 0.7),
+                      ),
+                    ),
+                    const Spacer(),
+                    IconButton(
+                      icon: const Icon(Icons.close_rounded, size: 18),
+                      onPressed: onClose,
+                      visualDensity: VisualDensity.compact,
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 8),
+              _QuickAction(
+                icon: Icons.add_rounded,
+                label: 'New Session',
+                onTap: onCreateSession,
+              ),
+              const Divider(indent: 16, endIndent: 16),
+              _QuickAction(
+                icon: Icons.dns_rounded,
+                label: 'Servers',
+                onTap: onServers,
+              ),
+              _QuickAction(
+                icon: Icons.settings_rounded,
+                label: 'Settings',
+                onTap: onSettings,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _QuickAction extends StatelessWidget {
+  const _QuickAction({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return ListTile(
+      dense: true,
+      visualDensity: VisualDensity.compact,
+      leading: Icon(icon, size: 20),
+      title: Text(
+        label,
+        style: theme.textTheme.bodyMedium,
+      ),
+      onTap: onTap,
+    );
+  }
+}
+
+/// Empty state shown when no session is active.
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({
+    required this.onCreateSession,
+    required this.onOpenDrawer,
+  });
+
+  final VoidCallback onCreateSession;
+  final VoidCallback onOpenDrawer;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.terminal_rounded,
+              size: 72,
+              color: colorScheme.onSurface.withValues(alpha: 0.15),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'No active session',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: colorScheme.onSurface.withValues(alpha: 0.4),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Swipe from the left edge to browse sessions\nor create a new one',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: colorScheme.onSurface.withValues(alpha: 0.3),
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 32),
+            FilledButton.icon(
+              onPressed: onCreateSession,
+              icon: const Icon(Icons.add_rounded),
+              label: const Text('New Session'),
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              onPressed: onOpenDrawer,
+              icon: const Icon(Icons.menu_rounded),
+              label: const Text('Browse Sessions'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/screens/server/add_server_screen.dart
+++ b/mobile/lib/presentation/screens/server/add_server_screen.dart
@@ -1,0 +1,358 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import 'package:remote_dev/domain/entities/server_config.dart';
+import 'package:remote_dev/domain/value_objects/auth_method.dart';
+import 'package:remote_dev/infrastructure/storage/server_scoped_storage.dart';
+import 'package:remote_dev/presentation/providers/server_config_providers.dart';
+import 'package:remote_dev/presentation/screens/server/qr_scan_screen.dart';
+import 'package:remote_dev/presentation/widgets/common/glassmorphic_container.dart';
+import 'package:remote_dev/presentation/widgets/server/host_input.dart';
+import 'package:remote_dev/presentation/widgets/server/port_stepper.dart';
+import 'package:remote_dev/presentation/widgets/server/protocol_dropdown.dart';
+
+/// Add server screen with QR scan hero + manual setup fallback.
+///
+/// QR payload format (JSON):
+/// ```json
+/// {
+///   "url": "https://dev.example.com",
+///   "port": "6002",
+///   "apiKey": "rdv_...",
+///   "userId": "...",
+///   "email": "user@example.com"
+/// }
+/// ```
+class AddServerScreen extends ConsumerStatefulWidget {
+  const AddServerScreen({super.key});
+
+  @override
+  ConsumerState<AddServerScreen> createState() => _AddServerScreenState();
+}
+
+class _AddServerScreenState extends ConsumerState<AddServerScreen> {
+  bool _showManualForm = false;
+
+  // Manual form state
+  String _protocol = 'https://';
+  final _hostController = TextEditingController();
+  int _port = 6001;
+  int _terminalPort = 6002;
+  String _authMethod = 'cloudflare';
+  final _apiKeyController = TextEditingController();
+  final _nicknameController = TextEditingController();
+
+  late final List<String> _recentHosts = _buildRecentHosts();
+
+  @override
+  void dispose() {
+    _hostController.dispose();
+    _apiKeyController.dispose();
+    _nicknameController.dispose();
+    super.dispose();
+  }
+
+  /// Extract unique hostnames from existing server configurations.
+  List<String> _buildRecentHosts() {
+    final servers = ref.read(serverListProvider);
+    return servers
+        .map((s) => Uri.tryParse(s.serverUrl)?.host)
+        .whereType<String>()
+        .toSet()
+        .toList();
+  }
+
+  Future<void> _handleQrScan() async {
+    final result = await Navigator.of(context).push<String>(
+      MaterialPageRoute(builder: (_) => const QrScanScreen()),
+    );
+    if (result != null && mounted) {
+      await _handleQrPayload(result);
+    }
+  }
+
+  Future<void> _handleQrPayload(String payload) async {
+    try {
+      final data = jsonDecode(payload) as Map<String, dynamic>;
+      final serverUrl = data['url'] as String;
+      final port = data['port'] as String? ?? '6002';
+      final apiKey = data['apiKey'] as String;
+      final userId = data['userId'] as String?;
+      final email = data['email'] as String?;
+
+      final config = ServerConfig(
+        id: const Uuid().v4(),
+        nickname: Uri.parse(serverUrl).host,
+        serverUrl: serverUrl,
+        terminalPort: port,
+        authMethod: QrScannedAuth(scannedAt: DateTime.now()),
+        createdAt: DateTime.now(),
+        lastConnectedAt: DateTime.now(),
+      );
+
+      // Store credentials first — if this fails, no server config is orphaned
+      final scopedStorage = ServerScopedStorage(
+        storage: ref.read(secureStorageProvider),
+        serverId: config.id,
+      );
+      await scopedStorage.storeCredentials(
+        apiKey: apiKey,
+        userId: userId ?? '',
+        email: email ?? '',
+      );
+
+      await _saveAndActivate(config);
+
+      if (mounted) {
+        HapticFeedback.heavyImpact();
+        Navigator.of(context).pop(true);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Invalid QR code: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _saveManualServer() async {
+    final host = _hostController.text.trim();
+    if (host.isEmpty) return;
+
+    final serverUrl = '$_protocol$host:$_port';
+    final authMethod = _authMethod == 'cloudflare'
+        ? const CfAccessAuth()
+        : const ApiKeyAuth();
+
+    final config = ServerConfig(
+      id: const Uuid().v4(),
+      nickname: _nicknameController.text.trim(),
+      serverUrl: serverUrl,
+      terminalPort: _terminalPort.toString(),
+      authMethod: authMethod,
+      createdAt: DateTime.now(),
+      lastConnectedAt: DateTime.now(),
+    );
+
+    if (_authMethod == 'apikey' && _apiKeyController.text.isNotEmpty) {
+      final scopedStorage = ServerScopedStorage(
+        storage: ref.read(secureStorageProvider),
+        serverId: config.id,
+      );
+      await scopedStorage.setApiKey(_apiKeyController.text.trim());
+    }
+
+    await _saveAndActivate(config);
+
+    if (mounted) {
+      HapticFeedback.heavyImpact();
+      Navigator.of(context).pop(true);
+    }
+  }
+
+  /// Persist the server config, set it as active, and refresh providers.
+  Future<void> _saveAndActivate(ServerConfig config) async {
+    final store = ref.read(serverConfigStoreProvider);
+    await store.save(config);
+    await store.setActiveServerId(config.id);
+    ref.invalidate(serverListProvider);
+    ref.read(activeServerIdProvider.notifier).state = config.id;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      appBar: AppBar(
+        title: const Text('Add Server'),
+        backgroundColor: colorScheme.surface,
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // QR Scan Hero
+              if (!_showManualForm) ...[
+                const SizedBox(height: 32),
+                Icon(
+                  Icons.qr_code_scanner_rounded,
+                  size: 80,
+                  color: colorScheme.primary,
+                ),
+                const SizedBox(height: 24),
+                Text(
+                  'Scan QR Code',
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Open your Remote Dev web dashboard\nand scan the connection QR code',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 32),
+                FilledButton.icon(
+                  onPressed: _handleQrScan,
+                  icon: const Icon(Icons.camera_alt_rounded),
+                  label: const Text('Open Scanner'),
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 32,
+                      vertical: 16,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 48),
+                Row(
+                  children: [
+                    Expanded(child: Divider(color: colorScheme.outlineVariant)),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: Text(
+                        'or',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                    Expanded(child: Divider(color: colorScheme.outlineVariant)),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                OutlinedButton(
+                  onPressed: () => setState(() => _showManualForm = true),
+                  child: const Text('Manual Setup'),
+                ),
+              ],
+
+              // Manual Setup Form
+              if (_showManualForm) ...[
+                // Nickname (optional)
+                TextField(
+                  controller: _nicknameController,
+                  decoration: const InputDecoration(
+                    labelText: 'Server Name (optional)',
+                    hintText: 'Home Lab, Office, etc.',
+                  ),
+                  textCapitalization: TextCapitalization.words,
+                ),
+                const SizedBox(height: 20),
+
+                // Protocol + Host
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    SizedBox(
+                      width: 120,
+                      child: ProtocolDropdown(
+                        value: _protocol,
+                        onChanged: (v) => setState(() => _protocol = v),
+                        label: 'Protocol',
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: HostInput(
+                        controller: _hostController,
+                        recentHosts: _recentHosts,
+                        label: 'Host',
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 20),
+
+                // Port
+                PortStepper(
+                  value: _port,
+                  onChanged: (v) => setState(() => _port = v),
+                  label: 'API Port',
+                ),
+                const SizedBox(height: 20),
+
+                // Auth Method
+                Text(
+                  'Authentication',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                SegmentedButton<String>(
+                  segments: const [
+                    ButtonSegment(
+                      value: 'cloudflare',
+                      label: Text('Cloudflare'),
+                      icon: Icon(Icons.cloud_rounded, size: 18),
+                    ),
+                    ButtonSegment(
+                      value: 'apikey',
+                      label: Text('API Key'),
+                      icon: Icon(Icons.key_rounded, size: 18),
+                    ),
+                  ],
+                  selected: {_authMethod},
+                  onSelectionChanged: (v) {
+                    setState(() => _authMethod = v.first);
+                  },
+                ),
+                const SizedBox(height: 20),
+
+                // API Key field (only for API key auth)
+                if (_authMethod == 'apikey') ...[
+                  TextField(
+                    controller: _apiKeyController,
+                    decoration: const InputDecoration(
+                      labelText: 'API Key',
+                      hintText: 'rdv_...',
+                    ),
+                    obscureText: true,
+                    autocorrect: false,
+                    enableSuggestions: false,
+                  ),
+                  const SizedBox(height: 20),
+                ],
+
+                // Terminal port (only for direct connections, not Cloudflare)
+                if (_authMethod != 'cloudflare') ...[
+                  PortStepper(
+                    value: _terminalPort,
+                    onChanged: (v) => setState(() => _terminalPort = v),
+                    label: 'Terminal Port',
+                  ),
+                  const SizedBox(height: 20),
+                ],
+
+                const SizedBox(height: 8),
+                FilledButton(
+                  onPressed: _saveManualServer,
+                  child: const Text('Connect'),
+                ),
+                const SizedBox(height: 12),
+                TextButton(
+                  onPressed: () => setState(() => _showManualForm = false),
+                  child: const Text('Back to QR Scan'),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/screens/server/qr_scan_screen.dart
+++ b/mobile/lib/presentation/screens/server/qr_scan_screen.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+import 'package:remote_dev/presentation/widgets/common/glassmorphic_container.dart';
+
+/// Full-screen QR code scanner using the device camera.
+///
+/// Returns the scanned QR code string via Navigator.pop(result).
+/// Handles camera permissions and provides a manual torch toggle.
+class QrScanScreen extends StatefulWidget {
+  const QrScanScreen({super.key});
+
+  @override
+  State<QrScanScreen> createState() => _QrScanScreenState();
+}
+
+class _QrScanScreenState extends State<QrScanScreen> {
+  final MobileScannerController _controller = MobileScannerController(
+    detectionSpeed: DetectionSpeed.normal,
+    facing: CameraFacing.back,
+  );
+  bool _hasScanned = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onDetect(BarcodeCapture capture) {
+    if (_hasScanned) return;
+    final barcode = capture.barcodes.firstOrNull;
+    if (barcode?.rawValue == null) return;
+
+    _hasScanned = true;
+    HapticFeedback.heavyImpact();
+    Navigator.of(context).pop(barcode!.rawValue);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final size = MediaQuery.of(context).size;
+    final scanAreaSize = size.width * 0.7;
+
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Stack(
+        children: [
+          MobileScanner(
+            controller: _controller,
+            onDetect: _onDetect,
+          ),
+
+          // Scan area overlay with cutout
+          ColorFiltered(
+            colorFilter: const ColorFilter.mode(
+              Colors.black54,
+              BlendMode.srcOut,
+            ),
+            child: Stack(
+              children: [
+                Container(
+                  decoration: const BoxDecoration(
+                    color: Colors.black,
+                    backgroundBlendMode: BlendMode.dstOut,
+                  ),
+                ),
+                Center(
+                  child: Container(
+                    width: scanAreaSize,
+                    height: scanAreaSize,
+                    decoration: BoxDecoration(
+                      color: Colors.red, // Any color — gets cut out
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // Scan area border
+          Center(
+            child: Container(
+              width: scanAreaSize,
+              height: scanAreaSize,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(20),
+                border: Border.all(
+                  color: colorScheme.primary.withValues(alpha: 0.6),
+                  width: 2,
+                ),
+              ),
+            ),
+          ),
+
+          // Top bar with back button
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: GlassmorphicContainer.statusBar(
+              child: SafeArea(
+                bottom: false,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 4,
+                  ),
+                  child: Row(
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.arrow_back_rounded),
+                        color: Colors.white,
+                        onPressed: () => Navigator.of(context).pop(),
+                      ),
+                      const Spacer(),
+                      Text(
+                        'Scan QR Code',
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          color: Colors.white,
+                        ),
+                      ),
+                      const Spacer(),
+                      // Torch toggle
+                      ValueListenableBuilder(
+                        valueListenable: _controller,
+                        builder: (context, state, _) {
+                          return IconButton(
+                            icon: Icon(
+                              state.torchState == TorchState.on
+                                  ? Icons.flash_on_rounded
+                                  : Icons.flash_off_rounded,
+                            ),
+                            color: Colors.white,
+                            onPressed: () => _controller.toggleTorch(),
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+
+          // Bottom hint
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: SafeArea(
+              top: false,
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  'Point camera at the QR code\nin your Remote Dev web dashboard',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: Colors.white70,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/theme/app_theme.dart
+++ b/mobile/lib/presentation/theme/app_theme.dart
@@ -65,12 +65,7 @@ class NerdFonts {
 /// Build a Material 3 ThemeData from a terminal palette.
 class AppTheme {
   static Color _mixColors(Color base, Color blend, double amount) {
-    return Color.fromARGB(
-      255,
-      (base.r * 255 * (1 - amount) + blend.r * 255 * amount).round().clamp(0, 255),
-      (base.g * 255 * (1 - amount) + blend.g * 255 * amount).round().clamp(0, 255),
-      (base.b * 255 * (1 - amount) + blend.b * 255 * amount).round().clamp(0, 255),
-    );
+    return Color.lerp(base, blend, amount)!;
   }
 
   static ThemeData fromPalette(TerminalPalette palette, {bool isDark = true}) {
@@ -109,7 +104,7 @@ class AppTheme {
             error: error,
             onError: fg,
             surface: bg,
-            onSurface: bg,
+            onSurface: fg,
           );
 
     return ThemeData(
@@ -118,12 +113,18 @@ class AppTheme {
       brightness: isDark ? Brightness.dark : Brightness.light,
       scaffoldBackgroundColor: bg,
       appBarTheme: AppBarTheme(
-        backgroundColor: bg,
+        backgroundColor: Colors.transparent,
         foregroundColor: fg,
         elevation: 0,
+        scrolledUnderElevation: 0,
       ),
       drawerTheme: DrawerThemeData(
-        backgroundColor: bg,
+        // Transparent — GlassmorphicContainer handles the frosted glass
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.horizontal(right: Radius.circular(20)),
+        ),
       ),
       cardTheme: CardThemeData(
         color: surfaceContainerLow,
@@ -191,19 +192,23 @@ class AppTheme {
         elevation: 4,
       ),
       navigationDrawerTheme: NavigationDrawerThemeData(
-        backgroundColor: bg,
+        // Transparent — GlassmorphicContainer.drawer handles surface
+        backgroundColor: Colors.transparent,
+        elevation: 0,
         indicatorColor: primary.withValues(alpha: 0.12),
         indicatorShape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
         ),
       ),
       bottomSheetTheme: BottomSheetThemeData(
-        backgroundColor: surfaceContainerLow,
+        // Semi-transparent for frosted glass bottom sheets
+        backgroundColor: surfaceContainerLow.withValues(alpha: 0.80),
         showDragHandle: true,
         dragHandleColor: fg.withValues(alpha: 0.2),
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
         ),
+        elevation: 0,
       ),
       filledButtonTheme: FilledButtonThemeData(
         style: FilledButton.styleFrom(
@@ -230,7 +235,9 @@ class AppTheme {
         ),
       ),
       dialogTheme: DialogThemeData(
-        backgroundColor: surfaceContainerHigh,
+        // Semi-transparent for frosted glass dialogs
+        backgroundColor: surfaceContainerHigh.withValues(alpha: 0.85),
+        elevation: 0,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(20),
         ),

--- a/mobile/lib/presentation/widgets/common/glassmorphic_container.dart
+++ b/mobile/lib/presentation/widgets/common/glassmorphic_container.dart
@@ -1,0 +1,179 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+/// A reusable frosted glass container using BackdropFilter.
+///
+/// Provides configurable blur, opacity, border, and border radius.
+/// Use over terminal or dark backgrounds for the glassmorphism effect.
+///
+/// Surface presets:
+/// - [GlassmorphicContainer.drawer] — Session drawer (sigma: 20, 0.75)
+/// - [GlassmorphicContainer.sheet] — Bottom sheets (sigma: 24, 0.80)
+/// - [GlassmorphicContainer.dialog] — Dialogs (sigma: 16, 0.85)
+/// - [GlassmorphicContainer.panel] — Quick actions panel (sigma: 20, 0.75)
+/// - [GlassmorphicContainer.statusBar] — Floating status overlay (sigma: 12, 0.60)
+class GlassmorphicContainer extends StatelessWidget {
+  const GlassmorphicContainer({
+    super.key,
+    required this.child,
+    this.blurSigma = 20.0,
+    this.opacity = 0.75,
+    this.borderRadius = BorderRadius.zero,
+    this.borderColor,
+    this.borderWidth = 1.0,
+    this.backgroundColor,
+    this.padding,
+    this.margin,
+    this.width,
+    this.height,
+    this.clipBehavior = Clip.antiAlias,
+  });
+
+  /// Session drawer surface.
+  const GlassmorphicContainer.drawer({
+    super.key,
+    required this.child,
+    this.borderRadius = const BorderRadius.only(
+      topRight: Radius.circular(20),
+      bottomRight: Radius.circular(20),
+    ),
+    this.padding,
+    this.margin,
+    this.width,
+    this.height,
+    this.clipBehavior = Clip.antiAlias,
+  })  : blurSigma = 20.0,
+        opacity = 0.75,
+        borderColor = null,
+        borderWidth = 1.0,
+        backgroundColor = null;
+
+  /// Bottom sheet surface.
+  const GlassmorphicContainer.sheet({
+    super.key,
+    required this.child,
+    this.borderRadius = const BorderRadius.vertical(
+      top: Radius.circular(20),
+    ),
+    this.padding,
+    this.margin,
+    this.width,
+    this.height,
+    this.clipBehavior = Clip.antiAlias,
+  })  : blurSigma = 24.0,
+        opacity = 0.80,
+        borderColor = null,
+        borderWidth = 1.0,
+        backgroundColor = null;
+
+  /// Dialog surface.
+  const GlassmorphicContainer.dialog({
+    super.key,
+    required this.child,
+    this.borderRadius = const BorderRadius.all(Radius.circular(20)),
+    this.padding,
+    this.margin,
+    this.width,
+    this.height,
+    this.clipBehavior = Clip.antiAlias,
+  })  : blurSigma = 16.0,
+        opacity = 0.85,
+        borderColor = null,
+        borderWidth = 1.0,
+        backgroundColor = null;
+
+  /// Quick actions panel surface.
+  const GlassmorphicContainer.panel({
+    super.key,
+    required this.child,
+    this.borderRadius = const BorderRadius.only(
+      topLeft: Radius.circular(20),
+      bottomLeft: Radius.circular(20),
+    ),
+    this.padding,
+    this.margin,
+    this.width,
+    this.height,
+    this.clipBehavior = Clip.antiAlias,
+  })  : blurSigma = 20.0,
+        opacity = 0.75,
+        borderColor = null,
+        borderWidth = 1.0,
+        backgroundColor = null;
+
+  /// Floating status bar overlay.
+  const GlassmorphicContainer.statusBar({
+    super.key,
+    required this.child,
+    this.borderRadius = const BorderRadius.all(Radius.circular(12)),
+    this.padding,
+    this.margin,
+    this.width,
+    this.height,
+    this.clipBehavior = Clip.antiAlias,
+  })  : blurSigma = 12.0,
+        opacity = 0.60,
+        borderColor = null,
+        borderWidth = 0.0,
+        backgroundColor = null;
+
+  final Widget child;
+  final double blurSigma;
+  final double opacity;
+  final BorderRadius borderRadius;
+  final Color? borderColor;
+  final double borderWidth;
+  final Color? backgroundColor;
+  final EdgeInsetsGeometry? padding;
+  final EdgeInsetsGeometry? margin;
+  final double? width;
+  final double? height;
+  final Clip clipBehavior;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    final bgColor = backgroundColor ??
+        (isDark
+            ? Colors.black.withValues(alpha: opacity)
+            : Colors.white.withValues(alpha: opacity));
+
+    final border = borderWidth > 0
+        ? Border.all(
+            color: borderColor ??
+                (isDark
+                    ? Colors.white.withValues(alpha: 0.08)
+                    : Colors.black.withValues(alpha: 0.06)),
+            width: borderWidth,
+          )
+        : null;
+
+    return Container(
+      width: width,
+      height: height,
+      margin: margin,
+      child: ClipRRect(
+        borderRadius: borderRadius,
+        clipBehavior: clipBehavior,
+        child: BackdropFilter(
+          filter: ImageFilter.blur(
+            sigmaX: blurSigma,
+            sigmaY: blurSigma,
+          ),
+          child: Container(
+            padding: padding,
+            decoration: BoxDecoration(
+              color: bgColor,
+              borderRadius: borderRadius,
+              border: border,
+            ),
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/widgets/server/host_input.dart
+++ b/mobile/lib/presentation/widgets/server/host_input.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+
+/// Host input field with recent history suggestions.
+///
+/// Shows a dropdown of previously used hosts below the field.
+/// Tapping a suggestion fills the field without typing.
+class HostInput extends StatefulWidget {
+  const HostInput({
+    super.key,
+    required this.controller,
+    this.recentHosts = const [],
+    this.label,
+    this.hintText = 'dev.example.com',
+    this.enabled = true,
+    this.onSubmitted,
+    this.focusNode,
+  });
+
+  final TextEditingController controller;
+  final List<String> recentHosts;
+  final String? label;
+  final String hintText;
+  final bool enabled;
+  final ValueChanged<String>? onSubmitted;
+  final FocusNode? focusNode;
+
+  @override
+  State<HostInput> createState() => _HostInputState();
+}
+
+class _HostInputState extends State<HostInput> {
+  late FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = widget.focusNode ?? FocusNode();
+    _focusNode.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    if (widget.focusNode == null) {
+      _focusNode.dispose();
+    }
+    super.dispose();
+  }
+
+  List<String> _getFilteredHosts() {
+    final query = widget.controller.text.trim().toLowerCase();
+    if (query.isEmpty) return widget.recentHosts;
+    return widget.recentHosts
+        .where((h) => h.toLowerCase().contains(query))
+        .toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final filtered = _getFilteredHosts();
+    final showSuggestions = _focusNode.hasFocus && filtered.isNotEmpty;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (widget.label != null)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Text(
+              widget.label!,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        TextField(
+          controller: widget.controller,
+          focusNode: _focusNode,
+          enabled: widget.enabled,
+          keyboardType: TextInputType.url,
+          autocorrect: false,
+          enableSuggestions: false,
+          textInputAction: TextInputAction.next,
+          style: theme.textTheme.bodyLarge?.copyWith(
+            fontFamily: 'JetBrainsMono Nerd Font',
+          ),
+          decoration: InputDecoration(
+            hintText: widget.hintText,
+            hintStyle: theme.textTheme.bodyLarge?.copyWith(
+              fontFamily: 'JetBrainsMono Nerd Font',
+              color: colorScheme.onSurface.withValues(alpha: 0.38),
+            ),
+            suffixIcon: widget.controller.text.isNotEmpty
+                ? IconButton(
+                    icon: const Icon(Icons.clear_rounded, size: 18),
+                    onPressed: () {
+                      widget.controller.clear();
+                      setState(() {});
+                    },
+                  )
+                : null,
+          ),
+          onChanged: (_) => setState(() {}),
+          onSubmitted: widget.onSubmitted,
+        ),
+        if (showSuggestions)
+          Container(
+            margin: const EdgeInsets.only(top: 4),
+            constraints: const BoxConstraints(maxHeight: 160),
+            decoration: BoxDecoration(
+              color: colorScheme.surfaceContainerHigh,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: colorScheme.outlineVariant),
+            ),
+            child: ListView.builder(
+              shrinkWrap: true,
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              itemCount: filtered.length,
+              itemBuilder: (context, index) {
+                final host = filtered[index];
+                return ListTile(
+                  dense: true,
+                  visualDensity: VisualDensity.compact,
+                  leading: Icon(
+                    Icons.history_rounded,
+                    size: 18,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  title: Text(
+                    host,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      fontFamily: 'JetBrainsMono Nerd Font',
+                    ),
+                  ),
+                  onTap: () {
+                    widget.controller.text = host;
+                    widget.controller.selection = TextSelection.fromPosition(
+                      TextPosition(offset: host.length),
+                    );
+                    _focusNode.unfocus();
+                  },
+                );
+              },
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/presentation/widgets/server/port_stepper.dart
+++ b/mobile/lib/presentation/widgets/server/port_stepper.dart
@@ -1,0 +1,245 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// A stepper widget for port numbers: [-] [6001] [+]
+///
+/// Material 3 styled with haptic feedback on increment/decrement.
+/// Supports tap-to-edit the center value directly.
+class PortStepper extends StatefulWidget {
+  const PortStepper({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.min = 1,
+    this.max = 65535,
+    this.step = 1,
+    this.label,
+    this.enabled = true,
+  });
+
+  final int value;
+  final ValueChanged<int> onChanged;
+  final int min;
+  final int max;
+  final int step;
+  final String? label;
+  final bool enabled;
+
+  @override
+  State<PortStepper> createState() => _PortStepperState();
+}
+
+class _PortStepperState extends State<PortStepper> {
+  bool _isEditing = false;
+  late TextEditingController _controller;
+  late FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.value.toString());
+    _focusNode = FocusNode()
+      ..addListener(() {
+        if (!_focusNode.hasFocus && _isEditing) {
+          _commitEdit();
+        }
+      });
+  }
+
+  @override
+  void didUpdateWidget(PortStepper old) {
+    super.didUpdateWidget(old);
+    if (!_isEditing && old.value != widget.value) {
+      _controller.text = widget.value.toString();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _decrement() {
+    if (!widget.enabled) return;
+    final newValue = (widget.value - widget.step).clamp(widget.min, widget.max);
+    if (newValue != widget.value) {
+      HapticFeedback.lightImpact();
+      widget.onChanged(newValue);
+    }
+  }
+
+  void _increment() {
+    if (!widget.enabled) return;
+    final newValue = (widget.value + widget.step).clamp(widget.min, widget.max);
+    if (newValue != widget.value) {
+      HapticFeedback.lightImpact();
+      widget.onChanged(newValue);
+    }
+  }
+
+  void _startEditing() {
+    if (!widget.enabled) return;
+    setState(() {
+      _isEditing = true;
+      _controller.text = widget.value.toString();
+      _controller.selection = TextSelection(
+        baseOffset: 0,
+        extentOffset: _controller.text.length,
+      );
+    });
+    _focusNode.requestFocus();
+  }
+
+  void _commitEdit() {
+    final parsed = int.tryParse(_controller.text.trim());
+    if (parsed != null) {
+      final clamped = parsed.clamp(widget.min, widget.max);
+      widget.onChanged(clamped);
+    }
+    setState(() => _isEditing = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (widget.label != null)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Text(
+              widget.label!,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        Container(
+          decoration: BoxDecoration(
+            color: colorScheme.surfaceContainer,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: _isEditing
+                  ? colorScheme.primary
+                  : colorScheme.outlineVariant,
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Decrement button
+              _StepButton(
+                icon: Icons.remove_rounded,
+                onPressed: widget.value > widget.min ? _decrement : null,
+                enabled: widget.enabled && widget.value > widget.min,
+                borderRadius: const BorderRadius.horizontal(
+                  left: Radius.circular(11),
+                ),
+              ),
+
+              // Value display / edit
+              _isEditing
+                  ? SizedBox(
+                      width: 72,
+                      child: TextField(
+                        controller: _controller,
+                        focusNode: _focusNode,
+                        keyboardType: TextInputType.number,
+                        textAlign: TextAlign.center,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontFamily: 'JetBrainsMono Nerd Font',
+                          fontWeight: FontWeight.w600,
+                        ),
+                        decoration: const InputDecoration(
+                          border: InputBorder.none,
+                          contentPadding: EdgeInsets.symmetric(vertical: 12),
+                          isDense: true,
+                          filled: false,
+                        ),
+                        inputFormatters: [
+                          FilteringTextInputFormatter.digitsOnly,
+                          LengthLimitingTextInputFormatter(5),
+                        ],
+                        onSubmitted: (_) => _commitEdit(),
+                      ),
+                    )
+                  : GestureDetector(
+                      onTap: _startEditing,
+                      child: Container(
+                        width: 72,
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        alignment: Alignment.center,
+                        child: Text(
+                          widget.value.toString(),
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            fontFamily: 'JetBrainsMono Nerd Font',
+                            fontWeight: FontWeight.w600,
+                            color: widget.enabled
+                                ? colorScheme.onSurface
+                                : colorScheme.onSurface.withValues(alpha: 0.38),
+                          ),
+                        ),
+                      ),
+                    ),
+
+              // Increment button
+              _StepButton(
+                icon: Icons.add_rounded,
+                onPressed: widget.value < widget.max ? _increment : null,
+                enabled: widget.enabled && widget.value < widget.max,
+                borderRadius: const BorderRadius.horizontal(
+                  right: Radius.circular(11),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StepButton extends StatelessWidget {
+  const _StepButton({
+    required this.icon,
+    required this.onPressed,
+    required this.enabled,
+    required this.borderRadius,
+  });
+
+  final IconData icon;
+  final VoidCallback? onPressed;
+  final bool enabled;
+  final BorderRadius borderRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: borderRadius,
+        child: Container(
+          width: 44,
+          height: 44,
+          alignment: Alignment.center,
+          child: Icon(
+            icon,
+            size: 20,
+            color: enabled
+                ? colorScheme.onSurfaceVariant
+                : colorScheme.onSurface.withValues(alpha: 0.38),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/widgets/server/protocol_dropdown.dart
+++ b/mobile/lib/presentation/widgets/server/protocol_dropdown.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+
+/// Protocol selector dropdown: http:// or https://
+///
+/// Material 3 styled dropdown that avoids typing.
+/// Defaults to https:// since most remote-dev instances use Cloudflare tunnels.
+class ProtocolDropdown extends StatelessWidget {
+  const ProtocolDropdown({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.label,
+    this.enabled = true,
+  });
+
+  final String value;
+  final ValueChanged<String> onChanged;
+  final String? label;
+  final bool enabled;
+
+  static const protocols = ['https://', 'http://'];
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (label != null)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Text(
+              label!,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        Container(
+          decoration: BoxDecoration(
+            color: colorScheme.surfaceContainer,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: colorScheme.outlineVariant),
+          ),
+          child: DropdownButtonHideUnderline(
+            child: DropdownButton<String>(
+              value: value,
+              onChanged: enabled ? (v) => onChanged(v!) : null,
+              isExpanded: true,
+              borderRadius: BorderRadius.circular(12),
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              dropdownColor: colorScheme.surfaceContainerHigh,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                fontFamily: 'JetBrainsMono Nerd Font',
+                color: enabled
+                    ? colorScheme.onSurface
+                    : colorScheme.onSurface.withValues(alpha: 0.38),
+              ),
+              icon: Icon(
+                Icons.keyboard_arrow_down_rounded,
+                color: colorScheme.onSurfaceVariant,
+              ),
+              items: protocols
+                  .map((p) => DropdownMenuItem(
+                        value: p,
+                        child: Text(p),
+                      ))
+                  .toList(),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/presentation/widgets/server/server_card.dart
+++ b/mobile/lib/presentation/widgets/server/server_card.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+
+import 'package:remote_dev/domain/entities/server_config.dart';
+import 'package:remote_dev/domain/value_objects/auth_method.dart';
+
+/// A card widget for displaying a server in the server list.
+///
+/// Shows server name, URL, auth method indicator, and connection status.
+/// Highlights the active server with a primary border.
+class ServerCard extends StatelessWidget {
+  const ServerCard({
+    super.key,
+    required this.server,
+    required this.isActive,
+    required this.onTap,
+    this.onLongPress,
+    this.isConnected = false,
+  });
+
+  final ServerConfig server;
+  final bool isActive;
+  final VoidCallback onTap;
+  final VoidCallback? onLongPress;
+  final bool isConnected;
+
+  IconData get _authIcon => switch (server.authMethod) {
+        CfAccessAuth() => Icons.cloud_rounded,
+        ApiKeyAuth() => Icons.key_rounded,
+        QrScannedAuth() => Icons.qr_code_rounded,
+      };
+
+  String get _authLabel => switch (server.authMethod) {
+        CfAccessAuth() => 'Cloudflare',
+        ApiKeyAuth() => 'API Key',
+        QrScannedAuth() => 'QR Code',
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: isActive
+            ? BorderSide(color: colorScheme.primary, width: 1.5)
+            : BorderSide(color: colorScheme.outlineVariant),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        onLongPress: onLongPress,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            children: [
+              // Connection status dot
+              Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: isConnected
+                      ? colorScheme.primary
+                      : colorScheme.outlineVariant,
+                ),
+              ),
+              const SizedBox(width: 12),
+
+              // Server info
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      server.displayName,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      Uri.parse(server.serverUrl).host,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        fontFamily: 'JetBrainsMono Nerd Font',
+                        color: colorScheme.onSurfaceVariant,
+                        fontSize: 11,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+
+              // Auth method chip
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: colorScheme.surfaceContainerHigh,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      _authIcon,
+                      size: 14,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      _authLabel,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              if (isActive) ...[
+                const SizedBox(width: 8),
+                Icon(
+                  Icons.check_circle_rounded,
+                  size: 20,
+                  color: colorScheme.primary,
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -45,9 +45,13 @@ dependencies:
   # Local preferences (non-sensitive)
   shared_preferences: ^2.3.2
 
+  # QR code scanning
+  mobile_scanner: ^6.0.2
+
   # Utilities
   collection: ^1.18.0
   equatable: ^2.0.5
+  uuid: ^4.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- **Material 3 + frosted glass surfaces** — `GlassmorphicContainer` widget with 5 presets (drawer, sheet, dialog, panel, statusBar) using `BackdropFilter` blur
- **Edge drawer navigation** — swipe from left edge for instant session switching (1 gesture vs 2-3 taps before), floating status pill showing active session
- **Multi-server support** — `ServerConfig` entity, `AuthMethod` sealed class (CfAccess/ApiKey/QrScanned), `ServerScopedStorage` for per-server credential isolation, `ServerConfigStore` with cached SharedPreferences persistence
- **QR code onboarding** — scan a QR from the web dashboard for zero-typing server setup, with smart manual fallback (protocol dropdown, host autocomplete, port stepper `[-][6001][+]`)
- **Auto-migration** — existing single-server credentials migrated to multi-server format on first launch
- **GoRouter ShellRoute** — stable navigation using `refreshListenable` instead of router recreation

### Key Decisions
- SharedPreferences over Isar for server config persistence (avoids heavy dependency for simple JSON list)
- xterm.dart kept as terminal renderer (best Flutter option, issues were input-related not rendering)
- Credentials stored before server config to prevent orphaned configs on failure
- `ServerConfigLegacy` bridge class delegates `wsUrl` to domain entity (single source of truth)

## Test plan

- [ ] Fresh install: app should show QR scan onboarding screen
- [ ] Manual server setup: protocol dropdown, host input with recents, port stepper
- [ ] QR scan: verify camera opens, scans, and auto-configures server
- [ ] Session drawer: swipe from left edge to reveal, tap session to switch
- [ ] Multi-server: add second server, switch between them in drawer
- [ ] Auth flow: Cloudflare Access login, API key login
- [ ] Credential migration: existing single-server users should auto-migrate
- [ ] Glassmorphism: frosted glass on drawer, bottom sheets, dialogs
- [ ] Status pill: floating indicator showing current session name

🤖 Generated with [Claude Code](https://claude.com/claude-code)