### PR TITLE
feat: add folder-scoped agent peer communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent peer communication**: Folder-scoped inter-agent messaging via MCP server (`rdv-peers`). Agents in the same project folder can discover each other (`list_peers`), exchange messages (`send_message`/`check_messages`), and share work summaries (`set_summary`). Auto-registered in each agent's settings.json at session creation. Messages delivered via PreToolUse hook. Also available via `rdv peer` CLI for non-MCP agents.
 - **SessionEnd hook**: Agent sessions now install a `SessionEnd` hook that reports "ended" status when the session closes, enabling learning analysis triggers
 - **Mobile toolbar backspace button**: ⌫ (DEL) button in both Keys and Nav toolbar modes for deleting characters in the terminal. Supports ALT+⌫ for delete-word.
 - **Mobile type/send mode toggle**: Long-press the send button to switch between Send mode (text + `\r`) and Type mode (text only, no `\r`). Enables building up terminal input piece by piece before executing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,10 @@ Rust CLI for agent interaction with the terminal server. Agents use `rdv` comman
 | `rdv browser click` | Click at coordinates |
 | `rdv browser type` | Type text in browser |
 | `rdv browser evaluate` | Evaluate JavaScript |
+| `rdv peer list` | List peer agents in same project folder |
+| `rdv peer send` | Send message to peers (direct or broadcast) |
+| `rdv peer messages` | Poll for new peer messages |
+| `rdv peer summary` | Set work summary visible to peers |
 | `rdv session git-status` | Get git status for session |
 | `rdv hook pre-tool-use` | Handle PreToolUse hook (report running, git identity guard) |
 | `rdv hook post-tool-use` | Handle PostToolUse hook (sync tasks from stdin) |
@@ -322,6 +326,7 @@ src/
 | `folder_github_account_link` | Per-folder GitHub account bindings |
 | `project_task` | Project tasks with priority, labels, subtasks, dependencies, and due dates |
 | `task_dependency` | Junction table for task blocked-by relationships |
+| `agent_peer_message` | Folder-scoped inter-agent messages with 24h TTL |
 
 ### Service Layer
 
@@ -350,6 +355,7 @@ Located in `src/services/`:
 | `ClaudeSessionService` | Discover resumable Claude Code sessions from `.jsonl` files |
 | `TaskService` | Project task CRUD, folder-scoped queries, dependency management, bulk archival |
 | `NotificationService` | Notification CRUD, debounced creation, read/delete management |
+| `PeerService` | Folder-scoped inter-agent peer discovery and messaging |
 | `BrowserService` | Headless browser automation (navigate, click, type, screenshot) |
 
 **Security**: All shell commands use `execFile` with array arguments (no shell interpolation).
@@ -386,6 +392,38 @@ Remote Dev supports multiple AI coding agents with unified management:
 ├── .gitconfig         # Isolated git identity
 └── .env               # Secrets from provider
 ```
+
+### Agent Peer Communication
+
+Folder-scoped inter-agent messaging allows agents in the same project folder to discover each other and coordinate work.
+
+**Architecture:**
+- `rdv-peers` MCP server auto-registered in each agent's `settings.json` at session creation
+- MCP server (stdio transport) talks to terminal server's `/internal/peers/*` endpoints
+- Messages stored in `agent_peer_messages` SQLite table with 24h cleanup
+- PreToolUse hook checks for pending messages and delivers them automatically
+
+**MCP Tools:**
+| Tool | Description |
+|------|-------------|
+| `list_peers` | Discover other agents in the same project folder |
+| `send_message` | Send direct or broadcast message to peers |
+| `check_messages` | Check for new messages since last poll |
+| `set_summary` | Set work summary visible to peers |
+
+**Key Files:**
+| File | Purpose |
+|------|---------|
+| `src/mcp/peer-server.ts` | Standalone MCP stdio server |
+| `src/services/peer-service.ts` | DB operations for peer messaging |
+| `crates/rdv/src/commands/peer.rs` | `rdv peer` CLI for non-MCP agents |
+
+**Internal API:**
+- `GET /internal/peers/list?sessionId=` — List peers in same folder
+- `POST /internal/peers/messages/send` — Send message
+- `GET /internal/peers/messages/poll?sessionId=&since=` — Poll new messages
+- `POST /internal/peers/summary` — Set work summary
+- `POST /internal/peers/cleanup` — Clean old messages
 
 ### Electron Desktop App
 

--- a/crates/rdv/src/commands/hook.rs
+++ b/crates/rdv/src/commands/hook.rs
@@ -256,6 +256,51 @@ async fn check_git_identity_guard(client: &Client) -> bool {
     }
 }
 
+/// Check for pending peer messages and print them to stderr.
+/// Persists the last poll timestamp to a file to avoid re-processing.
+async fn check_peer_messages(client: &Client) {
+    let sid = match client.session_id() {
+        Some(s) => s,
+        None => return,
+    };
+
+    let ts_file = format!("/tmp/rdv-peer-poll-{sid}");
+    let since = std::fs::read_to_string(&ts_file)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
+    let now = chrono::Utc::now().to_rfc3339();
+
+    let query = [("sessionId", sid), ("since", since.as_str())];
+    let result: Result<serde_json::Value, _> = client
+        .get_with_query("/internal/peers/messages/poll", &query)
+        .await;
+
+    // Always update timestamp to avoid re-processing on failure
+    let _ = std::fs::write(&ts_file, &now);
+
+    let resp = match result {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let messages = match resp.get("messages").and_then(|v| v.as_array()) {
+        Some(msgs) if !msgs.is_empty() => msgs,
+        _ => return,
+    };
+
+    for msg in messages {
+        let from = msg.get("fromSessionName")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let body = msg.get("body")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let is_broadcast = msg.get("toSessionId")
+            .map_or(true, |v| v.is_null());
+        let target = if is_broadcast { " (broadcast)" } else { "" };
+        eprintln!("📨 Peer message from {from}{target}: {body}");
+    }
+}
+
 /// Sync task/todo data from stdin to the terminal server.
 /// Drains stdin even if no session ID is available to prevent blocking the caller.
 async fn sync_todos_from_stdin(client: &Client) -> Result<(), Box<dyn std::error::Error>> {
@@ -281,6 +326,8 @@ pub async fn run(args: HookArgs, client: &Client, _human: bool) -> Result<(), Bo
     match args.command {
         HookCommand::PreToolUse => {
             report_status(client, "running").await;
+            // Check for peer messages (non-blocking, best-effort)
+            check_peer_messages(client).await;
             if check_git_identity_guard(client).await {
                 std::process::exit(2);
             }
@@ -370,6 +417,7 @@ pub async fn run(args: HookArgs, client: &Client, _human: bool) -> Result<(), Bo
             match event.as_str() {
                 "session-start" | "active" | "prompt-submit" => {
                     report_status(client, "running").await;
+                    check_peer_messages(client).await;
                 }
                 "stop" | "idle" => {
                     handle_stop(client, agent, reason).await?;

--- a/crates/rdv/src/commands/mod.rs
+++ b/crates/rdv/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod folder;
 pub mod hook;
 pub mod indicator;
 pub mod notification;
+pub mod peer;
 pub mod screen;
 pub mod send;
 pub mod session;

--- a/crates/rdv/src/commands/peer.rs
+++ b/crates/rdv/src/commands/peer.rs
@@ -130,8 +130,9 @@ impl From<&PeerMessage> for MessageRow {
             } else {
                 "broadcast".into()
             },
-            body: if m.body.len() > 80 {
-                format!("{}...", &m.body[..77])
+            body: if m.body.chars().count() > 80 {
+                let truncated: String = m.body.chars().take(77).collect();
+                format!("{truncated}...")
             } else {
                 m.body.clone()
             },

--- a/crates/rdv/src/commands/peer.rs
+++ b/crates/rdv/src/commands/peer.rs
@@ -1,0 +1,225 @@
+use clap::{Args, Subcommand};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tabled::{Table, Tabled};
+
+use crate::client::Client;
+
+#[derive(Args)]
+pub struct PeerArgs {
+    #[command(subcommand)]
+    command: PeerCommand,
+}
+
+#[derive(Subcommand)]
+enum PeerCommand {
+    /// List peer agents in the same project folder
+    List,
+    /// Send a message to peers
+    Send {
+        /// Message body
+        body: String,
+        /// Target session ID (omit to broadcast)
+        #[arg(long)]
+        to: Option<String>,
+    },
+    /// Check for new messages from peers
+    Messages {
+        /// ISO timestamp to poll from (default: epoch)
+        #[arg(long)]
+        since: Option<String>,
+    },
+    /// Set your work summary visible to peers
+    Summary {
+        /// 1-2 sentence summary of current work
+        text: String,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Peer {
+    #[serde(rename = "sessionId")]
+    session_id: String,
+    name: String,
+    #[serde(rename = "agentProvider")]
+    agent_provider: Option<String>,
+    #[serde(rename = "agentActivityStatus")]
+    agent_activity_status: Option<String>,
+    #[serde(rename = "peerSummary")]
+    peer_summary: Option<String>,
+    #[serde(rename = "isConnected")]
+    is_connected: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PeerListResponse {
+    peers: Vec<Peer>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PeerMessage {
+    id: String,
+    #[serde(rename = "fromSessionId")]
+    from_session_id: Option<String>,
+    #[serde(rename = "fromSessionName")]
+    from_session_name: String,
+    #[serde(rename = "toSessionId")]
+    to_session_id: Option<String>,
+    body: String,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct MessageListResponse {
+    messages: Vec<PeerMessage>,
+}
+
+#[derive(Tabled)]
+struct PeerRow {
+    #[tabled(rename = "Session ID")]
+    session_id: String,
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Provider")]
+    provider: String,
+    #[tabled(rename = "Status")]
+    status: String,
+    #[tabled(rename = "Summary")]
+    summary: String,
+}
+
+impl From<&Peer> for PeerRow {
+    fn from(p: &Peer) -> Self {
+        let connected = if p.is_connected { "" } else { " (disconnected)" };
+        Self {
+            session_id: p.session_id[..8].to_string(),
+            name: p.name.clone(),
+            provider: p.agent_provider.clone().unwrap_or_default(),
+            status: format!(
+                "{}{}",
+                p.agent_activity_status.clone().unwrap_or_default(),
+                connected
+            ),
+            summary: p
+                .peer_summary
+                .clone()
+                .unwrap_or_else(|| "-".to_string()),
+        }
+    }
+}
+
+#[derive(Tabled)]
+struct MessageRow {
+    #[tabled(rename = "From")]
+    from: String,
+    #[tabled(rename = "Type")]
+    msg_type: String,
+    #[tabled(rename = "Message")]
+    body: String,
+    #[tabled(rename = "Time")]
+    time: String,
+}
+
+impl From<&PeerMessage> for MessageRow {
+    fn from(m: &PeerMessage) -> Self {
+        Self {
+            from: m.from_session_name.clone(),
+            msg_type: if m.to_session_id.is_some() {
+                "direct".into()
+            } else {
+                "broadcast".into()
+            },
+            body: if m.body.len() > 80 {
+                format!("{}...", &m.body[..77])
+            } else {
+                m.body.clone()
+            },
+            time: m.created_at.clone(),
+        }
+    }
+}
+
+pub async fn run(
+    args: PeerArgs,
+    client: &Client,
+    human: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sid = client
+        .session_id()
+        .ok_or("RDV_SESSION_ID not set — run inside an agent session")?;
+
+    match args.command {
+        PeerCommand::List => {
+            let query = [("sessionId", sid)];
+            let resp: PeerListResponse = client
+                .get_with_query("/internal/peers/list", &query)
+                .await?;
+
+            if human {
+                if resp.peers.is_empty() {
+                    println!("No peers in this project folder.");
+                } else {
+                    let rows: Vec<PeerRow> = resp.peers.iter().map(PeerRow::from).collect();
+                    println!("{}", Table::new(rows));
+                }
+            } else {
+                println!("{}", serde_json::to_string_pretty(&resp.peers)?);
+            }
+        }
+        PeerCommand::Send { body, to } => {
+            let payload = json!({
+                "fromSessionId": sid,
+                "toSessionId": to,
+                "body": body,
+            });
+            let result: serde_json::Value =
+                client.post_json("/internal/peers/messages/send", &payload).await?;
+
+            if human {
+                let target = to
+                    .as_deref()
+                    .unwrap_or("all peers");
+                println!("Message sent to {target}");
+            } else {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+            }
+        }
+        PeerCommand::Messages { since } => {
+            let since_str = since.unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string());
+            let query = [("sessionId", sid), ("since", since_str.as_str())];
+            let resp: MessageListResponse = client
+                .get_with_query("/internal/peers/messages/poll", &query)
+                .await?;
+
+            if human {
+                if resp.messages.is_empty() {
+                    println!("No messages.");
+                } else {
+                    let rows: Vec<MessageRow> =
+                        resp.messages.iter().map(MessageRow::from).collect();
+                    println!("{}", Table::new(rows));
+                }
+            } else {
+                println!("{}", serde_json::to_string_pretty(&resp.messages)?);
+            }
+        }
+        PeerCommand::Summary { text } => {
+            let payload = json!({
+                "sessionId": sid,
+                "summary": text,
+            });
+            client
+                .post_json("/internal/peers/summary", &payload)
+                .await?;
+
+            if human {
+                println!("Summary updated.");
+            } else {
+                println!("{}", json!({ "ok": true }));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/rdv/src/main.rs
+++ b/crates/rdv/src/main.rs
@@ -3,7 +3,7 @@ mod commands;
 mod config;
 
 use clap::Parser;
-use commands::{agent, browser, context, folder, hook, indicator, notification, screen, send, session, status, system, task, teams, tmux_compat, worktree};
+use commands::{agent, browser, context, folder, hook, indicator, notification, peer, screen, send, session, status, system, task, teams, tmux_compat, worktree};
 
 #[derive(Parser)]
 #[command(name = "rdv", version, about = "CLI for Remote Dev terminal server")]
@@ -54,6 +54,8 @@ enum Command {
     ClearProgress(indicator::ClearProgressArgs),
     /// Write a per-session structured log entry
     Log(indicator::LogArgs),
+    /// Communicate with peer agents in the same project folder
+    Peer(peer::PeerArgs),
     /// Multi-agent team orchestration
     Teams(teams::TeamsArgs),
     /// tmux compatibility layer
@@ -85,6 +87,7 @@ async fn main() {
         Command::SetProgress(args) => indicator::run_set_progress(args, &client).await,
         Command::ClearProgress(args) => indicator::run_clear_progress(args, &client).await,
         Command::Log(args) => indicator::run_log(args, &client).await,
+        Command::Peer(args) => peer::run(args, &client, cli.human).await,
         Command::Teams(args) => teams::run(args, &client, cli.human).await,
         Command::Tmux(args) => tmux_compat::run(args, &client, cli.human).await,
     };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1633,6 +1633,35 @@ export const pushTokens = sqliteTable(
 );
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// Agent Peer Messages (folder-scoped inter-agent communication)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const agentPeerMessages = sqliteTable(
+  "agent_peer_message",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    folderId: text("folder_id").notNull(),
+    fromSessionId: text("from_session_id").references(() => terminalSessions.id, {
+      onDelete: "set null",
+    }),
+    fromSessionName: text("from_session_name").notNull(),
+    toSessionId: text("to_session_id").references(() => terminalSessions.id, {
+      onDelete: "set null",
+    }),
+    body: text("body").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("peer_message_folder_created_idx").on(table.folderId, table.createdAt),
+    index("peer_message_to_session_idx").on(table.toSessionId),
+  ]
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // System Update Cache
 // ═══════════════════════════════════════════════════════════════════════════════
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -33,5 +33,13 @@ export async function register() {
     } catch (error) {
       log.error("Trash cleanup failed", { error: String(error) });
     }
+
+    // Clean up old peer messages (24h TTL)
+    try {
+      const { cleanupOldMessages } = await import("@/services/peer-service");
+      await cleanupOldMessages();
+    } catch (error) {
+      log.error("Peer message cleanup failed", { error: String(error) });
+    }
   }
 }

--- a/src/mcp/peer-server.ts
+++ b/src/mcp/peer-server.ts
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+/**
+ * RDV Peers MCP Server
+ *
+ * A stdio MCP server that provides peer communication tools for Claude Code agents.
+ * Auto-registered in each agent's settings.json at session creation.
+ *
+ * Environment:
+ *   RDV_SESSION_ID       — Current session UUID (required)
+ *   RDV_TERMINAL_SOCKET  — Unix socket path (prod)
+ *   RDV_TERMINAL_PORT    — TCP port (dev, default 6002)
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import * as http from "node:http";
+
+const SESSION_ID = process.env.RDV_SESSION_ID;
+if (!SESSION_ID) {
+  process.stderr.write("rdv-peers: RDV_SESSION_ID not set, exiting\n");
+  process.exit(1);
+}
+
+// Track last poll time so we only get new messages
+let lastPollTimestamp = new Date().toISOString();
+
+// ── HTTP helper ──────────────────────────────────────────────────────────────
+
+interface InternalResponse {
+  status: number;
+  data: Record<string, unknown>;
+}
+
+/**
+ * Call a terminal server internal endpoint.
+ * Supports both Unix socket (RDV_TERMINAL_SOCKET) and TCP (RDV_TERMINAL_PORT).
+ */
+function callInternal(
+  path: string,
+  method: "GET" | "POST",
+  body?: Record<string, unknown>
+): Promise<InternalResponse> {
+  return new Promise((resolve, reject) => {
+    const socketPath = process.env.RDV_TERMINAL_SOCKET;
+    const port = process.env.RDV_TERMINAL_PORT || "6002";
+
+    const bodyStr = body ? JSON.stringify(body) : undefined;
+
+    const options: http.RequestOptions = {
+      method,
+      path,
+      headers: {
+        "Content-Type": "application/json",
+        ...(bodyStr ? { "Content-Length": Buffer.byteLength(bodyStr) } : {}),
+      },
+    };
+
+    if (socketPath) {
+      options.socketPath = socketPath;
+      options.host = "localhost";
+    } else {
+      options.hostname = "127.0.0.1";
+      options.port = parseInt(port, 10);
+    }
+
+    const req = http.request(options, (res) => {
+      let data = "";
+      res.on("data", (chunk) => (data += chunk));
+      res.on("end", () => {
+        try {
+          resolve({
+            status: res.statusCode ?? 500,
+            data: data ? JSON.parse(data) : {},
+          });
+        } catch {
+          resolve({ status: res.statusCode ?? 500, data: { raw: data } });
+        }
+      });
+    });
+
+    req.on("error", reject);
+    req.setTimeout(10000, () => {
+      req.destroy(new Error("Request timed out"));
+    });
+
+    if (bodyStr) req.write(bodyStr);
+    req.end();
+  });
+}
+
+/** Wrap a string in the MCP text content envelope. */
+function textResult(text: string) {
+  return { content: [{ type: "text" as const, text }] };
+}
+
+// ── MCP Server ───────────────────────────────────────────────────────────────
+
+const server = new Server(
+  { name: "rdv-peers", version: "1.0.0" },
+  {
+    capabilities: { tools: {} },
+    instructions: [
+      "You have peer communication tools to discover and message other AI agents working in the same project.",
+      "Use list_peers to see who else is working in this project folder.",
+      "Use send_message to coordinate with a specific peer or broadcast to all peers.",
+      "Use check_messages to read messages from other agents.",
+      "Use set_summary to describe what you're currently working on so peers can find you.",
+      "When you receive messages from peers, respond helpfully — treat them like a colleague asking for help.",
+    ].join(" "),
+  }
+);
+
+// ── Tool definitions ─────────────────────────────────────────────────────────
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "list_peers",
+      description:
+        "List other AI agent sessions working in the same project folder. Returns their name, status, provider, and work summary.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+      },
+    },
+    {
+      name: "send_message",
+      description:
+        "Send a message to another agent in the same project folder. Omit to_session_id to broadcast to all peers.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          body: {
+            type: "string",
+            description: "The message content (max 8192 chars)",
+          },
+          to_session_id: {
+            type: "string",
+            description:
+              "Target session ID from list_peers. Omit to broadcast to all peers.",
+          },
+        },
+        required: ["body"],
+      },
+    },
+    {
+      name: "check_messages",
+      description:
+        "Check for new messages from other agents. Returns messages received since last check.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+      },
+    },
+    {
+      name: "set_summary",
+      description:
+        "Set a short summary of what you're currently working on, visible to peer agents.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          summary: {
+            type: "string",
+            description: "1-2 sentence summary of current work",
+          },
+        },
+        required: ["summary"],
+      },
+    },
+  ],
+}));
+
+// ── Tool handlers ────────────────────────────────────────────────────────────
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const { name, arguments: args } = req.params;
+
+  try {
+    switch (name) {
+      case "list_peers": {
+        const resp = await callInternal(
+          `/internal/peers/list?sessionId=${SESSION_ID}`,
+          "GET"
+        );
+        if (resp.status !== 200) {
+          return textResult(`Error: ${JSON.stringify(resp.data)}`);
+        }
+
+        const peers = (resp.data.peers as Array<Record<string, unknown>>) || [];
+        if (peers.length === 0) {
+          return textResult("No other agents are currently active in this project folder.");
+        }
+
+        const peerList = peers
+          .map((p) => {
+            const parts = [
+              `- **${p.name}** (${p.sessionId})`,
+              `  Provider: ${p.agentProvider || "unknown"}`,
+              `  Status: ${p.agentActivityStatus || "unknown"}${p.isConnected ? " (connected)" : " (disconnected)"}`,
+            ];
+            if (p.peerSummary) {
+              parts.push(`  Working on: ${p.peerSummary}`);
+            }
+            return parts.join("\n");
+          })
+          .join("\n\n");
+
+        return textResult(`Found ${peers.length} peer(s):\n\n${peerList}`);
+      }
+
+      case "send_message": {
+        const { body, to_session_id } = (args || {}) as {
+          body: string;
+          to_session_id?: string;
+        };
+        if (!body) {
+          return textResult("Error: message body is required");
+        }
+
+        const resp = await callInternal("/internal/peers/messages/send", "POST", {
+          fromSessionId: SESSION_ID,
+          toSessionId: to_session_id,
+          body,
+        });
+        if (resp.status !== 200) {
+          return textResult(`Error: ${JSON.stringify(resp.data)}`);
+        }
+
+        const target = to_session_id ? `session ${to_session_id}` : "all peers";
+        return textResult(`Message sent to ${target} (id: ${resp.data.messageId})`);
+      }
+
+      case "check_messages": {
+        const resp = await callInternal(
+          `/internal/peers/messages/poll?sessionId=${SESSION_ID}&since=${encodeURIComponent(lastPollTimestamp)}`,
+          "GET"
+        );
+        lastPollTimestamp = new Date().toISOString();
+
+        if (resp.status !== 200) {
+          return textResult(`Error: ${JSON.stringify(resp.data)}`);
+        }
+
+        const messages =
+          (resp.data.messages as Array<Record<string, unknown>>) || [];
+        if (messages.length === 0) {
+          return textResult("No new messages.");
+        }
+
+        const msgList = messages
+          .map((m) => {
+            const from = m.fromSessionName || m.fromSessionId || "unknown";
+            const target = m.toSessionId ? "(direct)" : "(broadcast)";
+            return `**From ${from}** ${target}:\n${m.body}`;
+          })
+          .join("\n\n---\n\n");
+
+        return textResult(`${messages.length} new message(s):\n\n${msgList}`);
+      }
+
+      case "set_summary": {
+        const { summary } = (args || {}) as { summary: string };
+        if (!summary) {
+          return textResult("Error: summary is required");
+        }
+
+        const resp = await callInternal("/internal/peers/summary", "POST", {
+          sessionId: SESSION_ID,
+          summary,
+        });
+        if (resp.status !== 200) {
+          return textResult(`Error: ${JSON.stringify(resp.data)}`);
+        }
+
+        return textResult("Summary updated.");
+      }
+
+      default:
+        return textResult(`Unknown tool: ${name}`);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return textResult(`Error calling ${name}: ${message}`);
+  }
+});
+
+// ── Start ────────────────────────────────────────────────────────────────────
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/src/mcp/peer-server.ts
+++ b/src/mcp/peer-server.ts
@@ -19,11 +19,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import * as http from "node:http";
 
-const SESSION_ID = process.env.RDV_SESSION_ID;
-if (!SESSION_ID) {
-  process.stderr.write("rdv-peers: RDV_SESSION_ID not set, exiting\n");
-  process.exit(1);
-}
+const SESSION_ID = process.env.RDV_SESSION_ID ?? "";
 
 // Track last poll time so we only get new messages
 let lastPollTimestamp = new Date().toISOString();
@@ -179,6 +175,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 server.setRequestHandler(CallToolRequestSchema, async (req) => {
   const { name, arguments: args } = req.params;
 
+  if (!SESSION_ID) {
+    return textResult("Error: RDV_SESSION_ID not set. Peer tools require an active agent session.");
+  }
+
   try {
     switch (name) {
       case "list_peers": {
@@ -239,11 +239,13 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
           `/internal/peers/messages/poll?sessionId=${SESSION_ID}&since=${encodeURIComponent(lastPollTimestamp)}`,
           "GET"
         );
-        lastPollTimestamp = new Date().toISOString();
 
         if (resp.status !== 200) {
           return textResult(`Error: ${JSON.stringify(resp.data)}`);
         }
+
+        // Only advance timestamp after a successful response to avoid losing messages
+        lastPollTimestamp = new Date().toISOString();
 
         const messages =
           (resp.data.messages as Array<Record<string, unknown>>) || [];
@@ -291,4 +293,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 // ── Start ────────────────────────────────────────────────────────────────────
 
 const transport = new StdioServerTransport();
-await server.connect(transport);
+server.connect(transport).catch((err) => {
+  process.stderr.write(`rdv-peers: failed to start: ${err}\n`);
+  process.exit(1);
+});

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -20,6 +20,7 @@ const notifyLog = createLogger("Notify");
 const voiceLog = createLogger("Voice");
 const internalLog = createLogger("InternalAPI");
 const ptyLog = createLogger("PtyControl");
+const peerLog = createLogger("PeerAPI");
 
 // Re-export for backwards compatibility with API routes
 export { generateWsToken } from "../lib/ws-token.js";
@@ -1195,6 +1196,110 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
     return true;
   }
 
+  // ═══ Peer communication endpoints ═════════════════════════════════════════
+
+  // GET /internal/peers/list?sessionId=xxx
+  if (pathname === "/internal/peers/list" && req.method === "GET") {
+    const sessionId = query.sessionId as string;
+    if (!sessionId) {
+      sendJson(res, 400, { error: "Missing sessionId" });
+      return true;
+    }
+
+    try {
+      const PeerService = await import("@/services/peer-service");
+      const peers = await PeerService.getPeers(sessionId, (id) => sessionConnections.has(id));
+      sendJson(res, 200, { peers });
+    } catch (err) {
+      peerLog.error("Failed to list peers", { error: String(err) });
+      sendJson(res, 500, { error: "Failed to list peers" });
+    }
+    return true;
+  }
+
+  // POST /internal/peers/messages/send { fromSessionId, toSessionId?, body }
+  if (pathname === "/internal/peers/messages/send" && req.method === "POST") {
+    const payload = await parseRequestJson(req, res);
+    if (!payload) return true;
+
+    const { fromSessionId, toSessionId, body: msgBody } = payload;
+    if (!fromSessionId || !msgBody) {
+      sendJson(res, 400, { error: "Missing fromSessionId or body" });
+      return true;
+    }
+
+    try {
+      const PeerService = await import("@/services/peer-service");
+      const result = await PeerService.sendMessage({
+        fromSessionId: fromSessionId as string,
+        toSessionId: toSessionId as string | undefined,
+        body: msgBody as string,
+      });
+      sendJson(res, 200, result);
+    } catch (err) {
+      peerLog.error("Failed to send peer message", { error: String(err) });
+      sendJson(res, 400, { error: String(err) });
+    }
+    return true;
+  }
+
+  // GET /internal/peers/messages/poll?sessionId=xxx&since=<isoTimestamp>
+  if (pathname === "/internal/peers/messages/poll" && req.method === "GET") {
+    const sessionId = query.sessionId as string;
+    const since = query.since as string;
+    if (!sessionId) {
+      sendJson(res, 400, { error: "Missing sessionId" });
+      return true;
+    }
+
+    try {
+      const sinceDate = since ? new Date(since) : new Date(0);
+      const PeerService = await import("@/services/peer-service");
+      const messages = await PeerService.pollMessages(sessionId, sinceDate);
+      sendJson(res, 200, { messages });
+    } catch (err) {
+      peerLog.error("Failed to poll peer messages", { error: String(err) });
+      sendJson(res, 500, { error: "Failed to poll messages" });
+    }
+    return true;
+  }
+
+  // POST /internal/peers/summary { sessionId, summary }
+  if (pathname === "/internal/peers/summary" && req.method === "POST") {
+    const payload = await parseRequestJson(req, res);
+    if (!payload) return true;
+
+    const { sessionId, summary } = payload;
+    if (!sessionId || typeof summary !== "string") {
+      sendJson(res, 400, { error: "Missing sessionId or summary" });
+      return true;
+    }
+
+    try {
+      const PeerService = await import("@/services/peer-service");
+      await PeerService.setSummary(sessionId as string, summary);
+      broadcastToClients({ type: "peer_summary_updated", sessionId, summary });
+      sendJson(res, 200, { ok: true });
+    } catch (err) {
+      peerLog.error("Failed to set peer summary", { error: String(err) });
+      sendJson(res, 500, { error: "Failed to set summary" });
+    }
+    return true;
+  }
+
+  // POST /internal/peers/cleanup
+  if (pathname === "/internal/peers/cleanup" && req.method === "POST") {
+    try {
+      const PeerService = await import("@/services/peer-service");
+      await PeerService.cleanupOldMessages();
+      sendJson(res, 200, { ok: true });
+    } catch (err) {
+      peerLog.error("Failed to cleanup peer messages", { error: String(err) });
+      sendJson(res, 500, { error: "Failed to cleanup" });
+    }
+    return true;
+  }
+
   // --- end cmux parity endpoints ---
 
   if (!pathname?.startsWith("/internal/scheduler/")) {
@@ -1295,6 +1400,13 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       log.info("Terminal server running", { transport: "http", port, websocket: `ws://localhost:${port}`, internalApi: `http://localhost:${port}/internal/scheduler/*` });
     });
   }
+
+  // Periodic peer message cleanup (hourly, 24h TTL)
+  setInterval(() => {
+    import("@/services/peer-service")
+      .then((PeerService) => PeerService.cleanupOldMessages())
+      .catch((err) => peerLog.error("Periodic peer cleanup failed", { error: String(err) }));
+  }, 60 * 60 * 1000);
 
   wss.on("connection", async (ws, req) => {
     const query = Object.fromEntries(new URL(req.url || "", "http://localhost").searchParams);

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -1238,7 +1238,7 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
       sendJson(res, 200, result);
     } catch (err) {
       peerLog.error("Failed to send peer message", { error: String(err) });
-      sendJson(res, 400, { error: String(err) });
+      sendJson(res, 500, { error: String(err) });
     }
     return true;
   }

--- a/src/services/agent-profile-service.ts
+++ b/src/services/agent-profile-service.ts
@@ -714,7 +714,8 @@ function curlForStatus(status: string): string {
  */
 export async function installAgentHooks(
   configDir: string,
-  provider: AgentProvider
+  provider: AgentProvider,
+  rdvEnv?: Record<string, string>
 ): Promise<void> {
   // Only Claude Code supports hooks currently
   if (provider !== "claude") return;
@@ -814,17 +815,30 @@ export async function installAgentHooks(
 
   // Clean up stale MCP server entries from previous installations.
   // The MCP server backend was removed; leftover entries cause silent connection failures.
-  const mcpServers = existingSettings.mcpServers as Record<string, unknown> | undefined;
-  if (mcpServers && "remote-dev" in mcpServers) {
+  const mcpServers = (existingSettings.mcpServers ?? {}) as Record<string, unknown>;
+  if ("remote-dev" in mcpServers) {
     delete mcpServers["remote-dev"];
-    if (Object.keys(mcpServers).length === 0) {
-      delete existingSettings.mcpServers;
-    }
   }
+
+  // Register rdv-peers MCP server for inter-agent communication.
+  // RDV env vars must be passed explicitly since MCP servers spawned by Claude Code
+  // don't inherit the tmux session environment.
+  const peerServerPath = join(import.meta.dirname, "..", "mcp", "peer-server.ts");
+  const rdvKeys = ["RDV_SESSION_ID", "RDV_TERMINAL_SOCKET", "RDV_TERMINAL_PORT"] as const;
+  const peerMcpEnv: Record<string, string> = {};
+  for (const key of rdvKeys) {
+    if (rdvEnv?.[key]) peerMcpEnv[key] = rdvEnv[key];
+  }
+  mcpServers["rdv-peers"] = {
+    command: "node",
+    args: ["--import", "tsx/esm", peerServerPath],
+    env: peerMcpEnv,
+  };
 
   const updatedSettings = {
     ...existingSettings,
     hooks: mergedHooks,
+    ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
   };
 
   // Skip write if settings are unchanged (hooks already current)

--- a/src/services/peer-service.ts
+++ b/src/services/peer-service.ts
@@ -1,0 +1,236 @@
+/**
+ * PeerService - Folder-scoped inter-agent communication
+ */
+
+import { db } from "@/db";
+import { agentPeerMessages, terminalSessions } from "@/db/schema";
+import { eq, and, or, isNull, gt, inArray, sql } from "drizzle-orm";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("PeerService");
+
+const MAX_MESSAGE_LENGTH = 8192;
+
+export interface PeerInfo {
+  sessionId: string;
+  name: string;
+  agentProvider: string | null;
+  agentActivityStatus: string | null;
+  peerSummary: string | null;
+  isConnected: boolean;
+}
+
+export interface PeerMessage {
+  id: string;
+  fromSessionId: string | null;
+  fromSessionName: string;
+  toSessionId: string | null;
+  body: string;
+  createdAt: string;
+}
+
+/**
+ * List active agent peers in the same folder as the given session.
+ * The requesting session is excluded from results.
+ */
+export async function getPeers(
+  sessionId: string,
+  isConnectedFn?: (id: string) => boolean
+): Promise<PeerInfo[]> {
+  const session = await db.query.terminalSessions.findFirst({
+    where: eq(terminalSessions.id, sessionId),
+    columns: { folderId: true },
+  });
+
+  if (!session?.folderId) {
+    return [];
+  }
+
+  const peers = await db.query.terminalSessions.findMany({
+    where: and(
+      eq(terminalSessions.folderId, session.folderId),
+      inArray(terminalSessions.terminalType, ["agent", "loop"]),
+      inArray(terminalSessions.status, ["active", "suspended"]),
+    ),
+    columns: {
+      id: true,
+      name: true,
+      agentProvider: true,
+      agentActivityStatus: true,
+      typeMetadata: true,
+    },
+  });
+
+  return peers
+    .filter((p) => p.id !== sessionId)
+    .map((p) => ({
+      sessionId: p.id,
+      name: p.name,
+      agentProvider: p.agentProvider,
+      agentActivityStatus: p.agentActivityStatus,
+      peerSummary: parsePeerSummary(p.typeMetadata),
+      isConnected: isConnectedFn ? isConnectedFn(p.id) : false,
+    }));
+}
+
+/** Extract peerSummary from typeMetadata JSON, returning null on parse failure. */
+function parsePeerSummary(typeMetadata: string | null): string | null {
+  if (!typeMetadata) return null;
+  try {
+    const meta = JSON.parse(typeMetadata);
+    return meta.peerSummary ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Send a message to a specific peer or broadcast to all peers in the folder.
+ */
+export async function sendMessage(params: {
+  fromSessionId: string;
+  toSessionId?: string;
+  body: string;
+}): Promise<{ messageId: string }> {
+  const { fromSessionId, toSessionId, body } = params;
+
+  if (body.length > MAX_MESSAGE_LENGTH) {
+    throw new Error(`Message exceeds maximum length of ${MAX_MESSAGE_LENGTH} characters`);
+  }
+
+  const sender = await db.query.terminalSessions.findFirst({
+    where: eq(terminalSessions.id, fromSessionId),
+    columns: { folderId: true, name: true },
+  });
+
+  if (!sender?.folderId) {
+    throw new Error("Sender session not found or has no folder");
+  }
+
+  if (toSessionId) {
+    const recipient = await db.query.terminalSessions.findFirst({
+      where: eq(terminalSessions.id, toSessionId),
+      columns: { folderId: true },
+    });
+
+    if (!recipient || recipient.folderId !== sender.folderId) {
+      throw new Error("Recipient session not found or not in the same folder");
+    }
+  }
+
+  const messageId = crypto.randomUUID();
+
+  await db.insert(agentPeerMessages).values({
+    id: messageId,
+    folderId: sender.folderId,
+    fromSessionId,
+    fromSessionName: sender.name,
+    toSessionId: toSessionId ?? null,
+    body,
+  });
+
+  log.debug("Peer message sent", {
+    messageId,
+    fromSessionId,
+    toSessionId: toSessionId ?? "broadcast",
+    folderId: sender.folderId,
+  });
+
+  return { messageId };
+}
+
+/**
+ * Poll for new messages addressed to a session (direct or broadcast).
+ */
+export async function pollMessages(
+  sessionId: string,
+  since: Date
+): Promise<PeerMessage[]> {
+  const session = await db.query.terminalSessions.findFirst({
+    where: eq(terminalSessions.id, sessionId),
+    columns: { folderId: true },
+  });
+
+  if (!session?.folderId) {
+    return [];
+  }
+
+  const messages = await db
+    .select({
+      id: agentPeerMessages.id,
+      fromSessionId: agentPeerMessages.fromSessionId,
+      fromSessionName: agentPeerMessages.fromSessionName,
+      toSessionId: agentPeerMessages.toSessionId,
+      body: agentPeerMessages.body,
+      createdAt: agentPeerMessages.createdAt,
+    })
+    .from(agentPeerMessages)
+    .where(
+      and(
+        eq(agentPeerMessages.folderId, session.folderId),
+        gt(agentPeerMessages.createdAt, since),
+        // Direct messages to this session OR broadcasts (toSessionId IS NULL)
+        or(
+          eq(agentPeerMessages.toSessionId, sessionId),
+          isNull(agentPeerMessages.toSessionId)
+        ),
+        // Exclude messages from self (handle NULL fromSessionId from deleted sessions)
+        or(
+          isNull(agentPeerMessages.fromSessionId),
+          sql`${agentPeerMessages.fromSessionId} != ${sessionId}`
+        )
+      )
+    )
+    .orderBy(agentPeerMessages.createdAt);
+
+  return messages.map((m) => ({
+    id: m.id,
+    fromSessionId: m.fromSessionId,
+    fromSessionName: m.fromSessionName,
+    toSessionId: m.toSessionId,
+    body: m.body,
+    createdAt: m.createdAt instanceof Date ? m.createdAt.toISOString() : String(m.createdAt),
+  }));
+}
+
+/**
+ * Set the peer summary for a session (stored in typeMetadata).
+ * Uses a transaction to avoid race conditions with other typeMetadata writers.
+ */
+export async function setSummary(
+  sessionId: string,
+  summary: string
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    const session = await tx.query.terminalSessions.findFirst({
+      where: eq(terminalSessions.id, sessionId),
+      columns: { typeMetadata: true },
+    });
+
+    let metadata: Record<string, unknown> = {};
+    try {
+      if (session?.typeMetadata) metadata = JSON.parse(session.typeMetadata);
+    } catch {
+      // start fresh if existing metadata is corrupt
+    }
+    metadata.peerSummary = summary;
+
+    await tx
+      .update(terminalSessions)
+      .set({ typeMetadata: JSON.stringify(metadata) })
+      .where(eq(terminalSessions.id, sessionId));
+  });
+
+  log.debug("Peer summary updated", { sessionId, summary });
+}
+
+/** Delete peer messages older than 24 hours. */
+export async function cleanupOldMessages(): Promise<void> {
+  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  await db
+    .delete(agentPeerMessages)
+    .where(sql`${agentPeerMessages.createdAt} < ${cutoff.getTime()}`);
+
+  log.debug("Peer message cleanup complete");
+}

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -1133,7 +1133,7 @@ async function ensureAgentConfig(
 
   await Promise.all(
     [...configDirs].map((dir) =>
-      AgentProfileService.installAgentHooks(dir, provider)
+      AgentProfileService.installAgentHooks(dir, provider, rdvEnv)
         .catch((e) => log.error("Failed to install agent hooks", { sessionId, dir, error: String(e) }))
     )
   );

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -859,11 +859,6 @@ export async function resumeSession(
       ? (await AgentProfileService.getProfile(session.profileId, userId))?.configDir
       : process.env.HOME;
 
-    if (configDir && agentProvider !== "none") {
-      // On resume, hooks were installed at create time — just refresh the primary configDir
-      await ensureAgentConfig(new Set([configDir]), agentProvider, sessionId);
-    }
-
     // Refresh RDV + GitHub account env vars on resume (may be missing on older
     // sessions, or stale if the folder's account binding or OAuth token changed)
     try {
@@ -890,6 +885,11 @@ export async function resumeSession(
           : { RDV_API_PORT: process.env.PORT ?? "6001" }),
         ...(agentApiKey ? { RDV_API_KEY: agentApiKey } : {}),
       };
+
+      if (configDir && agentProvider !== "none") {
+        // On resume, refresh hooks/MCP config with current rdvEnv so peer MCP server gets env vars
+        await ensureAgentConfig(new Set([configDir]), agentProvider, sessionId, rdvEnv);
+      }
 
       let ghAccountEnv: Record<string, string> = {};
       try {


### PR DESCRIPTION
## Summary

- Add inter-agent messaging via MCP server (`rdv-peers`) auto-registered in each agent's `settings.json` at session creation
- Agents in the same project folder can discover each other (`list_peers`), exchange messages (`send_message`/`check_messages`), and share work summaries (`set_summary`)
- Messages auto-delivered via PreToolUse hook; also available via `rdv peer` CLI for non-MCP agents
- SQLite-backed message storage with 24h TTL and hourly cleanup

## New files
- `src/mcp/peer-server.ts` — Standalone MCP stdio server with 4 tools
- `src/services/peer-service.ts` — DB operations for peer messaging
- `crates/rdv/src/commands/peer.rs` — `rdv peer` CLI subcommand

## Modified files
- `src/db/schema.ts` — New `agent_peer_messages` table
- `src/server/terminal.ts` — 5 `/internal/peers/*` endpoints + hourly cleanup
- `src/services/agent-profile-service.ts` — Auto-registers `rdv-peers` MCP server with RDV env vars
- `src/services/session-service.ts` — Passes `rdvEnv` through to hook installer
- `crates/rdv/src/commands/hook.rs` — Peer message check in PreToolUse hook
- `src/instrumentation.ts` — Startup cleanup for old messages

## Test plan
- [ ] Start two agent sessions in the same folder, verify `list_peers` shows each other
- [ ] Send a direct message between agents, verify `check_messages` receives it
- [ ] Send a broadcast, verify all peers in the folder receive it
- [ ] Verify agents in different folders cannot see or message each other
- [ ] Verify `rdv peer list/send/messages` CLI commands work
- [ ] Verify PreToolUse hook delivers pending messages automatically
- [ ] Verify hourly cleanup deletes messages older than 24h

This pull request was AI-assisted by Isaac.