### PR TITLE
fix: resolve mobile app session selection deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mobile session selection deadlock**: Tapping a session in the Flutter app drawer now correctly loads the terminal instead of showing "No active session"
+
 ## [0.3.6] - 2026-03-22
 
 ### Added

--- a/mobile/lib/presentation/screens/home/terminal_home_screen.dart
+++ b/mobile/lib/presentation/screens/home/terminal_home_screen.dart
@@ -51,6 +51,7 @@ class _TerminalHomeScreenState extends ConsumerState<TerminalHomeScreen> {
   void _onSessionTap(Session session) {
     _scaffoldKey.currentState?.closeDrawer();
     HapticFeedback.selectionClick();
+    ref.read(activeSessionIdProvider.notifier).state = session.id;
     context.go('/sessions/${session.id}');
   }
 


### PR DESCRIPTION
## Summary

- Fixes a deadlock in the Flutter mobile app where tapping a session in the drawer showed "No active session" instead of loading the terminal
- **Root cause**: `TerminalHomeScreen.build()` gates rendering `widget.child` (TerminalScreen) on `activeSessionId != null`, but `activeSessionId` was only set inside `TerminalScreen.initState()` — which never fires because the widget never mounts. Classic chicken-and-egg.
- **Fix**: Set `activeSessionIdProvider` eagerly in `_onSessionTap` before calling `context.go()`, so the home screen renders the child immediately when GoRouter provides it

## Key decisions

- The redundant set in `TerminalScreen.initState()` is intentionally kept — it covers deep link / direct URL navigation where `_onSessionTap` isn't the entry point
- Setting a Riverpod `StateProvider` to the same value is a no-op, so the double-set is harmless

## Test plan

- [ ] Open the mobile APK on Android
- [ ] Swipe from left edge to open session drawer
- [ ] Tap an existing session → terminal should load immediately
- [ ] Create a new session → verify it also loads correctly
- [ ] Verify drawer closes after session selection
- [ ] Verify status pill appears at top showing active session name

🤖 Generated with [Claude Code](https://claude.com/claude-code)