### PR TITLE
fix: replace stableId 32-bit hash with dual-pass FNV for collision resistance

### DIFF
--- a/src/services/__tests__/agent-todo-sync.test.ts
+++ b/src/services/__tests__/agent-todo-sync.test.ts
@@ -334,6 +334,57 @@ describe("TaskCreate/TaskUpdate key mismatch (position-based fallback)", () => {
   });
 });
 
+describe("stableId collision resistance", () => {
+  it("numbered steps produce unique IDs", () => {
+    const ids = new Set<string>();
+    for (let i = 1; i <= 20; i++) {
+      const ops = parsePostToolUsePayload({
+        tool_name: "TaskCreate",
+        tool_input: { subject: `Step ${i}: Do something` },
+      });
+      if (ops[0].type === "create") {
+        ids.add(ops[0].agentTaskId);
+      }
+    }
+    expect(ids.size).toBe(20);
+  });
+
+  it("similar prefixed subjects produce unique IDs", () => {
+    const subjects = [
+      "Fix authentication bug",
+      "Fix authorization bug",
+      "Fix authentication flow",
+      "Fix authorization flow",
+      "Fix auth token refresh",
+    ];
+    const ids = new Set<string>();
+    for (const subject of subjects) {
+      const ops = parsePostToolUsePayload({
+        tool_name: "TaskCreate",
+        tool_input: { subject },
+      });
+      if (ops[0].type === "create") {
+        ids.add(ops[0].agentTaskId);
+      }
+    }
+    expect(ids.size).toBe(subjects.length);
+  });
+
+  it("1000 random-ish subjects have no collisions", () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      const ops = parsePostToolUsePayload({
+        tool_name: "TaskCreate",
+        tool_input: { subject: `Task ${i}: ${String.fromCharCode(65 + (i % 26))} work item` },
+      });
+      if (ops[0].type === "create") {
+        ids.add(ops[0].agentTaskId);
+      }
+    }
+    expect(ids.size).toBe(1000);
+  });
+});
+
 describe("classifyTask", () => {
   it("classifies a post-task via agentTaskKey", () => {
     const task = makeTask({

--- a/src/services/agent-todo-sync-pure.ts
+++ b/src/services/agent-todo-sync-pure.ts
@@ -139,13 +139,23 @@ function parseStringArray(value: unknown): string[] | undefined {
   return value.filter((v): v is string => typeof v === "string");
 }
 
-/** Create a stable short ID from a string (for dedup) */
+/** Create a stable short ID from a string (for dedup).
+ *
+ * Uses two independent 32-bit hash passes (FNV-1a and Murmur-inspired)
+ * combined into a wider value to reduce collision probability for similar
+ * strings like "Step 1: ...", "Step 2: ...".
+ */
 function stableId(s: string): string {
-  let hash = 0;
+  let h1 = 0x811c9dc5; // FNV-1a offset basis (32-bit)
+  let h2 = 0x01000193; // secondary seed
   for (let i = 0; i < s.length; i++) {
-    const char = s.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
-    hash |= 0; // Convert to 32-bit integer
+    const c = s.charCodeAt(i);
+    h1 ^= c;
+    h1 = Math.imul(h1, 0x01000193); // FNV-1a prime
+    h2 ^= c;
+    h2 = Math.imul(h2, 0x5bd1e995); // Murmur-inspired multiplier
   }
-  return `cc-${Math.abs(hash).toString(36)}`;
+  // Combine both hashes for wider distribution (~52 effective bits)
+  const combined = (Math.abs(h1) * 0x100000 + Math.abs(h2 >>> 12)) % Number.MAX_SAFE_INTEGER;
+  return `cc-${combined.toString(36)}`;
 }

--- a/src/services/agent-todo-sync.ts
+++ b/src/services/agent-todo-sync.ts
@@ -244,7 +244,9 @@ export async function checkTasksOnStop(
     const postTaskKey = `${POST_TASK_MARKER_PREFIX}${postTaskTitle}`;
     const exists = tasks.some(
       (t) => t.agentTaskKey === postTaskKey ||
-        // Fallback: check legacy description marker
+        // Legacy fallback: tasks created before agentTaskKey column was added
+        // stored the key in the description field instead. Safe to remove once
+        // all sessions from before the migration are closed.
         t.description?.startsWith(postTaskKey)
     );
     if (!exists) {


### PR DESCRIPTION
## Summary
- Replace single-pass 32-bit djb2 hash with dual-pass FNV-1a/Murmur-inspired hash (~52 effective bits)
- Add collision resistance tests: numbered steps, similar prefixes, and 1000-entry stress test
- Clarify legacy description-based post-task dedup comment

## Test plan
- [ ] All 337 existing tests pass
- [ ] New collision resistance tests pass
- [ ] Existing tasks with old `cc-{hash}` keys remain compatible (dedup is by exact match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)