### PR TITLE
fix: add touch-action and overscroll-behavior CSS for mobile terminal scroll

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -565,12 +565,17 @@
 /* xterm.js container - ensure it fills parent height */
 .terminal.xterm {
   height: 100%;
+  touch-action: none;           /* Let JS handle all touch gestures on terminal */
+  overscroll-behavior: contain;  /* Prevent pull-to-refresh and rubber-band on terminal */
 }
 
-/* Hide xterm scrollbar */
+/* Hide xterm scrollbar and configure touch behavior */
 .xterm-viewport {
   scrollbar-width: none; /* Firefox */
   -ms-overflow-style: none; /* IE and Edge */
+  touch-action: none;           /* Prevent browser default scroll — JS handles it */
+  overscroll-behavior: contain;  /* Contain scroll within viewport, no chain to parent */
+  -webkit-overflow-scrolling: touch; /* Smooth momentum scrolling on older iOS */
 }
 
 .xterm-viewport::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- Add `touch-action: none` to `.terminal.xterm` and `.xterm-viewport` so the browser defers all touch handling to JavaScript
- Add `overscroll-behavior: contain` to prevent iOS rubber-band bounce from interfering with terminal scrolling
- Add `-webkit-overflow-scrolling: touch` for smooth momentum on older iOS versions

## Context
Part of the mobile terminal scrollback fix. This CSS change complements the JS touch handler rewrite in #fix/mobile-terminal-scrollback.

## Test plan
- [ ] Open terminal on iOS Safari — verify no rubber-band bounce when swiping in terminal
- [ ] Open terminal on Android Chrome — verify no pull-to-refresh when scrolling up in terminal
- [ ] Verify terminal still scrolls via JS touch handler on mobile
- [ ] Verify desktop scrolling (mouse wheel) still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)