### PR TITLE
fix: improve hook installation with SessionEnd hook and better marker matching

### DIFF
--- a/src/services/agent-profile-service.ts
+++ b/src/services/agent-profile-service.ts
@@ -641,10 +641,22 @@ const RDV_HOOK_DIRECT_MARKER = "rdv hook ";
 const LEGACY_ACTIVITY_HOOK_MARKER = "/internal/agent-status";
 const LEGACY_TODO_HOOK_MARKER = "/internal/agent-todos";
 
-/** Check if a hook entry contains the given marker substring */
+/** Check if a hook entry is an RDV hook by inspecting its command field */
 function isRdvHook(entry: unknown, marker: string): boolean {
-  return typeof entry === "object" && entry !== null &&
-    JSON.stringify(entry).includes(marker);
+  if (typeof entry !== "object" || entry === null) return false;
+  const obj = entry as Record<string, unknown>;
+  // Check top-level command field
+  if (typeof obj.command === "string" && obj.command.includes(marker)) return true;
+  // Check nested hooks array (the common structure)
+  if (Array.isArray(obj.hooks)) {
+    return obj.hooks.some(
+      (h: unknown) =>
+        typeof h === "object" && h !== null &&
+        typeof (h as Record<string, unknown>).command === "string" &&
+        ((h as Record<string, unknown>).command as string).includes(marker)
+    );
+  }
+  return false;
 }
 
 /** Filter out RDV hooks matching any of the given markers (preserves user hooks) */

--- a/src/services/agent-profile-service.ts
+++ b/src/services/agent-profile-service.ts
@@ -707,6 +707,7 @@ function curlForStatus(status: string): string {
  * - PreCompact → status "compacting" (context window compaction in progress)
  * - Notification (permission/elicitation) → status "waiting" (needs user input)
  * - Stop → status "idle" + task completion check
+ * - SessionEnd → status "ended" + optional learning analysis
  *
  * Task sync hooks:
  * - PostToolUse (matcher: "TaskCreate|TaskUpdate|TodoWrite") → syncs tasks to project_task table
@@ -758,6 +759,11 @@ export async function installAgentHooks(
     hooks: [{ type: "command", command: rdvOrCurlCommand("rdv hook stop", stopCurlFallback), timeout: 15 }],
   };
 
+  // SessionEnd hook: report "ended" status + optional learning analysis
+  const sessionEndHook = {
+    hooks: [{ type: "command", command: rdvOrCurlCommand("rdv hook session-end", curlForStatus("ended")), timeout: 10 }],
+  };
+
   // Task sync hook: reads PostToolUse JSON from stdin
   const todoCurlFallback =
     'INPUT=$(cat); ' + CURL_ENV_PREAMBLE +
@@ -782,6 +788,7 @@ export async function installAgentHooks(
   const existingNotification = Array.isArray(existingHooks.Notification) ? existingHooks.Notification : [];
   const existingStop = Array.isArray(existingHooks.Stop) ? existingHooks.Stop : [];
   const existingPostToolUse = Array.isArray(existingHooks.PostToolUse) ? existingHooks.PostToolUse : [];
+  const existingSessionEnd = Array.isArray(existingHooks.SessionEnd) ? existingHooks.SessionEnd : [];
 
   // Clean up legacy SessionStart RDV hooks from older installations
   const existingSessionStart = Array.isArray(existingHooks.SessionStart) ? existingHooks.SessionStart : [];
@@ -795,6 +802,7 @@ export async function installAgentHooks(
     PostToolUse: [...withoutRdvHooks(existingPostToolUse, hookMarkers), postToolUseTodoHook],
     Notification: [...withoutRdvHooks(existingNotification, hookMarkers), notificationHook],
     Stop: [...withoutRdvHooks(existingStop, hookMarkers), stopHook],
+    SessionEnd: [...withoutRdvHooks(existingSessionEnd, hookMarkers), sessionEndHook],
     // Remove legacy SessionStart RDV hooks (replaced by PreToolUse)
     ...(cleanedSessionStart.length > 0 ? { SessionStart: cleanedSessionStart } : { SessionStart: undefined }),
   };


### PR DESCRIPTION
## Summary
- Install SessionEnd hook for agent sessions so session ended status is reported and learning analysis can trigger
- Improve hook marker matching to only inspect command fields (prevents false matches on user hooks with marker substrings in descriptions)

## Test plan
- [ ] Verify SessionEnd hook appears in installed `.claude/settings.json` for new agent sessions
- [ ] Verify existing hooks (PreToolUse, PostToolUse, Stop, etc.) still install correctly
- [ ] Verify user-defined hooks are preserved during hook installation
- [ ] Verify marker matching doesn't strip user hooks containing "/internal/agent-status" in descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)