### PR TITLE
feat: Slack/Discord-style chat channels with threading and markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Chat channels and groups: Slack/Discord-style channel organization for peer chat
+- Channel groups: "Channels" (default) and "Direct Messages" organizational containers
+- Default `#general` channel auto-created per project folder
+- Users and agents can create new channels via UI, rdv CLI, and MCP tools
+- Slack-style thread support: inline reply counts, slide-in thread panel
+- Full GFM markdown rendering in chat messages (headers, code blocks, links, tables)
+- Channel sidebar replaces task sidebar when chat view is active
+- DB-backed per-user unread tracking with `channel_read_state` table
+- New rdv CLI commands: `rdv channel list`, `rdv channel create`, `rdv channel send`, `rdv channel messages`
+- New MCP tools: `list_channels`, `create_channel`, `send_to_channel`, `read_channel`
+- Permanent message persistence (removed 24h TTL)
+- Channel migration script: `bun run db:migrate-channels`
 - **RDV skill documentation**: Comprehensive rewrite of `skills/rdv/SKILL.md` covering all CLI commands — teams orchestration, terminal I/O (`send`, `screen`), session UI (`set-status`, `set-progress`, `log`), system management, and tmux compatibility layer. Organized into 13 categories with practical workflow examples.
 - **Auto-inject RDV context into agent profiles**: All agent config files (CLAUDE.md, AGENTS.md, GEMINI.md, OPENCODE.md) now include an RDV quick-reference section with environment variables, a 16-command reference table, and a pointer to `rdv --help`. Agents spawned by Remote Dev immediately know about rdv capabilities without manual setup or plugin installation.
 - **Intelligent agent session titles**: Agent sessions are now auto-titled with a 2-3 word summary derived from the first user message in the Claude Code `.jsonl` session file. Titles are applied once via `rdv` hooks and broadcast to all connected clients in real-time. Manual rename locks the title. The stable Claude session UUID is stored in `typeMetadata` and surfaced in peer discovery for richer agent-to-agent context.
@@ -26,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Peer messages now scoped to channels (existing messages migrated to #general)
+- Right sidebar dynamically swaps between task tracker and channel list based on active view
 - Agent session auto-titles now use kebab-case format (e.g., "fix-login-bug" instead of "fix login bug")
 - Auto-title stop-word stripping produces more meaningful titles (e.g., "fix-login-bug" instead of "fix-the-login")
 - PreToolUse hook now shows full peer status digest (agent names, activity status, work summaries) alongside new messages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ bun run db:seed      # Seed authorized users
 bun run db:migrate-agents  # One-time agent session migration
 bun run db:migrate-github-accounts  # Backfill GitHub account metadata from existing OAuth accounts
 bun run db:migrate-profile-gitconfigs  # Add [credential] section to existing profile .gitconfig files
+bun run db:migrate-channels  # Migrate existing messages to channels
 ```
 
 ## Logging (NON-NEGOTIABLE)
@@ -226,6 +227,10 @@ Rust CLI for agent interaction with the terminal server. Agents use `rdv` comman
 | `rdv hook validate` | Validate hooks: check connectivity + auto-repair |
 | `rdv status` | System dashboard |
 | `rdv context` | Show current session context |
+| `rdv channel list` | List channels in project folder |
+| `rdv channel create` | Create new channel |
+| `rdv channel send` | Send message to channel |
+| `rdv channel messages` | Read channel messages |
 
 **Server Discovery (env vars):**
 - `RDV_SESSION_ID` — Current session UUID
@@ -327,6 +332,9 @@ src/
 | `project_task` | Project tasks with priority, labels, subtasks, dependencies, and due dates |
 | `task_dependency` | Junction table for task blocked-by relationships |
 | `agent_peer_message` | Folder-scoped inter-agent messages with 24h TTL |
+| `channel_groups` | Channel group containers (e.g., "Channels", "Direct Messages") |
+| `channels` | Individual channels within groups |
+| `channel_read_state` | Per-user/channel unread tracking |
 
 ### Service Layer
 
@@ -357,6 +365,7 @@ Located in `src/services/`:
 | `NotificationService` | Notification CRUD, debounced creation, read/delete management |
 | `PeerService` | Folder-scoped inter-agent peer discovery and messaging |
 | `BrowserService` | Headless browser automation (navigate, click, type, screenshot) |
+| `ChannelService` | Channel/group lifecycle, unread tracking, migration support |
 
 **Security**: All shell commands use `execFile` with array arguments (no shell interpolation).
 
@@ -410,6 +419,10 @@ Folder-scoped inter-agent messaging allows agents in the same project folder to 
 | `send_message` | Send direct or broadcast message to peers |
 | `check_messages` | Check for new messages since last poll |
 | `set_summary` | Set work summary visible to peers |
+| `list_channels` | List available channels in project folder |
+| `create_channel` | Create topic-specific channel |
+| `send_to_channel` | Send message to channel (GFM markdown) |
+| `read_channel` | Read messages from a channel |
 
 **Key Files:**
 | File | Purpose |
@@ -500,6 +513,11 @@ bun run test:coverage  # Run tests with coverage
 | `AgentProfileAppearanceSettings.tsx` | Per-profile theming with mode toggle and color schemes |
 | `TaskSidebar.tsx` | Right sidebar for project-scoped task tracking |
 | `TaskEditor.tsx` | Inline expandable task editor with subtasks, dependencies, and metadata |
+| `ChannelSidebar.tsx` | Right sidebar channel list for chat view |
+| `ChannelView.tsx` | Channel message view with auto-scroll |
+| `ChannelMessageRow.tsx` | GFM markdown message rendering |
+| `ThreadPanel.tsx` | Slide-in thread replies panel |
+| `CreateChannelModal.tsx` | Channel creation dialog |
 
 ### State Management
 
@@ -519,6 +537,7 @@ React Contexts in `src/contexts/`:
 | `GitHubAccountContext` | Multi-GitHub account state with folder bindings |
 | `TaskContext` | Project tasks state with folder-scoped CRUD |
 | `NotificationContext` | Notification state with toast integration and delete operations |
+| `ChannelContext` | Channel groups, messages, threads, unread tracking |
 
 **Preference Inheritance**: Default → User Settings → Folder Preferences
 
@@ -690,6 +709,17 @@ React Contexts in `src/contexts/`:
 - `GET /api/tasks/:id` - Get task details
 - `PATCH /api/tasks/:id` - Update task
 - `DELETE /api/tasks/:id` - Delete task
+
+### Channels
+- `GET /api/channels` - List channel groups with unread counts (requires `?folderId=`)
+- `POST /api/channels` - Create channel
+- `GET /api/channels/:channelId` - Get channel details
+- `DELETE /api/channels/:channelId` - Archive channel
+- `GET /api/channels/:channelId/messages` - List channel messages (paginated)
+- `POST /api/channels/:channelId/messages` - Send message to channel
+- `GET /api/channels/:channelId/messages/:messageId/thread` - Get thread replies
+- `POST /api/channels/:channelId/read` - Mark channel as read
+- `POST /api/channels/dm` - Find or create DM channel
 
 ## Quick Setup
 

--- a/crates/rdv/src/commands/channel.rs
+++ b/crates/rdv/src/commands/channel.rs
@@ -1,0 +1,197 @@
+use clap::{Args, Subcommand};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tabled::{Table, Tabled};
+
+use crate::client::Client;
+
+#[derive(Args)]
+pub struct ChannelArgs {
+    #[command(subcommand)]
+    command: ChannelCommand,
+}
+
+#[derive(Subcommand)]
+enum ChannelCommand {
+    /// List channels in the current project folder
+    List,
+    /// Create a new channel
+    Create {
+        /// Channel name (lowercase, hyphens allowed)
+        name: String,
+        /// Optional topic/description
+        #[arg(long)]
+        topic: Option<String>,
+    },
+    /// Send a message to a specific channel
+    Send {
+        /// Channel name
+        channel: String,
+        /// Message body
+        body: String,
+        /// Reply to a specific message ID (for threading)
+        #[arg(long)]
+        reply_to: Option<String>,
+    },
+    /// Read messages from a channel
+    Messages {
+        /// Channel name
+        channel: String,
+        /// Number of messages (default: 20)
+        #[arg(long, default_value = "20")]
+        limit: u32,
+    },
+}
+
+// Response types
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ChannelInfo {
+    id: String,
+    name: String,
+    #[serde(rename = "displayName")]
+    display_name: String,
+    #[serde(rename = "type")]
+    channel_type: String,
+    #[serde(rename = "messageCount")]
+    message_count: u64,
+    topic: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ChannelGroup {
+    id: String,
+    name: String,
+    channels: Vec<ChannelInfo>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ChannelListResponse {
+    groups: Vec<ChannelGroup>,
+}
+
+#[derive(Tabled)]
+struct ChannelRow {
+    #[tabled(rename = "Group")]
+    group: String,
+    #[tabled(rename = "Channel")]
+    name: String,
+    #[tabled(rename = "Type")]
+    channel_type: String,
+    #[tabled(rename = "Messages")]
+    messages: String,
+    #[tabled(rename = "Topic")]
+    topic: String,
+}
+
+pub async fn run(
+    args: ChannelArgs,
+    client: &Client,
+    human: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sid = client
+        .session_id()
+        .ok_or("RDV_SESSION_ID not set — run inside an agent session")?;
+
+    match args.command {
+        ChannelCommand::List => {
+            let query = [("sessionId", sid)];
+            let resp: ChannelListResponse = client
+                .get_with_query("/internal/channels/list", &query)
+                .await?;
+
+            if human {
+                let mut rows: Vec<ChannelRow> = Vec::new();
+                for group in &resp.groups {
+                    for ch in &group.channels {
+                        rows.push(ChannelRow {
+                            group: group.name.clone(),
+                            name: ch.display_name.clone(),
+                            channel_type: ch.channel_type.clone(),
+                            messages: ch.message_count.to_string(),
+                            topic: ch.topic.clone().unwrap_or_else(|| "-".to_string()),
+                        });
+                    }
+                }
+                if rows.is_empty() {
+                    println!("No channels found.");
+                } else {
+                    println!("{}", Table::new(rows));
+                }
+            } else {
+                println!("{}", serde_json::to_string_pretty(&resp.groups)?);
+            }
+        }
+        ChannelCommand::Create { name, topic } => {
+            let mut payload = json!({
+                "fromSessionId": sid,
+                "name": name,
+            });
+            if let Some(t) = &topic {
+                payload["topic"] = json!(t);
+            }
+
+            let result: serde_json::Value =
+                client.post_json("/internal/channels/create", &payload).await?;
+
+            if human {
+                println!("Channel #{name} created.");
+            } else {
+                let channel_val = result.get("channel").unwrap_or(&result);
+                println!("{}", serde_json::to_string_pretty(channel_val)?);
+            }
+        }
+        ChannelCommand::Send {
+            channel,
+            body,
+            reply_to,
+        } => {
+            let mut payload = json!({
+                "fromSessionId": sid,
+                "channelName": channel,
+                "body": body,
+            });
+            if let Some(parent) = &reply_to {
+                payload["parentMessageId"] = json!(parent);
+            }
+
+            let result: serde_json::Value =
+                client.post_json("/internal/channels/send", &payload).await?;
+
+            if human {
+                println!("Message sent to #{channel}");
+            } else {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+            }
+        }
+        ChannelCommand::Messages { channel, limit } => {
+            // First, list channels to resolve name to ID
+            let query = [("sessionId", sid)];
+            let list_resp: ChannelListResponse = client
+                .get_with_query("/internal/channels/list", &query)
+                .await?;
+
+            let channel_id = list_resp
+                .groups
+                .iter()
+                .flat_map(|g| &g.channels)
+                .find(|c| c.name == channel)
+                .map(|c| c.id.clone())
+                .ok_or_else(|| format!("Channel '{}' not found", channel))?;
+
+            // Use the API endpoint for messages
+            // Since internal endpoints don't have a messages-by-channel endpoint,
+            // we need to use the Next.js API. For now, return the channel info.
+            // The MCP tools handle message reading; CLI users can use the MCP tools.
+            let _ = limit;
+            if human {
+                println!("Channel #{channel} (id: {})", &channel_id[..8]);
+                println!("Use 'rdv peer messages' or the MCP read_channel tool to read messages.");
+            } else {
+                println!("{}", json!({"channelId": channel_id, "channelName": channel}));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/rdv/src/commands/channel.rs
+++ b/crates/rdv/src/commands/channel.rs
@@ -165,30 +165,52 @@ pub async fn run(
             }
         }
         ChannelCommand::Messages { channel, limit } => {
-            // First, list channels to resolve name to ID
-            let query = [("sessionId", sid)];
-            let list_resp: ChannelListResponse = client
-                .get_with_query("/internal/channels/list", &query)
+            #[derive(Deserialize)]
+            struct MessagesResponse {
+                messages: Vec<ChannelMessageInfo>,
+            }
+
+            #[derive(Deserialize, Serialize)]
+            struct ChannelMessageInfo {
+                #[serde(rename = "fromSessionName")]
+                from_session_name: String,
+                body: String,
+                #[serde(rename = "createdAt")]
+                created_at: String,
+                #[serde(rename = "replyCount")]
+                reply_count: u32,
+            }
+
+            let limit_str = limit.to_string();
+            let resp: MessagesResponse = client
+                .get_with_query(
+                    "/internal/channels/messages",
+                    &[
+                        ("sessionId", sid),
+                        ("channelName", channel.as_str()),
+                        ("limit", limit_str.as_str()),
+                    ],
+                )
                 .await?;
 
-            let channel_id = list_resp
-                .groups
-                .iter()
-                .flat_map(|g| &g.channels)
-                .find(|c| c.name == channel)
-                .map(|c| c.id.clone())
-                .ok_or_else(|| format!("Channel '{}' not found", channel))?;
-
-            // Use the API endpoint for messages
-            // Since internal endpoints don't have a messages-by-channel endpoint,
-            // we need to use the Next.js API. For now, return the channel info.
-            // The MCP tools handle message reading; CLI users can use the MCP tools.
-            let _ = limit;
             if human {
-                println!("Channel #{channel} (id: {})", &channel_id[..8]);
-                println!("Use 'rdv peer messages' or the MCP read_channel tool to read messages.");
+                if resp.messages.is_empty() {
+                    println!("No messages in #{channel}.");
+                } else {
+                    for msg in &resp.messages {
+                        let thread = if msg.reply_count > 0 {
+                            format!(" ({} replies)", msg.reply_count)
+                        } else {
+                            String::new()
+                        };
+                        println!(
+                            "[{}] {}{}: {}",
+                            msg.created_at, msg.from_session_name, thread, msg.body
+                        );
+                    }
+                }
             } else {
-                println!("{}", json!({"channelId": channel_id, "channelName": channel}));
+                println!("{}", serde_json::to_string_pretty(&resp.messages)?);
             }
         }
     }

--- a/crates/rdv/src/commands/mod.rs
+++ b/crates/rdv/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod browser;
+pub mod channel;
 pub mod context;
 pub mod folder;
 pub mod hook;

--- a/crates/rdv/src/main.rs
+++ b/crates/rdv/src/main.rs
@@ -3,7 +3,7 @@ mod commands;
 mod config;
 
 use clap::Parser;
-use commands::{agent, browser, context, folder, hook, indicator, notification, peer, screen, send, session, status, system, task, teams, tmux_compat, worktree};
+use commands::{agent, browser, channel, context, folder, hook, indicator, notification, peer, screen, send, session, status, system, task, teams, tmux_compat, worktree};
 
 #[derive(Parser)]
 #[command(name = "rdv", version, about = "CLI for Remote Dev terminal server")]
@@ -56,6 +56,8 @@ enum Command {
     Log(indicator::LogArgs),
     /// Communicate with peer agents in the same project folder
     Peer(peer::PeerArgs),
+    /// Manage chat channels in the project folder
+    Channel(channel::ChannelArgs),
     /// Multi-agent team orchestration
     Teams(teams::TeamsArgs),
     /// tmux compatibility layer
@@ -88,6 +90,7 @@ async fn main() {
         Command::ClearProgress(args) => indicator::run_clear_progress(args, &client).await,
         Command::Log(args) => indicator::run_log(args, &client).await,
         Command::Peer(args) => peer::run(args, &client, cli.human).await,
+        Command::Channel(args) => channel::run(args, &client, cli.human).await,
         Command::Teams(args) => teams::run(args, &client, cli.human).await,
         Command::Tmux(args) => tmux_compat::run(args, &client, cli.human).await,
     };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "db:migrate-agents": "bun run scripts/migrate-agent-sessions.ts",
     "db:migrate-github-accounts": "bun run scripts/migrate-github-accounts.ts",
     "db:migrate-profile-gitconfigs": "bun run scripts/migrate-profile-gitconfigs.ts",
+    "db:migrate-channels": "tsx src/db/migrations/migrate-channels.ts",
     "terminal:build": "bun build src/server/index.ts --outdir dist-terminal --target node --external node-pty --external better-sqlite3 --sourcemap",
     "electron:build": "tsc -p electron/tsconfig.json",
     "electron:dev": "bun run electron:build && concurrently --kill-others -n next,term,electron -c blue,green,yellow \"bun run dev:next\" \"bun run dev:terminal\" \"electron .\"",

--- a/src/app/api/channels/[channelId]/messages/[messageId]/thread/route.ts
+++ b/src/app/api/channels/[channelId]/messages/[messageId]/thread/route.ts
@@ -30,7 +30,8 @@ async function verifyChannelAccess(
 // GET /api/channels/:channelId/messages/:messageId/thread?limit=100
 export const GET = withApiAuth(async (request, context) => {
   try {
-    const { channelId, messageId } = await context.params;
+    const channelId = context.params!.channelId;
+    const messageId = context.params!.messageId;
 
     if (!(await verifyChannelAccess(channelId, context.userId))) {
       return errorResponse("Channel not found", 404);

--- a/src/app/api/channels/[channelId]/messages/[messageId]/thread/route.ts
+++ b/src/app/api/channels/[channelId]/messages/[messageId]/thread/route.ts
@@ -27,8 +27,8 @@ async function verifyChannelAccess(
   return !!folder;
 }
 
-// GET /api/channels/:channelId/messages/:messageId/thread
-export const GET = withApiAuth(async (_request, context) => {
+// GET /api/channels/:channelId/messages/:messageId/thread?limit=100
+export const GET = withApiAuth(async (request, context) => {
   try {
     const { channelId, messageId } = await context.params;
 
@@ -36,7 +36,11 @@ export const GET = withApiAuth(async (_request, context) => {
       return errorResponse("Channel not found", 404);
     }
 
-    const replies = await PeerService.listThreadReplies(messageId);
+    const { searchParams } = new URL(request.url);
+    const rawLimit = parseInt(searchParams.get("limit") ?? "100", 10);
+    const limit = Number.isNaN(rawLimit) ? 100 : Math.min(Math.max(1, rawLimit), 500);
+
+    const replies = await PeerService.listThreadReplies(messageId, limit);
     return NextResponse.json({ replies });
   } catch (err) {
     log.error("Failed to list thread replies", { error: String(err) });

--- a/src/app/api/channels/[channelId]/messages/[messageId]/thread/route.ts
+++ b/src/app/api/channels/[channelId]/messages/[messageId]/thread/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { withApiAuth, errorResponse } from "@/lib/api";
+import { db } from "@/db";
+import { sessionFolders } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import * as ChannelService from "@/services/channel-service";
+import * as PeerService from "@/services/peer-service";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("api/channels/[channelId]/messages/[messageId]/thread");
+
+/** Verify the user owns the folder that contains this channel. */
+async function verifyChannelAccess(
+  channelId: string,
+  userId: string
+): Promise<boolean> {
+  const channel = await ChannelService.getChannel(channelId);
+  if (!channel) return false;
+
+  const folder = await db.query.sessionFolders.findFirst({
+    where: and(
+      eq(sessionFolders.id, channel.folderId),
+      eq(sessionFolders.userId, userId)
+    ),
+    columns: { id: true },
+  });
+  return !!folder;
+}
+
+// GET /api/channels/:channelId/messages/:messageId/thread
+export const GET = withApiAuth(async (_request, context) => {
+  try {
+    const { channelId, messageId } = await context.params;
+
+    if (!(await verifyChannelAccess(channelId, context.userId))) {
+      return errorResponse("Channel not found", 404);
+    }
+
+    const replies = await PeerService.listThreadReplies(messageId);
+    return NextResponse.json({ replies });
+  } catch (err) {
+    log.error("Failed to list thread replies", { error: String(err) });
+    return errorResponse("Failed to list thread replies", 500);
+  }
+});

--- a/src/app/api/channels/[channelId]/messages/[messageId]/thread/route.ts
+++ b/src/app/api/channels/[channelId]/messages/[messageId]/thread/route.ts
@@ -1,31 +1,10 @@
 import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse } from "@/lib/api";
-import { db } from "@/db";
-import { sessionFolders } from "@/db/schema";
-import { eq, and } from "drizzle-orm";
 import * as ChannelService from "@/services/channel-service";
 import * as PeerService from "@/services/peer-service";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("api/channels/[channelId]/messages/[messageId]/thread");
-
-/** Verify the user owns the folder that contains this channel. */
-async function verifyChannelAccess(
-  channelId: string,
-  userId: string
-): Promise<boolean> {
-  const channel = await ChannelService.getChannel(channelId);
-  if (!channel) return false;
-
-  const folder = await db.query.sessionFolders.findFirst({
-    where: and(
-      eq(sessionFolders.id, channel.folderId),
-      eq(sessionFolders.userId, userId)
-    ),
-    columns: { id: true },
-  });
-  return !!folder;
-}
 
 // GET /api/channels/:channelId/messages/:messageId/thread?limit=100
 export const GET = withApiAuth(async (request, context) => {
@@ -33,7 +12,7 @@ export const GET = withApiAuth(async (request, context) => {
     const channelId = context.params!.channelId;
     const messageId = context.params!.messageId;
 
-    if (!(await verifyChannelAccess(channelId, context.userId))) {
+    if (!(await ChannelService.verifyChannelAccess(channelId, context.userId))) {
       return errorResponse("Channel not found", 404);
     }
 

--- a/src/app/api/channels/[channelId]/messages/route.ts
+++ b/src/app/api/channels/[channelId]/messages/route.ts
@@ -25,8 +25,11 @@ export const GET = withApiAuth(async (request, context) => {
     const limitParam = searchParams.get("limit");
 
     const before = beforeParam ? new Date(beforeParam) : undefined;
+    if (before && isNaN(before.getTime())) {
+      return errorResponse("Invalid before date parameter", 400);
+    }
     const rawLimit = parseInt(limitParam ?? "50", 10);
-    const limit = Number.isNaN(rawLimit) ? 50 : rawLimit;
+    const limit = Number.isNaN(rawLimit) ? 50 : Math.min(Math.max(1, rawLimit), 200);
 
     const messages = await PeerService.listChannelMessages(channelId, { before, limit });
     return NextResponse.json({ messages });
@@ -53,6 +56,7 @@ export const POST = withApiAuth(async (request, context) => {
     if (!body) {
       return errorResponse("body is required", 400);
     }
+    if (body.length > 8192) return errorResponse("Message body exceeds maximum length of 8192 characters", 400);
 
     // Look up user's display name
     const user = await db.query.users.findFirst({

--- a/src/app/api/channels/[channelId]/messages/route.ts
+++ b/src/app/api/channels/[channelId]/messages/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
 import { db } from "@/db";
-import { sessionFolders, users } from "@/db/schema";
-import { eq, and } from "drizzle-orm";
+import { users } from "@/db/schema";
+import { eq } from "drizzle-orm";
 import * as ChannelService from "@/services/channel-service";
 import * as PeerService from "@/services/peer-service";
 import { resolveTerminalServerUrl } from "@/lib/terminal-server-url";
@@ -10,32 +10,12 @@ import { createLogger } from "@/lib/logger";
 
 const log = createLogger("api/channels/[channelId]/messages");
 
-/** Verify the user owns the folder that contains this channel. */
-async function verifyChannelAccess(
-  channelId: string,
-  userId: string
-): Promise<{ folderId: string } | null> {
-  const channel = await ChannelService.getChannel(channelId);
-  if (!channel) return null;
-
-  const folder = await db.query.sessionFolders.findFirst({
-    where: and(
-      eq(sessionFolders.id, channel.folderId),
-      eq(sessionFolders.userId, userId)
-    ),
-    columns: { id: true },
-  });
-  if (!folder) return null;
-
-  return { folderId: channel.folderId };
-}
-
 // GET /api/channels/:channelId/messages?before=&limit=
 export const GET = withApiAuth(async (request, context) => {
   try {
     const channelId = context.params!.channelId;
 
-    const access = await verifyChannelAccess(channelId, context.userId);
+    const access = await ChannelService.verifyChannelAccess(channelId, context.userId);
     if (!access) {
       return errorResponse("Channel not found", 404);
     }
@@ -61,7 +41,7 @@ export const POST = withApiAuth(async (request, context) => {
   try {
     const channelId = context.params!.channelId;
 
-    const access = await verifyChannelAccess(channelId, context.userId);
+    const access = await ChannelService.verifyChannelAccess(channelId, context.userId);
     if (!access) {
       return errorResponse("Channel not found", 404);
     }

--- a/src/app/api/channels/[channelId]/messages/route.ts
+++ b/src/app/api/channels/[channelId]/messages/route.ts
@@ -58,6 +58,20 @@ export const POST = withApiAuth(async (request, context) => {
     }
     if (body.length > 8192) return errorResponse("Message body exceeds maximum length of 8192 characters", 400);
 
+    // Validate parentMessageId belongs to this channel
+    if (parentMessageId) {
+      const { agentPeerMessages } = await import("@/db/schema");
+      const { eq: eqOp, and: andOp } = await import("drizzle-orm");
+      const parent = await db.query.agentPeerMessages.findFirst({
+        where: andOp(
+          eqOp(agentPeerMessages.id, parentMessageId),
+          eqOp(agentPeerMessages.channelId, channelId)
+        ),
+        columns: { id: true },
+      });
+      if (!parent) return errorResponse("Parent message not found in this channel", 400);
+    }
+
     // Look up user's display name
     const user = await db.query.users.findFirst({
       where: eq(users.id, context.userId),

--- a/src/app/api/channels/[channelId]/messages/route.ts
+++ b/src/app/api/channels/[channelId]/messages/route.ts
@@ -33,7 +33,7 @@ async function verifyChannelAccess(
 // GET /api/channels/:channelId/messages?before=&limit=
 export const GET = withApiAuth(async (request, context) => {
   try {
-    const { channelId } = await context.params;
+    const channelId = context.params!.channelId;
 
     const access = await verifyChannelAccess(channelId, context.userId);
     if (!access) {
@@ -59,7 +59,7 @@ export const GET = withApiAuth(async (request, context) => {
 // POST /api/channels/:channelId/messages — send message { body, parentMessageId? }
 export const POST = withApiAuth(async (request, context) => {
   try {
-    const { channelId } = await context.params;
+    const channelId = context.params!.channelId;
 
     const access = await verifyChannelAccess(channelId, context.userId);
     if (!access) {

--- a/src/app/api/channels/[channelId]/messages/route.ts
+++ b/src/app/api/channels/[channelId]/messages/route.ts
@@ -95,10 +95,6 @@ export const POST = withApiAuth(async (request, context) => {
 
     return NextResponse.json({ messageId, message }, { status: 201 });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("exceeds maximum length")) {
-      return errorResponse(msg, 400);
-    }
     log.error("Failed to send channel message", { error: String(err) });
     return errorResponse("Failed to send message", 500);
   }

--- a/src/app/api/channels/[channelId]/messages/route.ts
+++ b/src/app/api/channels/[channelId]/messages/route.ts
@@ -92,10 +92,18 @@ export const POST = withApiAuth(async (request, context) => {
     // Broadcast to folder owner's WebSocket clients via terminal server
     try {
       const baseUrl = resolveTerminalServerUrl();
+      const eventType = parentMessageId ? "thread_reply_created" : "channel_message_created";
       await fetch(`${baseUrl}/internal/peers/broadcast`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId: context.userId, folderId: access.folderId, message }),
+        body: JSON.stringify({
+          userId: context.userId,
+          folderId: access.folderId,
+          channelId,
+          parentMessageId: parentMessageId ?? null,
+          message,
+          type: eventType,
+        }),
       });
     } catch (err) {
       log.warn("Failed to broadcast channel message", { error: String(err) });

--- a/src/app/api/channels/[channelId]/messages/route.ts
+++ b/src/app/api/channels/[channelId]/messages/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
 import { db } from "@/db";
-import { users } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { agentPeerMessages, users } from "@/db/schema";
+import { and, eq } from "drizzle-orm";
 import * as ChannelService from "@/services/channel-service";
 import * as PeerService from "@/services/peer-service";
 import { resolveTerminalServerUrl } from "@/lib/terminal-server-url";
@@ -60,12 +60,10 @@ export const POST = withApiAuth(async (request, context) => {
 
     // Validate parentMessageId belongs to this channel
     if (parentMessageId) {
-      const { agentPeerMessages } = await import("@/db/schema");
-      const { eq: eqOp, and: andOp } = await import("drizzle-orm");
       const parent = await db.query.agentPeerMessages.findFirst({
-        where: andOp(
-          eqOp(agentPeerMessages.id, parentMessageId),
-          eqOp(agentPeerMessages.channelId, channelId)
+        where: and(
+          eq(agentPeerMessages.id, parentMessageId),
+          eq(agentPeerMessages.channelId, channelId)
         ),
         columns: { id: true },
       });

--- a/src/app/api/channels/[channelId]/messages/route.ts
+++ b/src/app/api/channels/[channelId]/messages/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
+import { db } from "@/db";
+import { sessionFolders, users } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import * as ChannelService from "@/services/channel-service";
+import * as PeerService from "@/services/peer-service";
+import { resolveTerminalServerUrl } from "@/lib/terminal-server-url";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("api/channels/[channelId]/messages");
+
+/** Verify the user owns the folder that contains this channel. */
+async function verifyChannelAccess(
+  channelId: string,
+  userId: string
+): Promise<{ folderId: string } | null> {
+  const channel = await ChannelService.getChannel(channelId);
+  if (!channel) return null;
+
+  const folder = await db.query.sessionFolders.findFirst({
+    where: and(
+      eq(sessionFolders.id, channel.folderId),
+      eq(sessionFolders.userId, userId)
+    ),
+    columns: { id: true },
+  });
+  if (!folder) return null;
+
+  return { folderId: channel.folderId };
+}
+
+// GET /api/channels/:channelId/messages?before=&limit=
+export const GET = withApiAuth(async (request, context) => {
+  try {
+    const { channelId } = await context.params;
+
+    const access = await verifyChannelAccess(channelId, context.userId);
+    if (!access) {
+      return errorResponse("Channel not found", 404);
+    }
+
+    const { searchParams } = new URL(request.url);
+    const beforeParam = searchParams.get("before");
+    const limitParam = searchParams.get("limit");
+
+    const before = beforeParam ? new Date(beforeParam) : undefined;
+    const rawLimit = parseInt(limitParam ?? "50", 10);
+    const limit = Number.isNaN(rawLimit) ? 50 : rawLimit;
+
+    const messages = await PeerService.listChannelMessages(channelId, { before, limit });
+    return NextResponse.json({ messages });
+  } catch (err) {
+    log.error("Failed to list channel messages", { error: String(err) });
+    return errorResponse("Failed to list messages", 500);
+  }
+});
+
+// POST /api/channels/:channelId/messages — send message { body, parentMessageId? }
+export const POST = withApiAuth(async (request, context) => {
+  try {
+    const { channelId } = await context.params;
+
+    const access = await verifyChannelAccess(channelId, context.userId);
+    if (!access) {
+      return errorResponse("Channel not found", 404);
+    }
+
+    const result = await parseJsonBody<{ body: string; parentMessageId?: string }>(request);
+    if ("error" in result) return result.error;
+    const { body, parentMessageId } = result.data;
+
+    if (!body) {
+      return errorResponse("body is required", 400);
+    }
+
+    // Look up user's display name
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, context.userId),
+      columns: { name: true, email: true },
+    });
+    const fromName = user?.name || user?.email || "User";
+
+    const { messageId, message } = await PeerService.sendUserMessage({
+      folderId: access.folderId,
+      fromName,
+      body,
+      channelId,
+      parentMessageId,
+    });
+
+    // Broadcast to folder owner's WebSocket clients via terminal server
+    try {
+      const baseUrl = resolveTerminalServerUrl();
+      await fetch(`${baseUrl}/internal/peers/broadcast`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: context.userId, folderId: access.folderId, message }),
+      });
+    } catch (err) {
+      log.warn("Failed to broadcast channel message", { error: String(err) });
+    }
+
+    return NextResponse.json({ messageId, message }, { status: 201 });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("exceeds maximum length")) {
+      return errorResponse(msg, 400);
+    }
+    log.error("Failed to send channel message", { error: String(err) });
+    return errorResponse("Failed to send message", 500);
+  }
+});

--- a/src/app/api/channels/[channelId]/read/route.ts
+++ b/src/app/api/channels/[channelId]/read/route.ts
@@ -29,7 +29,7 @@ async function verifyChannelAccess(
 // POST /api/channels/:channelId/read — mark channel read { messageId }
 export const POST = withApiAuth(async (request, context) => {
   try {
-    const { channelId } = await context.params;
+    const channelId = context.params!.channelId;
 
     if (!(await verifyChannelAccess(channelId, context.userId))) {
       return errorResponse("Channel not found", 404);

--- a/src/app/api/channels/[channelId]/read/route.ts
+++ b/src/app/api/channels/[channelId]/read/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
+import { db } from "@/db";
+import { sessionFolders } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import * as ChannelService from "@/services/channel-service";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("api/channels/[channelId]/read");
+
+/** Verify the user owns the folder that contains this channel. */
+async function verifyChannelAccess(
+  channelId: string,
+  userId: string
+): Promise<boolean> {
+  const channel = await ChannelService.getChannel(channelId);
+  if (!channel) return false;
+
+  const folder = await db.query.sessionFolders.findFirst({
+    where: and(
+      eq(sessionFolders.id, channel.folderId),
+      eq(sessionFolders.userId, userId)
+    ),
+    columns: { id: true },
+  });
+  return !!folder;
+}
+
+// POST /api/channels/:channelId/read — mark channel read { messageId }
+export const POST = withApiAuth(async (request, context) => {
+  try {
+    const { channelId } = await context.params;
+
+    if (!(await verifyChannelAccess(channelId, context.userId))) {
+      return errorResponse("Channel not found", 404);
+    }
+
+    const result = await parseJsonBody<{ messageId: string }>(request);
+    if ("error" in result) return result.error;
+    const { messageId } = result.data;
+
+    if (!messageId) {
+      return errorResponse("messageId is required", 400);
+    }
+
+    await ChannelService.markChannelRead(channelId, context.userId, messageId);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error("Failed to mark channel read", { error: String(err) });
+    return errorResponse("Failed to mark channel read", 500);
+  }
+});

--- a/src/app/api/channels/[channelId]/read/route.ts
+++ b/src/app/api/channels/[channelId]/read/route.ts
@@ -1,37 +1,16 @@
 import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
-import { db } from "@/db";
-import { sessionFolders } from "@/db/schema";
-import { eq, and } from "drizzle-orm";
 import * as ChannelService from "@/services/channel-service";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("api/channels/[channelId]/read");
-
-/** Verify the user owns the folder that contains this channel. */
-async function verifyChannelAccess(
-  channelId: string,
-  userId: string
-): Promise<boolean> {
-  const channel = await ChannelService.getChannel(channelId);
-  if (!channel) return false;
-
-  const folder = await db.query.sessionFolders.findFirst({
-    where: and(
-      eq(sessionFolders.id, channel.folderId),
-      eq(sessionFolders.userId, userId)
-    ),
-    columns: { id: true },
-  });
-  return !!folder;
-}
 
 // POST /api/channels/:channelId/read — mark channel read { messageId }
 export const POST = withApiAuth(async (request, context) => {
   try {
     const channelId = context.params!.channelId;
 
-    if (!(await verifyChannelAccess(channelId, context.userId))) {
+    if (!(await ChannelService.verifyChannelAccess(channelId, context.userId))) {
       return errorResponse("Channel not found", 404);
     }
 

--- a/src/app/api/channels/[channelId]/route.ts
+++ b/src/app/api/channels/[channelId]/route.ts
@@ -1,37 +1,16 @@
 import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse } from "@/lib/api";
-import { db } from "@/db";
-import { sessionFolders } from "@/db/schema";
-import { eq, and } from "drizzle-orm";
 import * as ChannelService from "@/services/channel-service";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("api/channels/[channelId]");
-
-/** Verify the user owns the folder that contains this channel. */
-async function verifyChannelAccess(
-  channelId: string,
-  userId: string
-): Promise<boolean> {
-  const channel = await ChannelService.getChannel(channelId);
-  if (!channel) return false;
-
-  const folder = await db.query.sessionFolders.findFirst({
-    where: and(
-      eq(sessionFolders.id, channel.folderId),
-      eq(sessionFolders.userId, userId)
-    ),
-    columns: { id: true },
-  });
-  return !!folder;
-}
 
 // GET /api/channels/:channelId — get channel details
 export const GET = withApiAuth(async (_request, context) => {
   try {
     const channelId = context.params!.channelId;
 
-    if (!(await verifyChannelAccess(channelId, context.userId))) {
+    if (!(await ChannelService.verifyChannelAccess(channelId, context.userId))) {
       return errorResponse("Channel not found", 404);
     }
 
@@ -48,7 +27,7 @@ export const DELETE = withApiAuth(async (_request, context) => {
   try {
     const channelId = context.params!.channelId;
 
-    if (!(await verifyChannelAccess(channelId, context.userId))) {
+    if (!(await ChannelService.verifyChannelAccess(channelId, context.userId))) {
       return errorResponse("Channel not found", 404);
     }
 

--- a/src/app/api/channels/[channelId]/route.ts
+++ b/src/app/api/channels/[channelId]/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { withApiAuth, errorResponse } from "@/lib/api";
+import { db } from "@/db";
+import { sessionFolders } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import * as ChannelService from "@/services/channel-service";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("api/channels/[channelId]");
+
+/** Verify the user owns the folder that contains this channel. */
+async function verifyChannelAccess(
+  channelId: string,
+  userId: string
+): Promise<boolean> {
+  const channel = await ChannelService.getChannel(channelId);
+  if (!channel) return false;
+
+  const folder = await db.query.sessionFolders.findFirst({
+    where: and(
+      eq(sessionFolders.id, channel.folderId),
+      eq(sessionFolders.userId, userId)
+    ),
+    columns: { id: true },
+  });
+  return !!folder;
+}
+
+// GET /api/channels/:channelId — get channel details
+export const GET = withApiAuth(async (_request, context) => {
+  try {
+    const { channelId } = await context.params;
+
+    if (!(await verifyChannelAccess(channelId, context.userId))) {
+      return errorResponse("Channel not found", 404);
+    }
+
+    const channel = await ChannelService.getChannel(channelId);
+    return NextResponse.json({ channel });
+  } catch (err) {
+    log.error("Failed to get channel", { error: String(err) });
+    return errorResponse("Failed to get channel", 500);
+  }
+});
+
+// DELETE /api/channels/:channelId — archive channel
+export const DELETE = withApiAuth(async (_request, context) => {
+  try {
+    const { channelId } = await context.params;
+
+    if (!(await verifyChannelAccess(channelId, context.userId))) {
+      return errorResponse("Channel not found", 404);
+    }
+
+    await ChannelService.archiveChannel(channelId);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("Cannot archive the default channel")) {
+      return errorResponse(msg, 400);
+    }
+    log.error("Failed to archive channel", { error: String(err) });
+    return errorResponse("Failed to archive channel", 500);
+  }
+});

--- a/src/app/api/channels/[channelId]/route.ts
+++ b/src/app/api/channels/[channelId]/route.ts
@@ -29,7 +29,7 @@ async function verifyChannelAccess(
 // GET /api/channels/:channelId — get channel details
 export const GET = withApiAuth(async (_request, context) => {
   try {
-    const { channelId } = await context.params;
+    const channelId = context.params!.channelId;
 
     if (!(await verifyChannelAccess(channelId, context.userId))) {
       return errorResponse("Channel not found", 404);
@@ -46,7 +46,7 @@ export const GET = withApiAuth(async (_request, context) => {
 // DELETE /api/channels/:channelId — archive channel
 export const DELETE = withApiAuth(async (_request, context) => {
   try {
-    const { channelId } = await context.params;
+    const channelId = context.params!.channelId;
 
     if (!(await verifyChannelAccess(channelId, context.userId))) {
       return errorResponse("Channel not found", 404);

--- a/src/app/api/channels/[channelId]/route.ts
+++ b/src/app/api/channels/[channelId]/route.ts
@@ -36,7 +36,7 @@ export const DELETE = withApiAuth(async (_request, context) => {
     return NextResponse.json({ success: true });
   } catch (err) {
     if (err instanceof ChannelArchiveError) {
-      return errorResponse(String(err.message), 400);
+      return errorResponse(err.message, 400);
     }
     log.error("Failed to archive channel", { error: String(err) });
     return errorResponse("Failed to archive channel", 500);

--- a/src/app/api/channels/[channelId]/route.ts
+++ b/src/app/api/channels/[channelId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse } from "@/lib/api";
 import * as ChannelService from "@/services/channel-service";
+import { ChannelArchiveError } from "@/services/channel-service";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("api/channels/[channelId]");
@@ -34,9 +35,8 @@ export const DELETE = withApiAuth(async (_request, context) => {
     await ChannelService.archiveChannel(channelId);
     return NextResponse.json({ success: true });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("Cannot archive the default channel")) {
-      return errorResponse(msg, 400);
+    if (err instanceof ChannelArchiveError) {
+      return errorResponse(String(err.message), 400);
     }
     log.error("Failed to archive channel", { error: String(err) });
     return errorResponse("Failed to archive channel", 500);

--- a/src/app/api/channels/dm/route.ts
+++ b/src/app/api/channels/dm/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
 import * as ChannelService from "@/services/channel-service";
+import { db } from "@/db";
+import { terminalSessions } from "@/db/schema";
+import { and, eq } from "drizzle-orm";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("api/channels/dm");
@@ -23,6 +26,16 @@ export const POST = withApiAuth(async (request, { userId }) => {
     if (!(await ChannelService.verifyFolderOwnership(folderId, userId))) {
       return errorResponse("Folder not found", 404);
     }
+
+    // Verify fromSessionId belongs to this user
+    const fromSession = await db.query.terminalSessions.findFirst({
+      where: and(
+        eq(terminalSessions.id, fromSessionId),
+        eq(terminalSessions.userId, userId)
+      ),
+      columns: { id: true },
+    });
+    if (!fromSession) return errorResponse("fromSessionId not found or not owned by user", 403);
 
     const channel = await ChannelService.findOrCreateDmChannel(
       folderId,

--- a/src/app/api/channels/dm/route.ts
+++ b/src/app/api/channels/dm/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
+import { db } from "@/db";
+import { sessionFolders } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import * as ChannelService from "@/services/channel-service";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("api/channels/dm");
+
+/** Verify the user owns the given folder. */
+async function verifyFolderOwnership(folderId: string, userId: string): Promise<boolean> {
+  const folder = await db.query.sessionFolders.findFirst({
+    where: and(
+      eq(sessionFolders.id, folderId),
+      eq(sessionFolders.userId, userId)
+    ),
+    columns: { id: true },
+  });
+  return !!folder;
+}
+
+// POST /api/channels/dm — find/create DM { folderId, targetSessionId, fromSessionId }
+export const POST = withApiAuth(async (request, { userId }) => {
+  try {
+    const result = await parseJsonBody<{
+      folderId: string;
+      targetSessionId: string;
+      fromSessionId: string;
+    }>(request);
+    if ("error" in result) return result.error;
+    const { folderId, targetSessionId, fromSessionId } = result.data;
+
+    if (!folderId || !targetSessionId || !fromSessionId) {
+      return errorResponse("folderId, targetSessionId, and fromSessionId are required", 400);
+    }
+
+    if (!(await verifyFolderOwnership(folderId, userId))) {
+      return errorResponse("Folder not found", 404);
+    }
+
+    const channel = await ChannelService.findOrCreateDmChannel(
+      folderId,
+      fromSessionId,
+      targetSessionId
+    );
+    return NextResponse.json({ channel });
+  } catch (err) {
+    log.error("Failed to find/create DM channel", { error: String(err) });
+    return errorResponse("Failed to find or create DM channel", 500);
+  }
+});

--- a/src/app/api/channels/dm/route.ts
+++ b/src/app/api/channels/dm/route.ts
@@ -37,6 +37,16 @@ export const POST = withApiAuth(async (request, { userId }) => {
     });
     if (!fromSession) return errorResponse("fromSessionId not found or not owned by user", 403);
 
+    // Verify targetSessionId exists in the same folder
+    const targetSession = await db.query.terminalSessions.findFirst({
+      where: and(
+        eq(terminalSessions.id, targetSessionId),
+        eq(terminalSessions.folderId, folderId)
+      ),
+      columns: { id: true },
+    });
+    if (!targetSession) return errorResponse("Target session not found in this folder", 404);
+
     const channel = await ChannelService.findOrCreateDmChannel(
       folderId,
       fromSessionId,

--- a/src/app/api/channels/dm/route.ts
+++ b/src/app/api/channels/dm/route.ts
@@ -1,24 +1,9 @@
 import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
-import { db } from "@/db";
-import { sessionFolders } from "@/db/schema";
-import { eq, and } from "drizzle-orm";
 import * as ChannelService from "@/services/channel-service";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("api/channels/dm");
-
-/** Verify the user owns the given folder. */
-async function verifyFolderOwnership(folderId: string, userId: string): Promise<boolean> {
-  const folder = await db.query.sessionFolders.findFirst({
-    where: and(
-      eq(sessionFolders.id, folderId),
-      eq(sessionFolders.userId, userId)
-    ),
-    columns: { id: true },
-  });
-  return !!folder;
-}
 
 // POST /api/channels/dm — find/create DM { folderId, targetSessionId, fromSessionId }
 export const POST = withApiAuth(async (request, { userId }) => {
@@ -35,7 +20,7 @@ export const POST = withApiAuth(async (request, { userId }) => {
       return errorResponse("folderId, targetSessionId, and fromSessionId are required", 400);
     }
 
-    if (!(await verifyFolderOwnership(folderId, userId))) {
+    if (!(await ChannelService.verifyFolderOwnership(folderId, userId))) {
       return errorResponse("Folder not found", 404);
     }
 

--- a/src/app/api/channels/route.ts
+++ b/src/app/api/channels/route.ts
@@ -1,24 +1,9 @@
 import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
-import { db } from "@/db";
-import { sessionFolders } from "@/db/schema";
-import { eq, and } from "drizzle-orm";
 import * as ChannelService from "@/services/channel-service";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("api/channels");
-
-/** Verify the user owns the given folder. */
-async function verifyFolderOwnership(folderId: string, userId: string): Promise<boolean> {
-  const folder = await db.query.sessionFolders.findFirst({
-    where: and(
-      eq(sessionFolders.id, folderId),
-      eq(sessionFolders.userId, userId)
-    ),
-    columns: { id: true },
-  });
-  return !!folder;
-}
 
 // GET /api/channels?folderId= — list channel groups with unread counts
 export const GET = withApiAuth(async (request, { userId }) => {
@@ -30,7 +15,7 @@ export const GET = withApiAuth(async (request, { userId }) => {
       return errorResponse("folderId is required", 400);
     }
 
-    if (!(await verifyFolderOwnership(folderId, userId))) {
+    if (!(await ChannelService.verifyFolderOwnership(folderId, userId))) {
       return errorResponse("Folder not found", 404);
     }
 
@@ -53,7 +38,7 @@ export const POST = withApiAuth(async (request, { userId }) => {
       return errorResponse("folderId and name are required", 400);
     }
 
-    if (!(await verifyFolderOwnership(folderId, userId))) {
+    if (!(await ChannelService.verifyFolderOwnership(folderId, userId))) {
       return errorResponse("Folder not found", 404);
     }
 

--- a/src/app/api/channels/route.ts
+++ b/src/app/api/channels/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
 import * as ChannelService from "@/services/channel-service";
+import { ChannelValidationError } from "@/services/channel-service";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("api/channels");
@@ -45,9 +46,8 @@ export const POST = withApiAuth(async (request, { userId }) => {
     const channel = await ChannelService.createChannel({ folderId, name, topic });
     return NextResponse.json({ channel }, { status: 201 });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes("Invalid channel name")) {
-      return errorResponse(msg, 400);
+    if (err instanceof ChannelValidationError) {
+      return errorResponse(String(err.message), 400);
     }
     log.error("Failed to create channel", { error: String(err) });
     return errorResponse("Failed to create channel", 500);

--- a/src/app/api/channels/route.ts
+++ b/src/app/api/channels/route.ts
@@ -47,7 +47,7 @@ export const POST = withApiAuth(async (request, { userId }) => {
     return NextResponse.json({ channel }, { status: 201 });
   } catch (err) {
     if (err instanceof ChannelValidationError) {
-      return errorResponse(String(err.message), 400);
+      return errorResponse(err.message, 400);
     }
     log.error("Failed to create channel", { error: String(err) });
     return errorResponse("Failed to create channel", 500);

--- a/src/app/api/channels/route.ts
+++ b/src/app/api/channels/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
+import { db } from "@/db";
+import { sessionFolders } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import * as ChannelService from "@/services/channel-service";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("api/channels");
+
+/** Verify the user owns the given folder. */
+async function verifyFolderOwnership(folderId: string, userId: string): Promise<boolean> {
+  const folder = await db.query.sessionFolders.findFirst({
+    where: and(
+      eq(sessionFolders.id, folderId),
+      eq(sessionFolders.userId, userId)
+    ),
+    columns: { id: true },
+  });
+  return !!folder;
+}
+
+// GET /api/channels?folderId= — list channel groups with unread counts
+export const GET = withApiAuth(async (request, { userId }) => {
+  try {
+    const { searchParams } = new URL(request.url);
+    const folderId = searchParams.get("folderId");
+
+    if (!folderId) {
+      return errorResponse("folderId is required", 400);
+    }
+
+    if (!(await verifyFolderOwnership(folderId, userId))) {
+      return errorResponse("Folder not found", 404);
+    }
+
+    const groups = await ChannelService.listChannelGroups(folderId, userId);
+    return NextResponse.json({ groups });
+  } catch (err) {
+    log.error("Failed to list channel groups", { error: String(err) });
+    return errorResponse("Failed to list channels", 500);
+  }
+});
+
+// POST /api/channels — create channel { folderId, name, topic? }
+export const POST = withApiAuth(async (request, { userId }) => {
+  try {
+    const result = await parseJsonBody<{ folderId: string; name: string; topic?: string }>(request);
+    if ("error" in result) return result.error;
+    const { folderId, name, topic } = result.data;
+
+    if (!folderId || !name) {
+      return errorResponse("folderId and name are required", 400);
+    }
+
+    if (!(await verifyFolderOwnership(folderId, userId))) {
+      return errorResponse("Folder not found", 404);
+    }
+
+    const channel = await ChannelService.createChannel({ folderId, name, topic });
+    return NextResponse.json({ channel }, { status: 201 });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("Invalid channel name")) {
+      return errorResponse(msg, 400);
+    }
+    log.error("Failed to create channel", { error: String(err) });
+    return errorResponse("Failed to create channel", 500);
+  }
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,7 @@ import { TaskProvider } from "@/contexts/TaskContext";
 import { GitHubAccountProvider } from "@/contexts/GitHubAccountContext";
 import { NotificationProvider } from "@/contexts/NotificationContext";
 import { PeerChatProvider } from "@/contexts/PeerChatContext";
+import { ChannelProvider } from "@/contexts/ChannelContext";
 import { SessionManager } from "@/components/session/SessionManager";
 import { Header } from "@/components/header/Header";
 import type { TerminalSession } from "@/types/session";
@@ -131,6 +132,7 @@ export default async function Home() {
                               <TaskProvider>
                                 <SessionMCPProvider>
                                   <NotificationProvider>
+                                    <ChannelProvider>
                                     <PeerChatProvider>
                                     <div className="flex h-screen flex-col bg-background">
                                       {/* Header - hidden on mobile, shown in sidebar instead */}
@@ -146,6 +148,7 @@ export default async function Home() {
                                       <SessionManager isGitHubConnected={isGitHubConnected} />
                                     </div>
                                     </PeerChatProvider>
+                                    </ChannelProvider>
                                   </NotificationProvider>
                                 </SessionMCPProvider>
                               </TaskProvider>

--- a/src/components/channels/ChannelMessageRow.tsx
+++ b/src/components/channels/ChannelMessageRow.tsx
@@ -11,7 +11,7 @@ const MENTION_RE = /@<sid:([0-9a-f-]{36})>/g;
 
 interface ChannelMessageRowProps {
   message: ChannelMessage;
-  peerNameMap: Map<string, string>;
+  peerNameMap: ReadonlyMap<string, string>;
   onReplyClick?: (messageId: string) => void;
   isThreadReply?: boolean;
 }
@@ -48,57 +48,13 @@ function formatTime(isoString: string): string {
 }
 
 /**
- * Pre-process message body to replace @<sid:UUID> mention tokens with
- * displayable text. Returns a version of the body where mentions are replaced
- * with @name (or @shortId) so ReactMarkdown can render them as plain text.
- * Also returns a map of placeholder → ReactNode for inline rendering.
- */
-function buildMentionSegments(
-  body: string,
-  peerNameMap: Map<string, string>
-): ReactNode {
-  const matches = Array.from(body.matchAll(MENTION_RE));
-  if (matches.length === 0) return body;
-
-  const parts: ReactNode[] = [];
-  let lastIndex = 0;
-
-  for (const match of matches) {
-    const matchIndex = match.index!;
-    if (matchIndex > lastIndex) {
-      parts.push(body.slice(lastIndex, matchIndex));
-    }
-
-    const sessionId = match[1];
-    const name = peerNameMap.get(sessionId);
-    parts.push(
-      <span
-        key={`mention-${matchIndex}`}
-        className="text-primary font-medium"
-        title={name ? `Session: ${sessionId}` : `Unknown session: ${sessionId}`}
-      >
-        @{name ?? sessionId.slice(0, 8)}
-      </span>
-    );
-
-    lastIndex = matchIndex + match[0].length;
-  }
-
-  if (lastIndex < body.length) {
-    parts.push(body.slice(lastIndex));
-  }
-
-  return <>{parts}</>;
-}
-
-/**
  * Replace mention tokens in a string with a plain-text representation so
  * ReactMarkdown can safely parse the body without the custom token syntax
  * interfering with markdown parsing.
  */
 function preprocessBodyForMarkdown(
   body: string,
-  peerNameMap: Map<string, string>
+  peerNameMap: ReadonlyMap<string, string>
 ): string {
   return body.replace(MENTION_RE, (_match, sessionId) => {
     const name = peerNameMap.get(sessionId);
@@ -170,18 +126,17 @@ export function ChannelMessageRow({
                   {children}
                 </a>
               ),
-              code: ({ className, children, ...props }) => {
+              code: ({ className, children }: { className?: string; children?: ReactNode }) => {
                 const isInline = !className;
                 return isInline ? (
                   <code
                     className="bg-white/10 px-1 py-0.5 rounded text-sm font-mono"
-                    {...props}
                   >
                     {children}
                   </code>
                 ) : (
                   <pre className="bg-black/30 p-3 rounded-lg overflow-x-auto my-2">
-                    <code className={`${className ?? ""} font-mono`} {...props}>
+                    <code className={`${className ?? ""} font-mono`}>
                       {children}
                     </code>
                   </pre>

--- a/src/components/channels/ChannelMessageRow.tsx
+++ b/src/components/channels/ChannelMessageRow.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import React, { useState, type ReactNode } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { Bot, User, MessageSquare } from "lucide-react";
+import type { ChannelMessage } from "@/types/channels";
+
+// Mention token pattern: @<sid:UUID>
+const MENTION_RE = /@<sid:([0-9a-f-]{36})>/g;
+
+interface ChannelMessageRowProps {
+  message: ChannelMessage;
+  peerNameMap: Map<string, string>;
+  onReplyClick?: (messageId: string) => void;
+  isThreadReply?: boolean;
+}
+
+function formatTime(isoString: string): string {
+  const date = new Date(isoString);
+  const now = new Date();
+  const isToday =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+
+  if (isToday) {
+    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  const isYesterday =
+    date.getFullYear() === yesterday.getFullYear() &&
+    date.getMonth() === yesterday.getMonth() &&
+    date.getDate() === yesterday.getDate();
+
+  if (isYesterday) {
+    return `Yesterday ${date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
+  }
+
+  return date.toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Pre-process message body to replace @<sid:UUID> mention tokens with
+ * displayable text. Returns a version of the body where mentions are replaced
+ * with @name (or @shortId) so ReactMarkdown can render them as plain text.
+ * Also returns a map of placeholder → ReactNode for inline rendering.
+ */
+function buildMentionSegments(
+  body: string,
+  peerNameMap: Map<string, string>
+): ReactNode {
+  const matches = Array.from(body.matchAll(MENTION_RE));
+  if (matches.length === 0) return body;
+
+  const parts: ReactNode[] = [];
+  let lastIndex = 0;
+
+  for (const match of matches) {
+    const matchIndex = match.index!;
+    if (matchIndex > lastIndex) {
+      parts.push(body.slice(lastIndex, matchIndex));
+    }
+
+    const sessionId = match[1];
+    const name = peerNameMap.get(sessionId);
+    parts.push(
+      <span
+        key={`mention-${matchIndex}`}
+        className="text-primary font-medium"
+        title={name ? `Session: ${sessionId}` : `Unknown session: ${sessionId}`}
+      >
+        @{name ?? sessionId.slice(0, 8)}
+      </span>
+    );
+
+    lastIndex = matchIndex + match[0].length;
+  }
+
+  if (lastIndex < body.length) {
+    parts.push(body.slice(lastIndex));
+  }
+
+  return <>{parts}</>;
+}
+
+/**
+ * Replace mention tokens in a string with a plain-text representation so
+ * ReactMarkdown can safely parse the body without the custom token syntax
+ * interfering with markdown parsing.
+ */
+function preprocessBodyForMarkdown(
+  body: string,
+  peerNameMap: Map<string, string>
+): string {
+  return body.replace(MENTION_RE, (_match, sessionId) => {
+    const name = peerNameMap.get(sessionId);
+    return `@${name ?? sessionId.slice(0, 8)}`;
+  });
+}
+
+export function ChannelMessageRow({
+  message,
+  peerNameMap,
+  onReplyClick,
+  isThreadReply = false,
+}: ChannelMessageRowProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const processedBody = preprocessBodyForMarkdown(message.body, peerNameMap);
+
+  const senderName = message.isUserMessage ? "You" : message.fromSessionName;
+  const timestamp = formatTime(message.createdAt);
+
+  const avatarElement = message.isUserMessage ? (
+    <div className="flex-shrink-0 w-7 h-7 rounded-full bg-blue-500/20 border border-blue-500/30 flex items-center justify-center">
+      <User className="w-3.5 h-3.5 text-blue-400" />
+    </div>
+  ) : (
+    <div className="flex-shrink-0 w-7 h-7 rounded-full bg-primary/20 border border-primary/30 flex items-center justify-center">
+      <Bot className="w-3.5 h-3.5 text-primary" />
+    </div>
+  );
+
+  return (
+    <div
+      className={`group relative flex items-start gap-3 px-4 py-1.5 rounded-lg transition-colors ${
+        isHovered ? "bg-white/5" : "bg-transparent"
+      } ${isThreadReply ? "pl-6" : ""}`}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      {/* Avatar */}
+      <div className="mt-0.5">{avatarElement}</div>
+
+      {/* Message content */}
+      <div className="flex-1 min-w-0">
+        {/* Header: sender name + timestamp */}
+        <div className="flex items-baseline gap-2 mb-0.5">
+          <span
+            className={`text-sm font-semibold ${
+              message.isUserMessage ? "text-blue-300" : "text-primary"
+            }`}
+          >
+            {senderName}
+          </span>
+          <span className="text-[10px] text-muted-foreground/50 select-none">
+            {timestamp}
+          </span>
+        </div>
+
+        {/* Markdown body */}
+        <div className="text-sm text-foreground/90 leading-relaxed prose prose-invert prose-sm max-w-none">
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              a: ({ href, children }) => (
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-400 hover:underline"
+                >
+                  {children}
+                </a>
+              ),
+              code: ({ className, children, ...props }) => {
+                const isInline = !className;
+                return isInline ? (
+                  <code
+                    className="bg-white/10 px-1 py-0.5 rounded text-sm font-mono"
+                    {...props}
+                  >
+                    {children}
+                  </code>
+                ) : (
+                  <pre className="bg-black/30 p-3 rounded-lg overflow-x-auto my-2">
+                    <code className={`${className ?? ""} font-mono`} {...props}>
+                      {children}
+                    </code>
+                  </pre>
+                );
+              },
+              p: ({ children }) => <p className="mb-1 last:mb-0">{children}</p>,
+              ul: ({ children }) => (
+                <ul className="list-disc pl-4 mb-1">{children}</ul>
+              ),
+              ol: ({ children }) => (
+                <ol className="list-decimal pl-4 mb-1">{children}</ol>
+              ),
+              li: ({ children }) => <li className="mb-0.5">{children}</li>,
+              blockquote: ({ children }) => (
+                <blockquote className="border-l-2 border-white/20 pl-3 my-1 text-white/60">
+                  {children}
+                </blockquote>
+              ),
+              table: ({ children }) => (
+                <div className="overflow-x-auto my-2">
+                  <table className="min-w-full border-collapse">{children}</table>
+                </div>
+              ),
+              th: ({ children }) => (
+                <th className="border border-white/10 px-2 py-1 text-left text-sm font-medium bg-white/5">
+                  {children}
+                </th>
+              ),
+              td: ({ children }) => (
+                <td className="border border-white/10 px-2 py-1 text-sm">
+                  {children}
+                </td>
+              ),
+              h1: ({ children }) => (
+                <h1 className="text-base font-bold mt-2 mb-1">{children}</h1>
+              ),
+              h2: ({ children }) => (
+                <h2 className="text-sm font-bold mt-2 mb-1">{children}</h2>
+              ),
+              h3: ({ children }) => (
+                <h3 className="text-sm font-semibold mt-1.5 mb-0.5">
+                  {children}
+                </h3>
+              ),
+              strong: ({ children }) => (
+                <strong className="font-semibold text-foreground">
+                  {children}
+                </strong>
+              ),
+              em: ({ children }) => (
+                <em className="italic text-foreground/80">{children}</em>
+              ),
+              hr: () => <hr className="border-white/10 my-2" />,
+            }}
+          >
+            {processedBody}
+          </ReactMarkdown>
+        </div>
+
+        {/* Reply chip — shown when there are replies and we're not already in a thread */}
+        {!isThreadReply && message.replyCount > 0 && (
+          <button
+            onClick={() => onReplyClick?.(message.id)}
+            className="flex items-center gap-1.5 mt-1 text-xs text-blue-400 hover:text-blue-300 transition-colors"
+          >
+            <MessageSquare className="w-3 h-3" />
+            {message.replyCount}{" "}
+            {message.replyCount === 1 ? "reply" : "replies"}
+          </button>
+        )}
+      </div>
+
+      {/* Hover action: Reply button */}
+      {!isThreadReply && isHovered && (
+        <div className="absolute right-3 top-1.5 flex items-center gap-1">
+          <button
+            onClick={() => onReplyClick?.(message.id)}
+            className="flex items-center gap-1 px-2 py-1 rounded-md bg-card border border-border text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            title="Reply in thread"
+          >
+            <MessageSquare className="w-3 h-3" />
+            Reply
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/channels/ChannelMessageRow.tsx
+++ b/src/components/channels/ChannelMessageRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, type ReactNode } from "react";
+import React, { type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Bot, User, MessageSquare } from "lucide-react";
@@ -68,32 +68,27 @@ export function ChannelMessageRow({
   onReplyClick,
   isThreadReply = false,
 }: ChannelMessageRowProps) {
-  const [isHovered, setIsHovered] = useState(false);
   const processedBody = preprocessBodyForMarkdown(message.body, peerNameMap);
 
   const senderName = message.isUserMessage ? "You" : message.fromSessionName;
   const timestamp = formatTime(message.createdAt);
 
-  const avatarElement = message.isUserMessage ? (
-    <div className="flex-shrink-0 w-7 h-7 rounded-full bg-blue-500/20 border border-blue-500/30 flex items-center justify-center">
-      <User className="w-3.5 h-3.5 text-blue-400" />
-    </div>
-  ) : (
-    <div className="flex-shrink-0 w-7 h-7 rounded-full bg-primary/20 border border-primary/30 flex items-center justify-center">
-      <Bot className="w-3.5 h-3.5 text-primary" />
-    </div>
-  );
-
   return (
     <div
-      className={`group relative flex items-start gap-3 px-4 py-1.5 rounded-lg transition-colors ${
-        isHovered ? "bg-white/5" : "bg-transparent"
-      } ${isThreadReply ? "pl-6" : ""}`}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      className={`group relative flex items-start gap-3 px-4 py-1.5 rounded-lg transition-colors hover:bg-white/5 ${isThreadReply ? "pl-6" : ""}`}
     >
       {/* Avatar */}
-      <div className="mt-0.5">{avatarElement}</div>
+      <div className="mt-0.5">
+        {message.isUserMessage ? (
+          <div className="flex-shrink-0 w-7 h-7 rounded-full bg-blue-500/20 border border-blue-500/30 flex items-center justify-center">
+            <User className="w-3.5 h-3.5 text-blue-400" />
+          </div>
+        ) : (
+          <div className="flex-shrink-0 w-7 h-7 rounded-full bg-primary/20 border border-primary/30 flex items-center justify-center">
+            <Bot className="w-3.5 h-3.5 text-primary" />
+          </div>
+        )}
+      </div>
 
       {/* Message content */}
       <div className="flex-1 min-w-0">
@@ -210,8 +205,8 @@ export function ChannelMessageRow({
       </div>
 
       {/* Hover action: Reply button */}
-      {!isThreadReply && isHovered && (
-        <div className="absolute right-3 top-1.5 flex items-center gap-1">
+      {!isThreadReply && (
+        <div className="absolute right-3 top-1.5 hidden group-hover:flex items-center gap-1">
           <button
             onClick={() => onReplyClick?.(message.id)}
             className="flex items-center gap-1 px-2 py-1 rounded-md bg-card border border-border text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"

--- a/src/components/channels/ChannelSidebar.tsx
+++ b/src/components/channels/ChannelSidebar.tsx
@@ -21,7 +21,6 @@ import {
   Bot,
   MessageSquare,
 } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Tooltip,

--- a/src/components/channels/ChannelSidebar.tsx
+++ b/src/components/channels/ChannelSidebar.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+/**
+ * ChannelSidebar — Right sidebar for channel-based chat view.
+ *
+ * Mirrors TaskSidebar's localStorage/resize patterns.
+ * Shows channel groups with collapsible sections, unread indicators,
+ * and a "Peers" section at the bottom.
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { useChannelContext } from "@/contexts/ChannelContext";
+import { usePeerChatContext } from "@/contexts/PeerChatContext";
+import {
+  Hash,
+  Plus,
+  ChevronDown,
+  ChevronRight,
+  PanelRightClose,
+  Bot,
+  MessageSquare,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+// --- Sidebar state persistence ---
+
+const MIN_WIDTH = 200;
+const MAX_WIDTH = 400;
+const DEFAULT_WIDTH = 240;
+
+function getStoredCollapsed(): boolean {
+  if (typeof window === "undefined") return false;
+  return localStorage.getItem("channel-sidebar-collapsed") === "true";
+}
+
+function getStoredWidth(): number {
+  if (typeof window === "undefined") return DEFAULT_WIDTH;
+  const stored = localStorage.getItem("channel-sidebar-width");
+  return stored
+    ? Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, parseInt(stored, 10)))
+    : DEFAULT_WIDTH;
+}
+
+function setStoredCollapsed(val: boolean) {
+  localStorage.setItem("channel-sidebar-collapsed", String(val));
+  window.dispatchEvent(new CustomEvent("channel-sidebar-collapsed-change"));
+}
+
+function setStoredWidth(val: number) {
+  localStorage.setItem("channel-sidebar-width", String(val));
+  window.dispatchEvent(new CustomEvent("channel-sidebar-width-change"));
+}
+
+// --- Props ---
+
+interface ChannelSidebarProps {
+  onCreateChannel: () => void;
+}
+
+// --- Main Component ---
+
+export function ChannelSidebar({ onCreateChannel }: ChannelSidebarProps) {
+  const { groups, activeChannelId, setActiveChannelId, totalUnreadCount } =
+    useChannelContext();
+  const { peers } = usePeerChatContext();
+
+  // Sidebar state — lazy-initialize from localStorage
+  const [collapsed, setCollapsed] = useState(getStoredCollapsed);
+  const [width, setWidth] = useState(getStoredWidth);
+
+  // Group expand state: track which group IDs are collapsed
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    new Set()
+  );
+  const [peersExpanded, setPeersExpanded] = useState(true);
+
+  // Listen for collapse state changes (cross-tab sync)
+  useEffect(() => {
+    const onCollapsedChange = () => setCollapsed(getStoredCollapsed());
+    const onWidthChange = () => setWidth(getStoredWidth());
+    const onToggle = () => {
+      const next = !getStoredCollapsed();
+      setStoredCollapsed(next);
+      setCollapsed(next);
+    };
+
+    window.addEventListener("channel-sidebar-collapsed-change", onCollapsedChange);
+    window.addEventListener("channel-sidebar-width-change", onWidthChange);
+    window.addEventListener("channel-sidebar-toggle", onToggle);
+
+    return () => {
+      window.removeEventListener(
+        "channel-sidebar-collapsed-change",
+        onCollapsedChange
+      );
+      window.removeEventListener("channel-sidebar-width-change", onWidthChange);
+      window.removeEventListener("channel-sidebar-toggle", onToggle);
+    };
+  }, []);
+
+  // Resize handle
+  const resizeRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const latestWidthRef = useRef(width);
+  useEffect(() => {
+    latestWidthRef.current = width;
+  }, [width]);
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      resizeRef.current = { startX: e.clientX, startWidth: width };
+
+      const handleMouseMove = (e: MouseEvent) => {
+        if (!resizeRef.current) return;
+        // Dragging left = increasing width (sidebar is on the right)
+        const delta = resizeRef.current.startX - e.clientX;
+        const newWidth = Math.max(
+          MIN_WIDTH,
+          Math.min(MAX_WIDTH, resizeRef.current.startWidth + delta)
+        );
+        setWidth(newWidth);
+      };
+
+      const handleMouseUp = () => {
+        resizeRef.current = null;
+        setStoredWidth(latestWidthRef.current);
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+    },
+    [width]
+  );
+
+  // Toggle collapse
+  const toggleCollapsed = useCallback(() => {
+    const next = !collapsed;
+    setStoredCollapsed(next);
+    setCollapsed(next);
+  }, [collapsed]);
+
+  const toggleGroup = useCallback((groupId: string) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) {
+        next.delete(groupId);
+      } else {
+        next.add(groupId);
+      }
+      return next;
+    });
+  }, []);
+
+  // Collapsed state — icon strip
+  if (collapsed) {
+    return (
+      <div className="w-12 shrink-0 h-full flex flex-col items-center py-2 border-l border-border bg-card/30">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={toggleCollapsed}
+              className={cn(
+                "relative p-2 rounded-md transition-colors",
+                "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+              )}
+            >
+              <MessageSquare className="w-4 h-4" />
+              {totalUnreadCount > 0 && (
+                <span className="absolute -top-1 -right-1 w-4 h-4 text-[10px] bg-primary text-primary-foreground rounded-full flex items-center justify-center">
+                  {totalUnreadCount > 9 ? "9+" : totalUnreadCount}
+                </span>
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            Channels {totalUnreadCount > 0 ? `(${totalUnreadCount} unread)` : ""}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="shrink-0 h-full flex flex-col bg-card/50 backdrop-blur-md border-l border-border relative"
+      style={{ width }}
+    >
+      {/* Resize handle (left edge) */}
+      <div
+        className="absolute top-0 left-0 w-1 h-full cursor-col-resize hover:bg-primary/30 transition-colors z-10"
+        onMouseDown={handleResizeStart}
+      />
+
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
+        <MessageSquare className="w-4 h-4 text-primary shrink-0" />
+        <span className="text-xs font-semibold text-foreground flex-1">
+          Channels
+        </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={onCreateChannel}
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Plus className="w-3.5 h-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left">New channel</TooltipContent>
+        </Tooltip>
+        <button
+          onClick={toggleCollapsed}
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <PanelRightClose className="w-4 h-4" />
+        </button>
+      </div>
+
+      <ScrollArea className="flex-1">
+        <div className="py-1">
+          {groups.length === 0 ? (
+            <div className="flex items-center justify-center px-4 py-8">
+              <p className="text-xs text-muted-foreground text-center">
+                No channels yet. Click + to create one.
+              </p>
+            </div>
+          ) : (
+            groups.map((group) => {
+              const isGroupCollapsed = collapsedGroups.has(group.id);
+              return (
+                <div key={group.id}>
+                  {/* Group header */}
+                  <button
+                    onClick={() => toggleGroup(group.id)}
+                    className="flex items-center gap-1.5 w-full px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {isGroupCollapsed ? (
+                      <ChevronRight className="w-3 h-3" />
+                    ) : (
+                      <ChevronDown className="w-3 h-3" />
+                    )}
+                    <span className="flex-1 text-left">{group.name}</span>
+                  </button>
+
+                  {/* Channels in group */}
+                  {!isGroupCollapsed && (
+                    <div className="space-y-0.5 px-1 mb-1">
+                      {group.channels.map((channel) => {
+                        const isActive = channel.id === activeChannelId;
+                        const hasUnread = channel.unreadCount > 0;
+                        return (
+                          <button
+                            key={channel.id}
+                            onClick={() => setActiveChannelId(channel.id)}
+                            className={cn(
+                              "flex items-center gap-1.5 w-full px-2 py-1 rounded-md text-left transition-colors",
+                              isActive
+                                ? "bg-primary/10 text-foreground"
+                                : "text-muted-foreground hover:text-foreground hover:bg-accent/40"
+                            )}
+                          >
+                            <Hash
+                              className={cn(
+                                "w-3.5 h-3.5 shrink-0",
+                                isActive
+                                  ? "text-primary"
+                                  : "text-muted-foreground"
+                              )}
+                            />
+                            <span
+                              className={cn(
+                                "text-xs flex-1 truncate",
+                                hasUnread && !isActive && "font-semibold text-foreground"
+                              )}
+                            >
+                              {channel.displayName || channel.name}
+                            </span>
+                            {/* Unread dot */}
+                            {hasUnread && !isActive && (
+                              <span className="w-2 h-2 rounded-full bg-primary shrink-0" />
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
+
+          {/* Separator */}
+          <div className="border-t border-border my-1" />
+
+          {/* Peers section */}
+          <div>
+            <button
+              onClick={() => setPeersExpanded((v) => !v)}
+              className="flex items-center gap-1.5 w-full px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {peersExpanded ? (
+                <ChevronDown className="w-3 h-3" />
+              ) : (
+                <ChevronRight className="w-3 h-3" />
+              )}
+              <span className="flex-1 text-left">Peers</span>
+              {peers.length > 0 && (
+                <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                  {peers.length}
+                </span>
+              )}
+            </button>
+
+            {peersExpanded && (
+              <div className="space-y-0.5 px-1 mb-1">
+                {peers.length === 0 ? (
+                  <p className="text-[11px] text-muted-foreground px-3 py-1">
+                    No agents connected
+                  </p>
+                ) : (
+                  peers.map((peer) => (
+                    <div
+                      key={peer.sessionId}
+                      className="flex items-center gap-1.5 px-2 py-1 rounded-md text-muted-foreground"
+                    >
+                      <Bot className="w-3.5 h-3.5 shrink-0 text-primary/60" />
+                      <span className="text-xs truncate">{peer.name}</span>
+                      <span className="ml-auto w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
+                    </div>
+                  ))
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/src/components/channels/ChannelView.tsx
+++ b/src/components/channels/ChannelView.tsx
@@ -20,7 +20,7 @@ interface ChannelViewProps {
   folderName: string | null;
 }
 
-export function ChannelView({ folderId, folderName }: ChannelViewProps) {
+export function ChannelView({ folderId, folderName: _folderName }: ChannelViewProps) {
   const {
     groups,
     activeChannelId,

--- a/src/components/channels/ChannelView.tsx
+++ b/src/components/channels/ChannelView.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+/**
+ * ChannelView — Main channel message area.
+ *
+ * Shows the active channel's messages with auto-scroll, a reply thread panel,
+ * and a message input bar. Follows the PeerChatRoom scroll pattern closely.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Hash, MessageSquare, Users } from "lucide-react";
+import { useChannelContext } from "@/contexts/ChannelContext";
+import { usePeerChatContext } from "@/contexts/PeerChatContext";
+import { ChannelMessageRow } from "./ChannelMessageRow";
+import { ThreadPanel } from "./ThreadPanel";
+import { LoopChatInput } from "@/components/loop/LoopChatInput";
+
+interface ChannelViewProps {
+  folderId: string | null;
+  folderName: string | null;
+}
+
+export function ChannelView({ folderId, folderName }: ChannelViewProps) {
+  const {
+    groups,
+    activeChannelId,
+    activeChannelMessages,
+    loading,
+    sendMessage,
+    markChannelRead,
+    openThread,
+    openThreadId,
+  } = useChannelContext();
+  const { peers, peerNameMap } = usePeerChatContext();
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isUserScrolled, setIsUserScrolled] = useState(false);
+
+  // Find the active channel metadata
+  const activeChannel = (() => {
+    for (const group of groups) {
+      const ch = group.channels.find((c) => c.id === activeChannelId);
+      if (ch) return ch;
+    }
+    return null;
+  })();
+
+  // Auto-scroll to bottom when new messages arrive (unless user scrolled up)
+  useEffect(() => {
+    if (!isUserScrolled && messagesEndRef.current) {
+      messagesEndRef.current.scrollIntoView({ behavior: "instant" });
+    }
+  }, [activeChannelMessages, isUserScrolled]);
+
+  // Mark channel as read when messages are visible
+  useEffect(() => {
+    if (!activeChannelId || activeChannelMessages.length === 0) return;
+    const lastMessage = activeChannelMessages[activeChannelMessages.length - 1];
+    if (lastMessage && !lastMessage.id.startsWith("opt-")) {
+      markChannelRead(activeChannelId, lastMessage.id);
+    }
+  }, [activeChannelId, activeChannelMessages, markChannelRead]);
+
+  const handleScroll = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    setIsUserScrolled(scrollHeight - scrollTop - clientHeight > 50);
+  }, []);
+
+  const handleSend = useCallback(
+    (text: string) => {
+      setIsUserScrolled(false);
+      sendMessage(text);
+    },
+    [sendMessage]
+  );
+
+  const handleReplyClick = useCallback(
+    (messageId: string) => {
+      openThread(messageId);
+    },
+    [openThread]
+  );
+
+  // No folder selected
+  if (!folderId) {
+    return (
+      <div className="flex flex-col h-full w-full items-center justify-center text-muted-foreground/40">
+        <Hash className="w-10 h-10 mb-3" />
+        <p className="text-sm">Select a project folder to see channels</p>
+      </div>
+    );
+  }
+
+  // No channel selected
+  if (!activeChannelId || !activeChannel) {
+    return (
+      <div className="flex flex-col h-full w-full items-center justify-center text-muted-foreground/40">
+        <MessageSquare className="w-10 h-10 mb-3" />
+        <p className="text-sm">Select a channel to start messaging</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative flex flex-row h-full w-full bg-background overflow-hidden">
+      {/* Main channel area */}
+      <div className="flex flex-col flex-1 min-w-0 h-full">
+        {/* Header */}
+        <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-card/50 shrink-0">
+          <Hash className="w-4 h-4 text-primary shrink-0" />
+          <span className="text-xs font-semibold text-foreground">
+            {activeChannel.displayName || activeChannel.name}
+          </span>
+          {activeChannel.topic && (
+            <>
+              <span className="text-muted-foreground/30 text-xs">|</span>
+              <span className="text-xs text-muted-foreground truncate flex-1">
+                {activeChannel.topic}
+              </span>
+            </>
+          )}
+          {peers.length > 0 && (
+            <span className="flex items-center gap-1 text-[10px] text-muted-foreground ml-auto shrink-0">
+              <Users className="w-3 h-3" />
+              {peers.length} agent{peers.length !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+
+        {/* Messages */}
+        <div
+          ref={containerRef}
+          className="flex-1 overflow-y-auto py-3 space-y-1"
+          onScroll={handleScroll}
+        >
+          {activeChannelMessages.length === 0 && !loading && (
+            <div className="flex flex-col items-center justify-center h-full text-muted-foreground/40 px-4">
+              <Hash className="w-8 h-8 mb-2" />
+              <p className="text-sm font-medium">
+                #{activeChannel.displayName || activeChannel.name}
+              </p>
+              <p className="text-xs mt-1 text-center">
+                This is the beginning of the channel.
+                {activeChannel.topic && ` Topic: ${activeChannel.topic}`}
+              </p>
+            </div>
+          )}
+
+          {activeChannelMessages.map((msg) => (
+            <ChannelMessageRow
+              key={msg.id}
+              message={msg}
+              peerNameMap={peerNameMap}
+              onReplyClick={handleReplyClick}
+              isThreadReply={false}
+            />
+          ))}
+
+          {/* Scroll anchor */}
+          <div ref={messagesEndRef} />
+        </div>
+
+        {/* Scroll to bottom button */}
+        {isUserScrolled && (
+          <button
+            onClick={() => {
+              setIsUserScrolled(false);
+              messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+            }}
+            className="absolute bottom-16 left-1/2 -translate-x-1/2 bg-card/90 backdrop-blur border border-border rounded-full px-3 py-1 text-xs text-muted-foreground hover:text-foreground shadow-lg transition-colors z-10"
+          >
+            Scroll to bottom
+          </button>
+        )}
+
+        {/* Input */}
+        <div className="shrink-0 border-t border-border pb-safe-bottom">
+          <LoopChatInput
+            onSend={handleSend}
+            placeholder={`Message #${activeChannel.displayName || activeChannel.name}...`}
+          />
+        </div>
+      </div>
+
+      {/* Thread panel — rendered alongside when open */}
+      {openThreadId && <ThreadPanel />}
+    </div>
+  );
+}

--- a/src/components/channels/ChannelView.tsx
+++ b/src/components/channels/ChannelView.tsx
@@ -20,7 +20,7 @@ interface ChannelViewProps {
   folderName: string | null;
 }
 
-export function ChannelView({ folderId, folderName: _folderName }: ChannelViewProps) {
+export function ChannelView({ folderId }: ChannelViewProps) {
   const {
     groups,
     activeChannelId,
@@ -38,13 +38,9 @@ export function ChannelView({ folderId, folderName: _folderName }: ChannelViewPr
   const [isUserScrolled, setIsUserScrolled] = useState(false);
 
   // Find the active channel metadata
-  const activeChannel = (() => {
-    for (const group of groups) {
-      const ch = group.channels.find((c) => c.id === activeChannelId);
-      if (ch) return ch;
-    }
-    return null;
-  })();
+  const activeChannel = groups
+    .flatMap((g) => g.channels)
+    .find((c) => c.id === activeChannelId) ?? null;
 
   // Auto-scroll to bottom when new messages arrive (unless user scrolled up)
   useEffect(() => {
@@ -77,12 +73,7 @@ export function ChannelView({ folderId, folderName: _folderName }: ChannelViewPr
     [sendMessage]
   );
 
-  const handleReplyClick = useCallback(
-    (messageId: string) => {
-      openThread(messageId);
-    },
-    [openThread]
-  );
+  const handleReplyClick = openThread;
 
   // No folder selected
   if (!folderId) {

--- a/src/components/channels/ChannelView.tsx
+++ b/src/components/channels/ChannelView.tsx
@@ -73,8 +73,6 @@ export function ChannelView({ folderId }: ChannelViewProps) {
     [sendMessage]
   );
 
-  const handleReplyClick = openThread;
-
   // No folder selected
   if (!folderId) {
     return (
@@ -145,7 +143,7 @@ export function ChannelView({ folderId }: ChannelViewProps) {
               key={msg.id}
               message={msg}
               peerNameMap={peerNameMap}
-              onReplyClick={handleReplyClick}
+              onReplyClick={openThread}
               isThreadReply={false}
             />
           ))}

--- a/src/components/channels/CreateChannelModal.tsx
+++ b/src/components/channels/CreateChannelModal.tsx
@@ -7,7 +7,7 @@
  * Validates the name and calls createChannel from ChannelContext on submit.
  */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, type ChangeEvent } from "react";
 import { useChannelContext } from "@/contexts/ChannelContext";
 import {
   Dialog,
@@ -53,20 +53,14 @@ export function CreateChannelModal({ open, onClose }: CreateChannelModalProps) {
   const slugifiedName = slugify(nameInput);
   const nameIsValid = slugifiedName.length > 0 && isValidName(slugifiedName);
 
-  const handleNameChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setNameInput(e.target.value);
-      setError(null);
-    },
-    []
-  );
+  function handleNameChange(e: ChangeEvent<HTMLInputElement>): void {
+    setNameInput(e.target.value);
+    setError(null);
+  }
 
-  const handleTopicChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setTopic(e.target.value);
-    },
-    []
-  );
+  function handleTopicChange(e: ChangeEvent<HTMLInputElement>): void {
+    setTopic(e.target.value);
+  }
 
   const handleCreate = useCallback(async () => {
     if (!nameIsValid || isCreating) return;

--- a/src/components/channels/CreateChannelModal.tsx
+++ b/src/components/channels/CreateChannelModal.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+/**
+ * CreateChannelModal — Dialog for creating a new channel.
+ *
+ * Auto-slugifies the channel name to lowercase-hyphenated format.
+ * Validates the name and calls createChannel from ChannelContext on submit.
+ */
+
+import { useState, useCallback } from "react";
+import { useChannelContext } from "@/contexts/ChannelContext";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+interface CreateChannelModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/** Converts arbitrary text to a valid channel slug. */
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-+/, "")
+    .slice(0, 50);
+}
+
+/** Validates a channel name slug. */
+function isValidName(name: string): boolean {
+  return /^[a-z0-9][a-z0-9-]{0,48}[a-z0-9]$/.test(name) || /^[a-z0-9]$/.test(name);
+}
+
+export function CreateChannelModal({ open, onClose }: CreateChannelModalProps) {
+  const { createChannel } = useChannelContext();
+
+  const [nameInput, setNameInput] = useState("");
+  const [topic, setTopic] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const slugifiedName = slugify(nameInput);
+  const nameIsValid = slugifiedName.length > 0 && isValidName(slugifiedName);
+
+  const handleNameChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setNameInput(e.target.value);
+      setError(null);
+    },
+    []
+  );
+
+  const handleTopicChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setTopic(e.target.value);
+    },
+    []
+  );
+
+  const handleCreate = useCallback(async () => {
+    if (!nameIsValid || isCreating) return;
+
+    setIsCreating(true);
+    setError(null);
+    try {
+      await createChannel(slugifiedName, topic.trim() || undefined);
+      // Reset form and close on success
+      setNameInput("");
+      setTopic("");
+      onClose();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to create channel"
+      );
+    } finally {
+      setIsCreating(false);
+    }
+  }, [nameIsValid, isCreating, createChannel, slugifiedName, topic, onClose]);
+
+  const handleOpenChange = useCallback(
+    (v: boolean) => {
+      if (!v && !isCreating) {
+        setNameInput("");
+        setTopic("");
+        setError(null);
+        onClose();
+      }
+    },
+    [isCreating, onClose]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && nameIsValid && !isCreating) {
+        e.preventDefault();
+        handleCreate();
+      }
+    },
+    [nameIsValid, isCreating, handleCreate]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-sm">Create a Channel</DialogTitle>
+          <DialogDescription className="text-xs">
+            Channels are where your team communicates. Give it a clear, lowercase
+            name using letters, numbers, and hyphens.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          {/* Name input */}
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-foreground">
+              Channel name
+            </label>
+            <div className="relative">
+              <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground text-sm select-none pointer-events-none">
+                #
+              </span>
+              <Input
+                value={nameInput}
+                onChange={handleNameChange}
+                onKeyDown={handleKeyDown}
+                placeholder="e.g. general, bugs, release-v2"
+                className={cn(
+                  "pl-6 text-xs h-8",
+                  error && "border-destructive focus-visible:ring-destructive"
+                )}
+                autoFocus
+                maxLength={60}
+                disabled={isCreating}
+              />
+            </div>
+            {/* Preview slug */}
+            {nameInput && (
+              <p
+                className={cn(
+                  "text-[11px]",
+                  nameIsValid
+                    ? "text-muted-foreground"
+                    : "text-destructive"
+                )}
+              >
+                {nameIsValid
+                  ? `Will be created as: #${slugifiedName}`
+                  : "Name must be 1–50 lowercase alphanumeric characters or hyphens, and cannot start or end with a hyphen."}
+              </p>
+            )}
+            {error && (
+              <p className="text-[11px] text-destructive">{error}</p>
+            )}
+          </div>
+
+          {/* Topic input */}
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-foreground">
+              Topic{" "}
+              <span className="font-normal text-muted-foreground">(optional)</span>
+            </label>
+            <Input
+              value={topic}
+              onChange={handleTopicChange}
+              onKeyDown={handleKeyDown}
+              placeholder="What is this channel about?"
+              className="text-xs h-8"
+              maxLength={200}
+              disabled={isCreating}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-xs"
+            onClick={() => handleOpenChange(false)}
+            disabled={isCreating}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            className="text-xs"
+            onClick={handleCreate}
+            disabled={!nameIsValid || isCreating}
+          >
+            {isCreating ? "Creating..." : "Create Channel"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/channels/CreateChannelModal.tsx
+++ b/src/components/channels/CreateChannelModal.tsx
@@ -37,9 +37,9 @@ function slugify(value: string): string {
     .slice(0, 50);
 }
 
-/** Validates a channel name slug. */
+/** Validates a channel name slug (1-50 chars, alphanumeric/hyphens, no leading/trailing hyphen). */
 function isValidName(name: string): boolean {
-  return /^[a-z0-9][a-z0-9-]{0,48}[a-z0-9]$/.test(name) || /^[a-z0-9]$/.test(name);
+  return /^[a-z0-9](?:[a-z0-9-]{0,48}[a-z0-9])?$/.test(name);
 }
 
 export function CreateChannelModal({ open, onClose }: CreateChannelModalProps) {

--- a/src/components/channels/ThreadPanel.tsx
+++ b/src/components/channels/ThreadPanel.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+/**
+ * ThreadPanel — Slide-in panel for thread replies.
+ *
+ * Fixed 320px width panel showing the parent message and its thread replies.
+ * Auto-scrolls to the bottom on new replies.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { X, MessageSquare } from "lucide-react";
+import { useChannelContext } from "@/contexts/ChannelContext";
+import { usePeerChatContext } from "@/contexts/PeerChatContext";
+import { ChannelMessageRow } from "./ChannelMessageRow";
+import { LoopChatInput } from "@/components/loop/LoopChatInput";
+
+export function ThreadPanel() {
+  const {
+    activeChannelMessages,
+    openThreadId,
+    closeThread,
+    threadMessages,
+    sendMessage,
+  } = useChannelContext();
+  const { peerNameMap } = usePeerChatContext();
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isUserScrolled, setIsUserScrolled] = useState(false);
+
+  // Find parent message from active channel messages
+  const parentMessage = openThreadId
+    ? activeChannelMessages.find((m) => m.id === openThreadId) ?? null
+    : null;
+
+  // Auto-scroll when thread messages change
+  useEffect(() => {
+    if (!isUserScrolled && messagesEndRef.current) {
+      messagesEndRef.current.scrollIntoView({ behavior: "instant" });
+    }
+  }, [threadMessages, isUserScrolled]);
+
+  const handleScroll = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    setIsUserScrolled(scrollHeight - scrollTop - clientHeight > 50);
+  }, []);
+
+  const handleSend = useCallback(
+    (text: string) => {
+      if (!openThreadId) return;
+      setIsUserScrolled(false);
+      sendMessage(text, openThreadId);
+    },
+    [openThreadId, sendMessage]
+  );
+
+  if (!openThreadId) return null;
+
+  return (
+    <div className="flex flex-col w-80 shrink-0 h-full border-l border-border bg-card/30 backdrop-blur-sm">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-card/50 shrink-0">
+        <MessageSquare className="w-4 h-4 text-primary shrink-0" />
+        <span className="text-xs font-semibold text-foreground flex-1">
+          Thread
+        </span>
+        <button
+          onClick={closeThread}
+          className="text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="Close thread"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Scrollable content */}
+      <div
+        ref={containerRef}
+        className="flex-1 overflow-y-auto py-2"
+        onScroll={handleScroll}
+      >
+        {/* Parent message */}
+        {parentMessage && (
+          <>
+            <ChannelMessageRow
+              message={parentMessage}
+              peerNameMap={peerNameMap}
+              isThreadReply={false}
+            />
+            {/* Divider */}
+            <div className="flex items-center gap-2 px-4 my-2">
+              <div className="flex-1 border-t border-border" />
+              <span className="text-[10px] text-muted-foreground shrink-0">
+                {threadMessages.length}{" "}
+                {threadMessages.length === 1 ? "reply" : "replies"}
+              </span>
+              <div className="flex-1 border-t border-border" />
+            </div>
+          </>
+        )}
+
+        {/* Thread replies */}
+        {threadMessages.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-8 text-muted-foreground/40 px-4">
+            <MessageSquare className="w-6 h-6 mb-2" />
+            <p className="text-xs text-center">
+              No replies yet. Be the first to reply!
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {threadMessages.map((msg) => (
+              <ChannelMessageRow
+                key={msg.id}
+                message={msg}
+                peerNameMap={peerNameMap}
+                isThreadReply={true}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Scroll anchor */}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Scroll to bottom */}
+      {isUserScrolled && (
+        <button
+          onClick={() => {
+            setIsUserScrolled(false);
+            messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+          }}
+          className="mx-3 mb-1 bg-card/90 backdrop-blur border border-border rounded-full px-3 py-1 text-xs text-muted-foreground hover:text-foreground shadow-lg transition-colors"
+        >
+          Scroll to bottom
+        </button>
+      )}
+
+      {/* Reply input */}
+      <div className="shrink-0 border-t border-border">
+        <LoopChatInput
+          onSend={handleSend}
+          placeholder="Reply in thread..."
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/loop/LoopChatPane.tsx
+++ b/src/components/loop/LoopChatPane.tsx
@@ -63,6 +63,9 @@ interface LoopChatPaneProps {
     state: "running" | "exited" | "restarting" | "closed"
   ) => void;
   onPeerMessageCreated?: (folderId: string, message: import("@/types/peer-chat").PeerChatMessage) => void;
+  onChannelMessageCreated?: (folderId: string, channelId: string, message: import("@/types/peer-chat").PeerChatMessage) => void;
+  onThreadReplyCreated?: (folderId: string, parentMessageId: string, message: import("@/types/peer-chat").PeerChatMessage) => void;
+  onChannelCreated?: (folderId: string, channel: import("@/types/channels").Channel) => void;
 }
 
 export function LoopChatPane({
@@ -83,6 +86,9 @@ export function LoopChatPane({
   onSessionClose,
   onAgentStateChange,
   onPeerMessageCreated,
+  onChannelMessageCreated,
+  onThreadReplyCreated,
+  onChannelCreated,
 }: LoopChatPaneProps) {
   const { getAgentActivityStatus } = useSessionContext();
   const activityStatus = getAgentActivityStatus(session.id);
@@ -339,6 +345,9 @@ export function LoopChatPane({
             onSessionStatus={onSessionStatus}
             onSessionProgress={onSessionProgress}
             onPeerMessageCreated={onPeerMessageCreated}
+            onChannelMessageCreated={onChannelMessageCreated}
+            onThreadReplyCreated={onThreadReplyCreated}
+            onChannelCreated={onChannelCreated}
           />
         </TerminalDrawer>
       </div>

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -69,6 +69,10 @@ import { usePeerChatContext } from "@/contexts/PeerChatContext";
 import { FolderTabBar } from "@/components/peers/FolderTabBar";
 import { PeerChatRoom } from "@/components/peers/PeerChatRoom";
 import type { ActiveView, PeerChatMessage } from "@/types/peer-chat";
+import { ChannelSidebar } from "@/components/channels/ChannelSidebar";
+import { ChannelView } from "@/components/channels/ChannelView";
+import { CreateChannelModal } from "@/components/channels/CreateChannelModal";
+import { useChannelContext } from "@/contexts/ChannelContext";
 
 // Dynamically import TerminalWithKeyboard to avoid SSR issues with xterm
 const TerminalWithKeyboard = dynamic(
@@ -185,6 +189,8 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [activeView, setActiveView] = useState<ActiveView>("terminal");
   const peerChat = usePeerChatContext();
+  const channelCtx = useChannelContext();
+  const [isCreateChannelOpen, setIsCreateChannelOpen] = useState(false);
   const isMobile = useMobile();
   const isPWA = usePWA();
   // Use useSyncExternalStore for localStorage values to avoid hydration mismatches
@@ -397,6 +403,55 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
       }
     },
     [peerChat.addMessage, activeProject.folderId]
+  );
+
+  const handleChannelMessageCreated = useCallback(
+    (folderId: string, channelId: string, message: PeerChatMessage) => {
+      if (folderId === activeProject.folderId) {
+        channelCtx.addMessage({
+          id: message.id,
+          channelId: message.channelId ?? channelId,
+          fromSessionId: message.fromSessionId,
+          fromSessionName: message.fromSessionName,
+          toSessionId: message.toSessionId,
+          body: message.body,
+          isUserMessage: message.isUserMessage,
+          parentMessageId: message.parentMessageId,
+          replyCount: message.replyCount,
+          createdAt: message.createdAt,
+        });
+      }
+    },
+    [activeProject.folderId, channelCtx]
+  );
+
+  const handleThreadReplyCreated = useCallback(
+    (folderId: string, parentMessageId: string, message: PeerChatMessage) => {
+      if (folderId === activeProject.folderId && parentMessageId) {
+        channelCtx.addThreadReply(parentMessageId, {
+          id: message.id,
+          channelId: message.channelId ?? "",
+          fromSessionId: message.fromSessionId,
+          fromSessionName: message.fromSessionName,
+          toSessionId: message.toSessionId,
+          body: message.body,
+          isUserMessage: message.isUserMessage,
+          parentMessageId: message.parentMessageId,
+          replyCount: message.replyCount,
+          createdAt: message.createdAt,
+        });
+      }
+    },
+    [activeProject.folderId, channelCtx]
+  );
+
+  const handleChannelCreated = useCallback(
+    (folderId: string, channel: import("@/types/channels").Channel) => {
+      if (folderId === activeProject.folderId) {
+        channelCtx.addChannel(channel);
+      }
+    },
+    [activeProject.folderId, channelCtx]
   );
 
   // Handle server-pushed session rename (auto-title from .jsonl)
@@ -1714,7 +1769,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
             agentSessions={folderAgentSessions}
             activeSessionId={activeSessionId}
             onAgentTabClick={handleAgentTabClick}
-            chatUnreadCount={peerChat.unreadCount}
+            chatUnreadCount={channelCtx.totalUnreadCount}
           />
         )}
 
@@ -1866,6 +1921,9 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
                             onSessionProgress={setSessionProgress}
                             onSessionClose={(id) => handleSessionDelete(activeSessions.find(s => s.id === id) ?? session)}
                             onPeerMessageCreated={handlePeerMessageCreated}
+                            onChannelMessageCreated={handleChannelMessageCreated}
+                            onThreadReplyCreated={handleThreadReplyCreated}
+                            onChannelCreated={handleChannelCreated}
                           />
                         </div>
                       );
@@ -1900,6 +1958,9 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
                             onSessionStatus={setSessionStatusIndicator}
                             onSessionProgress={setSessionProgress}
                             onPeerMessageCreated={handlePeerMessageCreated}
+                            onChannelMessageCreated={handleChannelMessageCreated}
+                            onThreadReplyCreated={handleThreadReplyCreated}
+                            onChannelCreated={handleChannelCreated}
                           />
                         </div>
                       );
@@ -1943,6 +2004,9 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
                           onSessionStatus={setSessionStatusIndicator}
                           onSessionProgress={setSessionProgress}
                           onPeerMessageCreated={handlePeerMessageCreated}
+                          onChannelMessageCreated={handleChannelMessageCreated}
+                          onThreadReplyCreated={handleThreadReplyCreated}
+                          onChannelCreated={handleChannelCreated}
                         />
                       </div>
                     );
@@ -1952,9 +2016,9 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
             </div>
           </div>
 
-          {/* Peer Chat Room — visible when chat view is active */}
+          {/* Channel View — visible when chat view is active */}
           <div className={cn("flex-1 overflow-hidden", activeView !== "chat" && "hidden")}>
-            <PeerChatRoom
+            <ChannelView
               folderId={activeProject.folderId}
               folderName={getFolderName(activeProject.folderId)}
             />
@@ -1963,13 +2027,23 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
         )}
       </div>
 
-      {/* Right sidebar - Task Tracker + Schedules */}
-      <TaskSidebar
-        githubRepoId={taskSidebarRepoId}
-        onViewIssue={handleViewIssueByNumber}
-        onViewPR={handleViewPRByNumber}
-        scheduleTargetSessionId={scheduleTargetSessionId}
-        onScheduleTargetConsumed={() => setScheduleTargetSessionId(null)}
+      {/* Right sidebar — Channel list (chat) or Task tracker (terminal) */}
+      <div className={cn(activeView === "chat" && "hidden")}>
+        <TaskSidebar
+          githubRepoId={taskSidebarRepoId}
+          onViewIssue={handleViewIssueByNumber}
+          onViewPR={handleViewPRByNumber}
+          scheduleTargetSessionId={scheduleTargetSessionId}
+          onScheduleTargetConsumed={() => setScheduleTargetSessionId(null)}
+        />
+      </div>
+      {activeView === "chat" && activeProject.folderId && (
+        <ChannelSidebar onCreateChannel={() => setIsCreateChannelOpen(true)} />
+      )}
+
+      <CreateChannelModal
+        open={isCreateChannelOpen}
+        onClose={() => setIsCreateChannelOpen(false)}
       />
 
       {/* New Session Wizard */}

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -422,7 +422,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
         });
       }
     },
-    [activeProject.folderId, channelCtx]
+    [activeProject.folderId, channelCtx.addMessage]
   );
 
   const handleThreadReplyCreated = useCallback(
@@ -442,7 +442,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
         });
       }
     },
-    [activeProject.folderId, channelCtx]
+    [activeProject.folderId, channelCtx.addThreadReply]
   );
 
   const handleChannelCreated = useCallback(
@@ -451,7 +451,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
         channelCtx.addChannel(channel);
       }
     },
-    [activeProject.folderId, channelCtx]
+    [activeProject.folderId, channelCtx.addChannel]
   );
 
   // Handle server-pushed session rename (auto-title from .jsonl)

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -405,44 +405,39 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
     [peerChat.addMessage, activeProject.folderId]
   );
 
+  /** Convert a PeerChatMessage to a ChannelMessage, filling in channelId. */
+  const toChannelMessage = useCallback(
+    (msg: PeerChatMessage, fallbackChannelId: string): import("@/types/channels").ChannelMessage => ({
+      id: msg.id,
+      channelId: msg.channelId ?? fallbackChannelId,
+      fromSessionId: msg.fromSessionId,
+      fromSessionName: msg.fromSessionName,
+      toSessionId: msg.toSessionId,
+      body: msg.body,
+      isUserMessage: msg.isUserMessage,
+      parentMessageId: msg.parentMessageId,
+      replyCount: msg.replyCount,
+      createdAt: msg.createdAt,
+    }),
+    []
+  );
+
   const handleChannelMessageCreated = useCallback(
     (folderId: string, channelId: string, message: PeerChatMessage) => {
       if (folderId === activeProject.folderId) {
-        channelCtx.addMessage({
-          id: message.id,
-          channelId: message.channelId ?? channelId,
-          fromSessionId: message.fromSessionId,
-          fromSessionName: message.fromSessionName,
-          toSessionId: message.toSessionId,
-          body: message.body,
-          isUserMessage: message.isUserMessage,
-          parentMessageId: message.parentMessageId,
-          replyCount: message.replyCount,
-          createdAt: message.createdAt,
-        });
+        channelCtx.addMessage(toChannelMessage(message, channelId));
       }
     },
-    [activeProject.folderId, channelCtx.addMessage]
+    [activeProject.folderId, channelCtx.addMessage, toChannelMessage]
   );
 
   const handleThreadReplyCreated = useCallback(
     (folderId: string, parentMessageId: string, message: PeerChatMessage) => {
       if (folderId === activeProject.folderId && parentMessageId) {
-        channelCtx.addThreadReply(parentMessageId, {
-          id: message.id,
-          channelId: message.channelId ?? "",
-          fromSessionId: message.fromSessionId,
-          fromSessionName: message.fromSessionName,
-          toSessionId: message.toSessionId,
-          body: message.body,
-          isUserMessage: message.isUserMessage,
-          parentMessageId: message.parentMessageId,
-          replyCount: message.replyCount,
-          createdAt: message.createdAt,
-        });
+        channelCtx.addThreadReply(parentMessageId, toChannelMessage(message, ""));
       }
     },
-    [activeProject.folderId, channelCtx.addThreadReply]
+    [activeProject.folderId, channelCtx.addThreadReply, toChannelMessage]
   );
 
   const handleChannelCreated = useCallback(

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -68,6 +68,9 @@ interface TerminalProps {
   onSessionProgress?: (sessionId: string, progress: import("@/types/terminal-type").SessionProgress | null) => void;
   /** Called when a peer message is created (broadcast from terminal server) */
   onPeerMessageCreated?: (folderId: string, message: import("@/types/peer-chat").PeerChatMessage) => void;
+  onChannelMessageCreated?: (folderId: string, channelId: string, message: import("@/types/peer-chat").PeerChatMessage) => void;
+  onThreadReplyCreated?: (folderId: string, parentMessageId: string, message: import("@/types/peer-chat").PeerChatMessage) => void;
+  onChannelCreated?: (folderId: string, channel: import("@/types/channels").Channel) => void;
   onOutput?: (data: string) => void;
   onDimensionsChange?: (cols: number, rows: number) => void;
   /** Called when terminal scroll position changes between scrolled-up and at-bottom */
@@ -102,6 +105,9 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   onSessionStatus,
   onSessionProgress,
   onPeerMessageCreated,
+  onChannelMessageCreated,
+  onThreadReplyCreated,
+  onChannelCreated,
   onOutput,
   onDimensionsChange,
   onScrollStateChange,
@@ -162,6 +168,9 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   const onSessionStatusRef = useRef(onSessionStatus);
   const onSessionProgressRef = useRef(onSessionProgress);
   const onPeerMessageCreatedRef = useRef(onPeerMessageCreated);
+  const onChannelMessageCreatedRef = useRef(onChannelMessageCreated);
+  const onThreadReplyCreatedRef = useRef(onThreadReplyCreated);
+  const onChannelCreatedRef = useRef(onChannelCreated);
   const onOutputRef = useRef(onOutput);
   const onDimensionsChangeRef = useRef(onDimensionsChange);
   const onScrollStateChangeRef = useRef(onScrollStateChange);
@@ -202,6 +211,9 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
     onSessionStatusRef.current = onSessionStatus;
     onSessionProgressRef.current = onSessionProgress;
     onPeerMessageCreatedRef.current = onPeerMessageCreated;
+    onChannelMessageCreatedRef.current = onChannelMessageCreated;
+    onThreadReplyCreatedRef.current = onThreadReplyCreated;
+    onChannelCreatedRef.current = onChannelCreated;
     onOutputRef.current = onOutput;
     onDimensionsChangeRef.current = onDimensionsChange;
     onScrollStateChangeRef.current = onScrollStateChange;
@@ -217,7 +229,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
     environmentVarsRef.current = environmentVars;
     // Keep theme ref in sync for pending terminal initialization
     terminalThemeRef.current = terminalTheme;
-  }, [onStatusChange, onWebSocketReady, onSessionExit, onAgentExited, onAgentRestarted, onAgentActivityStatus, onAgentTodosUpdated, onSessionRenamed, onNotification, onSessionStatus, onSessionProgress, onPeerMessageCreated, onOutput, onDimensionsChange, onScrollStateChange, recordActivity, fontSize, fontFamily, scrollback, tmuxHistoryLimit, mobileMode, environmentVars, terminalTheme]);
+  }, [onStatusChange, onWebSocketReady, onSessionExit, onAgentExited, onAgentRestarted, onAgentActivityStatus, onAgentTodosUpdated, onSessionRenamed, onNotification, onSessionStatus, onSessionProgress, onPeerMessageCreated, onChannelMessageCreated, onThreadReplyCreated, onChannelCreated, onOutput, onDimensionsChange, onScrollStateChange, recordActivity, fontSize, fontFamily, scrollback, tmuxHistoryLimit, mobileMode, environmentVars, terminalTheme]);
 
   // Expose focus method to parent components
   useImperativeHandle(ref, () => ({
@@ -663,6 +675,32 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
                 // Peer message broadcast — forward to chat room context
                 if (msg.folderId && msg.message) {
                   onPeerMessageCreatedRef.current?.(msg.folderId as string, msg.message);
+                }
+                break;
+              case "channel_message_created":
+                if (msg.folderId && msg.message) {
+                  onChannelMessageCreatedRef.current?.(
+                    msg.folderId as string,
+                    (msg.channelId as string) ?? "",
+                    msg.message
+                  );
+                }
+                break;
+              case "thread_reply_created":
+                if (msg.folderId && msg.message && msg.parentMessageId) {
+                  onThreadReplyCreatedRef.current?.(
+                    msg.folderId as string,
+                    msg.parentMessageId as string,
+                    msg.message
+                  );
+                }
+                break;
+              case "channel_created":
+                if (msg.folderId && msg.channel) {
+                  onChannelCreatedRef.current?.(
+                    msg.folderId as string,
+                    msg.channel as import("@/types/channels").Channel
+                  );
                 }
                 break;
               case "voice_ready":

--- a/src/components/terminal/TerminalTypeRenderer.tsx
+++ b/src/components/terminal/TerminalTypeRenderer.tsx
@@ -57,6 +57,9 @@ interface TerminalTypeRendererProps {
   onSessionProgress?: (sessionId: string, progress: SessionProgress | null) => void;
   /** Called when a peer message is created (broadcast from terminal server) */
   onPeerMessageCreated?: (folderId: string, message: import("@/types/peer-chat").PeerChatMessage) => void;
+  onChannelMessageCreated?: (folderId: string, channelId: string, message: import("@/types/peer-chat").PeerChatMessage) => void;
+  onThreadReplyCreated?: (folderId: string, parentMessageId: string, message: import("@/types/peer-chat").PeerChatMessage) => void;
+  onChannelCreated?: (folderId: string, channel: import("@/types/channels").Channel) => void;
 }
 
 export function TerminalTypeRenderer({
@@ -84,6 +87,9 @@ export function TerminalTypeRenderer({
   onSessionStatus,
   onSessionProgress,
   onPeerMessageCreated,
+  onChannelMessageCreated,
+  onThreadReplyCreated,
+  onChannelCreated,
 }: TerminalTypeRendererProps) {
   const { getAgentActivityStatus } = useSessionContext();
   const activityStatus = getAgentActivityStatus(session.id);
@@ -158,6 +164,9 @@ export function TerminalTypeRenderer({
         onSessionStatus={onSessionStatus}
         onSessionProgress={onSessionProgress}
         onPeerMessageCreated={onPeerMessageCreated}
+        onChannelMessageCreated={onChannelMessageCreated}
+        onThreadReplyCreated={onThreadReplyCreated}
+        onChannelCreated={onChannelCreated}
         onOutput={onOutput}
         onDimensionsChange={onDimensionsChange}
       />

--- a/src/components/terminal/TerminalWithKeyboard.tsx
+++ b/src/components/terminal/TerminalWithKeyboard.tsx
@@ -57,6 +57,9 @@ interface TerminalWithKeyboardProps {
   onSessionProgress?: (sessionId: string, progress: SessionProgress | null) => void;
   /** Called when a peer message is created (broadcast from terminal server) */
   onPeerMessageCreated?: (folderId: string, message: import("@/types/peer-chat").PeerChatMessage) => void;
+  onChannelMessageCreated?: (folderId: string, channelId: string, message: import("@/types/peer-chat").PeerChatMessage) => void;
+  onThreadReplyCreated?: (folderId: string, parentMessageId: string, message: import("@/types/peer-chat").PeerChatMessage) => void;
+  onChannelCreated?: (folderId: string, channel: import("@/types/channels").Channel) => void;
 }
 
 export const TerminalWithKeyboard = forwardRef<TerminalWithKeyboardRef, TerminalWithKeyboardProps>(function TerminalWithKeyboard({
@@ -87,6 +90,9 @@ export const TerminalWithKeyboard = forwardRef<TerminalWithKeyboardRef, Terminal
   onSessionStatus,
   onSessionProgress,
   onPeerMessageCreated,
+  onChannelMessageCreated,
+  onThreadReplyCreated,
+  onChannelCreated,
 }, ref) {
   const wsRef = useRef<WebSocket | null>(null);
   const terminalRef = useRef<TerminalRef>(null);
@@ -178,6 +184,9 @@ export const TerminalWithKeyboard = forwardRef<TerminalWithKeyboardRef, Terminal
         onSessionStatus={onSessionStatus}
         onSessionProgress={onSessionProgress}
         onPeerMessageCreated={onPeerMessageCreated}
+        onChannelMessageCreated={onChannelMessageCreated}
+        onThreadReplyCreated={onThreadReplyCreated}
+        onChannelCreated={onChannelCreated}
         onScrollStateChange={setIsTerminalScrolledUp}
       />
     </ErrorBoundary>

--- a/src/contexts/ChannelContext.tsx
+++ b/src/contexts/ChannelContext.tsx
@@ -117,6 +117,8 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
   const [threadMessages, setThreadMessages] = useState<Map<string, ChannelMessage[]>>(new Map());
   const [openThreadId, setOpenThreadId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const threadMessagesRef = useRef(threadMessages);
+  threadMessagesRef.current = threadMessages;
 
   // ---------------------------------------------------------------------------
   // Channel group fetching
@@ -310,7 +312,7 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
     async (messageId: string) => {
       setOpenThreadId(messageId);
       // Fetch thread replies if not cached
-      if (!threadMessages.has(messageId)) {
+      if (!threadMessagesRef.current.has(messageId)) {
         try {
           const channelId = activeChannelId;
           if (!channelId) return;
@@ -328,7 +330,7 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
         }
       }
     },
-    [activeChannelId, threadMessages]
+    [activeChannelId]
   );
 
   const closeThread = useCallback(() => {

--- a/src/contexts/ChannelContext.tsx
+++ b/src/contexts/ChannelContext.tsx
@@ -217,8 +217,6 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeChannelId, fetchMessages]);
 
-  const setActiveChannelId = setActiveChannelIdState;
-
   // ---------------------------------------------------------------------------
   // Send message
   // ---------------------------------------------------------------------------
@@ -454,7 +452,7 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
     () => ({
       groups,
       activeChannelId,
-      setActiveChannelId,
+      setActiveChannelId: setActiveChannelIdState,
       activeChannelMessages,
       totalUnreadCount,
       loading,
@@ -473,7 +471,7 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
     [
       groups,
       activeChannelId,
-      setActiveChannelId,
+      setActiveChannelIdState,
       activeChannelMessages,
       totalUnreadCount,
       loading,

--- a/src/contexts/ChannelContext.tsx
+++ b/src/contexts/ChannelContext.tsx
@@ -61,6 +61,22 @@ function removeOptimistic(
   });
 }
 
+/** Increment a parent message's replyCount in the channel message map. */
+function incrementParentReplyCount(
+  setter: MapSetter<ChannelMessage>,
+  channelId: string,
+  parentId: string
+): void {
+  setter((prev) => {
+    const msgs = prev.get(channelId);
+    if (!msgs) return prev;
+    return new Map(prev).set(
+      channelId,
+      msgs.map((m) => (m.id === parentId ? { ...m, replyCount: m.replyCount + 1 } : m))
+    );
+  });
+}
+
 interface ChannelContextValue {
   groups: ChannelGroup[];
   activeChannelId: string | null;
@@ -370,18 +386,7 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
         return new Map(prev).set(message.parentMessageId!, [...current, message]);
       });
       // Also increment replyCount on the parent in messagesByChannel
-      setMessagesByChannel((prev) => {
-        const msgs = prev.get(message.channelId);
-        if (!msgs) return prev;
-        return new Map(prev).set(
-          message.channelId,
-          msgs.map((m) =>
-            m.id === message.parentMessageId
-              ? { ...m, replyCount: m.replyCount + 1 }
-              : m
-          )
-        );
-      });
+      incrementParentReplyCount(setMessagesByChannel, message.channelId, message.parentMessageId!);
     } else {
       setMessagesByChannel((prev) => {
         const current = prev.get(message.channelId) ?? [];
@@ -412,16 +417,7 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
       return new Map(prev).set(parentId, [...current, message]);
     });
     // Also bump parent's replyCount in messagesByChannel
-    setMessagesByChannel((prev) => {
-      const channelMsgs = prev.get(message.channelId);
-      if (!channelMsgs) return prev;
-      return new Map(prev).set(
-        message.channelId,
-        channelMsgs.map((m) =>
-          m.id === parentId ? { ...m, replyCount: m.replyCount + 1 } : m
-        )
-      );
-    });
+    incrementParentReplyCount(setMessagesByChannel, message.channelId, parentId);
   }, []);
 
   const addChannel = useCallback((channel: Channel) => {

--- a/src/contexts/ChannelContext.tsx
+++ b/src/contexts/ChannelContext.tsx
@@ -1,0 +1,524 @@
+"use client";
+
+/**
+ * ChannelContext - Primary chat state manager for channel-aware messaging.
+ *
+ * Manages channel groups, per-channel message cache, thread state, and unread
+ * tracking. Follows the same patterns as TaskContext and PeerChatContext:
+ * - Fetches initial data on folder change
+ * - Accepts real-time updates via addMessage / addThreadReply / addChannel
+ * - Optimistic updates for user-sent messages
+ * - Visibility-change re-fetch
+ */
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  type ReactNode,
+} from "react";
+import { usePreferencesContext } from "./PreferencesContext";
+import type { ChannelGroup, Channel, ChannelMessage } from "@/types/channels";
+
+interface ChannelContextValue {
+  groups: ChannelGroup[];
+  activeChannelId: string | null;
+  setActiveChannelId: (id: string | null) => void;
+  activeChannelMessages: ChannelMessage[];
+  totalUnreadCount: number;
+  loading: boolean;
+  sendMessage: (body: string, parentMessageId?: string) => Promise<void>;
+  markChannelRead: (channelId: string, messageId: string) => Promise<void>;
+  openThread: (messageId: string) => void;
+  closeThread: () => void;
+  openThreadId: string | null;
+  threadMessages: ChannelMessage[];
+  refreshChannels: () => Promise<void>;
+  createChannel: (name: string, topic?: string) => Promise<void>;
+  /** Called by WebSocket handler when a channel message arrives. */
+  addMessage: (message: ChannelMessage) => void;
+  /** Called by WebSocket handler when a thread reply arrives. */
+  addThreadReply: (parentId: string, message: ChannelMessage) => void;
+  /** Called by WebSocket handler when a new channel is created. */
+  addChannel: (channel: Channel) => void;
+}
+
+const ChannelContext = createContext<ChannelContextValue | null>(null);
+
+export function useChannelContext(): ChannelContextValue {
+  const context = useContext(ChannelContext);
+  if (!context) {
+    throw new Error("useChannelContext must be used within a ChannelProvider");
+  }
+  return context;
+}
+
+/** Returns the context or null if the provider is not mounted. */
+export function useChannelContextOptional(): ChannelContextValue | null {
+  return useContext(ChannelContext);
+}
+
+interface ChannelProviderProps {
+  children: ReactNode;
+}
+
+export function ChannelProvider({ children }: ChannelProviderProps) {
+  const { activeProject } = usePreferencesContext();
+  const folderId = activeProject.folderId;
+
+  const [groups, setGroups] = useState<ChannelGroup[]>([]);
+  const [activeChannelId, setActiveChannelIdState] = useState<string | null>(null);
+  const [messagesByChannel, setMessagesByChannel] = useState<Map<string, ChannelMessage[]>>(
+    new Map()
+  );
+  const [threadMessages, setThreadMessages] = useState<Map<string, ChannelMessage[]>>(new Map());
+  const [openThreadId, setOpenThreadId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // ---------------------------------------------------------------------------
+  // Channel group fetching
+  // ---------------------------------------------------------------------------
+
+  const fetchChannels = useCallback(async () => {
+    if (!folderId) {
+      setGroups([]);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const resp = await fetch(`/api/channels?folderId=${encodeURIComponent(folderId)}`);
+      if (resp.ok) {
+        const data = await resp.json();
+        const fetchedGroups: ChannelGroup[] = data.groups ?? [];
+        setGroups(fetchedGroups);
+
+        // Auto-select the default channel when loading channels for a folder
+        setActiveChannelIdState((prev) => {
+          // If already have a valid channel in this folder, keep it
+          if (prev) {
+            const existsInFetched = fetchedGroups.some((g) =>
+              g.channels.some((c) => c.id === prev)
+            );
+            if (existsInFetched) return prev;
+          }
+          // Find and select the default channel
+          for (const group of fetchedGroups) {
+            const defaultChannel = group.channels.find((c) => c.isDefault);
+            if (defaultChannel) return defaultChannel.id;
+          }
+          // Fall back to the first channel
+          if (fetchedGroups.length > 0 && fetchedGroups[0].channels.length > 0) {
+            return fetchedGroups[0].channels[0].id;
+          }
+          return null;
+        });
+      }
+    } catch {
+      // Silently fail -- channels will still be visible from cache
+    } finally {
+      setLoading(false);
+    }
+  }, [folderId]);
+
+  // Reset state on folder change
+  useEffect(() => {
+    setGroups([]);
+    setMessagesByChannel(new Map());
+    setThreadMessages(new Map());
+    setOpenThreadId(null);
+    setActiveChannelIdState(null);
+    fetchChannels();
+  }, [folderId, fetchChannels]);
+
+  // Refetch on tab focus
+  useEffect(() => {
+    function handleVisibility(): void {
+      if (!document.hidden && folderId) {
+        fetchChannels();
+      }
+    }
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => document.removeEventListener("visibilitychange", handleVisibility);
+  }, [folderId, fetchChannels]);
+
+  const refreshChannels = useCallback(async () => {
+    await fetchChannels();
+  }, [fetchChannels]);
+
+  // ---------------------------------------------------------------------------
+  // Message fetching for the active channel
+  // ---------------------------------------------------------------------------
+
+  const fetchMessages = useCallback(async (channelId: string) => {
+    try {
+      const resp = await fetch(
+        `/api/channels/${encodeURIComponent(channelId)}/messages?limit=50`
+      );
+      if (resp.ok) {
+        const data = await resp.json();
+        const msgs: ChannelMessage[] = data.messages ?? [];
+        setMessagesByChannel((prev) => new Map(prev).set(channelId, msgs));
+      }
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!activeChannelId) return;
+    // Only fetch if we don't have messages cached yet
+    if (!messagesByChannel.has(activeChannelId)) {
+      fetchMessages(activeChannelId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeChannelId, fetchMessages]);
+
+  const setActiveChannelId = useCallback((id: string | null) => {
+    setActiveChannelIdState(id);
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Send message
+  // ---------------------------------------------------------------------------
+
+  const sendMessage = useCallback(
+    async (body: string, parentMessageId?: string) => {
+      if (!activeChannelId || !body.trim()) return;
+
+      const trimmedBody = body.trim();
+      const targetChannelId = activeChannelId;
+
+      const optimistic: ChannelMessage = {
+        id: `opt-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+        channelId: targetChannelId,
+        fromSessionId: null,
+        fromSessionName: "You",
+        toSessionId: null,
+        body: trimmedBody,
+        isUserMessage: true,
+        parentMessageId: parentMessageId ?? null,
+        replyCount: 0,
+        createdAt: new Date().toISOString(),
+      };
+
+      if (parentMessageId) {
+        // Optimistic thread reply
+        setThreadMessages((prev) => {
+          const current = prev.get(parentMessageId) ?? [];
+          return new Map(prev).set(parentMessageId, [...current, optimistic]);
+        });
+      } else {
+        // Optimistic channel message
+        setMessagesByChannel((prev) => {
+          const current = prev.get(targetChannelId) ?? [];
+          return new Map(prev).set(targetChannelId, [...current, optimistic]);
+        });
+      }
+
+      try {
+        const resp = await fetch(
+          `/api/channels/${encodeURIComponent(targetChannelId)}/messages`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ body: trimmedBody, parentMessageId }),
+          }
+        );
+
+        if (resp.ok) {
+          const data = await resp.json();
+          if (data.message) {
+            const serverMsg: ChannelMessage = data.message;
+
+            if (parentMessageId) {
+              setThreadMessages((prev) => {
+                const current = prev.get(parentMessageId) ?? [];
+                if (current.some((m) => m.id === serverMsg.id)) {
+                  return new Map(prev).set(
+                    parentMessageId,
+                    current.filter((m) => m.id !== optimistic.id)
+                  );
+                }
+                return new Map(prev).set(
+                  parentMessageId,
+                  current.map((m) => (m.id === optimistic.id ? serverMsg : m))
+                );
+              });
+            } else {
+              setMessagesByChannel((prev) => {
+                const current = prev.get(targetChannelId) ?? [];
+                if (current.some((m) => m.id === serverMsg.id)) {
+                  return new Map(prev).set(
+                    targetChannelId,
+                    current.filter((m) => m.id !== optimistic.id)
+                  );
+                }
+                return new Map(prev).set(
+                  targetChannelId,
+                  current.map((m) => (m.id === optimistic.id ? serverMsg : m))
+                );
+              });
+            }
+          }
+        } else {
+          // Remove optimistic on error
+          if (parentMessageId) {
+            setThreadMessages((prev) => {
+              const current = prev.get(parentMessageId) ?? [];
+              return new Map(prev).set(
+                parentMessageId,
+                current.filter((m) => m.id !== optimistic.id)
+              );
+            });
+          } else {
+            setMessagesByChannel((prev) => {
+              const current = prev.get(targetChannelId) ?? [];
+              return new Map(prev).set(
+                targetChannelId,
+                current.filter((m) => m.id !== optimistic.id)
+              );
+            });
+          }
+        }
+      } catch {
+        // Remove optimistic on network error
+        if (parentMessageId) {
+          setThreadMessages((prev) => {
+            const current = prev.get(parentMessageId) ?? [];
+            return new Map(prev).set(
+              parentMessageId,
+              current.filter((m) => m.id !== optimistic.id)
+            );
+          });
+        } else {
+          setMessagesByChannel((prev) => {
+            const current = prev.get(targetChannelId) ?? [];
+            return new Map(prev).set(
+              targetChannelId,
+              current.filter((m) => m.id !== optimistic.id)
+            );
+          });
+        }
+      }
+    },
+    [activeChannelId]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Mark channel read
+  // ---------------------------------------------------------------------------
+
+  const markChannelRead = useCallback(async (channelId: string, messageId: string) => {
+    try {
+      await fetch(`/api/channels/${encodeURIComponent(channelId)}/read`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messageId }),
+      });
+      // Update local unread count for the channel
+      setGroups((prev) =>
+        prev.map((g) => ({
+          ...g,
+          channels: g.channels.map((c) =>
+            c.id === channelId ? { ...c, unreadCount: 0 } : c
+          ),
+        }))
+      );
+    } catch {
+      // Silently fail
+    }
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Thread management
+  // ---------------------------------------------------------------------------
+
+  const openThread = useCallback(
+    async (messageId: string) => {
+      setOpenThreadId(messageId);
+      // Fetch thread replies if not cached
+      if (!threadMessages.has(messageId)) {
+        try {
+          const channelId = activeChannelId;
+          if (!channelId) return;
+          const resp = await fetch(
+            `/api/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/thread`
+          );
+          if (resp.ok) {
+            const data = await resp.json();
+            setThreadMessages((prev) =>
+              new Map(prev).set(messageId, data.replies ?? [])
+            );
+          }
+        } catch {
+          // Silently fail
+        }
+      }
+    },
+    [activeChannelId, threadMessages]
+  );
+
+  const closeThread = useCallback(() => {
+    setOpenThreadId(null);
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Create channel
+  // ---------------------------------------------------------------------------
+
+  const createChannel = useCallback(
+    async (name: string, topic?: string) => {
+      if (!folderId) return;
+      try {
+        const resp = await fetch("/api/channels", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ folderId, name, topic }),
+        });
+        if (resp.ok) {
+          await fetchChannels();
+        }
+      } catch {
+        // Silently fail
+      }
+    },
+    [folderId, fetchChannels]
+  );
+
+  // ---------------------------------------------------------------------------
+  // WebSocket push handlers
+  // ---------------------------------------------------------------------------
+
+  const addMessage = useCallback((message: ChannelMessage) => {
+    if (message.parentMessageId) {
+      // It's a thread reply -- add to thread cache if that thread is open
+      setThreadMessages((prev) => {
+        const current = prev.get(message.parentMessageId!);
+        if (!current) return prev; // thread not loaded, skip
+        if (current.some((m) => m.id === message.id)) return prev; // dedup
+        return new Map(prev).set(message.parentMessageId!, [...current, message]);
+      });
+      // Also increment replyCount on the parent in messagesByChannel
+      setMessagesByChannel((prev) => {
+        const msgs = prev.get(message.channelId);
+        if (!msgs) return prev;
+        return new Map(prev).set(
+          message.channelId,
+          msgs.map((m) =>
+            m.id === message.parentMessageId
+              ? { ...m, replyCount: m.replyCount + 1 }
+              : m
+          )
+        );
+      });
+    } else {
+      setMessagesByChannel((prev) => {
+        const current = prev.get(message.channelId) ?? [];
+        if (current.some((m) => m.id === message.id)) return prev; // dedup
+        return new Map(prev).set(message.channelId, [...current, message]);
+      });
+    }
+
+    // Bump unread count for channels we're not currently viewing
+    setGroups((prev) =>
+      prev.map((g) => ({
+        ...g,
+        channels: g.channels.map((c) => {
+          if (c.id !== message.channelId) return c;
+          // Don't count user's own messages as unread
+          if (message.isUserMessage) return c;
+          return { ...c, unreadCount: c.unreadCount + 1 };
+        }),
+      }))
+    );
+  }, []);
+
+  const addThreadReply = useCallback((parentId: string, message: ChannelMessage) => {
+    setThreadMessages((prev) => {
+      const current = prev.get(parentId);
+      if (!current) return prev;
+      if (current.some((m) => m.id === message.id)) return prev;
+      return new Map(prev).set(parentId, [...current, message]);
+    });
+  }, []);
+
+  const addChannel = useCallback((channel: Channel) => {
+    setGroups((prev) =>
+      prev.map((g) => {
+        if (g.id !== channel.groupId) return g;
+        if (g.channels.some((c) => c.id === channel.id)) return g;
+        return { ...g, channels: [...g.channels, channel] };
+      })
+    );
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Derived values
+  // ---------------------------------------------------------------------------
+
+  const activeChannelMessages = useMemo(
+    () => (activeChannelId ? messagesByChannel.get(activeChannelId) ?? [] : []),
+    [activeChannelId, messagesByChannel]
+  );
+
+  const currentThreadMessages = useMemo(
+    () => (openThreadId ? threadMessages.get(openThreadId) ?? [] : []),
+    [openThreadId, threadMessages]
+  );
+
+  const totalUnreadCount = useMemo(
+    () =>
+      groups.reduce(
+        (sum, g) => sum + g.channels.reduce((cs, c) => cs + c.unreadCount, 0),
+        0
+      ),
+    [groups]
+  );
+
+  const value = useMemo<ChannelContextValue>(
+    () => ({
+      groups,
+      activeChannelId,
+      setActiveChannelId,
+      activeChannelMessages,
+      totalUnreadCount,
+      loading,
+      sendMessage,
+      markChannelRead,
+      openThread,
+      closeThread,
+      openThreadId,
+      threadMessages: currentThreadMessages,
+      refreshChannels,
+      createChannel,
+      addMessage,
+      addThreadReply,
+      addChannel,
+    }),
+    [
+      groups,
+      activeChannelId,
+      setActiveChannelId,
+      activeChannelMessages,
+      totalUnreadCount,
+      loading,
+      sendMessage,
+      markChannelRead,
+      openThread,
+      closeThread,
+      openThreadId,
+      currentThreadMessages,
+      refreshChannels,
+      createChannel,
+      addMessage,
+      addThreadReply,
+      addChannel,
+    ]
+  );
+
+  return <ChannelContext.Provider value={value}>{children}</ChannelContext.Provider>;
+}

--- a/src/contexts/ChannelContext.tsx
+++ b/src/contexts/ChannelContext.tsx
@@ -342,18 +342,16 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
   const createChannel = useCallback(
     async (name: string, topic?: string) => {
       if (!folderId) return;
-      try {
-        const resp = await fetch("/api/channels", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ folderId, name, topic }),
-        });
-        if (resp.ok) {
-          await fetchChannels();
-        }
-      } catch {
-        // Silently fail
+      const resp = await fetch("/api/channels", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ folderId, name, topic }),
+      });
+      if (!resp.ok) {
+        const data = await resp.json().catch(() => ({}));
+        throw new Error((data as { error?: string }).error || "Failed to create channel");
       }
+      await fetchChannels();
     },
     [folderId, fetchChannels]
   );
@@ -412,6 +410,17 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
       if (!current) return prev;
       if (current.some((m) => m.id === message.id)) return prev;
       return new Map(prev).set(parentId, [...current, message]);
+    });
+    // Also bump parent's replyCount in messagesByChannel
+    setMessagesByChannel((prev) => {
+      const channelMsgs = prev.get(message.channelId);
+      if (!channelMsgs) return prev;
+      return new Map(prev).set(
+        message.channelId,
+        channelMsgs.map((m) =>
+          m.id === parentId ? { ...m, replyCount: m.replyCount + 1 } : m
+        )
+      );
     });
   }, []);
 

--- a/src/contexts/ChannelContext.tsx
+++ b/src/contexts/ChannelContext.tsx
@@ -20,9 +20,46 @@ import {
   useMemo,
   useRef,
   type ReactNode,
+  type Dispatch,
+  type SetStateAction,
 } from "react";
 import { usePreferencesContext } from "./PreferencesContext";
 import type { ChannelGroup, Channel, ChannelMessage } from "@/types/channels";
+
+// ---------------------------------------------------------------------------
+// Map update helpers — reduces duplication in optimistic update logic
+// ---------------------------------------------------------------------------
+
+type MapSetter<V> = Dispatch<SetStateAction<Map<string, V[]>>>;
+
+/** Replace an optimistic message with the server version, or remove it if already present. */
+function reconcileOptimistic(
+  setter: MapSetter<ChannelMessage>,
+  key: string,
+  optimisticId: string,
+  serverMsg: ChannelMessage
+): void {
+  setter((prev) => {
+    const current = prev.get(key) ?? [];
+    if (current.some((m) => m.id === serverMsg.id)) {
+      // Server message already arrived via WebSocket — just remove the optimistic one
+      return new Map(prev).set(key, current.filter((m) => m.id !== optimisticId));
+    }
+    return new Map(prev).set(key, current.map((m) => (m.id === optimisticId ? serverMsg : m)));
+  });
+}
+
+/** Remove an optimistic message (on error). */
+function removeOptimistic(
+  setter: MapSetter<ChannelMessage>,
+  key: string,
+  optimisticId: string
+): void {
+  setter((prev) => {
+    const current = prev.get(key) ?? [];
+    return new Map(prev).set(key, current.filter((m) => m.id !== optimisticId));
+  });
+}
 
 interface ChannelContextValue {
   groups: ChannelGroup[];
@@ -148,9 +185,7 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
     return () => document.removeEventListener("visibilitychange", handleVisibility);
   }, [folderId, fetchChannels]);
 
-  const refreshChannels = useCallback(async () => {
-    await fetchChannels();
-  }, [fetchChannels]);
+  const refreshChannels = fetchChannels;
 
   // ---------------------------------------------------------------------------
   // Message fetching for the active channel
@@ -180,9 +215,7 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeChannelId, fetchMessages]);
 
-  const setActiveChannelId = useCallback((id: string | null) => {
-    setActiveChannelIdState(id);
-  }, []);
+  const setActiveChannelId = setActiveChannelIdState;
 
   // ---------------------------------------------------------------------------
   // Send message
@@ -208,19 +241,16 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
         createdAt: new Date().toISOString(),
       };
 
-      if (parentMessageId) {
-        // Optimistic thread reply
-        setThreadMessages((prev) => {
-          const current = prev.get(parentMessageId) ?? [];
-          return new Map(prev).set(parentMessageId, [...current, optimistic]);
-        });
-      } else {
-        // Optimistic channel message
-        setMessagesByChannel((prev) => {
-          const current = prev.get(targetChannelId) ?? [];
-          return new Map(prev).set(targetChannelId, [...current, optimistic]);
-        });
-      }
+      // Determine which map and key to use for optimistic updates
+      const [setter, key] = parentMessageId
+        ? [setThreadMessages, parentMessageId] as const
+        : [setMessagesByChannel, targetChannelId] as const;
+
+      // Add optimistic message
+      setter((prev) => {
+        const current = prev.get(key) ?? [];
+        return new Map(prev).set(key, [...current, optimistic]);
+      });
 
       try {
         const resp = await fetch(
@@ -235,77 +265,13 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
         if (resp.ok) {
           const data = await resp.json();
           if (data.message) {
-            const serverMsg: ChannelMessage = data.message;
-
-            if (parentMessageId) {
-              setThreadMessages((prev) => {
-                const current = prev.get(parentMessageId) ?? [];
-                if (current.some((m) => m.id === serverMsg.id)) {
-                  return new Map(prev).set(
-                    parentMessageId,
-                    current.filter((m) => m.id !== optimistic.id)
-                  );
-                }
-                return new Map(prev).set(
-                  parentMessageId,
-                  current.map((m) => (m.id === optimistic.id ? serverMsg : m))
-                );
-              });
-            } else {
-              setMessagesByChannel((prev) => {
-                const current = prev.get(targetChannelId) ?? [];
-                if (current.some((m) => m.id === serverMsg.id)) {
-                  return new Map(prev).set(
-                    targetChannelId,
-                    current.filter((m) => m.id !== optimistic.id)
-                  );
-                }
-                return new Map(prev).set(
-                  targetChannelId,
-                  current.map((m) => (m.id === optimistic.id ? serverMsg : m))
-                );
-              });
-            }
+            reconcileOptimistic(setter, key, optimistic.id, data.message);
           }
         } else {
-          // Remove optimistic on error
-          if (parentMessageId) {
-            setThreadMessages((prev) => {
-              const current = prev.get(parentMessageId) ?? [];
-              return new Map(prev).set(
-                parentMessageId,
-                current.filter((m) => m.id !== optimistic.id)
-              );
-            });
-          } else {
-            setMessagesByChannel((prev) => {
-              const current = prev.get(targetChannelId) ?? [];
-              return new Map(prev).set(
-                targetChannelId,
-                current.filter((m) => m.id !== optimistic.id)
-              );
-            });
-          }
+          removeOptimistic(setter, key, optimistic.id);
         }
       } catch {
-        // Remove optimistic on network error
-        if (parentMessageId) {
-          setThreadMessages((prev) => {
-            const current = prev.get(parentMessageId) ?? [];
-            return new Map(prev).set(
-              parentMessageId,
-              current.filter((m) => m.id !== optimistic.id)
-            );
-          });
-        } else {
-          setMessagesByChannel((prev) => {
-            const current = prev.get(targetChannelId) ?? [];
-            return new Map(prev).set(
-              targetChannelId,
-              current.filter((m) => m.id !== optimistic.id)
-            );
-          });
-        }
+        removeOptimistic(setter, key, optimistic.id);
       }
     },
     [activeChannelId]

--- a/src/contexts/ChannelContext.tsx
+++ b/src/contexts/ChannelContext.tsx
@@ -18,6 +18,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   type ReactNode,
 } from "react";
 import { usePreferencesContext } from "./PreferencesContext";
@@ -71,6 +72,8 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
 
   const [groups, setGroups] = useState<ChannelGroup[]>([]);
   const [activeChannelId, setActiveChannelIdState] = useState<string | null>(null);
+  const activeChannelIdRef = useRef(activeChannelId);
+  activeChannelIdRef.current = activeChannelId;
   const [messagesByChannel, setMessagesByChannel] = useState<Map<string, ChannelMessage[]>>(
     new Map()
   );
@@ -429,8 +432,8 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
         ...g,
         channels: g.channels.map((c) => {
           if (c.id !== message.channelId) return c;
-          // Don't count user's own messages as unread
           if (message.isUserMessage) return c;
+          if (c.id === activeChannelIdRef.current) return c; // currently viewing
           return { ...c, unreadCount: c.unreadCount + 1 };
         }),
       }))

--- a/src/contexts/PeerChatContext.tsx
+++ b/src/contexts/PeerChatContext.tsx
@@ -8,6 +8,11 @@
  * - Accepts real-time updates via addMessage (called from WebSocket handler)
  * - Optimistic updates for user-sent messages
  * - Visibility-change re-fetch
+ *
+ * When ChannelContext is available (ChannelProvider mounted above), this context
+ * acts as a shim: messages, sendMessage, and unreadCount delegate to ChannelContext
+ * so that all UI components continue working without changes. Peers are still
+ * fetched independently.
  */
 
 import {
@@ -21,6 +26,7 @@ import {
   type ReactNode,
 } from "react";
 import { usePreferencesContext } from "./PreferencesContext";
+import { useChannelContextOptional } from "./ChannelContext";
 import type { PeerChatMessage, PeerChatAgent } from "@/types/peer-chat";
 
 /** Map from session ID → current display name, built from active peers. */
@@ -60,6 +66,11 @@ export function PeerChatProvider({ children }: PeerChatProviderProps) {
   const { activeProject } = usePreferencesContext();
   const folderId = activeProject.folderId;
 
+  // ChannelContext shim: when ChannelProvider is mounted above us, delegate
+  // messages / sendMessage / unreadCount to it so all consumers get channel-
+  // aware data without needing code changes.
+  const channelCtx = useChannelContextOptional();
+
   const [messages, setMessages] = useState<PeerChatMessage[]>([]);
   const [peers, setPeers] = useState<PeerChatAgent[]>([]);
   const [loading, setLoading] = useState(false);
@@ -67,6 +78,9 @@ export function PeerChatProvider({ children }: PeerChatProviderProps) {
   const chatActiveRef = useRef(false);
 
   const fetchMessages = useCallback(async () => {
+    // When ChannelContext is available, it owns message fetching; skip.
+    if (channelCtx) return;
+
     if (!folderId) {
       setMessages([]);
       return;
@@ -84,7 +98,7 @@ export function PeerChatProvider({ children }: PeerChatProviderProps) {
     } finally {
       setLoading(false);
     }
-  }, [folderId]);
+  }, [folderId, channelCtx]);
 
   const fetchPeers = useCallback(async () => {
     if (!folderId) {
@@ -125,18 +139,29 @@ export function PeerChatProvider({ children }: PeerChatProviderProps) {
     return () => document.removeEventListener("visibilitychange", handleVisibility);
   }, [folderId, fetchMessages, fetchPeers]);
 
-  const addMessage = useCallback((msg: PeerChatMessage) => {
-    setMessages((prev) => {
-      // Deduplicate by ID (optimistic messages may arrive again from broadcast)
-      if (prev.some((m) => m.id === msg.id)) return prev;
-      const next = [...prev, msg];
-      return next.length > MAX_MESSAGES ? next.slice(next.length - MAX_MESSAGES) : next;
-    });
+  const addMessage = useCallback(
+    (msg: PeerChatMessage) => {
+      if (channelCtx) {
+        // Route through ChannelContext when available. ChannelMessage and
+        // PeerChatMessage share the same shape, so the cast is safe.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        channelCtx.addMessage(msg as any);
+        return;
+      }
 
-    if (!chatActiveRef.current) {
-      setUnreadCount((c) => c + 1);
-    }
-  }, []);
+      setMessages((prev) => {
+        // Deduplicate by ID (optimistic messages may arrive again from broadcast)
+        if (prev.some((m) => m.id === msg.id)) return prev;
+        const next = [...prev, msg];
+        return next.length > MAX_MESSAGES ? next.slice(next.length - MAX_MESSAGES) : next;
+      });
+
+      if (!chatActiveRef.current) {
+        setUnreadCount((c) => c + 1);
+      }
+    },
+    [channelCtx]
+  );
 
   const markAllRead = useCallback(() => {
     setUnreadCount(0);
@@ -147,48 +172,60 @@ export function PeerChatProvider({ children }: PeerChatProviderProps) {
     chatActiveRef.current = false;
   }, []);
 
-  const sendMessage = useCallback(async (body: string) => {
-    if (!folderId || !body.trim()) return;
+  const sendMessage = useCallback(
+    async (body: string) => {
+      if (channelCtx) {
+        // Delegate to ChannelContext which knows the active channel.
+        await channelCtx.sendMessage(body);
+        return;
+      }
 
-    const trimmedBody = body.trim();
+      if (!folderId || !body.trim()) return;
 
-    const optimistic: PeerChatMessage = {
-      id: `opt-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-      fromSessionId: null,
-      fromSessionName: "You",
-      toSessionId: null,
-      body: trimmedBody,
-      isUserMessage: true,
-      createdAt: new Date().toISOString(),
-    };
-    setMessages((prev) => [...prev, optimistic]);
+      const trimmedBody = body.trim();
 
-    try {
-      // Server handles @name → @<sid:UUID> mention resolution authoritatively
-      const resp = await fetch("/api/peers/messages", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ folderId, body: trimmedBody }),
-      });
+      const optimistic: PeerChatMessage = {
+        id: `opt-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+        fromSessionId: null,
+        fromSessionName: "You",
+        toSessionId: null,
+        body: trimmedBody,
+        isUserMessage: true,
+        createdAt: new Date().toISOString(),
+        channelId: null,
+        parentMessageId: null,
+        replyCount: 0,
+      };
+      setMessages((prev) => [...prev, optimistic]);
 
-      if (resp.ok) {
-        const data = await resp.json();
-        if (data.message) {
-          // Replace optimistic with server message, or remove if it already arrived via broadcast
-          setMessages((prev) => {
-            if (prev.some((m) => m.id === data.message.id)) {
-              return prev.filter((m) => m.id !== optimistic.id);
-            }
-            return prev.map((m) => (m.id === optimistic.id ? { ...data.message } : m));
-          });
+      try {
+        // Server handles @name → @<sid:UUID> mention resolution authoritatively
+        const resp = await fetch("/api/peers/messages", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ folderId, body: trimmedBody }),
+        });
+
+        if (resp.ok) {
+          const data = await resp.json();
+          if (data.message) {
+            // Replace optimistic with server message, or remove if it already arrived via broadcast
+            setMessages((prev) => {
+              if (prev.some((m) => m.id === data.message.id)) {
+                return prev.filter((m) => m.id !== optimistic.id);
+              }
+              return prev.map((m) => (m.id === optimistic.id ? { ...data.message } : m));
+            });
+          }
+        } else {
+          setMessages((prev) => prev.filter((m) => m.id !== optimistic.id));
         }
-      } else {
+      } catch {
         setMessages((prev) => prev.filter((m) => m.id !== optimistic.id));
       }
-    } catch {
-      setMessages((prev) => prev.filter((m) => m.id !== optimistic.id));
-    }
-  }, [folderId]);
+    },
+    [folderId, channelCtx]
+  );
 
   const refresh = useCallback(async () => {
     await Promise.all([fetchMessages(), fetchPeers()]);
@@ -205,20 +242,40 @@ export function PeerChatProvider({ children }: PeerChatProviderProps) {
     return map;
   }, [peers]);
 
+  // When ChannelContext is available, use its activeChannelMessages (cast to
+  // PeerChatMessage[] since the shapes are compatible) and totalUnreadCount.
+  const effectiveMessages = channelCtx
+    ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (channelCtx.activeChannelMessages as any as PeerChatMessage[])
+    : messages;
+  const effectiveLoading = channelCtx ? channelCtx.loading : loading;
+  const effectiveUnreadCount = channelCtx ? channelCtx.totalUnreadCount : unreadCount;
+
   const value = useMemo<PeerChatContextValue>(
     () => ({
-      messages,
+      messages: effectiveMessages,
       peers,
       peerNameMap,
-      unreadCount,
-      loading,
+      unreadCount: effectiveUnreadCount,
+      loading: effectiveLoading,
       sendMessage,
       addMessage,
       markAllRead,
       markChatInactive,
       refresh,
     }),
-    [messages, peers, peerNameMap, unreadCount, loading, sendMessage, addMessage, markAllRead, markChatInactive, refresh]
+    [
+      effectiveMessages,
+      peers,
+      peerNameMap,
+      effectiveUnreadCount,
+      effectiveLoading,
+      sendMessage,
+      addMessage,
+      markAllRead,
+      markChatInactive,
+      refresh,
+    ]
   );
 
   return (

--- a/src/db/migrations/migrate-channels.ts
+++ b/src/db/migrations/migrate-channels.ts
@@ -47,6 +47,20 @@ async function main() {
       .set({ messageCount: count })
       .where(eq(channels.id, generalChannelId));
 
+    // Backfill lastMessageAt
+    const lastMsgResult = await db
+      .select({ maxCreatedAt: sql<number>`max(${agentPeerMessages.createdAt})` })
+      .from(agentPeerMessages)
+      .where(eq(agentPeerMessages.channelId, generalChannelId));
+
+    const maxCreatedAt = lastMsgResult[0]?.maxCreatedAt;
+    if (maxCreatedAt) {
+      await db
+        .update(channels)
+        .set({ lastMessageAt: new Date(maxCreatedAt) })
+        .where(eq(channels.id, generalChannelId));
+    }
+
     console.log(`  Folder ${folderId}: assigned messages to #general (${count} total)`);
     migrated++;
   }

--- a/src/db/migrations/migrate-channels.ts
+++ b/src/db/migrations/migrate-channels.ts
@@ -9,7 +9,7 @@
 
 import { db } from "@/db";
 import { agentPeerMessages, channels } from "@/db/schema";
-import { eq, isNull, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import * as ChannelService from "@/services/channel-service";
 
 async function main() {

--- a/src/db/migrations/migrate-channels.ts
+++ b/src/db/migrations/migrate-channels.ts
@@ -1,0 +1,61 @@
+/**
+ * One-time migration: create default channels for existing folders with peer messages
+ * and assign all existing messages to their folder's #general channel.
+ *
+ * Safe to run multiple times (idempotent).
+ *
+ * Usage: bun run db:migrate-channels
+ */
+
+import { db } from "@/db";
+import { agentPeerMessages, channels } from "@/db/schema";
+import { eq, isNull, sql } from "drizzle-orm";
+import * as ChannelService from "@/services/channel-service";
+
+async function main() {
+  console.log("Starting channel migration...");
+
+  // Find all distinct folder IDs with peer messages
+  const folders = await db
+    .selectDistinct({ folderId: agentPeerMessages.folderId })
+    .from(agentPeerMessages);
+
+  console.log(`Found ${folders.length} folder(s) with peer messages`);
+
+  let migrated = 0;
+  for (const { folderId } of folders) {
+    // Ensure default group + #general channel
+    const { generalChannelId } = await ChannelService.ensureFolderChannels(folderId);
+
+    // Assign all unassigned messages to #general
+    await db
+      .update(agentPeerMessages)
+      .set({ channelId: generalChannelId })
+      .where(
+        sql`${agentPeerMessages.folderId} = ${folderId} AND ${agentPeerMessages.channelId} IS NULL`
+      );
+
+    // Update message count on the channel
+    const countResult = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(agentPeerMessages)
+      .where(eq(agentPeerMessages.channelId, generalChannelId));
+
+    const count = countResult[0]?.count ?? 0;
+    await db
+      .update(channels)
+      .set({ messageCount: count })
+      .where(eq(channels.id, generalChannelId));
+
+    console.log(`  Folder ${folderId}: assigned messages to #general (${count} total)`);
+    migrated++;
+  }
+
+  console.log(`Migration complete. Processed ${migrated} folder(s).`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -10,6 +10,7 @@ import type { TerminalType, AgentExitState } from "@/types/terminal-type";
 import type { AppearanceMode, ColorSchemeCategory, ColorSchemeId } from "@/types/appearance";
 import type { TaskPriority, TaskStatus, TaskSource } from "@/types/task";
 import type { NotificationType } from "@/types/notification";
+import type { ChannelType } from "@/types/channels";
 
 export const users = sqliteTable("user", {
   id: text("id")
@@ -1654,6 +1655,9 @@ export const agentPeerMessages = sqliteTable(
     isUserMessage: integer("is_user_message", { mode: "boolean" })
       .notNull()
       .default(false),
+    channelId: text("channel_id").references(() => channels.id, { onDelete: "set null" }),
+    parentMessageId: text("parent_message_id"),
+    replyCount: integer("reply_count").notNull().default(0),
     createdAt: integer("created_at", { mode: "timestamp_ms" })
       .notNull()
       .$defaultFn(() => new Date()),
@@ -1661,6 +1665,94 @@ export const agentPeerMessages = sqliteTable(
   (table) => [
     index("peer_message_folder_created_idx").on(table.folderId, table.createdAt),
     index("peer_message_to_session_idx").on(table.toSessionId),
+    index("peer_message_channel_created_idx").on(table.channelId, table.createdAt),
+    index("peer_message_parent_idx").on(table.parentMessageId),
+  ]
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Chat Channel Groups (folder-scoped organizational containers)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const channelGroups = sqliteTable(
+  "channel_group",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    folderId: text("folder_id")
+      .notNull()
+      .references(() => sessionFolders.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    position: integer("position").notNull().default(0),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("channel_group_folder_idx").on(table.folderId),
+    uniqueIndex("channel_group_folder_name_idx").on(table.folderId, table.name),
+  ]
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Chat Channels (message rooms within groups)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const channels = sqliteTable(
+  "channel",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    folderId: text("folder_id")
+      .notNull()
+      .references(() => sessionFolders.id, { onDelete: "cascade" }),
+    groupId: text("group_id")
+      .notNull()
+      .references(() => channelGroups.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    displayName: text("display_name").notNull(),
+    type: text("type").$type<ChannelType>().notNull().default("public"),
+    topic: text("topic"),
+    isDefault: integer("is_default", { mode: "boolean" }).notNull().default(false),
+    createdBySessionId: text("created_by_session_id"),
+    lastMessageAt: integer("last_message_at", { mode: "timestamp_ms" }),
+    messageCount: integer("message_count").notNull().default(0),
+    archivedAt: integer("archived_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("channel_folder_idx").on(table.folderId),
+    index("channel_group_idx").on(table.groupId),
+    uniqueIndex("channel_folder_name_idx").on(table.folderId, table.name),
+  ]
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Channel Read State (per-user unread tracking)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const channelReadState = sqliteTable(
+  "channel_read_state",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    channelId: text("channel_id")
+      .notNull()
+      .references(() => channels.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    lastReadMessageId: text("last_read_message_id"),
+    lastReadAt: integer("last_read_at", { mode: "timestamp_ms" }),
+  },
+  (table) => [
+    uniqueIndex("channel_read_state_unique_idx").on(table.channelId, table.userId),
+    index("channel_read_state_user_idx").on(table.userId),
   ]
 );
 

--- a/src/mcp/peer-server.ts
+++ b/src/mcp/peer-server.ts
@@ -430,7 +430,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       }
 
       case "read_channel": {
-        const { channel_name, limit: rawLimit } = (args || {}) as {
+        const { channel_name, limit: _limit } = (args || {}) as {
           channel_name: string;
           limit?: number;
         };

--- a/src/mcp/peer-server.ts
+++ b/src/mcp/peer-server.ts
@@ -100,12 +100,14 @@ const server = new Server(
   {
     capabilities: { tools: {} },
     instructions: [
-      "You have peer communication tools to discover and message other AI agents working in the same project.",
-      "Use list_peers to see who else is working in this project folder.",
-      "Use send_message to coordinate with a specific peer or broadcast to all peers.",
-      "Use check_messages to read messages from other agents.",
-      "Use set_summary to describe what you're currently working on so peers can find you.",
-      "When you receive messages from peers, respond helpfully — treat them like a colleague asking for help.",
+      "You have peer communication and channel tools for coordinating with other AI agents in this project.",
+      "Use list_channels to see available channels in the project folder.",
+      "Use create_channel to create topic-specific channels for coordinating work.",
+      "Use send_to_channel to send messages to a specific channel (GFM markdown supported).",
+      "Use read_channel to read recent messages from a channel.",
+      "Use list_peers, send_message, check_messages, and set_summary for direct peer communication.",
+      "When you start a significant piece of work, consider creating a channel for it.",
+      "Treat messages from peers as colleague requests — respond helpfully.",
     ].join(" "),
   }
 );
@@ -165,6 +167,77 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           },
         },
         required: ["summary"],
+      },
+    },
+    {
+      name: "list_channels",
+      description:
+        "List available channels in the current project folder. Shows channel groups, names, and message counts.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+      },
+    },
+    {
+      name: "create_channel",
+      description:
+        "Create a new channel in the current project folder. Use when starting a significant piece of work that warrants its own discussion space.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          name: {
+            type: "string",
+            description:
+              "Channel name (lowercase, alphanumeric and hyphens, 1-50 chars)",
+          },
+          topic: {
+            type: "string",
+            description: "Optional topic/description for the channel",
+          },
+        },
+        required: ["name"],
+      },
+    },
+    {
+      name: "send_to_channel",
+      description:
+        "Send a message to a specific channel. Supports GFM markdown for rich formatting. Use for channel-specific discussions rather than broadcast messages.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          channel_name: {
+            type: "string",
+            description: "Channel name (e.g., 'general', 'auth-refactor')",
+          },
+          body: {
+            type: "string",
+            description: "Message content (GFM markdown supported, max 8192 chars)",
+          },
+          reply_to: {
+            type: "string",
+            description: "Message ID to reply to (creates a thread)",
+          },
+        },
+        required: ["channel_name", "body"],
+      },
+    },
+    {
+      name: "read_channel",
+      description:
+        "Read recent messages from a specific channel.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          channel_name: {
+            type: "string",
+            description: "Channel name to read from (e.g., 'general')",
+          },
+          limit: {
+            type: "number",
+            description: "Number of messages to return (default: 20, max: 50)",
+          },
+        },
+        required: ["channel_name"],
       },
     },
   ],
@@ -282,6 +355,116 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         }
 
         return textResult("Summary updated.");
+      }
+
+      case "list_channels": {
+        const resp = await callInternal(
+          `/internal/channels/list?sessionId=${SESSION_ID}`,
+          "GET"
+        );
+        if (resp.status !== 200) {
+          return textResult(`Error: ${JSON.stringify(resp.data)}`);
+        }
+
+        const groups = (resp.data.groups as Array<Record<string, unknown>>) || [];
+        if (groups.length === 0) {
+          return textResult("No channels found. Channels will be created automatically when needed.");
+        }
+
+        const output = groups
+          .map((g) => {
+            const channels = (g.channels as Array<Record<string, unknown>>) || [];
+            const chList = channels
+              .map((c) => `  - ${c.displayName} (${c.messageCount} messages)${c.topic ? ` — ${c.topic}` : ""}`)
+              .join("\n");
+            return `**${g.name}**\n${chList}`;
+          })
+          .join("\n\n");
+
+        return textResult(output);
+      }
+
+      case "create_channel": {
+        const { name, topic } = (args || {}) as { name: string; topic?: string };
+        if (!name) {
+          return textResult("Error: channel name is required");
+        }
+
+        const payload: Record<string, unknown> = {
+          fromSessionId: SESSION_ID,
+          name,
+        };
+        if (topic) payload.topic = topic;
+
+        const resp = await callInternal("/internal/channels/create", "POST", payload);
+        if (resp.status !== 201) {
+          return textResult(`Error: ${JSON.stringify(resp.data)}`);
+        }
+
+        return textResult(`Channel #${name} created successfully.`);
+      }
+
+      case "send_to_channel": {
+        const { channel_name, body, reply_to } = (args || {}) as {
+          channel_name: string;
+          body: string;
+          reply_to?: string;
+        };
+        if (!channel_name || !body) {
+          return textResult("Error: channel_name and body are required");
+        }
+
+        const payload: Record<string, unknown> = {
+          fromSessionId: SESSION_ID,
+          channelName: channel_name,
+          body,
+        };
+        if (reply_to) payload.parentMessageId = reply_to;
+
+        const resp = await callInternal("/internal/channels/send", "POST", payload);
+        if (resp.status !== 200) {
+          return textResult(`Error: ${JSON.stringify(resp.data)}`);
+        }
+
+        return textResult(`Message sent to #${channel_name} (id: ${resp.data.messageId})`);
+      }
+
+      case "read_channel": {
+        const { channel_name, limit: rawLimit } = (args || {}) as {
+          channel_name: string;
+          limit?: number;
+        };
+        if (!channel_name) {
+          return textResult("Error: channel_name is required");
+        }
+
+        // First list channels to resolve name to ID
+        const listResp = await callInternal(
+          `/internal/channels/list?sessionId=${SESSION_ID}`,
+          "GET"
+        );
+        if (listResp.status !== 200) {
+          return textResult(`Error listing channels: ${JSON.stringify(listResp.data)}`);
+        }
+
+        const allGroups = (listResp.data.groups as Array<Record<string, unknown>>) || [];
+        let channelId: string | undefined;
+        for (const g of allGroups) {
+          const channels = (g.channels as Array<Record<string, unknown>>) || [];
+          const found = channels.find((c) => c.name === channel_name);
+          if (found) {
+            channelId = found.id as string;
+            break;
+          }
+        }
+
+        if (!channelId) {
+          return textResult(`Channel '${channel_name}' not found. Use list_channels to see available channels.`);
+        }
+
+        // Note: We can't directly call the Next.js API route from the MCP server.
+        // For now, return channel info. Messages are visible in the chat UI.
+        return textResult(`Channel #${channel_name} found (id: ${channelId}). Messages are available in the chat UI. Use send_to_channel to post messages.`);
       }
 
       default:

--- a/src/mcp/peer-server.ts
+++ b/src/mcp/peer-server.ts
@@ -430,7 +430,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       }
 
       case "read_channel": {
-        const { channel_name, limit: _limit } = (args || {}) as {
+        const { channel_name, limit: rawLimit } = (args || {}) as {
           channel_name: string;
           limit?: number;
         };
@@ -438,33 +438,35 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
           return textResult("Error: channel_name is required");
         }
 
-        // First list channels to resolve name to ID
-        const listResp = await callInternal(
-          `/internal/channels/list?sessionId=${SESSION_ID}`,
+        const limit = rawLimit ? Math.min(Math.max(1, rawLimit), 50) : 20;
+
+        const resp = await callInternal(
+          `/internal/channels/messages?sessionId=${SESSION_ID}&channelName=${encodeURIComponent(channel_name)}&limit=${limit}`,
           "GET"
         );
-        if (listResp.status !== 200) {
-          return textResult(`Error listing channels: ${JSON.stringify(listResp.data)}`);
-        }
 
-        const allGroups = (listResp.data.groups as Array<Record<string, unknown>>) || [];
-        let channelId: string | undefined;
-        for (const g of allGroups) {
-          const channels = (g.channels as Array<Record<string, unknown>>) || [];
-          const found = channels.find((c) => c.name === channel_name);
-          if (found) {
-            channelId = found.id as string;
-            break;
-          }
-        }
-
-        if (!channelId) {
+        if (resp.status === 404) {
           return textResult(`Channel '${channel_name}' not found. Use list_channels to see available channels.`);
         }
+        if (resp.status !== 200) {
+          return textResult(`Error: ${JSON.stringify(resp.data)}`);
+        }
 
-        // Note: We can't directly call the Next.js API route from the MCP server.
-        // For now, return channel info. Messages are visible in the chat UI.
-        return textResult(`Channel #${channel_name} found (id: ${channelId}). Messages are available in the chat UI. Use send_to_channel to post messages.`);
+        const messages = (resp.data.messages as Array<Record<string, unknown>>) || [];
+        if (messages.length === 0) {
+          return textResult(`No messages in #${channel_name}.`);
+        }
+
+        const msgList = messages
+          .map((m) => {
+            const from = m.fromSessionName || m.fromSessionId || "unknown";
+            const time = m.createdAt ? new Date(m.createdAt as string).toLocaleString() : "";
+            const thread = (m.replyCount as number) > 0 ? ` (${m.replyCount} replies)` : "";
+            return `**${from}** [${time}]${thread}:\n${m.body}`;
+          })
+          .join("\n\n---\n\n");
+
+        return textResult(`#${channel_name} — ${messages.length} message(s):\n\n${msgList}`);
       }
 
       default:

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -1345,6 +1345,7 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
       broadcastToUser(result.userId, {
         type: "peer_message_created",
         folderId: result.folderId,
+        channelId: result.channelId ?? null,
         message: {
           id: result.messageId,
           fromSessionId,
@@ -1352,6 +1353,9 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
           toSessionId: toSessionId ?? null,
           body: result.resolvedBody,
           isUserMessage: false,
+          channelId: result.channelId ?? null,
+          parentMessageId: null,
+          replyCount: 0,
           createdAt: result.createdAt,
         },
       });
@@ -1420,9 +1424,12 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
       return true;
     }
 
+    const eventType = (payload.type as string) || "peer_message_created";
     broadcastToUser(userId as string, {
-      type: "peer_message_created",
+      type: eventType,
       folderId,
+      channelId: payload.channelId ?? null,
+      parentMessageId: payload.parentMessageId ?? null,
       message,
     });
     sendJson(res, 200, { ok: true });
@@ -1438,6 +1445,158 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
     } catch (err) {
       peerLog.error("Failed to cleanup peer messages", { error: String(err) });
       sendJson(res, 500, { error: "Failed to cleanup" });
+    }
+    return true;
+  }
+
+  // ═══ Channel endpoints ════════════════════════════════════════════════════
+
+  // GET /internal/channels/list?sessionId=xxx
+  if (pathname === "/internal/channels/list" && req.method === "GET") {
+    const sessionId = query.sessionId as string;
+    if (!sessionId) {
+      sendJson(res, 400, { error: "Missing sessionId" });
+      return true;
+    }
+
+    try {
+      const { terminalSessions } = await import("@/db/schema");
+      const { eq } = await import("drizzle-orm");
+      const { db } = await import("@/db");
+      const session = await db.query.terminalSessions.findFirst({
+        where: eq(terminalSessions.id, sessionId),
+        columns: { folderId: true, userId: true },
+      });
+      if (!session?.folderId || !session.userId) {
+        sendJson(res, 404, { error: "Session not found or has no folder" });
+        return true;
+      }
+
+      const ChannelService = await import("@/services/channel-service");
+      const groups = await ChannelService.listChannelGroups(session.folderId, session.userId);
+      sendJson(res, 200, { groups });
+    } catch (err) {
+      peerLog.error("Failed to list channels", { error: String(err) });
+      sendJson(res, 500, { error: "Failed to list channels" });
+    }
+    return true;
+  }
+
+  // POST /internal/channels/create { fromSessionId, name, topic?, displayName? }
+  if (pathname === "/internal/channels/create" && req.method === "POST") {
+    const payload = await parseRequestJson(req, res);
+    if (!payload) return true;
+
+    const { fromSessionId, name, topic, displayName } = payload;
+    if (!fromSessionId || !name) {
+      sendJson(res, 400, { error: "Missing fromSessionId or name" });
+      return true;
+    }
+
+    try {
+      const { terminalSessions } = await import("@/db/schema");
+      const { eq } = await import("drizzle-orm");
+      const { db } = await import("@/db");
+      const session = await db.query.terminalSessions.findFirst({
+        where: eq(terminalSessions.id, fromSessionId as string),
+        columns: { folderId: true, userId: true },
+      });
+      if (!session?.folderId || !session.userId) {
+        sendJson(res, 404, { error: "Session not found or has no folder" });
+        return true;
+      }
+
+      const ChannelService = await import("@/services/channel-service");
+      const channel = await ChannelService.createChannel({
+        folderId: session.folderId,
+        name: name as string,
+        displayName: displayName as string | undefined,
+        topic: topic as string | undefined,
+        createdBySessionId: fromSessionId as string,
+      });
+
+      // Broadcast channel creation to UI
+      broadcastToUser(session.userId, {
+        type: "channel_created",
+        folderId: session.folderId,
+        channel,
+      });
+
+      sendJson(res, 201, { channel });
+    } catch (err) {
+      peerLog.error("Failed to create channel", { error: String(err) });
+      sendJson(res, 400, { error: String(err) });
+    }
+    return true;
+  }
+
+  // POST /internal/channels/send { fromSessionId, channelId?, channelName?, body, parentMessageId? }
+  if (pathname === "/internal/channels/send" && req.method === "POST") {
+    const payload = await parseRequestJson(req, res);
+    if (!payload) return true;
+
+    const { fromSessionId, channelId, channelName, body: msgBody, parentMessageId } = payload;
+    if (!fromSessionId || !msgBody) {
+      sendJson(res, 400, { error: "Missing fromSessionId or body" });
+      return true;
+    }
+
+    try {
+      let resolvedChannelId = channelId as string | undefined;
+
+      // Resolve channel name to ID if needed
+      if (!resolvedChannelId && channelName) {
+        const { terminalSessions, channels: channelsTable } = await import("@/db/schema");
+        const { eq, and } = await import("drizzle-orm");
+        const { db } = await import("@/db");
+        const session = await db.query.terminalSessions.findFirst({
+          where: eq(terminalSessions.id, fromSessionId as string),
+          columns: { folderId: true },
+        });
+        if (session?.folderId) {
+          const ch = await db.query.channels.findFirst({
+            where: and(
+              eq(channelsTable.folderId, session.folderId),
+              eq(channelsTable.name, channelName as string)
+            ),
+            columns: { id: true },
+          });
+          resolvedChannelId = ch?.id;
+        }
+      }
+
+      const PeerService = await import("@/services/peer-service");
+      const result = await PeerService.sendMessage({
+        fromSessionId: fromSessionId as string,
+        body: msgBody as string,
+        channelId: resolvedChannelId,
+        parentMessageId: parentMessageId as string | undefined,
+      });
+
+      const eventType = parentMessageId ? "thread_reply_created" : "channel_message_created";
+      broadcastToUser(result.userId, {
+        type: eventType,
+        folderId: result.folderId,
+        channelId: result.channelId ?? resolvedChannelId ?? null,
+        parentMessageId: parentMessageId ?? null,
+        message: {
+          id: result.messageId,
+          fromSessionId,
+          fromSessionName: result.senderName,
+          toSessionId: null,
+          body: result.resolvedBody,
+          isUserMessage: false,
+          channelId: result.channelId ?? resolvedChannelId ?? null,
+          parentMessageId: parentMessageId ?? null,
+          replyCount: 0,
+          createdAt: result.createdAt,
+        },
+      });
+
+      sendJson(res, 200, { messageId: result.messageId, resolvedBody: result.resolvedBody });
+    } catch (err) {
+      peerLog.error("Failed to send channel message", { error: String(err) });
+      sendJson(res, 500, { error: String(err) });
     }
     return true;
   }

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -1562,6 +1562,10 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
         if (ctx) {
           resolvedChannelId = await resolveChannelName(ctx.folderId, channelName as string);
         }
+        if (!resolvedChannelId) {
+          sendJson(res, 404, { error: `Channel '${channelName}' not found` });
+          return true;
+        }
       }
 
       const PeerService = await import("@/services/peer-service");

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -1601,6 +1601,53 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
     return true;
   }
 
+  // GET /internal/channels/messages?sessionId=xxx&channelName=yyy&limit=20
+  if (pathname === "/internal/channels/messages" && req.method === "GET") {
+    const sessionId = query.sessionId as string;
+    const channelName = query.channelName as string;
+    const limit = Math.min(Math.max(1, parseInt(query.limit as string || "20", 10) || 20), 50);
+
+    if (!sessionId || !channelName) {
+      sendJson(res, 400, { error: "Missing sessionId or channelName" });
+      return true;
+    }
+
+    try {
+      const { terminalSessions, channels: channelsTable } = await import("@/db/schema");
+      const { eq, and } = await import("drizzle-orm");
+      const { db } = await import("@/db");
+      const session = await db.query.terminalSessions.findFirst({
+        where: eq(terminalSessions.id, sessionId),
+        columns: { folderId: true },
+      });
+      if (!session?.folderId) {
+        sendJson(res, 404, { error: "Session not found or has no folder" });
+        return true;
+      }
+
+      // Resolve channel name to ID
+      const ch = await db.query.channels.findFirst({
+        where: and(
+          eq(channelsTable.folderId, session.folderId),
+          eq(channelsTable.name, channelName)
+        ),
+        columns: { id: true },
+      });
+      if (!ch) {
+        sendJson(res, 404, { error: `Channel '${channelName}' not found` });
+        return true;
+      }
+
+      const PeerService = await import("@/services/peer-service");
+      const messages = await PeerService.listChannelMessages(ch.id, { limit });
+      sendJson(res, 200, { channelId: ch.id, messages });
+    } catch (err) {
+      peerLog.error("Failed to read channel messages", { error: String(err) });
+      sendJson(res, 500, { error: "Failed to read channel messages" });
+    }
+    return true;
+  }
+
   // --- end cmux parity endpoints ---
 
   if (!pathname?.startsWith("/internal/scheduler/")) {

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -1451,6 +1451,31 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
 
   // ═══ Channel endpoints ════════════════════════════════════════════════════
 
+  /** Look up a session's folderId and userId by session ID. */
+  async function getSessionFolderContext(sessionId: string): Promise<{ folderId: string; userId: string } | null> {
+    const { terminalSessions } = await import("@/db/schema");
+    const { eq } = await import("drizzle-orm");
+    const { db } = await import("@/db");
+    const session = await db.query.terminalSessions.findFirst({
+      where: eq(terminalSessions.id, sessionId),
+      columns: { folderId: true, userId: true },
+    });
+    if (!session?.folderId || !session.userId) return null;
+    return { folderId: session.folderId, userId: session.userId };
+  }
+
+  /** Resolve a channel name to its ID within a folder. */
+  async function resolveChannelName(folderId: string, channelName: string): Promise<string | undefined> {
+    const { channels: channelsTable } = await import("@/db/schema");
+    const { eq, and } = await import("drizzle-orm");
+    const { db } = await import("@/db");
+    const ch = await db.query.channels.findFirst({
+      where: and(eq(channelsTable.folderId, folderId), eq(channelsTable.name, channelName)),
+      columns: { id: true },
+    });
+    return ch?.id;
+  }
+
   // GET /internal/channels/list?sessionId=xxx
   if (pathname === "/internal/channels/list" && req.method === "GET") {
     const sessionId = query.sessionId as string;
@@ -1460,20 +1485,14 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
     }
 
     try {
-      const { terminalSessions } = await import("@/db/schema");
-      const { eq } = await import("drizzle-orm");
-      const { db } = await import("@/db");
-      const session = await db.query.terminalSessions.findFirst({
-        where: eq(terminalSessions.id, sessionId),
-        columns: { folderId: true, userId: true },
-      });
-      if (!session?.folderId || !session.userId) {
+      const ctx = await getSessionFolderContext(sessionId);
+      if (!ctx) {
         sendJson(res, 404, { error: "Session not found or has no folder" });
         return true;
       }
 
       const ChannelService = await import("@/services/channel-service");
-      const groups = await ChannelService.listChannelGroups(session.folderId, session.userId);
+      const groups = await ChannelService.listChannelGroups(ctx.folderId, ctx.userId);
       sendJson(res, 200, { groups });
     } catch (err) {
       peerLog.error("Failed to list channels", { error: String(err) });
@@ -1494,31 +1513,24 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
     }
 
     try {
-      const { terminalSessions } = await import("@/db/schema");
-      const { eq } = await import("drizzle-orm");
-      const { db } = await import("@/db");
-      const session = await db.query.terminalSessions.findFirst({
-        where: eq(terminalSessions.id, fromSessionId as string),
-        columns: { folderId: true, userId: true },
-      });
-      if (!session?.folderId || !session.userId) {
+      const ctx = await getSessionFolderContext(fromSessionId as string);
+      if (!ctx) {
         sendJson(res, 404, { error: "Session not found or has no folder" });
         return true;
       }
 
       const ChannelService = await import("@/services/channel-service");
       const channel = await ChannelService.createChannel({
-        folderId: session.folderId,
+        folderId: ctx.folderId,
         name: name as string,
         displayName: displayName as string | undefined,
         topic: topic as string | undefined,
         createdBySessionId: fromSessionId as string,
       });
 
-      // Broadcast channel creation to UI
-      broadcastToUser(session.userId, {
+      broadcastToUser(ctx.userId, {
         type: "channel_created",
-        folderId: session.folderId,
+        folderId: ctx.folderId,
         channel,
       });
 
@@ -1546,22 +1558,9 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
 
       // Resolve channel name to ID if needed
       if (!resolvedChannelId && channelName) {
-        const { terminalSessions, channels: channelsTable } = await import("@/db/schema");
-        const { eq, and } = await import("drizzle-orm");
-        const { db } = await import("@/db");
-        const session = await db.query.terminalSessions.findFirst({
-          where: eq(terminalSessions.id, fromSessionId as string),
-          columns: { folderId: true },
-        });
-        if (session?.folderId) {
-          const ch = await db.query.channels.findFirst({
-            where: and(
-              eq(channelsTable.folderId, session.folderId),
-              eq(channelsTable.name, channelName as string)
-            ),
-            columns: { id: true },
-          });
-          resolvedChannelId = ch?.id;
+        const ctx = await getSessionFolderContext(fromSessionId as string);
+        if (ctx) {
+          resolvedChannelId = await resolveChannelName(ctx.folderId, channelName as string);
         }
       }
 
@@ -1574,10 +1573,11 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
       });
 
       const eventType = parentMessageId ? "thread_reply_created" : "channel_message_created";
+      const effectiveChannelId = result.channelId ?? resolvedChannelId ?? null;
       broadcastToUser(result.userId, {
         type: eventType,
         folderId: result.folderId,
-        channelId: result.channelId ?? resolvedChannelId ?? null,
+        channelId: effectiveChannelId,
         parentMessageId: parentMessageId ?? null,
         message: {
           id: result.messageId,
@@ -1586,7 +1586,7 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
           toSessionId: null,
           body: result.resolvedBody,
           isUserMessage: false,
-          channelId: result.channelId ?? resolvedChannelId ?? null,
+          channelId: effectiveChannelId,
           parentMessageId: parentMessageId ?? null,
           replyCount: 0,
           createdAt: result.createdAt,
@@ -1613,34 +1613,21 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
     }
 
     try {
-      const { terminalSessions, channels: channelsTable } = await import("@/db/schema");
-      const { eq, and } = await import("drizzle-orm");
-      const { db } = await import("@/db");
-      const session = await db.query.terminalSessions.findFirst({
-        where: eq(terminalSessions.id, sessionId),
-        columns: { folderId: true },
-      });
-      if (!session?.folderId) {
+      const ctx = await getSessionFolderContext(sessionId);
+      if (!ctx) {
         sendJson(res, 404, { error: "Session not found or has no folder" });
         return true;
       }
 
-      // Resolve channel name to ID
-      const ch = await db.query.channels.findFirst({
-        where: and(
-          eq(channelsTable.folderId, session.folderId),
-          eq(channelsTable.name, channelName)
-        ),
-        columns: { id: true },
-      });
-      if (!ch) {
+      const channelDbId = await resolveChannelName(ctx.folderId, channelName);
+      if (!channelDbId) {
         sendJson(res, 404, { error: `Channel '${channelName}' not found` });
         return true;
       }
 
       const PeerService = await import("@/services/peer-service");
-      const messages = await PeerService.listChannelMessages(ch.id, { limit });
-      sendJson(res, 200, { channelId: ch.id, messages });
+      const messages = await PeerService.listChannelMessages(channelDbId, { limit });
+      sendJson(res, 200, { channelId: channelDbId, messages });
     } catch (err) {
       peerLog.error("Failed to read channel messages", { error: String(err) });
       sendJson(res, 500, { error: "Failed to read channel messages" });

--- a/src/services/channel-service.ts
+++ b/src/services/channel-service.ts
@@ -224,15 +224,14 @@ export async function listChannelGroups(
 
   const readStateMap = new Map(readStates.map((rs) => [rs.channelId, rs.lastReadAt]));
 
-  // Batch: get unread counts for channels that have been read
+  // Batch: count unread messages per channel since each channel's last-read timestamp
   const channelsWithReadState = allChannels
     .filter((c) => readStateMap.has(c.id))
     .map((c) => ({ id: c.id, lastReadAt: readStateMap.get(c.id)! }));
 
-  let unreadCountMap = new Map<string, number>();
+  const unreadCountMap = new Map<string, number>();
 
   if (channelsWithReadState.length > 0) {
-    // Single query: count unread messages per channel since last read
     const unreadRows = await db
       .select({
         channelId: agentPeerMessages.channelId,
@@ -260,13 +259,8 @@ export async function listChannelGroups(
 
   const channelsWithUnread = allChannels.map((ch) => {
     const lastReadAt = readStateMap.get(ch.id);
-    let unreadCount: number;
-    if (!lastReadAt) {
-      // Never read — all messages are unread
-      unreadCount = ch.messageCount;
-    } else {
-      unreadCount = unreadCountMap.get(ch.id) ?? 0;
-    }
+    // Never read → all messages are unread; otherwise use the batched count
+    const unreadCount = lastReadAt ? (unreadCountMap.get(ch.id) ?? 0) : ch.messageCount;
 
     return {
       id: ch.id,

--- a/src/services/channel-service.ts
+++ b/src/services/channel-service.ts
@@ -257,10 +257,34 @@ export async function listChannelGroups(
     }
   }
 
+  // For never-read channels, count only top-level messages (not thread replies)
+  const neverReadIds = allChannels.filter((c) => !readStateMap.has(c.id)).map((c) => c.id);
+  const neverReadCountMap = new Map<string, number>();
+  if (neverReadIds.length > 0) {
+    const neverReadRows = await db
+      .select({
+        channelId: agentPeerMessages.channelId,
+        count: sql<number>`count(*)`,
+      })
+      .from(agentPeerMessages)
+      .where(
+        and(
+          inArray(agentPeerMessages.channelId, neverReadIds),
+          isNull(agentPeerMessages.parentMessageId)
+        )
+      )
+      .groupBy(agentPeerMessages.channelId);
+    for (const row of neverReadRows) {
+      if (row.channelId) neverReadCountMap.set(row.channelId, row.count);
+    }
+  }
+
   const channelsWithUnread = allChannels.map((ch) => {
     const lastReadAt = readStateMap.get(ch.id);
-    // Never read → all messages are unread; otherwise use the batched count
-    const unreadCount = lastReadAt ? (unreadCountMap.get(ch.id) ?? 0) : ch.messageCount;
+    // Never read → count top-level messages only; otherwise use the batched count
+    const unreadCount = lastReadAt
+      ? (unreadCountMap.get(ch.id) ?? 0)
+      : (neverReadCountMap.get(ch.id) ?? 0);
 
     return {
       id: ch.id,
@@ -416,11 +440,13 @@ export async function findOrCreateDmChannel(
 
 /**
  * Mark a channel as read for a user up to a specific message.
+ * Pass messageCreatedAt to use the message's actual timestamp instead of now.
  */
 export async function markChannelRead(
   channelId: string,
   userId: string,
-  messageId: string
+  messageId: string,
+  messageCreatedAt?: Date
 ) {
   // Verify message belongs to this channel
   const message = await db.query.agentPeerMessages.findFirst({
@@ -428,21 +454,21 @@ export async function markChannelRead(
       eq(agentPeerMessages.id, messageId),
       eq(agentPeerMessages.channelId, channelId)
     ),
-    columns: { id: true },
+    columns: { id: true, createdAt: true },
   });
   if (!message) {
     throw new Error("Message does not belong to this channel");
   }
 
-  const now = new Date();
+  const lastReadAt = messageCreatedAt ?? message.createdAt ?? new Date();
 
   // Upsert read state
   await db
     .insert(channelReadState)
-    .values({ channelId, userId, lastReadMessageId: messageId, lastReadAt: now })
+    .values({ channelId, userId, lastReadMessageId: messageId, lastReadAt })
     .onConflictDoUpdate({
       target: [channelReadState.channelId, channelReadState.userId],
-      set: { lastReadMessageId: messageId, lastReadAt: now },
+      set: { lastReadMessageId: messageId, lastReadAt },
     });
 }
 

--- a/src/services/channel-service.ts
+++ b/src/services/channel-service.ts
@@ -11,6 +11,7 @@ import {
   channels,
   channelReadState,
   agentPeerMessages,
+  sessionFolders,
 } from "@/db/schema";
 import { eq, and, sql, gt, isNull } from "drizzle-orm";
 import { createLogger } from "@/lib/logger";
@@ -269,6 +270,49 @@ export async function verifyChannelInFolder(
     columns: { id: true },
   });
   return !!ch;
+}
+
+// ─── Access Checks (shared by API routes) ────────────────────────────────────
+
+/**
+ * Verify the user owns the folder containing a channel.
+ * Returns the folderId on success, or null if the channel doesn't exist
+ * or the user doesn't own the folder.
+ */
+export async function verifyChannelAccess(
+  channelId: string,
+  userId: string
+): Promise<{ folderId: string } | null> {
+  const channel = await getChannel(channelId);
+  if (!channel) return null;
+
+  const folder = await db.query.sessionFolders.findFirst({
+    where: and(
+      eq(sessionFolders.id, channel.folderId),
+      eq(sessionFolders.userId, userId)
+    ),
+    columns: { id: true },
+  });
+  if (!folder) return null;
+
+  return { folderId: channel.folderId };
+}
+
+/**
+ * Verify the user owns the given folder.
+ */
+export async function verifyFolderOwnership(
+  folderId: string,
+  userId: string
+): Promise<boolean> {
+  const folder = await db.query.sessionFolders.findFirst({
+    where: and(
+      eq(sessionFolders.id, folderId),
+      eq(sessionFolders.userId, userId)
+    ),
+    columns: { id: true },
+  });
+  return !!folder;
 }
 
 /**

--- a/src/services/channel-service.ts
+++ b/src/services/channel-service.ts
@@ -1,0 +1,387 @@
+/**
+ * ChannelService - Channel and group lifecycle management
+ *
+ * Handles creation, listing, and management of chat channels and groups.
+ * Channels are folder-scoped and organized into groups.
+ */
+
+import { db } from "@/db";
+import {
+  channelGroups,
+  channels,
+  channelReadState,
+  agentPeerMessages,
+} from "@/db/schema";
+import { eq, and, sql, desc, gt, isNull } from "drizzle-orm";
+import { createLogger } from "@/lib/logger";
+import type { ChannelType } from "@/types/channels";
+
+const log = createLogger("ChannelService");
+
+const CHANNEL_NAME_RE = /^[a-z0-9][a-z0-9-]{0,49}$/;
+const DEFAULT_GROUP_NAME = "Channels";
+const DM_GROUP_NAME = "Direct Messages";
+const GENERAL_CHANNEL_NAME = "general";
+
+/** Cache for general channel IDs to avoid repeated lookups. */
+const generalChannelCache = new Map<string, { id: string; expiresAt: number }>();
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+// ─── Bootstrap ──────────────────────────────────────────────────────────────
+
+/**
+ * Ensure a folder has the default "Channels" group and "#general" channel.
+ * Idempotent — safe to call multiple times and concurrently.
+ */
+export async function ensureFolderChannels(
+  folderId: string
+): Promise<{ groupId: string; generalChannelId: string }> {
+  // Check cache first
+  const cached = generalChannelCache.get(folderId);
+  if (cached && cached.expiresAt > Date.now()) {
+    const ch = await db.query.channels.findFirst({
+      where: eq(channels.id, cached.id),
+      columns: { groupId: true },
+    });
+    if (ch) return { groupId: ch.groupId, generalChannelId: cached.id };
+  }
+
+  // Upsert the default group
+  await db
+    .insert(channelGroups)
+    .values({ folderId, name: DEFAULT_GROUP_NAME, position: 0 })
+    .onConflictDoNothing();
+
+  const group = await db.query.channelGroups.findFirst({
+    where: and(
+      eq(channelGroups.folderId, folderId),
+      eq(channelGroups.name, DEFAULT_GROUP_NAME)
+    ),
+    columns: { id: true },
+  });
+
+  if (!group) {
+    throw new Error(`Failed to ensure default group for folder ${folderId}`);
+  }
+
+  // Upsert the #general channel
+  await db
+    .insert(channels)
+    .values({
+      folderId,
+      groupId: group.id,
+      name: GENERAL_CHANNEL_NAME,
+      displayName: "#general",
+      type: "public",
+      isDefault: true,
+    })
+    .onConflictDoNothing();
+
+  const general = await db.query.channels.findFirst({
+    where: and(
+      eq(channels.folderId, folderId),
+      eq(channels.name, GENERAL_CHANNEL_NAME)
+    ),
+    columns: { id: true },
+  });
+
+  if (!general) {
+    throw new Error(`Failed to ensure #general channel for folder ${folderId}`);
+  }
+
+  // Update cache
+  generalChannelCache.set(folderId, {
+    id: general.id,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
+
+  log.debug("Folder channels ensured", { folderId, generalChannelId: general.id });
+  return { groupId: group.id, generalChannelId: general.id };
+}
+
+/**
+ * Get the #general channel ID for a folder (cached).
+ */
+export async function getGeneralChannelId(folderId: string): Promise<string> {
+  const { generalChannelId } = await ensureFolderChannels(folderId);
+  return generalChannelId;
+}
+
+// ─── Channel CRUD ───────────────────────────────────────────────────────────
+
+export interface CreateChannelParams {
+  folderId: string;
+  groupId?: string;
+  name: string;
+  displayName?: string;
+  topic?: string;
+  type?: ChannelType;
+  createdBySessionId?: string;
+}
+
+/**
+ * Create a new channel in a folder.
+ * If no groupId is provided, uses the default "Channels" group.
+ */
+export async function createChannel(params: CreateChannelParams) {
+  const { folderId, name, topic, type = "public", createdBySessionId } = params;
+
+  if (!CHANNEL_NAME_RE.test(name)) {
+    throw new Error(
+      `Invalid channel name "${name}". Must be 1-50 chars, lowercase alphanumeric and hyphens, starting with alphanumeric.`
+    );
+  }
+
+  // Ensure default group exists and use it if no groupId specified
+  let groupId = params.groupId;
+  if (!groupId) {
+    const { groupId: defaultGroupId } = await ensureFolderChannels(folderId);
+    groupId = defaultGroupId;
+  }
+
+  const displayName = params.displayName || `#${name}`;
+
+  const [channel] = await db
+    .insert(channels)
+    .values({
+      folderId,
+      groupId,
+      name,
+      displayName,
+      type,
+      topic,
+      createdBySessionId,
+    })
+    .returning();
+
+  log.info("Channel created", { channelId: channel.id, name, folderId });
+  return channel;
+}
+
+/**
+ * List all channel groups with nested channels for a folder.
+ * Includes unread counts for the given user.
+ */
+export async function listChannelGroups(
+  folderId: string,
+  userId: string
+) {
+  // Ensure defaults exist
+  await ensureFolderChannels(folderId);
+
+  const groups = await db.query.channelGroups.findMany({
+    where: eq(channelGroups.folderId, folderId),
+    orderBy: channelGroups.position,
+  });
+
+  const allChannels = await db.query.channels.findMany({
+    where: and(
+      eq(channels.folderId, folderId),
+      isNull(channels.archivedAt)
+    ),
+    orderBy: channels.createdAt,
+  });
+
+  // Get read states for this user
+  const channelIds = allChannels.map((c) => c.id);
+  const readStates =
+    channelIds.length > 0
+      ? await db.query.channelReadState.findMany({
+          where: and(
+            eq(channelReadState.userId, userId),
+            sql`${channelReadState.channelId} IN (${sql.join(
+              channelIds.map((id) => sql`${id}`),
+              sql`, `
+            )})`
+          ),
+        })
+      : [];
+
+  const readStateMap = new Map(readStates.map((rs) => [rs.channelId, rs]));
+
+  // Compute unread counts per channel
+  const channelsWithUnread = await Promise.all(
+    allChannels.map(async (ch) => {
+      const rs = readStateMap.get(ch.id);
+      let unreadCount = 0;
+
+      if (rs?.lastReadAt) {
+        const result = await db
+          .select({ count: sql<number>`count(*)` })
+          .from(agentPeerMessages)
+          .where(
+            and(
+              eq(agentPeerMessages.channelId, ch.id),
+              isNull(agentPeerMessages.parentMessageId),
+              gt(agentPeerMessages.createdAt, rs.lastReadAt)
+            )
+          );
+        unreadCount = result[0]?.count ?? 0;
+      } else {
+        // Never read — count all messages
+        unreadCount = ch.messageCount;
+      }
+
+      return {
+        id: ch.id,
+        folderId: ch.folderId,
+        groupId: ch.groupId,
+        name: ch.name,
+        displayName: ch.displayName,
+        type: ch.type as ChannelType,
+        topic: ch.topic,
+        isDefault: ch.isDefault,
+        lastMessageAt: ch.lastMessageAt?.toISOString() ?? null,
+        messageCount: ch.messageCount,
+        unreadCount,
+        createdAt: ch.createdAt.toISOString(),
+      };
+    })
+  );
+
+  return groups.map((g) => ({
+    id: g.id,
+    folderId: g.folderId,
+    name: g.name,
+    position: g.position,
+    channels: channelsWithUnread.filter((c) => c.groupId === g.id),
+  }));
+}
+
+/**
+ * Get a single channel by ID.
+ */
+export async function getChannel(channelId: string) {
+  return db.query.channels.findFirst({
+    where: eq(channels.id, channelId),
+  });
+}
+
+/**
+ * Verify a channel belongs to a specific folder.
+ */
+export async function verifyChannelInFolder(
+  channelId: string,
+  folderId: string
+): Promise<boolean> {
+  const ch = await db.query.channels.findFirst({
+    where: and(eq(channels.id, channelId), eq(channels.folderId, folderId)),
+    columns: { id: true },
+  });
+  return !!ch;
+}
+
+/**
+ * Find or create a DM channel between two sessions.
+ * DM channel names are deterministic: `dm-{minId8}-{maxId8}` for idempotency.
+ */
+export async function findOrCreateDmChannel(
+  folderId: string,
+  sessionIdA: string,
+  sessionIdB: string
+) {
+  const [minId, maxId] = [sessionIdA, sessionIdB].sort();
+  const dmName = `dm-${minId.slice(0, 8)}-${maxId.slice(0, 8)}`;
+
+  // Check if already exists
+  const existing = await db.query.channels.findFirst({
+    where: and(eq(channels.folderId, folderId), eq(channels.name, dmName)),
+  });
+  if (existing) return existing;
+
+  // Ensure DM group exists
+  await db
+    .insert(channelGroups)
+    .values({ folderId, name: DM_GROUP_NAME, position: 100 })
+    .onConflictDoNothing();
+
+  const dmGroup = await db.query.channelGroups.findFirst({
+    where: and(
+      eq(channelGroups.folderId, folderId),
+      eq(channelGroups.name, DM_GROUP_NAME)
+    ),
+    columns: { id: true },
+  });
+
+  if (!dmGroup) throw new Error("Failed to create DM group");
+
+  const [channel] = await db
+    .insert(channels)
+    .values({
+      folderId,
+      groupId: dmGroup.id,
+      name: dmName,
+      displayName: dmName, // Will be resolved to peer name at render time
+      type: "dm",
+    })
+    .onConflictDoNothing()
+    .returning();
+
+  // Handle race condition: if onConflictDoNothing fired, re-query
+  if (!channel) {
+    const raced = await db.query.channels.findFirst({
+      where: and(eq(channels.folderId, folderId), eq(channels.name, dmName)),
+    });
+    if (!raced) throw new Error("Failed to create DM channel");
+    return raced;
+  }
+
+  log.info("DM channel created", { channelId: channel.id, folderId });
+  return channel;
+}
+
+// ─── Read State ─────────────────────────────────────────────────────────────
+
+/**
+ * Mark a channel as read for a user up to a specific message.
+ */
+export async function markChannelRead(
+  channelId: string,
+  userId: string,
+  messageId: string
+) {
+  const now = new Date();
+
+  // Upsert read state
+  await db
+    .insert(channelReadState)
+    .values({ channelId, userId, lastReadMessageId: messageId, lastReadAt: now })
+    .onConflictDoUpdate({
+      target: [channelReadState.channelId, channelReadState.userId],
+      set: { lastReadMessageId: messageId, lastReadAt: now },
+    });
+}
+
+/**
+ * Archive a channel (soft delete). Cannot archive default channels.
+ */
+export async function archiveChannel(channelId: string) {
+  const ch = await db.query.channels.findFirst({
+    where: eq(channels.id, channelId),
+    columns: { isDefault: true },
+  });
+  if (ch?.isDefault) {
+    throw new Error("Cannot archive the default channel");
+  }
+
+  await db
+    .update(channels)
+    .set({ archivedAt: new Date() })
+    .where(eq(channels.id, channelId));
+
+  log.info("Channel archived", { channelId });
+}
+
+/**
+ * Increment message count and update lastMessageAt on a channel.
+ * Called after inserting a message.
+ */
+export async function incrementChannelMessageCount(channelId: string) {
+  await db
+    .update(channels)
+    .set({
+      messageCount: sql`${channels.messageCount} + 1`,
+      lastMessageAt: new Date(),
+    })
+    .where(eq(channels.id, channelId));
+}

--- a/src/services/channel-service.ts
+++ b/src/services/channel-service.ts
@@ -13,11 +13,25 @@ import {
   agentPeerMessages,
   sessionFolders,
 } from "@/db/schema";
-import { eq, and, sql, gt, isNull } from "drizzle-orm";
+import { eq, and, sql, gt, isNull, inArray } from "drizzle-orm";
 import { createLogger } from "@/lib/logger";
 import type { ChannelType } from "@/types/channels";
 
 const log = createLogger("ChannelService");
+
+export class ChannelValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ChannelValidationError";
+  }
+}
+
+export class ChannelArchiveError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ChannelArchiveError";
+  }
+}
 
 const CHANNEL_NAME_RE = /^[a-z0-9][a-z0-9-]{0,49}$/;
 const DEFAULT_GROUP_NAME = "Channels";
@@ -44,7 +58,14 @@ export async function ensureFolderChannels(
       where: eq(channels.id, cached.id),
       columns: { groupId: true },
     });
-    if (ch) return { groupId: ch.groupId, generalChannelId: cached.id };
+    if (ch) {
+      // Refresh cache expiry
+      cached.expiresAt = Date.now() + CACHE_TTL_MS;
+      return { groupId: ch.groupId, generalChannelId: cached.id };
+    } else {
+      // Channel was deleted — evict stale cache
+      generalChannelCache.delete(folderId);
+    }
   }
 
   // Upsert the default group
@@ -128,7 +149,7 @@ export async function createChannel(params: CreateChannelParams) {
   const { folderId, name, topic, type = "public", createdBySessionId } = params;
 
   if (!CHANNEL_NAME_RE.test(name)) {
-    throw new Error(
+    throw new ChannelValidationError(
       `Invalid channel name "${name}". Must be 1-50 chars, lowercase alphanumeric and hyphens, starting with alphanumeric.`
     );
   }
@@ -183,62 +204,85 @@ export async function listChannelGroups(
     orderBy: channels.createdAt,
   });
 
-  // Get read states for this user
+  // Batch: get read states for all channels in one query
   const channelIds = allChannels.map((c) => c.id);
   const readStates =
     channelIds.length > 0
-      ? await db.query.channelReadState.findMany({
-          where: and(
-            eq(channelReadState.userId, userId),
-            sql`${channelReadState.channelId} IN (${sql.join(
-              channelIds.map((id) => sql`${id}`),
-              sql`, `
-            )})`
-          ),
-        })
-      : [];
-
-  const readStateMap = new Map(readStates.map((rs) => [rs.channelId, rs]));
-
-  // Compute unread counts per channel
-  const channelsWithUnread = await Promise.all(
-    allChannels.map(async (ch) => {
-      const rs = readStateMap.get(ch.id);
-      let unreadCount = 0;
-
-      if (rs?.lastReadAt) {
-        const result = await db
-          .select({ count: sql<number>`count(*)` })
-          .from(agentPeerMessages)
+      ? await db
+          .select({
+            channelId: channelReadState.channelId,
+            lastReadAt: channelReadState.lastReadAt,
+          })
+          .from(channelReadState)
           .where(
             and(
-              eq(agentPeerMessages.channelId, ch.id),
-              isNull(agentPeerMessages.parentMessageId),
-              gt(agentPeerMessages.createdAt, rs.lastReadAt)
+              eq(channelReadState.userId, userId),
+              inArray(channelReadState.channelId, channelIds)
             )
-          );
-        unreadCount = result[0]?.count ?? 0;
-      } else {
-        // Never read — count all messages
-        unreadCount = ch.messageCount;
-      }
+          )
+      : [];
 
-      return {
-        id: ch.id,
-        folderId: ch.folderId,
-        groupId: ch.groupId,
-        name: ch.name,
-        displayName: ch.displayName,
-        type: ch.type as ChannelType,
-        topic: ch.topic,
-        isDefault: ch.isDefault,
-        lastMessageAt: ch.lastMessageAt?.toISOString() ?? null,
-        messageCount: ch.messageCount,
-        unreadCount,
-        createdAt: ch.createdAt.toISOString(),
-      };
-    })
-  );
+  const readStateMap = new Map(readStates.map((rs) => [rs.channelId, rs.lastReadAt]));
+
+  // Batch: get unread counts for channels that have been read
+  const channelsWithReadState = allChannels
+    .filter((c) => readStateMap.has(c.id))
+    .map((c) => ({ id: c.id, lastReadAt: readStateMap.get(c.id)! }));
+
+  let unreadCountMap = new Map<string, number>();
+
+  if (channelsWithReadState.length > 0) {
+    // Single query: count unread messages per channel since last read
+    const unreadRows = await db
+      .select({
+        channelId: agentPeerMessages.channelId,
+        count: sql<number>`count(*)`,
+      })
+      .from(agentPeerMessages)
+      .where(
+        sql`${agentPeerMessages.channelId} IN (${sql.join(
+          channelsWithReadState.map((c) => sql`${c.id}`),
+          sql`, `
+        )}) AND ${agentPeerMessages.parentMessageId} IS NULL AND (${sql.join(
+          channelsWithReadState.map(
+            (c) =>
+              sql`(${agentPeerMessages.channelId} = ${c.id} AND ${agentPeerMessages.createdAt} > ${c.lastReadAt.getTime()})`
+          ),
+          sql` OR `
+        )})`
+      )
+      .groupBy(agentPeerMessages.channelId);
+
+    for (const row of unreadRows) {
+      if (row.channelId) unreadCountMap.set(row.channelId, row.count);
+    }
+  }
+
+  const channelsWithUnread = allChannels.map((ch) => {
+    const lastReadAt = readStateMap.get(ch.id);
+    let unreadCount: number;
+    if (!lastReadAt) {
+      // Never read — all messages are unread
+      unreadCount = ch.messageCount;
+    } else {
+      unreadCount = unreadCountMap.get(ch.id) ?? 0;
+    }
+
+    return {
+      id: ch.id,
+      folderId: ch.folderId,
+      groupId: ch.groupId,
+      name: ch.name,
+      displayName: ch.displayName,
+      type: ch.type as ChannelType,
+      topic: ch.topic,
+      isDefault: ch.isDefault,
+      lastMessageAt: ch.lastMessageAt?.toISOString() ?? null,
+      messageCount: ch.messageCount,
+      unreadCount,
+      createdAt: ch.createdAt.toISOString(),
+    };
+  });
 
   return groups.map((g) => ({
     id: g.id,
@@ -384,6 +428,18 @@ export async function markChannelRead(
   userId: string,
   messageId: string
 ) {
+  // Verify message belongs to this channel
+  const message = await db.query.agentPeerMessages.findFirst({
+    where: and(
+      eq(agentPeerMessages.id, messageId),
+      eq(agentPeerMessages.channelId, channelId)
+    ),
+    columns: { id: true },
+  });
+  if (!message) {
+    throw new Error("Message does not belong to this channel");
+  }
+
   const now = new Date();
 
   // Upsert read state
@@ -405,7 +461,7 @@ export async function archiveChannel(channelId: string) {
     columns: { isDefault: true },
   });
   if (ch?.isDefault) {
-    throw new Error("Cannot archive the default channel");
+    throw new ChannelArchiveError("Cannot archive the default channel");
   }
 
   await db

--- a/src/services/channel-service.ts
+++ b/src/services/channel-service.ts
@@ -440,15 +440,14 @@ export async function findOrCreateDmChannel(
 
 /**
  * Mark a channel as read for a user up to a specific message.
- * Pass messageCreatedAt to use the message's actual timestamp instead of now.
+ * Uses the message's actual createdAt timestamp for consistency.
  */
 export async function markChannelRead(
   channelId: string,
   userId: string,
-  messageId: string,
-  messageCreatedAt?: Date
+  messageId: string
 ) {
-  // Verify message belongs to this channel
+  // Verify message belongs to this channel and get its timestamp
   const message = await db.query.agentPeerMessages.findFirst({
     where: and(
       eq(agentPeerMessages.id, messageId),
@@ -460,7 +459,7 @@ export async function markChannelRead(
     throw new Error("Message does not belong to this channel");
   }
 
-  const lastReadAt = messageCreatedAt ?? message.createdAt ?? new Date();
+  const lastReadAt = message.createdAt ?? new Date();
 
   // Upsert read state
   await db

--- a/src/services/channel-service.ts
+++ b/src/services/channel-service.ts
@@ -12,7 +12,7 @@ import {
   channelReadState,
   agentPeerMessages,
 } from "@/db/schema";
-import { eq, and, sql, desc, gt, isNull } from "drizzle-orm";
+import { eq, and, sql, gt, isNull } from "drizzle-orm";
 import { createLogger } from "@/lib/logger";
 import type { ChannelType } from "@/types/channels";
 

--- a/src/services/peer-service.ts
+++ b/src/services/peer-service.ts
@@ -365,8 +365,6 @@ export async function listFolderMessages(
   folderId: string,
   limit: number = 200
 ): Promise<PeerMessage[]> {
-  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
-
   const rows = await db
     .select({
       id: agentPeerMessages.id,
@@ -378,16 +376,12 @@ export async function listFolderMessages(
       createdAt: agentPeerMessages.createdAt,
     })
     .from(agentPeerMessages)
-    .where(
-      and(
-        eq(agentPeerMessages.folderId, folderId),
-        gt(agentPeerMessages.createdAt, cutoff)
-      )
-    )
-    .orderBy(agentPeerMessages.createdAt)
+    .where(eq(agentPeerMessages.folderId, folderId))
+    .orderBy(desc(agentPeerMessages.createdAt))
     .limit(limit);
 
-  return rows.map(toMessageRow);
+  // Reverse to chronological order
+  return rows.reverse().map(toMessageRow);
 }
 
 /**

--- a/src/services/peer-service.ts
+++ b/src/services/peer-service.ts
@@ -4,7 +4,7 @@
 
 import { db } from "@/db";
 import { agentPeerMessages, terminalSessions } from "@/db/schema";
-import { eq, and, or, isNull, gt, inArray, sql } from "drizzle-orm";
+import { eq, and, or, isNull, gt, inArray, sql, desc } from "drizzle-orm";
 import { createLogger } from "@/lib/logger";
 import { safeJsonParse } from "@/lib/utils";
 
@@ -60,6 +60,9 @@ export interface PeerMessage {
   toSessionId: string | null;
   body: string;
   isUserMessage: boolean;
+  channelId: string | null;
+  parentMessageId: string | null;
+  replyCount: number;
   createdAt: string;
 }
 
@@ -104,6 +107,9 @@ function toMessageRow(row: {
   toSessionId: string | null;
   body: string;
   isUserMessage?: boolean | null;
+  channelId?: string | null;
+  parentMessageId?: string | null;
+  replyCount?: number | null;
   createdAt: Date | string | number;
 }): PeerMessage {
   return {
@@ -113,6 +119,9 @@ function toMessageRow(row: {
     toSessionId: row.toSessionId,
     body: row.body,
     isUserMessage: row.isUserMessage ?? false,
+    channelId: row.channelId ?? null,
+    parentMessageId: row.parentMessageId ?? null,
+    replyCount: row.replyCount ?? 0,
     createdAt: row.createdAt instanceof Date ? row.createdAt.toISOString() : String(row.createdAt),
   };
 }
@@ -124,6 +133,7 @@ export interface SendMessageResult {
   folderId: string;
   userId: string;
   createdAt: string;
+  channelId: string | null;
 }
 
 /**
@@ -133,8 +143,10 @@ export async function sendMessage(params: {
   fromSessionId: string;
   toSessionId?: string;
   body: string;
+  channelId?: string;
+  parentMessageId?: string;
 }): Promise<SendMessageResult> {
-  const { fromSessionId, toSessionId, body } = params;
+  const { fromSessionId, toSessionId, body, channelId, parentMessageId } = params;
 
   if (body.length > MAX_MESSAGE_LENGTH) {
     throw new Error(`Message exceeds maximum length of ${MAX_MESSAGE_LENGTH} characters`);
@@ -148,6 +160,10 @@ export async function sendMessage(params: {
   if (!sender?.folderId || !sender.userId) {
     throw new Error("Sender session not found or has no folder");
   }
+
+  // Resolve channel — default to #general if not specified
+  const ChannelService = await import("@/services/channel-service");
+  const resolvedChannelId = channelId ?? await ChannelService.getGeneralChannelId(sender.folderId);
 
   if (toSessionId) {
     const recipient = await db.query.terminalSessions.findFirst({
@@ -171,8 +187,23 @@ export async function sendMessage(params: {
     fromSessionName: sender.name,
     toSessionId: toSessionId ?? null,
     body: resolvedBody,
+    channelId: resolvedChannelId,
+    parentMessageId: parentMessageId ?? null,
     createdAt: now,
   });
+
+  // Update channel message count
+  if (resolvedChannelId) {
+    await ChannelService.incrementChannelMessageCount(resolvedChannelId);
+  }
+
+  // If this is a thread reply, increment parent's reply count
+  if (parentMessageId) {
+    await db
+      .update(agentPeerMessages)
+      .set({ replyCount: sql`${agentPeerMessages.replyCount} + 1` })
+      .where(eq(agentPeerMessages.id, parentMessageId));
+  }
 
   log.debug("Peer message sent", {
     messageId,
@@ -188,6 +219,7 @@ export async function sendMessage(params: {
     folderId: sender.folderId,
     userId: sender.userId,
     createdAt: now.toISOString(),
+    channelId: resolvedChannelId,
   };
 }
 
@@ -265,15 +297,9 @@ export async function setSummary(
   log.debug("Peer summary updated", { sessionId, summary });
 }
 
-/** Delete peer messages older than 24 hours. */
+/** @deprecated Messages are now permanent. This function is a no-op. */
 export async function cleanupOldMessages(): Promise<void> {
-  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
-
-  await db
-    .delete(agentPeerMessages)
-    .where(sql`${agentPeerMessages.createdAt} < ${cutoff.getTime()}`);
-
-  log.debug("Peer message cleanup complete");
+  log.debug("Peer message cleanup skipped (messages are permanent)");
 }
 
 /**
@@ -284,12 +310,17 @@ export async function sendUserMessage(params: {
   folderId: string;
   fromName: string;
   body: string;
+  channelId?: string;
+  parentMessageId?: string;
 }): Promise<{ messageId: string; message: PeerMessage }> {
-  const { folderId, fromName, body } = params;
+  const { folderId, fromName, body, channelId, parentMessageId } = params;
 
   if (body.length > MAX_MESSAGE_LENGTH) {
     throw new Error(`Message exceeds maximum length of ${MAX_MESSAGE_LENGTH} characters`);
   }
+
+  const ChannelService = await import("@/services/channel-service");
+  const resolvedChannelId = channelId ?? await ChannelService.getGeneralChannelId(folderId);
 
   const messageId = crypto.randomUUID();
   const now = new Date();
@@ -303,10 +334,23 @@ export async function sendUserMessage(params: {
     toSessionId: null,
     body: resolvedBody,
     isUserMessage: true,
+    channelId: resolvedChannelId,
+    parentMessageId: parentMessageId ?? null,
     createdAt: now,
   };
 
   await db.insert(agentPeerMessages).values(row);
+
+  if (resolvedChannelId) {
+    await ChannelService.incrementChannelMessageCount(resolvedChannelId);
+  }
+
+  if (parentMessageId) {
+    await db
+      .update(agentPeerMessages)
+      .set({ replyCount: sql`${agentPeerMessages.replyCount} + 1` })
+      .where(eq(agentPeerMessages.id, parentMessageId));
+  }
 
   log.debug("User message sent", { messageId, folderId, fromName });
 
@@ -342,6 +386,75 @@ export async function listFolderMessages(
     )
     .orderBy(agentPeerMessages.createdAt)
     .limit(limit);
+
+  return rows.map(toMessageRow);
+}
+
+/**
+ * List messages in a specific channel (top-level only, no thread replies).
+ * Cursor-based pagination using `before` timestamp.
+ */
+export async function listChannelMessages(
+  channelId: string,
+  params: { before?: Date; limit?: number } = {}
+): Promise<PeerMessage[]> {
+  const limit = Math.min(Math.max(1, params.limit ?? 50), 200);
+
+  const conditions = [
+    eq(agentPeerMessages.channelId, channelId),
+    isNull(agentPeerMessages.parentMessageId), // top-level only
+  ];
+
+  if (params.before) {
+    conditions.push(sql`${agentPeerMessages.createdAt} < ${params.before.getTime()}`);
+  }
+
+  const rows = await db
+    .select({
+      id: agentPeerMessages.id,
+      fromSessionId: agentPeerMessages.fromSessionId,
+      fromSessionName: agentPeerMessages.fromSessionName,
+      toSessionId: agentPeerMessages.toSessionId,
+      body: agentPeerMessages.body,
+      isUserMessage: agentPeerMessages.isUserMessage,
+      channelId: agentPeerMessages.channelId,
+      parentMessageId: agentPeerMessages.parentMessageId,
+      replyCount: agentPeerMessages.replyCount,
+      createdAt: agentPeerMessages.createdAt,
+    })
+    .from(agentPeerMessages)
+    .where(and(...conditions))
+    .orderBy(desc(agentPeerMessages.createdAt))
+    .limit(limit);
+
+  // Reverse to chronological order
+  return rows.reverse().map(toMessageRow);
+}
+
+/**
+ * List replies to a specific message (thread).
+ */
+export async function listThreadReplies(
+  parentMessageId: string,
+  limit: number = 100
+): Promise<PeerMessage[]> {
+  const rows = await db
+    .select({
+      id: agentPeerMessages.id,
+      fromSessionId: agentPeerMessages.fromSessionId,
+      fromSessionName: agentPeerMessages.fromSessionName,
+      toSessionId: agentPeerMessages.toSessionId,
+      body: agentPeerMessages.body,
+      isUserMessage: agentPeerMessages.isUserMessage,
+      channelId: agentPeerMessages.channelId,
+      parentMessageId: agentPeerMessages.parentMessageId,
+      replyCount: agentPeerMessages.replyCount,
+      createdAt: agentPeerMessages.createdAt,
+    })
+    .from(agentPeerMessages)
+    .where(eq(agentPeerMessages.parentMessageId, parentMessageId))
+    .orderBy(agentPeerMessages.createdAt)
+    .limit(Math.min(limit, 500));
 
   return rows.map(toMessageRow);
 }

--- a/src/types/channels.ts
+++ b/src/types/channels.ts
@@ -1,0 +1,41 @@
+/** Channel type discriminator. */
+export type ChannelType = "public" | "dm" | "system";
+
+/** A channel group (e.g., "Channels", "Direct Messages"). */
+export interface ChannelGroup {
+  id: string;
+  folderId: string;
+  name: string;
+  position: number;
+  channels: Channel[];
+}
+
+/** A channel within a group. */
+export interface Channel {
+  id: string;
+  folderId: string;
+  groupId: string;
+  name: string;
+  displayName: string;
+  type: ChannelType;
+  topic: string | null;
+  isDefault: boolean;
+  lastMessageAt: string | null;
+  messageCount: number;
+  unreadCount: number;
+  createdAt: string;
+}
+
+/** A message within a channel, including thread metadata. */
+export interface ChannelMessage {
+  id: string;
+  channelId: string;
+  fromSessionId: string | null;
+  fromSessionName: string;
+  toSessionId: string | null;
+  body: string;
+  isUserMessage: boolean;
+  parentMessageId: string | null;
+  replyCount: number;
+  createdAt: string;
+}

--- a/src/types/peer-chat.ts
+++ b/src/types/peer-chat.ts
@@ -14,6 +14,9 @@ export interface PeerChatMessage {
   body: string;
   isUserMessage: boolean;
   createdAt: string; // ISO string
+  channelId: string | null;
+  parentMessageId: string | null;
+  replyCount: number;
 }
 
 /** Info about an active agent peer. Subset of PeerInfo from PeerService. */


### PR DESCRIPTION
## Summary

- Add Slack/Discord-style channel system to peer chat: channel groups, `#general` default channel per folder, user/agent-created channels, DM channels
- Full GFM markdown rendering in chat messages (code blocks, tables, links, headers)
- Thread support with inline reply counts and slide-in thread panel
- Right sidebar dynamically swaps between task tracker (terminal view) and channel list (chat view)
- DB-backed per-user unread tracking with `channel_read_state` table
- Permanent message persistence (removed 24h TTL)
- New `rdv channel` CLI commands: `list`, `create`, `send`, `messages`
- New MCP tools: `list_channels`, `create_channel`, `send_to_channel`, `read_channel`
- Migration script (`bun run db:migrate-channels`) for existing messages

## Architecture

**Database:** 3 new tables (`channel_groups`, `channels`, `channel_read_state`) + extended `agent_peer_messages` with `channelId`, `parentMessageId`, `replyCount`

**Backend:** `ChannelService` for lifecycle/unread, `PeerService` extended for channel-aware messaging + threading, 9 API routes, 4 terminal server internal endpoints

**Frontend:** `ChannelContext` for state management, 5 new components (ChannelSidebar, ChannelView, ThreadPanel, CreateChannelModal, ChannelMessageRow), wired into SessionManager with WebSocket event forwarding

**Agent tooling:** rdv CLI `channel` subcommand (Rust), MCP server tools for Claude Code

## Test plan

- [ ] Run `bun run db:push` to create new tables
- [ ] Run `bun run db:migrate-channels` on existing data
- [ ] Verify #general channel auto-created when opening chat view
- [ ] Send messages in #general, verify GFM markdown renders
- [ ] Create new channel via UI "+" button, verify it appears in sidebar
- [ ] Test thread replies: click reply, verify thread panel opens
- [ ] Verify unread dots appear on channels when messages arrive
- [ ] Test `rdv channel list/create/send/messages` CLI commands
- [ ] Verify MCP tools work from Claude Code agent session
- [ ] Run `bun run typecheck && bun run lint` — passes

This pull request was AI-assisted by Isaac.