### PR TITLE
feat: two-mode mobile keyboard with sticky modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Two-mode mobile keyboard**: Switchable Keys/Nav modes in the mobile terminal toolbar — Keys mode has ESC, TAB, ^C, ^D, CTRL/ALT/SHIFT sticky modifiers; Nav mode has arrow keys, HOME/END, PGUP/PGDN, ENTER, SHIFT+ENTER
+- **Sticky modifier keys**: CTRL/ALT/SHIFT toggles in the toolbar intercept the next keystroke typed in the text input, enabling Ctrl+C, Alt+key, and other combos on mobile
+- **`useMobileModifiers` hook**: Shared modifier state between MobileKeyboard and MobileInputBar with IME composition guard and double-consumption protection
+
+### Fixed
+
+- **Empty input submit**: Send button now works without text, sending bare `\r` to confirm terminal prompts
+- **Ctrl+non-alpha keys**: CTRL modifier now correctly handles Ctrl+[ (ESC), Ctrl+\ (SIGQUIT), and other non-letter control codes
+
 ## [0.3.5] - 2026-03-21
 
 ### Added

--- a/src/components/terminal/MobileInputBar.tsx
+++ b/src/components/terminal/MobileInputBar.tsx
@@ -95,6 +95,11 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
       onHeightChange?.();
     }, [onHeightChange]);
 
+    const handleChange = useCallback(
+      (e: React.ChangeEvent<HTMLTextAreaElement>) => setValue(e.target.value),
+      []
+    );
+
     return (
       <form
         onSubmit={handleSubmit}
@@ -106,7 +111,7 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
         <textarea
           ref={textareaRef}
           value={value}
-          onChange={(e) => setValue(e.target.value)}
+          onChange={handleChange}
           onKeyDown={handleKeyDown}
           onInput={handleInput}
           placeholder={placeholder}

--- a/src/components/terminal/MobileInputBar.tsx
+++ b/src/components/terminal/MobileInputBar.tsx
@@ -6,7 +6,13 @@ import { cn } from "@/lib/utils";
 
 interface MobileInputBarProps {
   onSubmit: (text: string) => void;
+  /** Send a single modifier-resolved sequence to the terminal (bypasses textarea) */
+  onModifiedKeyPress?: (sequence: string) => void;
   onHeightChange?: () => void;
+  /** Whether any sticky modifier is active (shows visual indicator) */
+  modifierActive?: boolean;
+  /** Resolve the next keystroke through active modifiers */
+  resolveKey?: (key: string) => string;
   disabled?: boolean;
   placeholder?: string;
   className?: string;
@@ -27,7 +33,10 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
   function MobileInputBar(
     {
       onSubmit,
+      onModifiedKeyPress,
       onHeightChange,
+      modifierActive = false,
+      resolveKey,
       disabled = false,
       placeholder = "Type a message...",
       className,
@@ -49,22 +58,34 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
 
     const handleSubmit = useCallback((e?: React.FormEvent) => {
       e?.preventDefault();
-      const trimmed = value.trim();
-      if (!trimmed || disabled) return;
+      if (disabled) return;
 
-      onSubmit(trimmed + "\r");
+      onSubmit(value ? value + "\r" : "\r");
       setValue("");
       resetTextareaHeight();
     }, [value, disabled, onSubmit, resetTextareaHeight]);
 
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        if (e.key === "Enter" && !e.shiftKey) {
+        // Sticky modifier interception: when a modifier is active, consume the next
+        // real keystroke, resolve it through modifiers, and send directly to terminal.
+        // Guards: skip hardware modifiers, IME composition, and non-character keys.
+        if (modifierActive && resolveKey && onModifiedKeyPress && !e.isComposing && !e.ctrlKey && !e.altKey && !e.metaKey) {
+          const { key } = e;
+          if (key.length === 1 || key === "Enter" || key === "Backspace") {
+            e.preventDefault();
+            const raw = key === "Enter" ? "\r" : key === "Backspace" ? "\x7f" : key;
+            onModifiedKeyPress(resolveKey(raw));
+            return;
+          }
+        }
+
+        if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
           e.preventDefault();
           handleSubmit();
         }
       },
-      [handleSubmit]
+      [handleSubmit, modifierActive, resolveKey, onModifiedKeyPress]
     );
 
     const handleInput = useCallback((e: React.FormEvent<HTMLTextAreaElement>) => {
@@ -102,17 +123,18 @@ export const MobileInputBar = forwardRef<HTMLTextAreaElement, MobileInputBarProp
             "placeholder:text-muted-foreground/60",
             "focus:outline-none focus:ring-1 focus:ring-primary/50",
             "overflow-y-auto",
-            disabled && "opacity-50 cursor-not-allowed"
+            disabled && "opacity-50 cursor-not-allowed",
+            modifierActive && "ring-1 ring-primary/70 bg-primary/5"
           )}
         />
 
         <button
           type="submit"
-          disabled={disabled || !value.trim()}
+          disabled={disabled}
           className={cn(
             "p-2 rounded-md shrink-0 touch-manipulation",
             "transition-colors duration-100",
-            value.trim() && !disabled
+            !disabled
               ? "text-primary active:bg-primary/20"
               : "text-muted-foreground/40"
           )}

--- a/src/components/terminal/MobileKeyboard.tsx
+++ b/src/components/terminal/MobileKeyboard.tsx
@@ -176,11 +176,15 @@ export function MobileKeyboard({
     </button>
   );
 
+  const handleCameraClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
   const cameraButton = onImageUpload && (
     <>
       <div className="w-px bg-border mx-1 self-stretch" />
       <button
-        onClick={() => fileInputRef.current?.click()}
+        onClick={handleCameraClick}
         disabled={isUploading}
         className={cn(
           "px-2.5 py-1.5 rounded-md text-xs font-medium",

--- a/src/components/terminal/MobileKeyboard.tsx
+++ b/src/components/terminal/MobileKeyboard.tsx
@@ -3,9 +3,23 @@
 import { useState, useCallback, useRef } from "react";
 import { Camera, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import type { ModifierKey } from "@/hooks/useMobileModifiers";
+
+type KeyboardMode = "keys" | "nav";
 
 interface MobileKeyboardProps {
-  onKeyPress: (key: string, modifiers?: { ctrl?: boolean; alt?: boolean }) => void;
+  /** Send a pre-resolved ANSI sequence to the terminal */
+  onKeyPress: (sequence: string) => void;
+  /** Toggle a sticky modifier on/off */
+  onModifierToggle: (modifier: ModifierKey) => void;
+  /** Whether each modifier is currently active */
+  ctrlActive: boolean;
+  altActive: boolean;
+  shiftActive: boolean;
+  /** Whether any modifier is active (for resolving keys through modifiers) */
+  anyModifierActive: boolean;
+  /** Resolve a key through active modifiers and clear them */
+  resolveKey: (key: string) => string;
   onImageUpload?: (file: File) => Promise<void>;
   className?: string;
 }
@@ -14,21 +28,23 @@ interface KeyConfig {
   label: string;
   key: string;
   className?: string;
-  isModifier?: boolean;
+  type?: "modifier" | "mode-switch";
+  modifier?: ModifierKey;
 }
 
-const SPECIAL_KEYS: KeyConfig[] = [
+// ── Keys Mode: modifiers, control combos, punctuation ──────────────────────
+
+const KEYS_ROW1: KeyConfig[] = [
   { label: "ESC", key: "\x1b" },
   { label: "TAB", key: "\t" },
-  { label: "CTRL", key: "ctrl", isModifier: true },
-  { label: "ALT", key: "alt", isModifier: true },
-  { label: "↑", key: "\x1b[A" },
-  { label: "↓", key: "\x1b[B" },
-  { label: "←", key: "\x1b[D" },
-  { label: "→", key: "\x1b[C" },
+  { label: "^C", key: "\x03" },
+  { label: "^D", key: "\x04" },
+  { label: "CTRL", key: "ctrl", type: "modifier", modifier: "ctrl" },
+  { label: "ALT", key: "alt", type: "modifier", modifier: "alt" },
+  { label: "SHIFT", key: "shift", type: "modifier", modifier: "shift" },
 ];
 
-const EXTRA_KEYS: KeyConfig[] = [
+const KEYS_ROW2: KeyConfig[] = [
   { label: "|", key: "|" },
   { label: "/", key: "/" },
   { label: "~", key: "~" },
@@ -37,9 +53,36 @@ const EXTRA_KEYS: KeyConfig[] = [
   { label: ":", key: ":" },
 ];
 
-export function MobileKeyboard({ onKeyPress, onImageUpload, className }: MobileKeyboardProps) {
-  const [ctrlActive, setCtrlActive] = useState(false);
-  const [altActive, setAltActive] = useState(false);
+// ── Nav Mode: arrows, navigation, enter keys ───────────────────────────────
+
+const NAV_ROW1: KeyConfig[] = [
+  { label: "↑", key: "\x1b[A" },
+  { label: "HOME", key: "\x1b[H" },
+  { label: "END", key: "\x1b[F" },
+  { label: "ENTER", key: "\r" },
+  { label: "⇧↵", key: "\x1b\r" },
+];
+
+const NAV_ROW2: KeyConfig[] = [
+  { label: "←", key: "\x1b[D" },
+  { label: "↓", key: "\x1b[B" },
+  { label: "→", key: "\x1b[C" },
+  { label: "PGUP", key: "\x1b[5~" },
+  { label: "PGDN", key: "\x1b[6~" },
+];
+
+export function MobileKeyboard({
+  onKeyPress,
+  onModifierToggle,
+  ctrlActive,
+  altActive,
+  shiftActive,
+  anyModifierActive,
+  resolveKey,
+  onImageUpload,
+  className,
+}: MobileKeyboardProps) {
+  const [mode, setMode] = useState<KeyboardMode>("keys");
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -48,7 +91,6 @@ export function MobileKeyboard({ onKeyPress, onImageUpload, className }: MobileK
     async (e: React.ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0];
       if (!file || !onImageUpload) return;
-      // Reset so the same file can be selected again
       e.target.value = "";
 
       setIsUploading(true);
@@ -68,107 +110,131 @@ export function MobileKeyboard({ onKeyPress, onImageUpload, className }: MobileK
 
   const handleKeyPress = useCallback(
     (config: KeyConfig) => {
-      if (config.isModifier) {
-        if (config.key === "ctrl") {
-          setCtrlActive((prev) => !prev);
-        } else if (config.key === "alt") {
-          setAltActive((prev) => !prev);
-        }
+      if (config.type === "modifier" && config.modifier) {
+        onModifierToggle(config.modifier);
         return;
       }
 
-      onKeyPress(config.key, {
-        ctrl: ctrlActive,
-        alt: altActive,
-      });
-
-      // Reset modifiers after keypress
-      if (ctrlActive || altActive) {
-        setCtrlActive(false);
-        setAltActive(false);
+      // Pre-composed sequences (arrows, ⇧↵, PGUP, HOME, etc.) send directly
+      // — don't resolve through modifiers to avoid corrupted double-escapes
+      const isPrecomposed = config.key.length > 1;
+      if (anyModifierActive && !isPrecomposed) {
+        onKeyPress(resolveKey(config.key));
+      } else {
+        onKeyPress(config.key);
       }
     },
-    [ctrlActive, altActive, onKeyPress]
+    [onKeyPress, onModifierToggle, anyModifierActive, resolveKey]
   );
 
-  const renderKey = (config: KeyConfig) => {
-    const isActive =
-      (config.key === "ctrl" && ctrlActive) ||
-      (config.key === "alt" && altActive);
+  const renderKey = useCallback(
+    (config: KeyConfig) => {
+      const isActive =
+        (config.modifier === "ctrl" && ctrlActive) ||
+        (config.modifier === "alt" && altActive) ||
+        (config.modifier === "shift" && shiftActive);
 
-    return (
+      return (
+        <button
+          key={config.label}
+          onClick={() => handleKeyPress(config)}
+          className={cn(
+            "px-2.5 py-1.5 rounded-md text-xs font-medium",
+            "bg-card/80 text-muted-foreground",
+            "active:bg-primary active:text-primary-foreground",
+            "touch-manipulation select-none",
+            "transition-colors duration-100",
+            isActive && "bg-primary text-primary-foreground",
+            config.className
+          )}
+        >
+          {config.label}
+        </button>
+      );
+    },
+    [ctrlActive, altActive, shiftActive, handleKeyPress]
+  );
+
+  const handleModeSwitch = useCallback(() => {
+    setMode((prev) => (prev === "keys" ? "nav" : "keys"));
+  }, []);
+
+  const modeSwitchButton = (
+    <button
+      onClick={handleModeSwitch}
+      className={cn(
+        "px-2.5 py-1.5 rounded-md text-xs font-medium",
+        "bg-muted/60 text-muted-foreground",
+        "active:bg-primary active:text-primary-foreground",
+        "touch-manipulation select-none",
+        "transition-colors duration-100",
+        "border border-border/50"
+      )}
+      aria-label={mode === "keys" ? "Switch to navigation keys" : "Switch to control keys"}
+    >
+      {mode === "keys" ? "NAV" : "KEYS"}
+    </button>
+  );
+
+  const cameraButton = onImageUpload && (
+    <>
+      <div className="w-px bg-border mx-1 self-stretch" />
       <button
-        key={config.label}
-        onClick={() => handleKeyPress(config)}
+        onClick={() => fileInputRef.current?.click()}
+        disabled={isUploading}
         className={cn(
           "px-2.5 py-1.5 rounded-md text-xs font-medium",
           "bg-card/80 text-muted-foreground",
           "active:bg-primary active:text-primary-foreground",
           "touch-manipulation select-none",
           "transition-colors duration-100",
-          isActive && "bg-primary text-primary-foreground",
-          config.className
+          isUploading && "opacity-50",
+          uploadError && "text-destructive"
         )}
+        aria-label={uploadError || "Upload screenshot"}
       >
-        {config.label}
+        {isUploading ? (
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+        ) : (
+          <Camera className="w-3.5 h-3.5" />
+        )}
       </button>
-    );
-  };
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/gif,image/webp"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+    </>
+  );
+
+  const row1 = mode === "keys" ? KEYS_ROW1 : NAV_ROW1;
+  const row2 = mode === "keys" ? KEYS_ROW2 : NAV_ROW2;
 
   return (
     <div
       className={cn(
-        "flex flex-wrap gap-1.5 p-2 bg-popover/95 backdrop-blur-sm border-t border-border",
+        "flex flex-col gap-1.5 p-2 bg-popover/95 backdrop-blur-sm border-t border-border",
         "pb-safe-bottom",
         className
       )}
     >
-      {/* Main special keys */}
-      <div className="flex gap-1.5 flex-wrap">
-        {SPECIAL_KEYS.map(renderKey)}
+      {/* Row 1: main keys + mode switch */}
+      <div className="flex gap-1.5 items-center">
+        <div className="flex gap-1.5 flex-wrap flex-1">
+          {row1.map(renderKey)}
+        </div>
+        {modeSwitchButton}
       </div>
 
-      {/* Separator */}
-      <div className="w-px bg-border mx-1 self-stretch" />
-
-      {/* Extra common characters */}
-      <div className="flex gap-1.5 flex-wrap">
-        {EXTRA_KEYS.map(renderKey)}
+      {/* Row 2: extras/nav + camera */}
+      <div className="flex gap-1.5 items-center">
+        <div className="flex gap-1.5 flex-wrap flex-1">
+          {row2.map(renderKey)}
+        </div>
+        {cameraButton}
       </div>
-
-      {/* Image upload button */}
-      {onImageUpload && (
-        <>
-          <div className="w-px bg-border mx-1 self-stretch" />
-          <button
-            onClick={() => fileInputRef.current?.click()}
-            disabled={isUploading}
-            className={cn(
-              "px-2.5 py-1.5 rounded-md text-xs font-medium",
-              "bg-card/80 text-muted-foreground",
-              "active:bg-primary active:text-primary-foreground",
-              "touch-manipulation select-none",
-              "transition-colors duration-100",
-              isUploading && "opacity-50",
-              uploadError && "text-destructive"
-            )}
-            aria-label={uploadError || "Upload screenshot"}
-          >
-            {isUploading ? (
-              <Loader2 className="w-3.5 h-3.5 animate-spin" />
-            ) : (
-              <Camera className="w-3.5 h-3.5" />
-            )}
-          </button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/jpeg,image/png,image/gif,image/webp"
-            className="hidden"
-            onChange={handleFileChange}
-          />
-        </>
-      )}
     </div>
   );
 }

--- a/src/components/terminal/MobileKeyboard.tsx
+++ b/src/components/terminal/MobileKeyboard.tsx
@@ -176,9 +176,7 @@ export function MobileKeyboard({
     </button>
   );
 
-  const handleCameraClick = useCallback(() => {
-    fileInputRef.current?.click();
-  }, []);
+  const handleCameraClick = useCallback(() => fileInputRef.current?.click(), []);
 
   const cameraButton = onImageUpload && (
     <>

--- a/src/components/terminal/MobileTerminalView.tsx
+++ b/src/components/terminal/MobileTerminalView.tsx
@@ -11,6 +11,7 @@ import { useTerminalWebSocket } from "@/hooks/useTerminalWebSocket";
 import { useTerminalTheme } from "@/contexts/AppearanceContext";
 import { useSessionContext } from "@/contexts/SessionContext";
 import { sendImageToTerminal } from "@/lib/image-upload";
+import { useMobileModifiers } from "@/hooks/useMobileModifiers";
 import { cn } from "@/lib/utils";
 import type { TerminalSession } from "@/types/session";
 import type { ConnectionStatus } from "@/types/terminal";
@@ -205,6 +206,9 @@ export const MobileTerminalView = forwardRef<MobileTerminalViewRef, MobileTermin
     } | null>(null);
     const [isRestarting, setIsRestarting] = useState(false);
 
+    // ── Modifiers ────────────────────────────────────────────────────────────
+    const modifiers = useMobileModifiers();
+
     // ── Theme ─────────────────────────────────────────────────────────────────
     const terminalTheme = useTerminalTheme();
     const { getAgentActivityStatus } = useSessionContext();
@@ -321,23 +325,6 @@ export const MobileTerminalView = forwardRef<MobileTerminalViewRef, MobileTermin
     }, []);
 
     // ── Input handlers ───────────────────────────────────────────────────────
-    const handleMobileKeyPress = useCallback(
-      (key: string, modifiers?: { ctrl?: boolean; alt?: boolean }) => {
-        let data = key;
-        if (modifiers?.ctrl && key.length === 1) {
-          const charCode = key.toUpperCase().charCodeAt(0);
-          if (charCode >= 65 && charCode <= 90) {
-            data = String.fromCharCode(charCode - 64);
-          }
-        }
-        if (modifiers?.alt) {
-          data = "\x1b" + data;
-        }
-        sendInput(data);
-      },
-      [sendInput]
-    );
-
     const handleImageUpload = useCallback(
       async (file: File) => {
         await sendImageToTerminal(file, wsRef.current);
@@ -415,6 +402,9 @@ export const MobileTerminalView = forwardRef<MobileTerminalViewRef, MobileTermin
         <MobileInputBar
           ref={inputBarRef}
           onSubmit={sendInput}
+          onModifiedKeyPress={sendInput}
+          modifierActive={modifiers.anyActive}
+          resolveKey={modifiers.resolveKey}
           onHeightChange={scrollToBottom}
           disabled={status !== "connected"}
           placeholder={session?.terminalType === "agent" ? "Ask the agent..." : "Type a command..."}
@@ -422,7 +412,13 @@ export const MobileTerminalView = forwardRef<MobileTerminalViewRef, MobileTermin
 
         {/* Special keys toolbar */}
         <MobileKeyboard
-          onKeyPress={handleMobileKeyPress}
+          onKeyPress={sendInput}
+          onModifierToggle={modifiers.toggleModifier}
+          ctrlActive={modifiers.ctrlActive}
+          altActive={modifiers.altActive}
+          shiftActive={modifiers.shiftActive}
+          anyModifierActive={modifiers.anyActive}
+          resolveKey={modifiers.resolveKey}
           onImageUpload={handleImageUpload}
         />
 

--- a/src/components/terminal/MobileTerminalView.tsx
+++ b/src/components/terminal/MobileTerminalView.tsx
@@ -329,7 +329,7 @@ export const MobileTerminalView = forwardRef<MobileTerminalViewRef, MobileTermin
       async (file: File) => {
         await sendImageToTerminal(file, wsRef.current);
       },
-      [wsRef]
+      []
     );
 
     // ── Agent restart / close ────────────────────────────────────────────────

--- a/src/components/terminal/TerminalWithKeyboard.tsx
+++ b/src/components/terminal/TerminalWithKeyboard.tsx
@@ -8,6 +8,7 @@ import { VoiceMicButton } from "./VoiceMicButton";
 import { SessionEndedOverlay } from "./SessionEndedOverlay";
 import { ErrorBoundary } from "@/components/common/ErrorBoundary";
 import { useMobile } from "@/hooks/useMobile";
+import { useMobileModifiers } from "@/hooks/useMobileModifiers";
 import { sendImageToTerminal } from "@/lib/image-upload";
 import type { ConnectionStatus } from "@/types/terminal";
 import type { TerminalSession } from "@/types/session";
@@ -87,6 +88,7 @@ export const TerminalWithKeyboard = forwardRef<TerminalWithKeyboardRef, Terminal
   const [exitCode, setExitCode] = useState(0);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>("disconnected");
   const isMobile = useMobile();
+  const modifiers = useMobileModifiers();
 
   useImperativeHandle(ref, () => ({
     focus: () => {
@@ -125,33 +127,15 @@ export const TerminalWithKeyboard = forwardRef<TerminalWithKeyboardRef, Terminal
   }, [onSessionDelete, onSessionExit, exitCode]);
 
   // ── Mobile input handlers ─────────────────────────────────────────────
-  const handleMobileTextSubmit = useCallback((text: string) => {
-    terminalRef.current?.sendInput(text);
+  const sendToTerminal = useCallback((data: string) => {
+    terminalRef.current?.sendInput(data);
   }, []);
-
-  const handleMobileKeyPress = useCallback(
-    (key: string, modifiers?: { ctrl?: boolean; alt?: boolean }) => {
-      let data = key;
-      // Convert Ctrl+letter to ANSI control code (Ctrl+A = 0x01, ..., Ctrl+Z = 0x1A)
-      if (modifiers?.ctrl && key.length === 1) {
-        const charCode = key.toUpperCase().charCodeAt(0);
-        if (charCode >= 65 && charCode <= 90) {
-          data = String.fromCharCode(charCode - 64);
-        }
-      }
-      if (modifiers?.alt) {
-        data = "\x1b" + data;
-      }
-      terminalRef.current?.sendInput(data);
-    },
-    []
-  );
 
   const handleImageUpload = useCallback(
     async (file: File) => {
       await sendImageToTerminal(file, wsRef.current);
     },
-    []
+    [wsRef]
   );
 
   // ── Shared terminal component ─────────────────────────────────────────
@@ -212,13 +196,22 @@ export const TerminalWithKeyboard = forwardRef<TerminalWithKeyboardRef, Terminal
 
         <MobileInputBar
           ref={mobileInputRef}
-          onSubmit={handleMobileTextSubmit}
+          onSubmit={sendToTerminal}
+          onModifiedKeyPress={sendToTerminal}
+          modifierActive={modifiers.anyActive}
+          resolveKey={modifiers.resolveKey}
           disabled={connectionStatus !== "connected"}
           placeholder={session?.terminalType === "agent" ? "Ask the agent..." : "Type a command..."}
         />
 
         <MobileKeyboard
-          onKeyPress={handleMobileKeyPress}
+          onKeyPress={sendToTerminal}
+          onModifierToggle={modifiers.toggleModifier}
+          ctrlActive={modifiers.ctrlActive}
+          altActive={modifiers.altActive}
+          shiftActive={modifiers.shiftActive}
+          anyModifierActive={modifiers.anyActive}
+          resolveKey={modifiers.resolveKey}
           onImageUpload={handleImageUpload}
         />
 

--- a/src/components/terminal/TerminalWithKeyboard.tsx
+++ b/src/components/terminal/TerminalWithKeyboard.tsx
@@ -135,7 +135,7 @@ export const TerminalWithKeyboard = forwardRef<TerminalWithKeyboardRef, Terminal
     async (file: File) => {
       await sendImageToTerminal(file, wsRef.current);
     },
-    [wsRef]
+    []
   );
 
   // ── Shared terminal component ─────────────────────────────────────────

--- a/src/hooks/useMobileModifiers.ts
+++ b/src/hooks/useMobileModifiers.ts
@@ -67,11 +67,14 @@ export function useMobileModifiers(): MobileModifiers {
         return "\x1b\r";
       }
 
-      // Ctrl+letter → ANSI control code (Ctrl+A = 0x01, ..., Ctrl+Z = 0x1A)
+      // Ctrl+key → ANSI control code
+      // Ctrl+A..Z = 0x01..0x1A, Ctrl+@.._ = 0x00..0x1F (includes Ctrl+[ = ESC, Ctrl+\ = SIGQUIT)
       if (ctrlActive && sequence.length === 1) {
-        const charCode = sequence.toUpperCase().charCodeAt(0);
-        if (charCode >= 65 && charCode <= 90) {
+        const charCode = sequence.charCodeAt(0);
+        if (charCode >= 64 && charCode <= 95) {
           sequence = String.fromCharCode(charCode - 64);
+        } else if (charCode >= 97 && charCode <= 122) {
+          sequence = String.fromCharCode(charCode - 96);
         }
       }
 

--- a/src/hooks/useMobileModifiers.ts
+++ b/src/hooks/useMobileModifiers.ts
@@ -1,0 +1,100 @@
+import { useState, useCallback, useRef } from "react";
+
+export type ModifierKey = "ctrl" | "alt" | "shift";
+
+export interface MobileModifiers {
+  ctrlActive: boolean;
+  altActive: boolean;
+  shiftActive: boolean;
+  toggleModifier: (modifier: ModifierKey) => void;
+  clearModifiers: () => void;
+  /** True if any modifier is currently active */
+  anyActive: boolean;
+  /**
+   * Resolve a key string through active modifiers and return the ANSI sequence.
+   * Clears modifiers after resolution. Idempotent within the same activation —
+   * a second call before re-render returns the key unchanged.
+   */
+  resolveKey: (key: string) => string;
+}
+
+/**
+ * Shared modifier state for mobile terminal keyboard.
+ *
+ * Manages CTRL/ALT/SHIFT sticky toggles that are consumed by either
+ * MobileKeyboard (toolbar key presses) or MobileInputBar (text input keystrokes).
+ * Modifiers auto-reset after being consumed.
+ */
+export function useMobileModifiers(): MobileModifiers {
+  const [ctrlActive, setCtrlActive] = useState(false);
+  const [altActive, setAltActive] = useState(false);
+  const [shiftActive, setShiftActive] = useState(false);
+  // Guard against double-consumption in the same event loop tick
+  const consumedRef = useRef(false);
+
+  const toggleModifier = useCallback((modifier: ModifierKey) => {
+    consumedRef.current = false; // new activation resets guard
+    switch (modifier) {
+      case "ctrl":
+        setCtrlActive((prev) => !prev);
+        break;
+      case "alt":
+        setAltActive((prev) => !prev);
+        break;
+      case "shift":
+        setShiftActive((prev) => !prev);
+        break;
+    }
+  }, []);
+
+  const clearModifiers = useCallback(() => {
+    consumedRef.current = true;
+    setCtrlActive(false);
+    setAltActive(false);
+    setShiftActive(false);
+  }, []);
+
+  const resolveKey = useCallback(
+    (key: string): string => {
+      // If modifiers were already consumed this activation, pass key through
+      if (consumedRef.current) return key;
+
+      let sequence = key;
+
+      // Shift+Enter → ESC + CR
+      if (shiftActive && key === "\r") {
+        clearModifiers();
+        return "\x1b\r";
+      }
+
+      // Ctrl+letter → ANSI control code (Ctrl+A = 0x01, ..., Ctrl+Z = 0x1A)
+      if (ctrlActive && sequence.length === 1) {
+        const charCode = sequence.toUpperCase().charCodeAt(0);
+        if (charCode >= 65 && charCode <= 90) {
+          sequence = String.fromCharCode(charCode - 64);
+        }
+      }
+
+      // Alt prefix: ESC + key
+      if (altActive) {
+        sequence = "\x1b" + sequence;
+      }
+
+      clearModifiers();
+      return sequence;
+    },
+    [ctrlActive, altActive, shiftActive, clearModifiers]
+  );
+
+  const anyActive = ctrlActive || altActive || shiftActive;
+
+  return {
+    ctrlActive,
+    altActive,
+    shiftActive,
+    toggleModifier,
+    clearModifiers,
+    anyActive,
+    resolveKey,
+  };
+}


### PR DESCRIPTION
## Summary

- Add switchable **Keys/Nav modes** to the mobile terminal keyboard toolbar
- **Keys mode**: ESC, TAB, ^C, ^D (instant), CTRL/ALT/SHIFT (sticky modifiers), punctuation, camera
- **Nav mode**: arrow keys, HOME/END, PGUP/PGDN, ENTER, SHIFT+ENTER for prompt navigation
- Sticky modifiers work cross-component: tap CTRL in toolbar → type letter in text input → sends control code
- New `useMobileModifiers` hook shares modifier state between MobileKeyboard and MobileInputBar
- Send button now works with empty input (sends `\r` for prompt confirmation)

## Key decisions

- **Custom hook over Context**: Only 2 consumers, always co-located — hook + props is simpler than a Provider
- **Two modes over one large toolbar**: Keeps vertical space minimal while providing full keyboard coverage
- **Pre-composed sequences bypass modifiers**: Arrow keys and ⇧↵ send their ANSI sequences directly to avoid double-escape corruption
- **IME composition guard**: `e.isComposing` check prevents modifier interception during CJK input
- **Ref-based double-consumption guard**: Prevents stale closures from applying modifiers twice in the same event tick

## Test plan

- [ ] Open on mobile device (iOS Safari / Android Chrome)
- [ ] Verify Keys mode: tap ^C sends SIGINT, tap ^D sends EOF
- [ ] Verify sticky CTRL: tap CTRL → type 'a' in text input → sends Ctrl+A (cursor to line start)
- [ ] Verify sticky SHIFT: tap SHIFT → type letter → sends uppercase
- [ ] Verify Nav mode: tap NAV toggle, verify arrow keys, ENTER, ⇧↵ work
- [ ] Verify ENTER in Nav mode sends bare `\r` (confirms prompts)
- [ ] Verify ⇧↵ sends `\x1b\r` (selects AskUserQuestion responses)
- [ ] Verify mode toggle switches between Keys and Nav
- [ ] Verify visual ring indicator appears on text input when modifier is active
- [ ] Verify modifier auto-resets after consuming a keystroke
- [ ] Verify empty send button sends `\r` (no text required)
- [ ] Test with CJK input (IME composition should not be intercepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)