### PR TITLE
fix: rename misleading session-start hook command to active

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "rdv hook claude session-start",
+            "command": "rdv hook claude active",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary
- Rename empty-matcher PreToolUse hook command from `rdv hook claude session-start` to `rdv hook claude active`
- Both event names map to identical handler in hook.rs — pure naming clarification
- "active" better describes purpose: reports agent is actively working on every tool use

## Test plan
- [x] Verify hooks.json is valid JSON
- [x] Verify `rdv hook claude active` maps to same handler as `session-start` in hook.rs (line 366)

🤖 Generated with [Claude Code](https://claude.com/claude-code)