### PR TITLE
feat: auto-select git account per folder and guard against identity leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Git credential suppression**: Automatically configure `gh` as the git credential helper in all terminal sessions, preventing macOS Keychain GUI prompts when agents run `git push/pull/fetch`. Profile sessions get `[credential]` in their `.gitconfig`; non-profile sessions get a session-scoped gitconfig with cleanup on close
+- **Folder git identity override**: Per-folder pseudonymous git name/email in folder preferences, injected as `GIT_AUTHOR_NAME/EMAIL` and `GIT_COMMITTER_NAME/EMAIL` into session environment. Identity inherits child-first through folder hierarchy
+- **Sensitive folder protection**: Mark folders as "sensitive" to require pseudonymous identity for commits and pushes. `isSensitive` flag propagates from any ancestor folder. Git guard API (`POST /api/folders/[id]/git-guard`) evaluates identity risk with `none/warn/block` levels
+- **Git identity guard hook**: rdv CLI `PreToolUse` hook intercepts `git commit` and `git push` Bash commands, calls the git-guard API, and blocks tool use (exit 2) when identity would leak in a sensitive folder
+- **Profile gitconfig migration**: `bun run db:migrate-profile-gitconfigs` adds `[credential]` section to existing profile `.gitconfig` files with idempotency checks
 - **Two-mode mobile keyboard**: Switchable Keys/Nav modes in the mobile terminal toolbar — Keys mode has ESC, TAB, ^C, ^D, CTRL/ALT/SHIFT sticky modifiers; Nav mode has arrow keys, HOME/END, PGUP/PGDN, ENTER, SHIFT+ENTER
 - **Sticky modifier keys**: CTRL/ALT/SHIFT toggles in the toolbar intercept the next keystroke typed in the text input, enabling Ctrl+C, Alt+key, and other combos on mobile
 - **`useMobileModifiers` hook**: Shared modifier state between MobileKeyboard and MobileInputBar with IME composition guard and double-consumption protection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ bun run db:studio    # Open Drizzle Studio
 bun run db:seed      # Seed authorized users
 bun run db:migrate-agents  # One-time agent session migration
 bun run db:migrate-github-accounts  # Backfill GitHub account metadata from existing OAuth accounts
+bun run db:migrate-profile-gitconfigs  # Add [credential] section to existing profile .gitconfig files
 ```
 
 ## Logging (NON-NEGOTIABLE)
@@ -211,7 +212,7 @@ Rust CLI for agent interaction with the terminal server. Agents use `rdv` comman
 | `rdv browser type` | Type text in browser |
 | `rdv browser evaluate` | Evaluate JavaScript |
 | `rdv session git-status` | Get git status for session |
-| `rdv hook pre-tool-use` | Handle PreToolUse hook (report running) |
+| `rdv hook pre-tool-use` | Handle PreToolUse hook (report running, git identity guard) |
 | `rdv hook post-tool-use` | Handle PostToolUse hook (sync tasks from stdin) |
 | `rdv hook pre-compact` | Handle PreCompact hook (report compacting) |
 | `rdv hook notification` | Handle Notification hook (report waiting) |
@@ -539,6 +540,7 @@ React Contexts in `src/contexts/`:
 - `POST /api/folders` - Create folder
 - `PATCH /api/folders/:id` - Update folder
 - `DELETE /api/folders/:id` - Delete folder
+- `POST /api/folders/:id/git-guard` - Evaluate git identity risk for commit/push in folder
 
 ### Preferences
 - `GET /api/preferences` - Get user settings + all folder preferences

--- a/crates/rdv/src/commands/hook.rs
+++ b/crates/rdv/src/commands/hook.rs
@@ -124,6 +124,118 @@ async fn handle_stop(client: &Client, agent: Option<String>, reason: Option<Stri
     Ok(())
 }
 
+/// Check if a git command in a sensitive folder would leak identity.
+/// Reads the PreToolUse payload from stdin, inspects for git commit/push commands,
+/// and calls the git-guard API to evaluate identity risk.
+/// Returns true if the tool use should be blocked.
+async fn check_git_identity_guard(client: &Client) -> bool {
+    // Read stdin to get the tool payload
+    let mut buf = Vec::new();
+    if std::io::stdin().read_to_end(&mut buf).is_err() {
+        return false;
+    }
+
+    let payload: serde_json::Value = match serde_json::from_slice(&buf) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+
+    // Only check Bash tool calls
+    let tool_name = payload.get("tool_name").and_then(|v| v.as_str()).unwrap_or("");
+    if tool_name != "Bash" {
+        return false;
+    }
+
+    let command = payload
+        .get("tool_input")
+        .and_then(|v| v.get("command"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    // Check if the command is a git commit or git push
+    let is_git_commit = command.contains("git commit") || command.contains("git-commit");
+    let is_git_push = command.contains("git push") || command.contains("git-push");
+    if !is_git_commit && !is_git_push {
+        return false;
+    }
+
+    let operation = if is_git_push { "push" } else { "commit" };
+
+    // Need session ID to look up folder
+    let sid = match client.session_id() {
+        Some(s) => s,
+        None => return false,
+    };
+
+    // Get the session's folder ID
+    #[derive(serde::Deserialize)]
+    struct SessionInfo {
+        #[serde(rename = "folderId")]
+        folder_id: Option<String>,
+    }
+
+    let session: SessionInfo = match client.get(&format!("/api/sessions/{sid}")).await {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+
+    let folder_id = match &session.folder_id {
+        Some(id) => id,
+        None => return false,
+    };
+
+    // Read git identity from environment (set by session-service)
+    let proposed_name = std::env::var("GIT_AUTHOR_NAME")
+        .or_else(|_| std::env::var("GIT_COMMITTER_NAME"))
+        .unwrap_or_default();
+    let proposed_email = std::env::var("GIT_AUTHOR_EMAIL")
+        .or_else(|_| std::env::var("GIT_COMMITTER_EMAIL"))
+        .unwrap_or_default();
+
+    // Always call the guard API — the server determines if the folder is sensitive
+    // even when no identity env vars are set (which is the most dangerous case)
+
+    // Call the git-guard API
+    let guard_payload = json!({
+        "proposedName": proposed_name,
+        "proposedEmail": proposed_email,
+        "operation": operation,
+    });
+
+    #[derive(serde::Deserialize)]
+    struct GuardResult {
+        risk: String,
+        reason: Option<String>,
+    }
+
+    let result: GuardResult = match client
+        .post_json(&format!("/api/folders/{folder_id}/git-guard"), &guard_payload)
+        .await
+    {
+        Ok(val) => match serde_json::from_value(val) {
+            Ok(r) => r,
+            Err(_) => return false,
+        },
+        Err(_) => return false,
+    };
+
+    match result.risk.as_str() {
+        "block" => {
+            if let Some(reason) = &result.reason {
+                eprintln!("🛡️  Git identity guard: {reason}");
+            }
+            true
+        }
+        "warn" => {
+            if let Some(reason) = &result.reason {
+                eprintln!("⚠️  Git identity warning: {reason}");
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
 /// Sync task/todo data from stdin to the terminal server.
 /// Drains stdin even if no session ID is available to prevent blocking the caller.
 async fn sync_todos_from_stdin(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
@@ -149,6 +261,9 @@ pub async fn run(args: HookArgs, client: &Client, _human: bool) -> Result<(), Bo
     match args.command {
         HookCommand::PreToolUse => {
             report_status(client, "running").await;
+            if check_git_identity_guard(client).await {
+                std::process::exit(2);
+            }
         }
         HookCommand::PostToolUse => {
             sync_todos_from_stdin(client).await?;

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,6 +11,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rdv hook pre-tool-use",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "PreCompact": [

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "db:seed": "bun run src/db/seed.ts",
     "db:migrate-agents": "bun run scripts/migrate-agent-sessions.ts",
     "db:migrate-github-accounts": "bun run scripts/migrate-github-accounts.ts",
+    "db:migrate-profile-gitconfigs": "bun run scripts/migrate-profile-gitconfigs.ts",
     "terminal:build": "bun build src/server/index.ts --outdir dist-terminal --target node --external node-pty --external better-sqlite3 --sourcemap",
     "electron:build": "tsc -p electron/tsconfig.json",
     "electron:dev": "bun run electron:build && concurrently --kill-others -n next,term,electron -c blue,green,yellow \"bun run dev:next\" \"bun run dev:terminal\" \"electron .\"",

--- a/scripts/migrate-profile-gitconfigs.ts
+++ b/scripts/migrate-profile-gitconfigs.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env bun
+/**
+ * Migration script: Add [credential] section to existing profile .gitconfig files.
+ *
+ * Existing agent profiles have .gitconfig files with only [user] section.
+ * This script adds the [credential] section that configures `gh` as the
+ * git credential helper, suppressing macOS Keychain credential prompts.
+ *
+ * The credential section format:
+ *   [credential]
+ *       helper =                              # Clear inherited chain (e.g., osxkeychain)
+ *       helper = !/path/to/gh auth git-credential  # Set gh as the only helper
+ *
+ * Run with: bun run scripts/migrate-profile-gitconfigs.ts
+ *
+ * Options:
+ *   --dry-run   Show what would be changed without making changes
+ */
+
+import { db } from "../src/db";
+import { agentProfiles } from "../src/db/schema";
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+import { execFile as execFileCb } from "child_process";
+import { promisify } from "util";
+
+const execFile = promisify(execFileCb);
+const dryRun = process.argv.includes("--dry-run");
+
+async function resolveGhPath(): Promise<string> {
+  try {
+    const { stdout } = await execFile("which", ["gh"]);
+    const resolved = stdout.trim();
+    if (resolved) return resolved;
+  } catch {
+    // gh not installed
+  }
+  return "gh";
+}
+
+function buildCredentialSection(ghPath: string): string {
+  return [
+    "[credential]",
+    "\thelper =",
+    `\thelper = !${ghPath} auth git-credential`,
+    "",
+  ].join("\n");
+}
+
+async function main() {
+  console.log("🔄 Adding [credential] section to existing profile .gitconfig files...\n");
+  if (dryRun) console.log("  (dry run mode - no changes will be made)\n");
+
+  // Resolve gh binary path once
+  const ghPath = await resolveGhPath();
+  console.log(`  gh binary path: ${ghPath}\n`);
+
+  const credentialSection = buildCredentialSection(ghPath);
+
+  // Find all profiles
+  const profiles = await db.query.agentProfiles.findMany();
+  console.log(`  Found ${profiles.length} agent profile(s)\n`);
+
+  let migrated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const profile of profiles) {
+    const gitconfigPath = join(profile.configDir, ".gitconfig");
+
+    // Read existing gitconfig
+    let existingContent: string;
+    try {
+      existingContent = await readFile(gitconfigPath, "utf-8");
+    } catch {
+      console.log(`  ✗ ${profile.name} (${profile.id}) - .gitconfig not found (skipping)`);
+      failed++;
+      continue;
+    }
+
+    // Check idempotency: skip if [credential] section already present
+    if (existingContent.includes("[credential]")) {
+      console.log(`  ✓ ${profile.name} (${profile.id}) - already has [credential] (skipping)`);
+      skipped++;
+      continue;
+    }
+
+    if (!dryRun) {
+      // Append credential section to existing gitconfig
+      const newContent = existingContent.trimEnd() + "\n" + credentialSection;
+      await writeFile(gitconfigPath, newContent, { mode: 0o600 });
+    }
+
+    console.log(`  ${dryRun ? "Would migrate" : "✓ Migrated"} ${profile.name} (${profile.id})`);
+    migrated++;
+  }
+
+  console.log(`\n📊 Results:`);
+  console.log(`  Migrated: ${migrated}`);
+  console.log(`  Skipped (already done): ${skipped}`);
+  console.log(`  Failed: ${failed}`);
+}
+
+main().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/src/app/api/folders/[id]/git-guard/route.ts
+++ b/src/app/api/folders/[id]/git-guard/route.ts
@@ -1,0 +1,88 @@
+/**
+ * POST /api/folders/[id]/git-guard
+ *
+ * Evaluate whether a proposed git operation (commit or push) is safe
+ * from an identity perspective in the context of this folder.
+ *
+ * Used by the rdv CLI PreToolUse hook to warn or block when an agent
+ * is about to commit/push with an identity that doesn't match the
+ * folder's configured pseudonymous identity.
+ *
+ * Request body:
+ *   - proposedName: string - The git user.name that would be used
+ *   - proposedEmail: string - The git user.email that would be used
+ *   - operation: "commit" | "push" (default: "commit")
+ *
+ * Response:
+ *   - risk: "none" | "warn" | "block"
+ *   - reason: string | null
+ *   - isSensitive: boolean
+ *   - configuredIdentity: { name, email } | null
+ */
+
+import { NextResponse } from "next/server";
+import { withApiAuth, errorResponse } from "@/lib/api";
+import { getFolderGitIdentity } from "@/services/preferences-service";
+import { githubAccountRepository, folderRepository } from "@/infrastructure/container";
+import { FolderGitIdentity } from "@/domain/value-objects/FolderGitIdentity";
+import { GitIdentityGuard } from "@/domain/value-objects/GitIdentityGuard";
+
+export const POST = withApiAuth(async (request, { userId, params }) => {
+  const folderId = params!.id;
+
+  // Verify folder ownership
+  const folder = await folderRepository.findById(folderId, userId);
+  if (!folder) {
+    return errorResponse("Folder not found", 404);
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+  const proposedName = (body.proposedName as string) || "";
+  const proposedEmail = (body.proposedEmail as string) || "";
+  const operation = (body.operation as "commit" | "push") || "commit";
+
+  if (operation !== "commit" && operation !== "push") {
+    return errorResponse("operation must be 'commit' or 'push'", 400);
+  }
+
+  // Resolve folder's git identity and sensitivity
+  const gitIdentityResult = await getFolderGitIdentity(userId, folderId);
+
+  // Resolve bound GitHub account for context
+  let boundAccountLogin: string | null = null;
+  try {
+    const account = await githubAccountRepository.findByFolder(folderId, userId);
+    boundAccountLogin = account?.login ?? null;
+  } catch {
+    // Non-critical — proceed without account context
+  }
+
+  const folderIdentity = FolderGitIdentity.create({
+    folderId,
+    ...gitIdentityResult,
+    boundAccountLogin,
+  });
+
+  const result = GitIdentityGuard.evaluate(
+    folderIdentity,
+    proposedName,
+    proposedEmail,
+    operation
+  );
+
+  return NextResponse.json({
+    ...result,
+    isSensitive: gitIdentityResult.isSensitive,
+    configuredIdentity: folderIdentity.hasIdentity()
+      ? {
+          name: gitIdentityResult.gitIdentityName,
+          email: gitIdentityResult.gitIdentityEmail,
+        }
+      : null,
+  });
+});

--- a/src/app/api/preferences/folders/[folderId]/route.ts
+++ b/src/app/api/preferences/folders/[folderId]/route.ts
@@ -42,6 +42,9 @@ export const PUT = withAuth(async (request, { userId, params }) => {
     "environmentVars",
     "pinnedFiles",
     "defaultAgentProvider",
+    "gitIdentityName",
+    "gitIdentityEmail",
+    "isSensitive",
   ];
 
   const filteredUpdates: Record<string, unknown> = {};

--- a/src/application/ports/SessionGitConfigGateway.ts
+++ b/src/application/ports/SessionGitConfigGateway.ts
@@ -1,0 +1,30 @@
+/**
+ * SessionGitConfigGateway - Port for session-scoped git configuration file I/O.
+ *
+ * Abstracts the filesystem operations for writing and cleaning up
+ * session-scoped .gitconfig files used by non-profile terminal sessions.
+ */
+
+export interface SessionGitConfigGateway {
+  /**
+   * Write a session-scoped .gitconfig file.
+   * @param sessionId - The session UUID (used as filename)
+   * @param content - The gitconfig content to write
+   * @returns The absolute path to the written file
+   */
+  writeSessionGitConfig(sessionId: string, content: string): Promise<string>;
+
+  /**
+   * Remove a session-scoped .gitconfig file.
+   * Silent if the file does not exist.
+   * @param sessionId - The session UUID
+   */
+  removeSessionGitConfig(sessionId: string): Promise<void>;
+
+  /**
+   * Resolve the absolute path to the gh CLI binary.
+   * Result is cached after the first successful resolution.
+   * Falls back to bare "gh" if the binary cannot be found.
+   */
+  resolveGhBinaryPath(): Promise<string>;
+}

--- a/src/application/services/GitCredentialManager.ts
+++ b/src/application/services/GitCredentialManager.ts
@@ -1,0 +1,81 @@
+/**
+ * GitCredentialManager - Application service for git credential suppression.
+ *
+ * Orchestrates the setup and teardown of git credential configuration
+ * for terminal sessions. Handles two modes:
+ *
+ * 1. **Profile sessions**: The profile's .gitconfig already has [credential]
+ *    section from initialization. Only GIT_TERMINAL_PROMPT=0 is injected.
+ *
+ * 2. **Non-profile sessions**: A session-scoped .gitconfig is written to
+ *    ~/.remote-dev/session-gitconfigs/{sessionId}.gitconfig with the gh
+ *    credential helper configured. GIT_CONFIG_GLOBAL points to it.
+ *
+ * The gh credential helper reads GH_CONFIG_DIR (set by GitHubAccountEnvironment)
+ * to authenticate as the correct GitHub account automatically.
+ */
+
+import { GitCredentialConfig } from "@/domain/value-objects/GitCredentialConfig";
+import { TmuxEnvironment } from "@/domain/value-objects/TmuxEnvironment";
+import type { SessionGitConfigGateway } from "@/application/ports/SessionGitConfigGateway";
+
+export class GitCredentialManager {
+  private credentialConfig: GitCredentialConfig | null = null;
+
+  constructor(private readonly gateway: SessionGitConfigGateway) {}
+
+  /**
+   * Build the environment variables to inject for credential suppression.
+   *
+   * For profile sessions: returns only GIT_TERMINAL_PROMPT=0
+   * (the profile's .gitconfig already has [credential] configured).
+   *
+   * For non-profile sessions: writes a session-scoped .gitconfig with the
+   * gh credential helper and returns GIT_TERMINAL_PROMPT=0 + GIT_CONFIG_GLOBAL.
+   */
+  async buildSessionEnv(
+    sessionId: string,
+    hasProfile: boolean
+  ): Promise<TmuxEnvironment> {
+    const config = await this.getOrCreateConfig();
+
+    if (hasProfile) {
+      return config.toBaseEnvironment();
+    }
+
+    // Non-profile session: write a session-scoped gitconfig
+    const content = config.toGitConfigSection();
+    const configPath = await this.gateway.writeSessionGitConfig(
+      sessionId,
+      content
+    );
+    return config.toSessionEnvironment(configPath);
+  }
+
+  /**
+   * Generate the [credential] section content for a profile's .gitconfig.
+   * Called during profile initialization and git identity updates.
+   */
+  async getCredentialSection(): Promise<string> {
+    const config = await this.getOrCreateConfig();
+    return config.toGitConfigSection();
+  }
+
+  /**
+   * Clean up the session-scoped .gitconfig on session close.
+   */
+  async cleanupSession(sessionId: string): Promise<void> {
+    await this.gateway.removeSessionGitConfig(sessionId);
+  }
+
+  /**
+   * Lazily resolve the gh binary path and create the config.
+   */
+  private async getOrCreateConfig(): Promise<GitCredentialConfig> {
+    if (!this.credentialConfig) {
+      const ghPath = await this.gateway.resolveGhBinaryPath();
+      this.credentialConfig = GitCredentialConfig.create(ghPath);
+    }
+    return this.credentialConfig;
+  }
+}

--- a/src/components/preferences/FolderPreferencesModal.tsx
+++ b/src/components/preferences/FolderPreferencesModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Folder, RotateCcw, Github, FolderGit2, Loader2, Terminal, AlertTriangle, Settings, Palette, Check, Download, FolderOpen, Fingerprint, FileText, ChevronDown, ChevronRight } from "lucide-react";
+import { Folder, RotateCcw, Github, FolderGit2, Loader2, Terminal, AlertTriangle, Settings, Palette, Check, Download, FolderOpen, Fingerprint, FileText, ChevronDown, ChevronRight, Shield } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -14,6 +14,7 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -499,7 +500,14 @@ export function FolderPreferencesModal({
   };
 
   // Check if any settings in a tab are overridden
-  const hasGeneralOverrides = isOverridden("defaultWorkingDirectory") || isOverridden("defaultShell") || isOverridden("startupCommand") || isOverridden("defaultAgentProvider");
+  const hasGeneralOverrides =
+    isOverridden("defaultWorkingDirectory") ||
+    isOverridden("defaultShell") ||
+    isOverridden("startupCommand") ||
+    isOverridden("defaultAgentProvider") ||
+    isOverridden("gitIdentityName") ||
+    isOverridden("gitIdentityEmail") ||
+    getValue("isSensitive");
   const hasAppearanceOverrides = isOverridden("theme") || isOverridden("fontSize") || isOverridden("fontFamily");
   const hasRepoOverrides = isOverridden("githubRepoId") || isOverridden("localRepoPath");
   const hasEnvOverrides = isOverridden("environmentVars");
@@ -750,6 +758,84 @@ export function FolderPreferencesModal({
                   </div>
                 );
               })()}
+
+              {/* Git Identity Section */}
+              <div className="pt-2 border-t border-border space-y-3">
+                <div className="flex items-center gap-2">
+                  <Shield className="w-4 h-4 text-muted-foreground" />
+                  <Label className="text-muted-foreground font-medium">Git Identity</Label>
+                </div>
+
+                {/* Sensitive Toggle */}
+                <div className="flex items-center justify-between p-3 rounded-lg bg-muted/50 border border-border">
+                  <div className="space-y-0.5">
+                    <Label className="text-foreground">Sensitive Folder</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Require pseudonymous identity for commits and pushes.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={getValue("isSensitive") ?? false}
+                    onCheckedChange={(checked) => setValue("isSensitive", checked)}
+                  />
+                </div>
+
+                {/* Git Identity Name */}
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-muted-foreground">Commit Author Name</Label>
+                    {isOverridden("gitIdentityName") && (
+                      <span className="text-xs text-primary">Overridden</span>
+                    )}
+                  </div>
+                  <Input
+                    value={getValue("gitIdentityName") || ""}
+                    onChange={(e) =>
+                      setValue("gitIdentityName", e.target.value || null)
+                    }
+                    placeholder="Pseudonymous name for git commits"
+                    className={cn(
+                      "bg-card border-border text-foreground placeholder:text-muted-foreground",
+                      isOverridden("gitIdentityName") && "border-primary/50"
+                    )}
+                  />
+                </div>
+
+                {/* Git Identity Email */}
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-muted-foreground">Commit Author Email</Label>
+                    {isOverridden("gitIdentityEmail") && (
+                      <span className="text-xs text-primary">Overridden</span>
+                    )}
+                  </div>
+                  <Input
+                    value={getValue("gitIdentityEmail") || ""}
+                    onChange={(e) =>
+                      setValue("gitIdentityEmail", e.target.value || null)
+                    }
+                    placeholder="Pseudonymous email for git commits"
+                    className={cn(
+                      "bg-card border-border text-foreground placeholder:text-muted-foreground",
+                      isOverridden("gitIdentityEmail") && "border-primary/50"
+                    )}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Override git author identity for sessions in this folder.
+                    {getValue("isSensitive") && " Required when folder is marked sensitive."}
+                  </p>
+                </div>
+
+                {/* Validation warning */}
+                {getValue("isSensitive") && !getValue("gitIdentityName") && !getValue("gitIdentityEmail") && (
+                  <div className="flex items-center gap-2 p-2 rounded-md bg-yellow-500/10 border border-yellow-500/20">
+                    <AlertTriangle className="w-4 h-4 text-yellow-500 shrink-0" />
+                    <p className="text-xs text-yellow-500">
+                      Sensitive folder requires a pseudonymous git identity. Configure name and email above.
+                    </p>
+                  </div>
+                )}
+              </div>
             </TabsContent>
 
             {/* Appearance Tab */}

--- a/src/components/preferences/FolderPreferencesModal.tsx
+++ b/src/components/preferences/FolderPreferencesModal.tsx
@@ -827,7 +827,7 @@ export function FolderPreferencesModal({
                 </div>
 
                 {/* Validation warning */}
-                {getValue("isSensitive") && !getValue("gitIdentityName") && !getValue("gitIdentityEmail") && (
+                {getValue("isSensitive") && (!getValue("gitIdentityName") || !getValue("gitIdentityEmail")) && (
                   <div className="flex items-center gap-2 p-2 rounded-md bg-yellow-500/10 border border-yellow-500/20">
                     <AlertTriangle className="w-4 h-4 text-yellow-500 shrink-0" />
                     <p className="text-xs text-yellow-500">

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -208,6 +208,12 @@ export const folderPreferences = sqliteTable(
     environmentVars: text("environment_vars"),
     // Pinned files as JSON: PinnedFile[]
     pinnedFiles: text("pinned_files"),
+    // Git identity override for pseudonymous/anonymous commits
+    // When set, these are injected as GIT_AUTHOR_NAME/EMAIL + GIT_COMMITTER_NAME/EMAIL
+    gitIdentityName: text("git_identity_name"),
+    gitIdentityEmail: text("git_identity_email"),
+    // Sensitive folder flag — requires pseudonymous identity, enables push protection
+    isSensitive: integer("is_sensitive", { mode: "boolean" }).default(false),
     createdAt: integer("created_at", { mode: "timestamp_ms" })
       .notNull()
       .$defaultFn(() => new Date()),

--- a/src/domain/value-objects/FolderGitIdentity.ts
+++ b/src/domain/value-objects/FolderGitIdentity.ts
@@ -1,0 +1,61 @@
+/**
+ * FolderGitIdentity - Value object for a folder's git identity configuration.
+ *
+ * Represents the pseudonymous/anonymous git identity override configured
+ * for a specific folder. When a folder is marked as "sensitive", commits
+ * and pushes are subject to identity validation to prevent doxxing.
+ */
+
+import { InvalidValueError } from "../errors/DomainError";
+
+export interface FolderGitIdentityOptions {
+  folderId: string;
+  gitIdentityName: string | null;
+  gitIdentityEmail: string | null;
+  isSensitive: boolean;
+  boundAccountLogin: string | null;
+}
+
+export class FolderGitIdentity {
+  readonly folderId: string;
+  readonly gitIdentityName: string | null;
+  readonly gitIdentityEmail: string | null;
+  readonly isSensitive: boolean;
+  readonly boundAccountLogin: string | null;
+
+  private constructor(options: FolderGitIdentityOptions) {
+    this.folderId = options.folderId;
+    this.gitIdentityName = options.gitIdentityName;
+    this.gitIdentityEmail = options.gitIdentityEmail;
+    this.isSensitive = options.isSensitive;
+    this.boundAccountLogin = options.boundAccountLogin;
+  }
+
+  static create(options: FolderGitIdentityOptions): FolderGitIdentity {
+    if (!options.folderId) {
+      throw new InvalidValueError(
+        "FolderGitIdentity.folderId",
+        options.folderId,
+        "Must be a non-empty string"
+      );
+    }
+    return new FolderGitIdentity(options);
+  }
+
+  /**
+   * Check if this folder has a pseudonymous identity configured.
+   */
+  hasIdentity(): boolean {
+    return !!(this.gitIdentityName || this.gitIdentityEmail);
+  }
+
+  /**
+   * Check if the identity configuration is valid for a sensitive folder.
+   * A sensitive folder requires both name and email to be set.
+   */
+  isValidForSensitive(): boolean {
+    if (!this.isSensitive) return true;
+    return !!(this.gitIdentityName && this.gitIdentityEmail);
+  }
+
+}

--- a/src/domain/value-objects/GitCredentialConfig.ts
+++ b/src/domain/value-objects/GitCredentialConfig.ts
@@ -1,0 +1,89 @@
+/**
+ * GitCredentialConfig - Value object for git credential helper configuration.
+ *
+ * Encapsulates the configuration needed to suppress git credential prompts
+ * and route authentication through the gh CLI credential helper.
+ *
+ * The key pattern is:
+ *   [credential]
+ *       helper =                              # Clear inherited chain (e.g., osxkeychain)
+ *       helper = !/path/to/gh auth git-credential  # Set gh as the only helper
+ *
+ * The empty `helper =` clears the inherited credential helper chain (including
+ * macOS osxkeychain), and the second line sets gh as the sole helper. This is
+ * the same pattern used by `gh auth setup-git`.
+ *
+ * When combined with GH_CONFIG_DIR (set by GitHubAccountEnvironment), the gh
+ * credential helper automatically authenticates as the correct GitHub account.
+ */
+
+import { InvalidValueError } from "../errors/DomainError";
+import { TmuxEnvironment } from "./TmuxEnvironment";
+
+export class GitCredentialConfig {
+  private constructor(private readonly ghBinaryPath: string) {}
+
+  /**
+   * Create a GitCredentialConfig with a resolved gh binary path.
+   * @throws InvalidValueError if ghBinaryPath is empty
+   */
+  static create(ghBinaryPath: string): GitCredentialConfig {
+    if (!ghBinaryPath || typeof ghBinaryPath !== "string") {
+      throw new InvalidValueError(
+        "GitCredentialConfig.ghBinaryPath",
+        ghBinaryPath,
+        "Must be a non-empty string"
+      );
+    }
+    return new GitCredentialConfig(ghBinaryPath);
+  }
+
+  /**
+   * Generate the [credential] section for a .gitconfig file.
+   *
+   * The empty `helper =` line clears the inherited credential helper chain
+   * (including macOS osxkeychain), ensuring only the gh helper is used.
+   */
+  toGitConfigSection(): string {
+    return [
+      "[credential]",
+      "\thelper =",
+      `\thelper = !${this.ghBinaryPath} auth git-credential`,
+      "",
+    ].join("\n");
+  }
+
+  /**
+   * Base environment variables to inject into every session.
+   * Prevents git from prompting for credentials interactively.
+   */
+  toBaseEnvironment(): TmuxEnvironment {
+    return TmuxEnvironment.create({
+      GIT_TERMINAL_PROMPT: "0",
+    });
+  }
+
+  /**
+   * Full environment for a non-profile session.
+   * Includes GIT_CONFIG_GLOBAL pointing to a session-scoped gitconfig.
+   */
+  toSessionEnvironment(gitconfigPath: string): TmuxEnvironment {
+    if (!gitconfigPath?.startsWith("/")) {
+      throw new InvalidValueError(
+        "GitCredentialConfig.gitconfigPath",
+        gitconfigPath,
+        "Must be an absolute path"
+      );
+    }
+
+    return this.toBaseEnvironment().with("GIT_CONFIG_GLOBAL", gitconfigPath);
+  }
+
+  getGhBinaryPath(): string {
+    return this.ghBinaryPath;
+  }
+
+  equals(other: GitCredentialConfig): boolean {
+    return this.ghBinaryPath === other.ghBinaryPath;
+  }
+}

--- a/src/domain/value-objects/GitIdentityGuard.ts
+++ b/src/domain/value-objects/GitIdentityGuard.ts
@@ -1,0 +1,97 @@
+/**
+ * GitIdentityGuard - Pure domain rule for evaluating commit identity risks.
+ *
+ * Evaluates whether a proposed commit author identity would leak the user's
+ * real identity in a sensitive folder context. Returns a risk level and
+ * human-readable reason.
+ *
+ * Risk levels:
+ * - "none": No identity concern — proceed normally
+ * - "warn": Identity mismatch detected — advise the user
+ * - "block": Sensitive folder without pseudonymous identity configured — block push
+ */
+
+import { FolderGitIdentity } from "./FolderGitIdentity";
+
+export type IdentityRisk = "none" | "warn" | "block";
+
+export interface IdentityGuardResult {
+  risk: IdentityRisk;
+  reason: string | null;
+}
+
+export class GitIdentityGuard {
+  /**
+   * Evaluate whether a proposed git operation is safe from an identity perspective.
+   *
+   * @param identity - The folder's git identity configuration
+   * @param proposedName - The git user.name that would be used for the commit
+   * @param proposedEmail - The git user.email that would be used for the commit
+   * @param operation - The git operation being performed ("commit" or "push")
+   */
+  static evaluate(
+    identity: FolderGitIdentity,
+    proposedName: string,
+    proposedEmail: string,
+    operation: "commit" | "push" = "commit"
+  ): IdentityGuardResult {
+    // Non-sensitive folders have no restrictions
+    if (!identity.isSensitive) {
+      return { risk: "none", reason: null };
+    }
+
+    // Sensitive folder without pseudonymous identity configured (or incomplete)
+    if (!identity.isValidForSensitive()) {
+      const detail = !identity.hasIdentity()
+        ? "no pseudonymous git identity is configured"
+        : "the configured identity is incomplete (both name and email are required)";
+
+      if (operation === "push") {
+        return {
+          risk: "block",
+          reason:
+            `This folder is marked as sensitive but ${detail}. ` +
+            "Configure a git identity in folder preferences before pushing.",
+        };
+      }
+      return {
+        risk: "warn",
+        reason:
+          `This folder is marked as sensitive but ${detail}. ` +
+          "Commits may use your real identity. Configure a git identity in folder preferences.",
+      };
+    }
+
+    // Build mismatch descriptions for the proposed identity vs configured pseudonym
+    const mismatches: string[] = [];
+    if (identity.gitIdentityName && proposedName !== identity.gitIdentityName) {
+      mismatches.push(
+        `name "${proposedName}" does not match configured "${identity.gitIdentityName}"`
+      );
+    }
+    if (identity.gitIdentityEmail && proposedEmail !== identity.gitIdentityEmail) {
+      mismatches.push(
+        `email "${proposedEmail}" does not match configured "${identity.gitIdentityEmail}"`
+      );
+    }
+
+    if (mismatches.length > 0) {
+      const detail = `Identity mismatch in sensitive folder: ${mismatches.join("; ")}.`;
+
+      if (operation === "push") {
+        return {
+          risk: "block",
+          reason: `${detail} This may leak your real identity. Update your git config or folder preferences.`,
+        };
+      }
+
+      return {
+        risk: "warn",
+        reason: `${detail} This may leak your real identity.`,
+      };
+    }
+
+    // Identity matches — all clear
+    return { risk: "none", reason: null };
+  }
+}

--- a/src/infrastructure/container.ts
+++ b/src/infrastructure/container.ts
@@ -16,6 +16,7 @@ import { TmuxGatewayImpl } from "./external/tmux/TmuxGatewayImpl";
 import { WorktreeGatewayImpl } from "./external/worktree/WorktreeGatewayImpl";
 import { GitHubIssueGatewayImpl } from "./external/github/GitHubIssueGatewayImpl";
 import { GhCliConfigGatewayImpl } from "./external/github/GhCliConfigGatewayImpl";
+import { SessionGitConfigGatewayImpl } from "./external/git/SessionGitConfigGatewayImpl";
 import { SystemEnvironmentGateway } from "./external/environment/SystemEnvironmentGateway";
 import type { SessionRepository } from "@/application/ports/SessionRepository";
 import type { SessionFolderQueryPort } from "@/application/ports/SessionFolderQueryPort";
@@ -27,6 +28,8 @@ import type { GitHubIssueRepository } from "@/application/ports/GitHubIssueRepos
 import type { GitHubIssueGateway } from "@/application/ports/GitHubIssueGateway";
 import type { GitHubAccountRepository } from "@/application/ports/GitHubAccountRepository";
 import type { GhCliConfigGateway } from "@/application/ports/GhCliConfigGateway";
+import type { SessionGitConfigGateway } from "@/application/ports/SessionGitConfigGateway";
+import { GitCredentialManager } from "@/application/services/GitCredentialManager";
 
 // Session Use Cases
 import { CreateSessionUseCase } from "@/application/use-cases/session/CreateSessionUseCase";
@@ -168,6 +171,10 @@ export const githubIssueGateway: GitHubIssueGateway = new GitHubIssueGatewayImpl
 export const environmentGateway: EnvironmentGateway = new SystemEnvironmentGateway();
 
 export const ghCliConfigGateway: GhCliConfigGateway = new GhCliConfigGatewayImpl();
+
+export const sessionGitConfigGateway: SessionGitConfigGateway = new SessionGitConfigGatewayImpl();
+
+export const gitCredentialManager = new GitCredentialManager(sessionGitConfigGateway);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Use Case Instances
@@ -471,6 +478,7 @@ export interface Container {
   worktreeGateway: WorktreeGateway;
   githubIssueGateway: GitHubIssueGateway;
   ghCliConfigGateway: GhCliConfigGateway;
+  sessionGitConfigGateway: SessionGitConfigGateway;
   environmentGateway: EnvironmentGateway;
   logRepository: LogRepository;
   releaseRepository: ReleaseRepository;
@@ -495,6 +503,7 @@ export const defaultContainer: Container = {
   worktreeGateway,
   githubIssueGateway,
   ghCliConfigGateway,
+  sessionGitConfigGateway,
   environmentGateway,
   logRepository,
   releaseRepository,

--- a/src/infrastructure/external/git/SessionGitConfigGatewayImpl.ts
+++ b/src/infrastructure/external/git/SessionGitConfigGatewayImpl.ts
@@ -1,0 +1,55 @@
+/**
+ * SessionGitConfigGatewayImpl - Manages session-scoped git configuration files.
+ *
+ * Writes lightweight .gitconfig files for non-profile sessions to suppress
+ * credential prompts and configure the gh credential helper. Files are stored
+ * in ~/.remote-dev/session-gitconfigs/{sessionId}.gitconfig and cleaned up
+ * when the session closes.
+ */
+
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import { getSessionGitconfigsDir } from "@/lib/paths";
+import type { SessionGitConfigGateway } from "@/application/ports/SessionGitConfigGateway";
+
+const execFile = promisify(execFileCb);
+
+export class SessionGitConfigGatewayImpl implements SessionGitConfigGateway {
+  private cachedGhPath: string | null = null;
+
+  async writeSessionGitConfig(
+    sessionId: string,
+    content: string
+  ): Promise<string> {
+    const dir = getSessionGitconfigsDir();
+    await mkdir(dir, { recursive: true });
+    const configPath = join(dir, `${sessionId}.gitconfig`);
+    await writeFile(configPath, content, { mode: 0o600 });
+    return configPath;
+  }
+
+  async removeSessionGitConfig(sessionId: string): Promise<void> {
+    const configPath = join(getSessionGitconfigsDir(), `${sessionId}.gitconfig`);
+    await rm(configPath, { force: true });
+  }
+
+  async resolveGhBinaryPath(): Promise<string> {
+    if (this.cachedGhPath) return this.cachedGhPath;
+
+    try {
+      const { stdout } = await execFile("which", ["gh"]);
+      const resolved = stdout.trim();
+      if (resolved) {
+        this.cachedGhPath = resolved;
+        return resolved;
+      }
+    } catch {
+      // gh not installed — fall back to bare command
+    }
+
+    this.cachedGhPath = "gh";
+    return "gh";
+  }
+}

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -11,6 +11,7 @@
  * ├── profiles/          # Agent profiles
  * ├── projects/          # Worktree storage
  * ├── repos/             # Cloned repositories
+ * ├── session-gitconfigs/ # Session-scoped gitconfigs for non-profile sessions
  * ├── recordings/        # Session recordings
  * ├── server/            # Server runtime files
  * └── rdv/               # rdv CLI runtime files (.local-key)
@@ -116,6 +117,15 @@ export function getGhConfigsDir(): string {
 }
 
 /**
+ * Get the session-scoped gitconfig directory path.
+ * Non-profile sessions get a lightweight .gitconfig here for credential suppression.
+ * Files are named {sessionId}.gitconfig and cleaned up on session close.
+ */
+export function getSessionGitconfigsDir(): string {
+  return join(getDataDir(), "session-gitconfigs");
+}
+
+/**
  * Get the session recordings directory path.
  */
 export function getRecordingsDir(): string {
@@ -204,6 +214,7 @@ export function ensureDataDirectories(): void {
     getProjectsDir(),
     getReposDir(),
     getGhConfigsDir(),
+    getSessionGitconfigsDir(),
     getRecordingsDir(),
     getServerDir(),
     getRdvDir(),
@@ -250,6 +261,9 @@ export const AppPaths = {
   },
   get ghConfigsDir() {
     return getGhConfigsDir();
+  },
+  get sessionGitconfigsDir() {
+    return getSessionGitconfigsDir();
   },
   get recordingsDir() {
     return getRecordingsDir();

--- a/src/services/agent-profile-service.ts
+++ b/src/services/agent-profile-service.ts
@@ -30,6 +30,7 @@ import { execFileNoThrow } from "@/lib/exec";
 import { safeJsonParse } from "@/lib/utils";
 import { getProfilesDir } from "@/lib/paths";
 import { ProfileIsolation } from "@/domain/value-objects/ProfileIsolation";
+import { gitCredentialManager } from "@/infrastructure/container";
 import type {
   AgentProfile,
   CreateAgentProfileInput,
@@ -44,6 +45,19 @@ import type {
 
 // Profile base directory - use centralized path configuration
 const getProfilesBaseDir = () => getProfilesDir();
+
+/**
+ * Resolve the git [credential] section for profile .gitconfig files.
+ * Returns an empty string if the credential manager is unavailable.
+ */
+async function getCredentialSection(): Promise<string> {
+  try {
+    return await gitCredentialManager.getCredentialSection();
+  } catch (error) {
+    log.warn("Failed to get credential section for profile gitconfig", { error: String(error) });
+    return "";
+  }
+}
 
 /**
  * Sanitize a git config value to prevent injection attacks.
@@ -314,11 +328,12 @@ export async function initializeProfileDirectory(
     await mkdir(dir, { recursive: true });
   }
 
-  // Create default .gitconfig
+  // Create default .gitconfig with credential helper to suppress macOS keychain prompts
+  const credentialSection = await getCredentialSection();
   const gitConfig = `[user]
 \tname =
 \temail =
-`;
+${credentialSection}`;
   await writeFile(join(configDir, ".gitconfig"), gitConfig);
 
   // Create default CLAUDE.md if Claude provider
@@ -504,12 +519,15 @@ export async function setProfileGitIdentity(
       ? sanitizeGitConfigValue(identity.gpgKeyId)
       : null;
 
+    // Preserve credential helper section when rewriting gitconfig
+    const credentialSection = await getCredentialSection();
+
     const gitConfig = `[user]
 \tname = ${safeName}
 \temail = ${safeEmail}
 ${safeGpgKey ? `\tsigningkey = ${safeGpgKey}` : ""}
 ${safeGpgKey ? "[commit]\n\tgpgsign = true" : ""}
-`;
+${credentialSection}`;
     await writeFile(join(profile.configDir, ".gitconfig"), gitConfig);
   }
 }

--- a/src/services/preferences-service.ts
+++ b/src/services/preferences-service.ts
@@ -408,6 +408,64 @@ export async function getEnvironmentForSession(
   return resolved?.variables ?? null;
 }
 
+/**
+ * Resolve git identity override for a folder.
+ *
+ * Walks the folder ancestry chain to find the nearest folder with a git identity
+ * configured (child overrides parent). Returns the identity as env vars that
+ * override GIT_AUTHOR_NAME/EMAIL and GIT_COMMITTER_NAME/EMAIL.
+ *
+ * Also returns the sensitive flag from the nearest folder that has it set.
+ */
+export async function getFolderGitIdentity(
+  userId: string,
+  folderId?: string | null
+): Promise<{
+  env: Record<string, string> | null;
+  isSensitive: boolean;
+  gitIdentityName: string | null;
+  gitIdentityEmail: string | null;
+}> {
+  if (!folderId) {
+    return { env: null, isSensitive: false, gitIdentityName: null, gitIdentityEmail: null };
+  }
+
+  const chain = await getFolderPreferencesChain(folderId, userId);
+
+  // Any ancestor marking the subtree sensitive propagates to all descendants
+  const isSensitive = chain.some((prefs) => prefs.isSensitive);
+
+  // Walk child-first (most specific) for identity override — child overrides parent
+  let gitIdentityName: string | null = null;
+  let gitIdentityEmail: string | null = null;
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const prefs = chain[i];
+    if (prefs.gitIdentityName && !gitIdentityName) {
+      gitIdentityName = prefs.gitIdentityName;
+    }
+    if (prefs.gitIdentityEmail && !gitIdentityEmail) {
+      gitIdentityEmail = prefs.gitIdentityEmail;
+    }
+    if (gitIdentityName && gitIdentityEmail) break;
+  }
+
+  if (!gitIdentityName && !gitIdentityEmail) {
+    return { env: null, isSensitive, gitIdentityName: null, gitIdentityEmail: null };
+  }
+
+  const env: Record<string, string> = {};
+  if (gitIdentityName) {
+    env.GIT_AUTHOR_NAME = gitIdentityName;
+    env.GIT_COMMITTER_NAME = gitIdentityName;
+  }
+  if (gitIdentityEmail) {
+    env.GIT_AUTHOR_EMAIL = gitIdentityEmail;
+    env.GIT_COMMITTER_EMAIL = gitIdentityEmail;
+  }
+
+  return { env, isSensitive, gitIdentityName, gitIdentityEmail };
+}
+
 // ============================================================================
 // Database Mappers
 // ============================================================================
@@ -453,6 +511,9 @@ function mapDbFolderPreferences(
     defaultAgentProvider: dbRow.defaultAgentProvider ?? null,
     environmentVars: parseEnvironmentVars(dbRow.environmentVars),
     pinnedFiles: parsePinnedFiles(dbRow.pinnedFiles),
+    gitIdentityName: dbRow.gitIdentityName ?? null,
+    gitIdentityEmail: dbRow.gitIdentityEmail ?? null,
+    isSensitive: dbRow.isSensitive ?? false,
     createdAt: new Date(dbRow.createdAt),
     updatedAt: new Date(dbRow.updatedAt),
   };

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -39,6 +39,39 @@ initializeBuiltInPlugins();
 export { SessionServiceError };
 
 /**
+ * Resolve git credential suppression env vars for a session.
+ * Returns GIT_TERMINAL_PROMPT=0 and optionally GIT_CONFIG_GLOBAL for non-profile sessions.
+ */
+async function resolveGitCredentialEnv(
+  sessionId: string,
+  hasProfile: boolean
+): Promise<Record<string, string>> {
+  try {
+    const env = await gitCredentialManager.buildSessionEnv(sessionId, hasProfile);
+    return env.toRecord();
+  } catch (error) {
+    log.error("Failed to build git credential env", { sessionId, error: String(error) });
+    return {};
+  }
+}
+
+/**
+ * Resolve folder-level git identity override env vars (pseudonymous commits).
+ */
+async function resolveFolderGitIdentityEnv(
+  userId: string,
+  folderId: string | null | undefined
+): Promise<Record<string, string>> {
+  try {
+    const { env } = await getFolderGitIdentity(userId, folderId);
+    return env ?? {};
+  } catch (error) {
+    log.error("Failed to resolve folder git identity", { folderId, error: String(error) });
+    return {};
+  }
+}
+
+/**
  * Create a new terminal session.
  * SECURITY: Wraps tmux creation with proper cleanup on DB failure.
  */
@@ -319,23 +352,8 @@ export async function createSession(
 
   // File and browser sessions don't need tmux — they're pure UI
   if (input.terminalType !== "file" && input.terminalType !== "browser") {
-    // Build git credential suppression env (GIT_TERMINAL_PROMPT=0, GIT_CONFIG_GLOBAL for non-profile)
-    let gitCredentialEnv: Record<string, string> = {};
-    try {
-      const credEnv = await gitCredentialManager.buildSessionEnv(sessionId, !!profile);
-      gitCredentialEnv = credEnv.toRecord();
-    } catch (error) {
-      log.error("Failed to build git credential env", { sessionId, error: String(error) });
-    }
-
-    // Resolve folder-level git identity override (pseudonymous commits for sensitive folders)
-    let folderGitIdentityEnv: Record<string, string> = {};
-    try {
-      const { env } = await getFolderGitIdentity(userId, input.folderId);
-      folderGitIdentityEnv = env ?? {};
-    } catch (error) {
-      log.error("Failed to resolve folder git identity", { sessionId, error: String(error) });
-    }
+    const gitCredentialEnv = await resolveGitCredentialEnv(sessionId, !!profile);
+    const folderGitIdentityEnv = await resolveFolderGitIdentityEnv(userId, input.folderId);
 
     // Initial environment — all must be present at PTY spawn so agent processes inherit them immediately
     // Precedence: profileEnv < folderEnv < folderGitIdentityEnv < gitCredentialEnv < ghAccountEnv < rdvEnv
@@ -894,23 +912,8 @@ export async function resumeSession(
         log.error("Failed to resolve GitHub account env on resume", { sessionId, error: String(error) });
       }
 
-      // Refresh git credential suppression env on resume
-      let gitCredentialEnv: Record<string, string> = {};
-      try {
-        const credEnv = await gitCredentialManager.buildSessionEnv(sessionId, !!session.profileId);
-        gitCredentialEnv = credEnv.toRecord();
-      } catch (error) {
-        log.error("Failed to build git credential env on resume", { sessionId, error: String(error) });
-      }
-
-      // Refresh folder git identity env on resume (may have changed while suspended)
-      let folderGitIdentityEnv: Record<string, string> = {};
-      try {
-        const { env } = await getFolderGitIdentity(userId, session.folderId);
-        folderGitIdentityEnv = env ?? {};
-      } catch (error) {
-        log.error("Failed to resolve folder git identity on resume", { sessionId, error: String(error) });
-      }
+      const gitCredentialEnv = await resolveGitCredentialEnv(sessionId, !!session.profileId);
+      const folderGitIdentityEnv = await resolveFolderGitIdentityEnv(userId, session.folderId);
 
       await TmuxService.setSessionEnvironment(session.tmuxSessionName, {
         ...folderGitIdentityEnv,

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -903,7 +903,17 @@ export async function resumeSession(
         log.error("Failed to build git credential env on resume", { sessionId, error: String(error) });
       }
 
+      // Refresh folder git identity env on resume (may have changed while suspended)
+      let folderGitIdentityEnv: Record<string, string> = {};
+      try {
+        const { env } = await getFolderGitIdentity(userId, session.folderId);
+        folderGitIdentityEnv = env ?? {};
+      } catch (error) {
+        log.error("Failed to resolve folder git identity on resume", { sessionId, error: String(error) });
+      }
+
       await TmuxService.setSessionEnvironment(session.tmuxSessionName, {
+        ...folderGitIdentityEnv,
         ...gitCredentialEnv,
         ...ghAccountEnv,
         ...rdvEnv,

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -19,11 +19,11 @@ import * as TmuxService from "./tmux-service";
 import * as WorktreeService from "./worktree-service";
 import * as GitHubService from "./github-service";
 import * as AgentProfileService from "./agent-profile-service";
-import { getResolvedPreferences, getFolderPreferences, getEnvironmentForSession } from "./preferences-service";
+import { getResolvedPreferences, getFolderPreferences, getEnvironmentForSession, getFolderGitIdentity } from "./preferences-service";
 import { SessionServiceError } from "@/lib/errors";
 import { TerminalTypeRegistry } from "@/lib/terminal-plugins/registry";
 import { initializeBuiltInPlugins } from "@/lib/terminal-plugins/init";
-import { githubAccountRepository } from "@/infrastructure/container";
+import { githubAccountRepository, gitCredentialManager } from "@/infrastructure/container";
 import { GitHubAccountEnvironment } from "@/domain/value-objects/GitHubAccountEnvironment";
 import { archiveSessionTodos } from "./agent-todo-sync";
 import { createApiKey } from "@/services/api-key-service";
@@ -319,14 +319,31 @@ export async function createSession(
 
   // File and browser sessions don't need tmux — they're pure UI
   if (input.terminalType !== "file" && input.terminalType !== "browser") {
-    // Initial environment: profile env + folder env + GitHub account env + RDV vars
-    // All must be present at PTY spawn so agent processes inherit them immediately
-    // Precedence: profileEnv < folderEnv < ghAccountEnv < rdvEnv
-    // Bound GitHub account identity intentionally overrides folder-level env
-    // (e.g., user-set GH_TOKEN in folder prefs is superseded by the account binding)
+    // Build git credential suppression env (GIT_TERMINAL_PROMPT=0, GIT_CONFIG_GLOBAL for non-profile)
+    let gitCredentialEnv: Record<string, string> = {};
+    try {
+      const credEnv = await gitCredentialManager.buildSessionEnv(sessionId, !!profile);
+      gitCredentialEnv = credEnv.toRecord();
+    } catch (error) {
+      log.error("Failed to build git credential env", { sessionId, error: String(error) });
+    }
+
+    // Resolve folder-level git identity override (pseudonymous commits for sensitive folders)
+    let folderGitIdentityEnv: Record<string, string> = {};
+    try {
+      const { env } = await getFolderGitIdentity(userId, input.folderId);
+      folderGitIdentityEnv = env ?? {};
+    } catch (error) {
+      log.error("Failed to resolve folder git identity", { sessionId, error: String(error) });
+    }
+
+    // Initial environment — all must be present at PTY spawn so agent processes inherit them immediately
+    // Precedence: profileEnv < folderEnv < folderGitIdentityEnv < gitCredentialEnv < ghAccountEnv < rdvEnv
     const initialEnv: Record<string, string> = {
       ...(profileEnv ?? {}),
       ...(folderEnv ?? {}),
+      ...folderGitIdentityEnv,
+      ...gitCredentialEnv,
       ...(ghAccountEnv ?? {}),
       ...rdvEnv,
     };
@@ -877,7 +894,20 @@ export async function resumeSession(
         log.error("Failed to resolve GitHub account env on resume", { sessionId, error: String(error) });
       }
 
-      await TmuxService.setSessionEnvironment(session.tmuxSessionName, { ...ghAccountEnv, ...rdvEnv });
+      // Refresh git credential suppression env on resume
+      let gitCredentialEnv: Record<string, string> = {};
+      try {
+        const credEnv = await gitCredentialManager.buildSessionEnv(sessionId, !!session.profileId);
+        gitCredentialEnv = credEnv.toRecord();
+      } catch (error) {
+        log.error("Failed to build git credential env on resume", { sessionId, error: String(error) });
+      }
+
+      await TmuxService.setSessionEnvironment(session.tmuxSessionName, {
+        ...gitCredentialEnv,
+        ...ghAccountEnv,
+        ...rdvEnv,
+      });
     } catch (error) {
       log.error("Failed to set env on resume", { sessionId, error: String(error) });
     }
@@ -940,6 +970,13 @@ export async function closeSession(
     );
   } catch (error) {
     log.error("Failed to revoke API key", { sessionId, error: String(error) });
+  }
+
+  // Clean up session-scoped gitconfig (non-profile sessions)
+  try {
+    await gitCredentialManager.cleanupSession(sessionId);
+  } catch (error) {
+    log.error("Failed to clean up session gitconfig", { sessionId, error: String(error) });
   }
 
   // Auto-archive completed agent tasks for this session

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -94,6 +94,11 @@ export interface FolderPreferences {
   environmentVars: EnvironmentVariables | null;
   // Pinned files for quick access in sidebar
   pinnedFiles: PinnedFile[] | null;
+  // Git identity override for pseudonymous/anonymous commits
+  gitIdentityName: string | null;
+  gitIdentityEmail: string | null;
+  // Sensitive folder flag — requires pseudonymous identity, enables push protection
+  isSensitive: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -177,4 +182,9 @@ export interface UpdateFolderPreferencesInput {
   environmentVars?: EnvironmentVariables | null;
   // Pinned files for quick access in sidebar
   pinnedFiles?: PinnedFile[] | null;
+  // Git identity override for pseudonymous/anonymous commits
+  gitIdentityName?: string | null;
+  gitIdentityEmail?: string | null;
+  // Sensitive folder flag — requires pseudonymous identity, enables push protection
+  isSensitive?: boolean;
 }


### PR DESCRIPTION
## Summary

- **Git credential suppression**: Configure `gh` as the git credential helper in all terminal sessions, preventing macOS Keychain GUI prompts when agents run `git push/pull/fetch`. Uses `helper =` to clear the inherited chain (including osxkeychain), then sets `gh auth git-credential` as the sole helper — the same pattern as `gh auth setup-git`
- **Folder git identity override**: Per-folder pseudonymous git name/email in folder preferences, injected as `GIT_AUTHOR_NAME/EMAIL` and `GIT_COMMITTER_NAME/EMAIL`. Identity inherits child-first through folder hierarchy
- **Sensitive folder protection**: Mark folders as "sensitive" to require pseudonymous identity for commits/pushes. `isSensitive` propagates from any ancestor. Git guard API evaluates identity risk with `none/warn/block` levels
- **rdv CLI hook integration**: PreToolUse hook intercepts `git commit`/`git push` Bash commands, calls the git-guard API, and blocks tool use (exit 2) when identity would leak
- **UI controls**: Git Identity section in folder preferences modal with sensitive toggle, name/email inputs, and validation warning
- **Migration script**: `bun run db:migrate-profile-gitconfigs` adds `[credential]` section to existing profile `.gitconfig` files

## Key decisions

- Used `gh auth git-credential` (not a custom askpass script) to leverage existing `GH_CONFIG_DIR` infrastructure for multi-account selection
- Folder identity is separate from general env vars — dedicated resolution with ancestry inheritance
- `isSensitive` walks full ancestry chain (any ancestor propagates), while identity uses child-first override
- Session-scoped gitconfigs for non-profile sessions are cleaned up on session close
- Partial identity (name without email) is treated as incomplete for sensitive folders

## Test plan

- [ ] Create a session in a folder with a bound GitHub account — verify `git push` works without macOS keychain prompt
- [ ] Create a non-profile shell session — verify session-scoped `.gitconfig` is created in `~/.remote-dev/session-gitconfigs/` and cleaned up on close
- [ ] Set pseudonymous name/email on a folder — verify commits use the pseudonymous identity
- [ ] Mark a folder as sensitive with no identity — verify `git push` is blocked by rdv hook
- [ ] Mark a folder as sensitive with full identity — verify matching commits/pushes succeed
- [ ] Run `bun run db:migrate-profile-gitconfigs` — verify existing profiles get `[credential]` section
- [ ] Run `bun run db:migrate-profile-gitconfigs` again — verify idempotency (skips already-migrated)
- [ ] Verify `bun run typecheck` and `cargo build` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)