### PR TITLE
fix: prevent false agent exit detection during WebSocket reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **"ended" agent activity status**: Sessions whose Claude Code session ends now show "ended" status instead of falling through to "idle". Supported across web sidebar, loop status bar, mobile home screen, and browser notifications
+
 ### Fixed
 
+- **False agent exit detection on reconnect**: Race condition where old PTY async `onExit` handlers could fire after WebSocket reconnection, destroying the new session and showing a false "Agent completed" exit screen. Added PTY/WS identity guards and proper pre-cleanup on reconnect
+- **Stale error status after session resume**: Resuming a suspended agent/loop session now resets `agentExitState`, `agentExitCode`, and `agentActivityStatus` so stale error indicators don't persist
 - **Mobile session selection deadlock**: Tapping a session in the Flutter app drawer now correctly loads the terminal instead of showing "No active session"
 
 ## [0.3.6] - 2026-03-22

--- a/mobile/lib/domain/value_objects/agent_provider.dart
+++ b/mobile/lib/domain/value_objects/agent_provider.dart
@@ -47,7 +47,8 @@ enum AgentActivityStatus {
   waiting('waiting'),
   idle('idle'),
   error('error'),
-  compacting('compacting');
+  compacting('compacting'),
+  ended('ended');
 
   const AgentActivityStatus(this.value);
   final String value;
@@ -58,6 +59,7 @@ enum AgentActivityStatus {
         'idle' => AgentActivityStatus.idle,
         'error' => AgentActivityStatus.error,
         'compacting' => AgentActivityStatus.compacting,
+        'ended' => AgentActivityStatus.ended,
         _ => null,
       };
 }

--- a/mobile/lib/presentation/screens/home/terminal_home_screen.dart
+++ b/mobile/lib/presentation/screens/home/terminal_home_screen.dart
@@ -252,7 +252,7 @@ class _SessionTile extends StatelessWidget {
     return switch (session.agentActivityStatus) {
       AgentActivityStatus.running => Colors.green,
       AgentActivityStatus.waiting => Colors.amber,
-      AgentActivityStatus.idle => Colors.grey,
+      AgentActivityStatus.idle || AgentActivityStatus.ended => Colors.grey,
       AgentActivityStatus.error => colorScheme.error,
       AgentActivityStatus.compacting => Colors.blue,
       null => session.isActive

--- a/packages/domain/src/entities/Session.ts
+++ b/packages/domain/src/entities/Session.ts
@@ -234,12 +234,24 @@ export class Session {
     return this.withUpdates({ status: SessionStatus.suspended() });
   }
 
+  /**
+   * Resume this session from suspended state.
+   * Resets agent exit state so stale exit/error status doesn't persist.
+   * @throws InvalidStateTransitionError if not in suspended state
+   */
   resume(): Session {
     this.props.status.validateTransitionTo(SessionStatus.active(), "resume");
-    return this.withUpdates({
+    const updates: Partial<SessionProps> = {
       status: SessionStatus.active(),
       lastActivityAt: new Date(),
-    });
+    };
+    if (this.props.terminalType === "agent") {
+      updates.agentExitState = "running";
+      updates.agentExitCode = null;
+      updates.agentExitedAt = null;
+      updates.agentActivityStatus = null;
+    }
+    return this.withUpdates(updates);
   }
 
   close(): Session {

--- a/src/components/loop/LoopStatusBar.tsx
+++ b/src/components/loop/LoopStatusBar.tsx
@@ -31,6 +31,7 @@ const STATUS_LABELS: Record<string, string> = {
   idle: "Idle",
   error: "Error",
   compacting: "Thinking",
+  ended: "Ended",
 };
 
 const STATUS_COLORS: Record<string, string> = {
@@ -39,6 +40,7 @@ const STATUS_COLORS: Record<string, string> = {
   idle: "bg-muted-foreground/50",
   error: "bg-red-500",
   compacting: "bg-blue-500",
+  ended: "bg-muted-foreground/50",
 };
 
 export function LoopStatusBar({

--- a/src/components/session/Sidebar.tsx
+++ b/src/components/session/Sidebar.tsx
@@ -159,6 +159,7 @@ function getSessionIconColor(
     case "compacting":
       return "text-blue-500 agent-breathing";
     case "idle":
+    case "ended":
       return "text-muted-foreground";
     case "error":
       return "text-red-500";

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -21,7 +21,7 @@ import type {
 import type { AgentActivityStatus, SessionStatusIndicator, SessionProgress } from "@/types/terminal-type";
 
 const ACTIVE_SESSION_STORAGE_KEY = "remote-dev:activeSessionId";
-const VALID_ACTIVITY_STATUSES = new Set<AgentActivityStatus>(["running", "waiting", "idle", "error", "compacting"]);
+const VALID_ACTIVITY_STATUSES = new Set<AgentActivityStatus>(["running", "waiting", "idle", "error", "compacting", "ended"]);
 
 /**
  * Get the saved active session ID from localStorage.

--- a/src/domain/entities/Session.ts
+++ b/src/domain/entities/Session.ts
@@ -268,14 +268,22 @@ export class Session {
 
   /**
    * Resume this session from suspended state.
+   * Resets agent exit state so stale exit/error status doesn't persist.
    * @throws InvalidStateTransitionError if not in suspended state
    */
   resume(): Session {
     this.props.status.validateTransitionTo(SessionStatus.active(), "resume");
-    return this.withUpdates({
+    const updates: Partial<SessionProps> = {
       status: SessionStatus.active(),
       lastActivityAt: new Date(),
-    });
+    };
+    if (this.props.terminalType === "agent" || this.props.terminalType === "loop") {
+      updates.agentExitState = "running";
+      updates.agentExitCode = null;
+      updates.agentExitedAt = null;
+      updates.agentActivityStatus = null;
+    }
+    return this.withUpdates(updates);
   }
 
   /**

--- a/src/hooks/useAgentNotifications.ts
+++ b/src/hooks/useAgentNotifications.ts
@@ -22,6 +22,10 @@ const STATUS_MESSAGES: Partial<
     title: (n) => `${n} — Compacting context`,
     body: "Agent is compacting its context window",
   },
+  ended: {
+    title: (n) => `${n} — Session ended`,
+    body: "Agent session has ended",
+  },
 };
 
 interface UseAgentNotificationsOptions {

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -200,6 +200,26 @@ function destroyPty(ptyProcess: IPty): void {
   }
 }
 
+/**
+ * Destroy a PTY, ignoring errors if it's already dead.
+ */
+function safeDestroyPty(ptyProcess: IPty): void {
+  try { destroyPty(ptyProcess); } catch { /* PTY may already be dead */ }
+}
+
+/**
+ * Check whether the current session map entry has been replaced by a newer
+ * connection. Used to guard against stale PTY onExit and WebSocket close/error
+ * handlers that fire after a reconnection has already swapped in a new session.
+ */
+function isStaleConnection(sessionId: string, pty: IPty | null, ws: WebSocket | null): boolean {
+  const current = sessions.get(sessionId);
+  if (!current) return false;
+  if (pty && current.pty !== pty) return true;
+  if (ws && current.ws !== ws) return true;
+  return false;
+}
+
 // Track sessions currently in the process of connecting to prevent rapid reconnection
 // that can exhaust PTY/FD resources and cause posix_spawnp failures
 const connectingSessionIds = new Set<string>();
@@ -1317,6 +1337,19 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
     }
     connectingSessionIds.add(sessionId);
 
+    // Clean up any existing session for this ID before creating a new one.
+    // This prevents the old PTY's async onExit handler from firing after
+    // the new session is established and destroying it.
+    const existingSession = sessions.get(sessionId);
+    if (existingSession) {
+      log.debug("Replacing existing session connection", { sessionId });
+      sessions.delete(sessionId);
+      safeDestroyPty(existingSession.pty);
+      if (existingSession.ws !== ws && existingSession.ws.readyState === WebSocket.OPEN) {
+        existingSession.ws.close();
+      }
+    }
+
     // Check if tmux session exists (for attach vs create decision)
     const tmuxExists = tmuxSessionExists(tmuxSessionName);
 
@@ -1397,6 +1430,11 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
 
     ptyProcess.onExit(({ exitCode }) => {
       log.debug("PTY exited", { sessionId, exitCode, terminalType });
+
+      if (isStaleConnection(sessionId, ptyProcess, null)) {
+        log.debug("Stale PTY exit ignored (session has newer PTY)", { sessionId });
+        return;
+      }
 
       if (ws.readyState === WebSocket.OPEN) {
         // For agent/loop terminals, send a special agent_exited message
@@ -1517,7 +1555,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
 
             agentLog.info("Restarting agent session", { sessionId });
             try {
-              try { destroyPty(session.pty); } catch { /* old PTY may be dead */ }
+              safeDestroyPty(session.pty);
 
               execFile("tmux", ["kill-session", "-t", tmuxSessionName], () => {});
               createTmuxSession(tmuxSessionName, session.lastCols, session.lastRows, cwd, tmuxHistoryLimit);
@@ -1533,6 +1571,10 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
 
               newPty.onExit(({ exitCode: newExitCode }) => {
                 agentLog.info("Restarted agent session exited", { sessionId, exitCode: newExitCode });
+                if (isStaleConnection(sessionId, newPty, null)) {
+                  log.debug("Stale restarted PTY exit ignored", { sessionId });
+                  return;
+                }
                 if (ws.readyState === WebSocket.OPEN) {
                   ws.send(JSON.stringify({
                     type: "agent_exited",
@@ -1615,11 +1657,19 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
 
     ws.on("close", () => {
       log.debug("WebSocket closed", { sessionId });
+      if (isStaleConnection(sessionId, null, ws)) {
+        log.debug("Stale WebSocket close ignored (session has newer connection)", { sessionId });
+        return;
+      }
       cleanupSession(sessionId);
     });
 
     ws.on("error", (error) => {
       log.error("Terminal session error", { sessionId, error: String(error) });
+      if (isStaleConnection(sessionId, null, ws)) {
+        log.debug("Stale WebSocket error ignored (session has newer connection)", { sessionId });
+        return;
+      }
       cleanupSession(sessionId);
     });
 
@@ -1635,7 +1685,7 @@ function cleanup() {
   log.info("Shutting down terminal server (tmux sessions preserved)...");
   for (const [id, session] of sessions) {
     cleanupVoiceFifo(session);
-    try { destroyPty(session.pty); } catch { /* PTY may already be dead */ }
+    safeDestroyPty(session.pty);
     session.ws.close();
     log.debug("Closed PTY wrapper", { sessionId: id });
   }

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -1339,14 +1339,14 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
 
     // Clean up any existing session for this ID before creating a new one.
     // This prevents the old PTY's async onExit handler from firing after
-    // the new session is established and destroying it.
-    const existingSession = sessions.get(sessionId);
-    if (existingSession) {
+    // the new session is established and destroying it. Uses cleanupSession()
+    // to ensure all resources (timers, voice FIFO, status maps) are released.
+    if (sessions.has(sessionId)) {
       log.debug("Replacing existing session connection", { sessionId });
-      sessions.delete(sessionId);
-      safeDestroyPty(existingSession.pty);
-      if (existingSession.ws !== ws && existingSession.ws.readyState === WebSocket.OPEN) {
-        existingSession.ws.close();
+      const oldWs = sessions.get(sessionId)!.ws;
+      cleanupSession(sessionId);
+      if (oldWs !== ws && oldWs.readyState === WebSocket.OPEN) {
+        oldWs.close();
       }
     }
 

--- a/src/types/terminal-type.ts
+++ b/src/types/terminal-type.ts
@@ -326,7 +326,7 @@ export type AgentExitState = "running" | "exited" | "restarting" | "closed";
  * Agent activity status for real-time sidebar indicator.
  * Reported by Claude Code hooks via /internal/agent-status endpoint.
  */
-export type AgentActivityStatus = "running" | "waiting" | "idle" | "error" | "compacting";
+export type AgentActivityStatus = "running" | "waiting" | "idle" | "error" | "compacting" | "ended";
 
 /**
  * Agent session metadata stored with the session


### PR DESCRIPTION
## Summary

- **Race condition fix**: Old PTY async `onExit` handlers could fire after WebSocket reconnection, destroying new sessions and sending false `agent_exited` messages. Added PTY/WS identity guards and pre-cleanup on reconnect in `terminal.ts`.
- **Session resume fix**: `Session.resume()` now resets `agentExitState`, `agentExitCode`, `agentExitedAt`, and `agentActivityStatus` for agent/loop sessions, preventing stale error indicators after resume.
- **"ended" status**: Added `"ended"` as a valid `AgentActivityStatus` across the type system (TS + Dart), validation sets, and UI color mappings (web sidebar, loop status bar, mobile home screen, browser notifications).

## Key decisions

- Identity guards (`sessions.get(id)?.pty !== ptyProcess`) are used instead of generation counters for simplicity — reference equality on the PTY/WS objects is sufficient.
- Agent state is reset to "running" on resume (not null) to match the pattern in `markAgentRunning()`.
- "ended" maps to muted/grey in the UI, same as "idle" — both represent inactive states.
- `agentRestartCount` is intentionally NOT reset on resume — it's a lifetime metric.

## Test plan

- [ ] Open agent session on mobile, switch app to background, return — session should NOT show exit screen
- [ ] Suspend and resume an agent session that previously had an error exit — should show as active, not error
- [ ] Verify Claude Code `session-end` hook sets "ended" status correctly in sidebar
- [ ] Verify "ended" shows grey dot in both web sidebar and mobile session list
- [ ] Rapid WebSocket disconnect/reconnect (toggle airplane mode) — no false exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)