### PR TITLE
fix(sessions): null scope_key in updateSession path (not just closeSession)

### DIFF
--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -1321,11 +1321,20 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
   // Resolve a valid project_id for a global singleton session. The session's
   // project_id is never user-visible (Option C sidebar renders these in a
   // Global section regardless of projectId) but the DB requires NOT NULL + a
-  // valid FK. Prefer the active node when it's a project; otherwise fall back
-  // to any project. Returns null only if the user has zero projects.
+  // valid FK on projects.id. Prefer the active node when it's a project AND
+  // actually exists in the projects list; otherwise fall back to any project.
+  // Validating against projectTree.projects guards against stale activeNode
+  // state referencing a deleted project.
   const resolveSingletonCarrierProjectId = useCallback((): string | null => {
-    if (projectTree.activeNode?.type === "project") {
-      return projectTree.activeNode.id;
+    const activeProjectId =
+      projectTree.activeNode?.type === "project"
+        ? projectTree.activeNode.id
+        : null;
+    if (
+      activeProjectId &&
+      projectTree.projects.some((p) => p.id === activeProjectId)
+    ) {
+      return activeProjectId;
     }
     return projectTree.projects[0]?.id ?? null;
   }, [projectTree.activeNode, projectTree.projects]);

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -878,8 +878,11 @@ export async function updateSession(
   const isBecomingInactive =
     (updates.status === "closed" || updates.status === "trashed") &&
     existing.status !== updates.status;
-  if (isBecomingInactive && directUpdates.scopeKey === undefined) {
-    (directUpdates as { scopeKey?: string | null }).scopeKey = null;
+  const directUpdatesWithScope = directUpdates as typeof directUpdates & {
+    scopeKey?: string | null;
+  };
+  if (isBecomingInactive && directUpdatesWithScope.scopeKey === undefined) {
+    directUpdatesWithScope.scopeKey = null;
   }
   let mergedTypeMetadata: string | undefined;
 

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -870,6 +870,17 @@ export async function updateSession(
 
   // Build the DB-level updates, handling typeMetadataPatch merge
   const { typeMetadataPatch, ...directUpdates } = updates;
+
+  // Null out scope_key whenever the session transitions to closed or trashed
+  // so the partial UNIQUE index on (user_id, terminal_type, scope_key) frees
+  // the slot for a future create-session call with the same scope. Applies
+  // regardless of whether the caller explicitly set scopeKey in the patch.
+  const isBecomingInactive =
+    (updates.status === "closed" || updates.status === "trashed") &&
+    existing.status !== updates.status;
+  if (isBecomingInactive && directUpdates.scopeKey === undefined) {
+    (directUpdates as { scopeKey?: string | null }).scopeKey = null;
+  }
   let mergedTypeMetadata: string | undefined;
 
   if (typeMetadataPatch) {


### PR DESCRIPTION
## Problem

User reported Settings still fails after PR #190. Error was the same UNIQUE violation — after clicking Settings, closing via X, then clicking Settings again, the insert fails.

## Root cause

PR #190 nulled scope_key in \`SessionService.closeSession\`, but client-initiated closes go through a different path:

- The **X close button** in SettingsView → \`onSessionClose\` → \`SessionContext.closeSession\` → \`DELETE /api/sessions/:id\` → \`SessionService.closeSession\` ✓
- But the **DELETE route** might also route through \`updateSession({ status: "closed" })\` in some code paths, and  
- The **client reducer** may dispatch DELETE while the server uses UPDATE for certain transitions

Checking the DB after the user's repro:
\`\`\`
c1ce3465-0c83-4ff3-862c-e2ef66a33cad | Settings | closed | settings
\`\`\`

scope_key was NOT nulled — so the close went through \`updateSession\`, not \`closeSession\`.

## Fix

\`SessionService.updateSession\` now detects \`status → closed | trashed\` transitions and nulls \`scope_key\` in the same UPDATE (unless the caller explicitly sets scope_key). Complements the direct \`closeSession\` and \`worktree-trash-service\` fixes from PR #190.

Also: \`resolveSingletonCarrierProjectId\` now validates the active node's id exists in \`projectTree.projects\` before returning it — guards against stale activeNode state.

## Test plan

- [x] typecheck 0 errors
- [x] lint 0 warnings
- [x] 723 tests pass
- [ ] Manual: open Settings, close via X, open again → works (no UNIQUE error)