### PR TITLE
fix(mobile+settings): three production regressions from modals epic

### DIFF
--- a/src/components/session/ProjectTreeSidebar.tsx
+++ b/src/components/session/ProjectTreeSidebar.tsx
@@ -476,7 +476,16 @@ export const ProjectTreeSidebar = forwardRef<
               onTouchStart={(e) => swipe.handleTouchStart(e, s.id)}
               onTouchMove={swipe.handleTouchMove}
               onTouchEnd={swipe.handleTouchEnd}
-              onClick={() => props.onSessionClick(s.id)}
+              onClick={() => {
+                // Tap on the row dismisses a committed swipe instead of
+                // activating the session. Gives the user an escape hatch
+                // when they swiped by accident and don't want to close.
+                if (swipe.swipedSessionId === s.id) {
+                  swipe.clearSwipe();
+                  return;
+                }
+                props.onSessionClick(s.id);
+              }}
               onClose={() => {
                 props.onSessionClose(s.id);
                 swipe.clearSwipe();
@@ -938,7 +947,16 @@ export const ProjectTreeSidebar = forwardRef<
                         onTouchStart={(e) => swipe.handleTouchStart(e, s.id)}
                         onTouchMove={swipe.handleTouchMove}
                         onTouchEnd={swipe.handleTouchEnd}
-                        onClick={() => props.onSessionClick(s.id)}
+                        onClick={() => {
+                // Tap on the row dismisses a committed swipe instead of
+                // activating the session. Gives the user an escape hatch
+                // when they swiped by accident and don't want to close.
+                if (swipe.swipedSessionId === s.id) {
+                  swipe.clearSwipe();
+                  return;
+                }
+                props.onSessionClick(s.id);
+              }}
                         onClose={() => {
                           props.onSessionClose(s.id);
                           swipe.clearSwipe();

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -1338,6 +1338,10 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
         });
         if (session) {
           setActiveSession(session.id);
+          // Force the terminal pane visible. Singleton session tabs render
+          // inside the terminal container; if the user is on chat view, the
+          // container is hidden and clicking Settings appears to do nothing.
+          setActiveView("terminal");
           // F5: seeding `typeMetadata.activeTab` only applies on CREATE. If
           // the server reused an existing Settings tab (scope-key dedup),
           // the requested section would be ignored. Patch the tab explicitly
@@ -1354,7 +1358,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
         logSessionError("open settings session", error);
       }
     },
-    [activeProject.folderId, projectTree.projects, createSession, setActiveSession, updateSession, logSessionError]
+    [activeProject.folderId, projectTree.projects, createSession, setActiveSession, setActiveView, updateSession, logSessionError]
   );
 
   // Listen for open-settings event from Header gear button and Sidebar
@@ -1439,11 +1443,12 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
       });
       if (session) {
         setActiveSession(session.id);
+        setActiveView("terminal");
       }
     } catch (error) {
       logSessionError("open recordings session", error);
     }
-  }, [activeProject.folderId, projectTree.projects, createSession, setActiveSession, logSessionError]);
+  }, [activeProject.folderId, projectTree.projects, createSession, setActiveSession, setActiveView, logSessionError]);
 
   // Open (or reuse) the global Profiles session. Scope key is fixed so
   // repeated opens jump to the existing tab instead of spawning duplicates.
@@ -1463,11 +1468,12 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
       });
       if (session) {
         setActiveSession(session.id);
+        setActiveView("terminal");
       }
     } catch (error) {
       logSessionError("open profiles session", error);
     }
-  }, [activeProject.folderId, projectTree.projects, createSession, setActiveSession, logSessionError]);
+  }, [activeProject.folderId, projectTree.projects, createSession, setActiveSession, setActiveView, logSessionError]);
 
   // Handle view change from FolderTabBar (terminal/chat toggle)
   const handleViewChange = useCallback(

--- a/src/components/session/project-tree/SessionRow.tsx
+++ b/src/components/session/project-tree/SessionRow.tsx
@@ -154,7 +154,11 @@ export function SessionRow({
             e.stopPropagation();
             onClose();
           }}
-          className="absolute right-0 top-0 bottom-0 w-[72px] bg-destructive text-destructive-foreground flex items-center justify-center rounded-md"
+          // z-20 so the revealed button sits above the row even after the row
+          // snaps back to translateX(0) on touchend. Without this the row
+          // covers the button visually AND intercepts taps, making it look
+          // like "click does nothing".
+          className="absolute right-0 top-0 bottom-0 w-[72px] z-20 bg-destructive text-destructive-foreground flex items-center justify-center rounded-md"
         >
           <X className="w-4 h-4" />
         </button>

--- a/src/components/session/project-tree/SessionRow.tsx
+++ b/src/components/session/project-tree/SessionRow.tsx
@@ -157,8 +157,10 @@ export function SessionRow({
           // z-20 so the revealed button sits above the row even after the row
           // snaps back to translateX(0) on touchend. Without this the row
           // covers the button visually AND intercepts taps, making it look
-          // like "click does nothing".
-          className="absolute right-0 top-0 bottom-0 w-[72px] z-20 bg-destructive text-destructive-foreground flex items-center justify-center rounded-md"
+          // like "click does nothing". Width matches useSwipeToClose's
+          // DEFAULT_MAX_DRAG_PX (80px) so there's no visible gap between the
+          // button edge and the translated row.
+          className="absolute right-0 top-0 bottom-0 w-20 z-20 bg-destructive text-destructive-foreground flex items-center justify-center rounded-md"
         >
           <X className="w-4 h-4" />
         </button>
@@ -184,7 +186,14 @@ export function SessionRow({
             onClick();
           }
         }}
-        style={mergedInnerStyle}
+        // touchAction: pan-y tells the browser this element handles its
+        // own horizontal gestures but should defer vertical pans to native
+        // scroll. Without this hint, iOS Safari coalesces early touchmove
+        // events with accumulated motion, causing our axis-decision logic
+        // to lock "horizontal" on gestures the user intended as scrolls —
+        // and then preventDefault kills the scroll entirely. Symptom: scroll
+        // works intermittently inside the sidebar on mobile.
+        style={{ ...mergedInnerStyle, touchAction: "pan-y" }}
         className={cn(
           "group relative flex items-center gap-2 px-2 py-1.5 rounded-md",
           "transition-all duration-200",

--- a/src/components/session/project-tree/useSwipeToClose.ts
+++ b/src/components/session/project-tree/useSwipeToClose.ts
@@ -183,12 +183,21 @@ export function useSwipeToClose(
           transition: "none",
         };
       }
+      // After commit, keep the row translated so the revealed close button
+      // stays visible until the user taps it or the swipe is cleared.
+      // Without this the row snaps back over the button on touchend.
+      if (swipedSessionId === sessionId) {
+        return {
+          transform: `translateX(${-maxDragPx}px)`,
+          transition: "transform 200ms ease-out",
+        };
+      }
       return {
         transform: "translateX(0)",
         transition: "transform 200ms ease-out",
       };
     },
-    [currentDx],
+    [currentDx, swipedSessionId, maxDragPx],
   );
 
   return {

--- a/src/components/session/project-tree/useSwipeToClose.ts
+++ b/src/components/session/project-tree/useSwipeToClose.ts
@@ -89,6 +89,9 @@ export function useSwipeToClose(
       if (canSwipe && !canSwipe(sessionId)) return;
       const touch = e.touches[0];
       if (!touch) return;
+      // Clear a prior swipe commit on a different row so its revealed
+      // button doesn't stay stuck while the user interacts elsewhere.
+      setSwipedSessionId((prev) => (prev && prev !== sessionId ? null : prev));
       touchRef.current = {
         sessionId,
         startX: touch.clientX,

--- a/tests/components/project-tree/useSwipeToClose.test.ts
+++ b/tests/components/project-tree/useSwipeToClose.test.ts
@@ -79,6 +79,29 @@ describe("useSwipeToClose", () => {
       ctx.result.current.handleTouchEnd();
     });
     expect(ctx.result.current.swipedSessionId).toBe("s1");
+    // After commit the row must stay translated so the revealed close
+    // button stays visible. Regression guard for the "button reveals but
+    // click does nothing" bug.
+    const postStyle = ctx.result.current.getRowStyle("s1");
+    expect(postStyle.transform).toBe("translateX(-80px)");
+  });
+
+  it("handleTouchStart on a different row clears a prior swipe commit", () => {
+    const ctx = setup();
+    act(() => {
+      ctx.result.current.handleTouchStart(touchEvent(100, 200), "s1");
+    });
+    act(() => {
+      ctx.result.current.handleTouchMove(touchEvent(50, 200));
+    });
+    act(() => {
+      ctx.result.current.handleTouchEnd();
+    });
+    expect(ctx.result.current.swipedSessionId).toBe("s1");
+    act(() => {
+      ctx.result.current.handleTouchStart(touchEvent(100, 300), "s2");
+    });
+    expect(ctx.result.current.swipedSessionId).toBeNull();
   });
 
   it("horizontal swipe below threshold does not commit", () => {


### PR DESCRIPTION
## Problem

User reported three production bugs after the modals-as-terminal-types epic (PRs #183–#187):

1. **Mobile swipe-to-close button reveals but clicking does nothing.**
2. **Clicking Settings in header/command-palette does nothing.**
3. **Scroll works intermittently on mobile.**

## Root causes

**#1 Swipe button invisible behind row.** After `touchend` the drag state reset to null, so `getRowStyle` returned `translateX(0)` — snapping the row back over the revealed close button. The row's CSS transform created a stacking context, so the button (first in DOM, no z-index) was both visually covered AND intercepting taps.

**#2 Settings pane hidden by `activeView=chat`.** Singleton plugin tabs (settings/recordings/profiles) render inside the "terminal" pane container, which is hidden via `hidden` class when `effectiveActiveView !== "terminal"`. Users on chat view (peer messages with agent sessions present) saw nothing happen when they clicked the gear.

**#3 iOS Safari touchmove coalescing.** `useSwipeToClose` locks its axis on the first touchmove where `|dx| > 10 || |dy| > 10`. iOS Safari coalesces early touchmove events at gesture start, delivering an initial event with accumulated motion. A slightly diagonal scroll gesture could lock to "horizontal" → `preventDefault` kills the scroll. Effect: scroll "worked intermittently" depending on finger path.

## Fixes

- `useSwipeToClose.getRowStyle` holds the row at `translateX(-maxDragPx)` while a swipe is committed (was snapping back to 0).
- `useSwipeToClose.handleTouchStart` clears any prior committed swipe on a different row (prevents stuck-button-elsewhere state).
- `SessionRow` reveal button gets `z-20` + width fixed to `w-20` (matches `DEFAULT_MAX_DRAG_PX`).
- `SessionRow` outer row gets `touch-action: pan-y` — the core fix for bug #3.
- `ProjectTreeSidebar` row `onClick` calls `swipe.clearSwipe()` when the row is swipe-revealed, so the user can tap anywhere on the row to retract an accidental swipe.
- `openSettingsSession` / `openRecordingsSession` / `openProfilesSession` now `setActiveView("terminal")` after activating the session.

## Tests

- Regression: `getRowStyle` returns `translateX(-80px)` after a committed swipe.
- Regression: `handleTouchStart` on a different row clears prior swipe commit.

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 warnings
- [x] `bun run test:run` — 723 pass / 1 skip
- [ ] Manual on mobile Safari: swipe a session, tap X → closes. Swipe + tap elsewhere → retracts.
- [ ] Manual on mobile Safari: vertical scroll in sidebar works reliably regardless of finger path.
- [ ] Manual: click Settings while on chat view → settings pane visible.

## Known limitations (documented, not in this PR)

- After closing Settings, `activeView` stays on "terminal" instead of restoring the user's prior view. Minor UX cost for the straightforward fix; revisit if users complain.