### PR TITLE
fix(sessions): null scope_key on close so singleton slot frees up

### DIFF
--- a/drizzle/0016_clear_scope_key_on_closed_sessions.sql
+++ b/drizzle/0016_clear_scope_key_on_closed_sessions.sql
@@ -1,0 +1,10 @@
+-- F-hotfix: null out scope_key on sessions that are already closed or trashed.
+-- Without this, the partial UNIQUE index on (user_id, terminal_type, scope_key)
+-- blocks a fresh create-session even though scope-key dedup (which filters to
+-- active/suspended rows) doesn't find the blocking row. Closing/trashing a
+-- session now nulls scope_key at the same time; this migration retroactively
+-- clears the slot for any row that was closed before that fix landed.
+UPDATE `terminal_session`
+SET `scope_key` = NULL
+WHERE `scope_key` IS NOT NULL
+  AND `status` IN ('closed', 'trashed');

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -1281,11 +1281,16 @@ export async function closeSession(
     });
   }
 
-  // Mark as closed in database
+  // Mark as closed in database. Null out scope_key at the same time so the
+  // partial UNIQUE index on (user_id, terminal_type, scope_key) frees the
+  // slot for a future create-session call with the same scope. Without this,
+  // the next "Open Settings" (or recordings/profiles) would fail the UNIQUE
+  // constraint because dedup skips closed rows but the index does not.
   await db
     .update(terminalSessions)
     .set({
       status: "closed",
+      scopeKey: null,
       updatedAt: new Date(),
     })
     .where(

--- a/src/services/worktree-trash-service.ts
+++ b/src/services/worktree-trash-service.ts
@@ -237,10 +237,15 @@ export async function trashWorktreeSession(
   // NOT NULL, so we keep the original project_id on the trashed row — the
   // worktreeTrashMetadata table independently records originalProjectId for
   // restore purposes, and trashed sessions are filtered out of UI listings.
+  //
+  // Null out scope_key so the partial UNIQUE index on (user_id, terminal_type,
+  // scope_key) doesn't block a future create-session with the same scope
+  // (active rows only own the slot; trashed rows must release it).
   await db
     .update(terminalSessions)
     .set({
       status: "trashed",
+      scopeKey: null,
       updatedAt: new Date(),
     })
     .where(eq(terminalSessions.id, sessionId));


### PR DESCRIPTION
## Problem

Clicking Settings (or Recordings/Profiles) still failed silently after PR #189. Server log:

\`\`\`
[api/sessions] Error creating session { error: 'Error: Failed query: insert into "terminal_session" ... }
POST /api/sessions 500
\`\`\`

## Root cause

The partial UNIQUE index on \`(user_id, terminal_type, scope_key)\` (migration 0015) covers *all* rows regardless of \`status\`. But scope-key dedup in \`SessionService.createSession\` filters to \`status IN ("active", "suspended")\`. When a prior Settings session was closed, its row kept \`scope_key='settings'\` — dedup couldn't reuse it (closed), and INSERT couldn't claim the slot (UNIQUE violation). The F7 race-recovery path only looks at active/suspended too, so the error fell through.

Local DB confirmation:
\`\`\`
c281e895-1d8e-4b15-8465-0653b56b8c2d|Settings|closed|settings|settings
\`\`\`

## Fix

- \`closeSession\` and \`worktree-trash-service.moveToTrash\` both null \`scope_key\` alongside the status change. Active rows own the slot; closed/trashed rows release it.
- Migration \`0016_clear_scope_key_on_closed_sessions.sql\` retroactively nulls scope_key on rows that were already closed/trashed before this fix. Users must run \`bun run db:push\` OR apply the SQL manually (drizzle-kit \`push\` doesn't auto-apply raw migrations).

## Test plan

- [x] typecheck 0 errors
- [x] 723 tests pass
- [x] Manual: ran migration locally, confirmed blocking row's scope_key = NULL
- [ ] Manual: click Settings → opens
- [ ] Manual: close Settings, click again → opens a fresh one (no UNIQUE failure)