### PR TITLE
feat(terminal-types): trash global tab

### DIFF
--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -9,7 +9,6 @@ import { ProjectPreferencesModal } from "@/components/preferences/ProjectPrefere
 import { CommandPalette } from "@/components/CommandPalette";
 import { KeyboardShortcutsPanel } from "@/components/KeyboardShortcutsPanel";
 import { SaveRecordingModal } from "@/components/session/SaveRecordingModal";
-import { TrashModal } from "@/components/trash/TrashModal";
 import { ResumeSessionModal } from "./ResumeSessionModal";
 import { shouldPatchSettingsTab } from "./settings-deep-link";
 import { BeadsSidebar } from "@/components/beads/BeadsSidebar";
@@ -283,7 +282,6 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
 
   // Trash state from context
   const { count: trashCount, trashSession } = useTrashContext();
-  const [isTrashOpen, setIsTrashOpen] = useState(false);
 
   // Resume Claude Session modal state
   const [isResumeModalOpen, setIsResumeModalOpen] = useState(false);
@@ -1512,6 +1510,28 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
     }
   }, [resolveSingletonCarrierProjectId, createSession, setActiveSession, setActiveView, logSessionError]);
 
+  const openTrashSession = useCallback(async () => {
+    const carrierProjectId = resolveSingletonCarrierProjectId();
+    if (!carrierProjectId) {
+      console.error("Cannot open trash: no project available");
+      return;
+    }
+    try {
+      const session = await createSession({
+        name: "Trash",
+        projectId: carrierProjectId,
+        terminalType: "trash",
+        scopeKey: "trash",
+      });
+      if (session) {
+        setActiveSession(session.id);
+        setActiveView("terminal");
+      }
+    } catch (error) {
+      logSessionError("open trash session", error);
+    }
+  }, [resolveSingletonCarrierProjectId, createSession, setActiveSession, setActiveView, logSessionError]);
+
   // Handle view change from FolderTabBar (terminal/chat toggle)
   const handleViewChange = useCallback(
     (view: ActiveView) => {
@@ -1601,7 +1621,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
             onProjectAdvancedSession={handleFolderAdvancedSession}
             onProjectNewWorktree={handleFolderNewWorktree}
             trashCount={trashCount}
-            onTrashOpen={() => setIsTrashOpen(true)}
+            onTrashOpen={() => { void openTrashSession(); }}
             onSessionSchedule={handleScheduleSession}
             onProfilesOpen={() => { void openProfilesSession(); }}
             onPortsOpen={() => { void openPortManagerSession(); }}
@@ -1915,9 +1935,6 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
         duration={recordingDuration}
         sessionName={activeSessions.find((s) => s.id === activeSessionId)?.name}
       />
-
-      {/* Trash Modal */}
-      <TrashModal open={isTrashOpen} onClose={() => setIsTrashOpen(false)} />
 
       {/* Resume Claude Session Modal */}
       <ResumeSessionModal

--- a/src/components/session/TrashButtonContextMenu.tsx
+++ b/src/components/session/TrashButtonContextMenu.tsx
@@ -39,7 +39,7 @@ interface Props extends ContentProps {
 /**
  * Right-click affordance on the sidebar footer Trash button. Restores the
  * legacy "Empty Permanently" escape hatch removed in Phase G; the primary
- * click opens the TrashModal (handled by the parent).
+ * click opens the Trash terminal-tab (handled by the parent).
  *
  * See remote-dev-mtv7.7.
  */

--- a/src/lib/terminal-plugins/init-client.ts
+++ b/src/lib/terminal-plugins/init-client.ts
@@ -19,6 +19,7 @@ import { PRsClientPlugin } from "./plugins/prs-plugin-client";
 import { IssuesClientPlugin } from "./plugins/issues-plugin-client";
 import { ProfilesClientPlugin } from "./plugins/profiles-plugin-client";
 import { PortManagerClientPlugin } from "./plugins/port-manager-plugin-client";
+import { TrashClientPlugin } from "./plugins/trash-plugin-client";
 
 // Client-only: use console directly to avoid pulling the server-side logger
 // (which depends on better-sqlite3) into the browser bundle.
@@ -54,6 +55,7 @@ export function initializeClientPlugins(): void {
   TerminalTypeClientRegistry.register(IssuesClientPlugin, { builtIn: true });
   TerminalTypeClientRegistry.register(ProfilesClientPlugin, { builtIn: true });
   TerminalTypeClientRegistry.register(PortManagerClientPlugin, { builtIn: true });
+  TerminalTypeClientRegistry.register(TrashClientPlugin, { builtIn: true });
 
   TerminalTypeClientRegistry.setDefaultType("shell");
 

--- a/src/lib/terminal-plugins/init-server.ts
+++ b/src/lib/terminal-plugins/init-server.ts
@@ -19,6 +19,7 @@ import { PRsServerPlugin } from "./plugins/prs-plugin-server";
 import { IssuesServerPlugin } from "./plugins/issues-plugin-server";
 import { ProfilesServerPlugin } from "./plugins/profiles-plugin-server";
 import { PortManagerServerPlugin } from "./plugins/port-manager-plugin-server";
+import { TrashServerPlugin } from "./plugins/trash-plugin-server";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("PluginInit.Server");
@@ -48,6 +49,7 @@ export function initializeServerPlugins(): void {
   TerminalTypeServerRegistry.register(IssuesServerPlugin, { builtIn: true });
   TerminalTypeServerRegistry.register(ProfilesServerPlugin, { builtIn: true });
   TerminalTypeServerRegistry.register(PortManagerServerPlugin, { builtIn: true });
+  TerminalTypeServerRegistry.register(TrashServerPlugin, { builtIn: true });
 
   TerminalTypeServerRegistry.setDefaultType("shell");
 

--- a/src/lib/terminal-plugins/plugins/trash-plugin-client.tsx
+++ b/src/lib/terminal-plugins/plugins/trash-plugin-client.tsx
@@ -1,30 +1,35 @@
-"use client";
+/**
+ * TrashPlugin (client half) — React rendering for the Trash tab.
+ *
+ * Replaces the Dialog-based `TrashModal`: the list of trash items and the
+ * "Trash is empty" state now render directly in the workspace pane as a
+ * Global-section terminal tab. The confirm dialogs (`RestoreDialog`,
+ * `DeleteConfirmDialog`) remain as real Dialogs — they are short-lived
+ * yes/no affordances and don't warrant their own tab.
+ *
+ * @see ./trash-plugin-server.ts for lifecycle.
+ */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Trash2, RotateCcw, Calendar, GitBranch } from "lucide-react";
+import type {
+  TerminalTypeClientPlugin,
+  TerminalTypeClientComponentProps,
+} from "@/types/terminal-type-client";
 import { cn } from "@/lib/utils";
 import { useTrashContext } from "@/contexts/TrashContext";
 import { useSessionContext } from "@/contexts/SessionContext";
 import { getDaysUntilExpiry } from "@/types/trash";
-import type { WorktreeTrashItem, TrashItemWithMetadata } from "@/types/trash";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import type {
+  WorktreeTrashItem,
+  TrashItemWithMetadata,
+} from "@/types/trash";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { RestoreDialog } from "./RestoreDialog";
-import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
+import { RestoreDialog } from "@/components/trash/RestoreDialog";
+import { DeleteConfirmDialog } from "@/components/trash/DeleteConfirmDialog";
 
-interface TrashModalProps {
-  open: boolean;
-  onClose: () => void;
-}
-
-export function TrashModal({ open, onClose }: TrashModalProps) {
+function TrashTabContent({ session }: TerminalTypeClientComponentProps) {
   const {
     trashItems,
     loading,
@@ -36,9 +41,10 @@ export function TrashModal({ open, onClose }: TrashModalProps) {
     cleanupExpired,
   } = useTrashContext();
 
-  const { refreshSessions } = useSessionContext();
+  const { refreshSessions, closeSession } = useSessionContext();
 
-  const [selectedItem, setSelectedItem] = useState<TrashItemWithMetadata | null>(null);
+  const [selectedItem, setSelectedItem] =
+    useState<TrashItemWithMetadata | null>(null);
   const [showRestoreDialog, setShowRestoreDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [isPathAvailable, setIsPathAvailable] = useState(true);
@@ -46,12 +52,12 @@ export function TrashModal({ open, onClose }: TrashModalProps) {
   const [isProcessing, setIsProcessing] = useState(false);
   const [restoreError, setRestoreError] = useState<string | null>(null);
 
-  // Trigger cleanup when modal opens
+  // Trigger cleanup when the tab mounts. Matches the modal's "cleanup on
+  // open" behavior; remount happens on every session.id change (new tab)
+  // so we don't need a separate `open` flag.
   useEffect(() => {
-    if (open) {
-      cleanupExpired();
-    }
-  }, [open, cleanupExpired]);
+    cleanupExpired();
+  }, [cleanupExpired]);
 
   const handleRestoreClick = async (item: TrashItemWithMetadata) => {
     const availability = await checkRestoreAvailability(item.id);
@@ -69,13 +75,19 @@ export function TrashModal({ open, onClose }: TrashModalProps) {
     setShowDeleteDialog(true);
   };
 
-  const handleRestore = async (restorePath?: string, targetFolderId?: string | null) => {
+  const handleRestore = async (
+    restorePath?: string,
+    targetFolderId?: string | null
+  ) => {
     if (!selectedItem) return;
 
     setIsProcessing(true);
     setRestoreError(null);
     try {
-      const success = await restoreItem(selectedItem.id, { restorePath, targetFolderId });
+      const success = await restoreItem(selectedItem.id, {
+        restorePath,
+        targetFolderId,
+      });
       if (success) {
         setShowRestoreDialog(false);
         setSelectedItem(null);
@@ -83,7 +95,8 @@ export function TrashModal({ open, onClose }: TrashModalProps) {
         await Promise.all([refreshTrash(), refreshSessions()]);
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to restore";
+      const message =
+        error instanceof Error ? error.message : "Failed to restore";
       setRestoreError(message);
     } finally {
       setIsProcessing(false);
@@ -105,53 +118,56 @@ export function TrashModal({ open, onClose }: TrashModalProps) {
     }
   };
 
+  // Close the Trash tab. Mirrors the modal's "Close" button: since the tab
+  // is a singleton (scope-key dedup), closing it is cheap — the next open
+  // reopens it via the carrier project.
+  const handleClose = useCallback(() => {
+    void closeSession(session.id);
+  }, [closeSession, session.id]);
+
   return (
-    <>
-      <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Trash2 className="w-5 h-5 text-muted-foreground" />
-              Trash
-            </DialogTitle>
-            <DialogDescription>
-              Items are automatically deleted after 30 days.
-            </DialogDescription>
-          </DialogHeader>
+    <div className="flex flex-col h-full min-h-0 overflow-hidden">
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-border bg-popover/30 shrink-0">
+        <Trash2 className="w-4 h-4 text-muted-foreground" />
+        <span className="text-sm font-medium text-foreground">Trash</span>
+        <span className="text-xs text-muted-foreground">
+          Items are automatically deleted after 30 days.
+        </span>
+      </div>
 
-          <ScrollArea className="max-h-[400px]">
-            {loading ? (
-              <div className="flex items-center justify-center py-8 text-muted-foreground">
-                Loading...
-              </div>
-            ) : isEmpty ? (
-              <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
-                <Trash2 className="w-8 h-8 mb-2 opacity-50" />
-                <p className="text-sm">Trash is empty</p>
-              </div>
-            ) : (
-              <div className="space-y-2">
-                {trashItems.map((item) => (
-                  <TrashItemRow
-                    key={item.id}
-                    item={item}
-                    onRestore={() => handleRestoreClick(item)}
-                    onDelete={() => handleDeleteClick(item)}
-                  />
-                ))}
-              </div>
-            )}
-          </ScrollArea>
-
-          {!isEmpty && (
-            <div className="flex justify-end pt-4 border-t border-border">
-              <Button variant="ghost" size="sm" onClick={onClose}>
-                Close
-              </Button>
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <ScrollArea className="h-full">
+          {loading ? (
+            <div className="flex items-center justify-center py-8 text-muted-foreground">
+              Loading...
+            </div>
+          ) : isEmpty ? (
+            <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+              <Trash2 className="w-8 h-8 mb-2 opacity-50" />
+              <p className="text-sm">Trash is empty</p>
+            </div>
+          ) : (
+            <div className="space-y-2 p-4">
+              {trashItems.map((item) => (
+                <TrashItemRow
+                  key={item.id}
+                  item={item}
+                  onRestore={() => handleRestoreClick(item)}
+                  onDelete={() => handleDeleteClick(item)}
+                />
+              ))}
             </div>
           )}
-        </DialogContent>
-      </Dialog>
+        </ScrollArea>
+      </div>
+
+      {!isEmpty && (
+        <div className="flex justify-end px-4 py-3 border-t border-border shrink-0">
+          <Button variant="ghost" size="sm" onClick={handleClose}>
+            Close
+          </Button>
+        </div>
+      )}
 
       {/* Restore confirmation dialog */}
       <RestoreDialog
@@ -180,7 +196,7 @@ export function TrashModal({ open, onClose }: TrashModalProps) {
         onDelete={handleDelete}
         isProcessing={isProcessing}
       />
-    </>
+    </div>
   );
 }
 
@@ -206,14 +222,15 @@ function TrashItemRow({ item, onRestore, onDelete }: TrashItemRowProps) {
       const worktreeItem = item as WorktreeTrashItem;
       const parts: string[] = [];
 
-      // Add folder name if available
       if (worktreeItem.metadata?.originalProjectName) {
         parts.push(worktreeItem.metadata.originalProjectName);
       }
 
-      // Add repo name if available and different from folder
-      if (worktreeItem.metadata?.repoName &&
-          worktreeItem.metadata.repoName !== worktreeItem.metadata?.originalProjectName) {
+      if (
+        worktreeItem.metadata?.repoName &&
+        worktreeItem.metadata.repoName !==
+          worktreeItem.metadata?.originalProjectName
+      ) {
         parts.push(worktreeItem.metadata.repoName);
       }
 
@@ -222,7 +239,6 @@ function TrashItemRow({ item, onRestore, onDelete }: TrashItemRowProps) {
     return null;
   };
 
-  // Get the branch name for worktree items
   const getBranchName = (): string | null => {
     if (item.resourceType === "worktree") {
       const worktreeItem = item as WorktreeTrashItem;
@@ -236,21 +252,19 @@ function TrashItemRow({ item, onRestore, onDelete }: TrashItemRowProps) {
 
   return (
     <div className="group flex items-center gap-3 p-3 rounded-lg bg-muted/50 hover:bg-accent transition-colors">
-      {/* Icon */}
       <div className="shrink-0">
         <GitBranch className="w-4 h-4 text-primary" />
       </div>
 
-      {/* Info */}
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-foreground truncate">{item.resourceName}</p>
+        <p className="text-sm font-medium text-foreground truncate">
+          {item.resourceName}
+        </p>
 
-        {/* Folder/Repo path */}
         {itemPath && (
           <p className="text-xs text-muted-foreground truncate">{itemPath}</p>
         )}
 
-        {/* Branch and expiry info */}
         <div className="flex items-center gap-3 text-xs text-muted-foreground mt-0.5">
           {branchName && (
             <span className="flex items-center gap-1">
@@ -260,14 +274,18 @@ function TrashItemRow({ item, onRestore, onDelete }: TrashItemRowProps) {
               </span>
             </span>
           )}
-          <span className={cn("flex items-center gap-1", isExpiringSoon && "text-amber-400")}>
+          <span
+            className={cn(
+              "flex items-center gap-1",
+              isExpiringSoon && "text-amber-400"
+            )}
+          >
             <Calendar className="w-3 h-3" />
             {formatDaysLeft(daysLeft)}
           </span>
         </div>
       </div>
 
-      {/* Actions */}
       <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
         <Button
           variant="ghost"
@@ -291,3 +309,15 @@ function TrashItemRow({ item, onRestore, onDelete }: TrashItemRowProps) {
     </div>
   );
 }
+
+/** Default trash client plugin instance */
+export const TrashClientPlugin: TerminalTypeClientPlugin = {
+  type: "trash",
+  displayName: "Trash",
+  description: "Restore or permanently delete trashed items",
+  icon: Trash2,
+  priority: 50,
+  builtIn: true,
+  component: TrashTabContent,
+  deriveTitle: () => "Trash",
+};

--- a/src/lib/terminal-plugins/plugins/trash-plugin-server.ts
+++ b/src/lib/terminal-plugins/plugins/trash-plugin-server.ts
@@ -1,0 +1,73 @@
+/**
+ * TrashPlugin (server half) — lifecycle for the Trash tab.
+ *
+ * The trash view is a pure client-side browser over the `trash_item` table;
+ * it never spawns a shell, never uses tmux, and has no process to attach to.
+ * The lifecycle here is metadata-only. Confirm dialogs (`RestoreDialog`,
+ * `DeleteConfirmDialog`) still render as modals owned by the client
+ * component — those are short-lived yes/no affordances, not first-class UI.
+ *
+ * Singleton dedup: callers set `scopeKey: "trash"` on the create-session call
+ * so every user gets at most one Trash tab open at a time — re-invoking
+ * "Open Trash" jumps to the existing tab instead of spawning a duplicate.
+ *
+ * @see ./trash-plugin-client.tsx for rendering.
+ */
+
+import type {
+  TerminalTypeServerPlugin,
+  SessionConfig,
+  ExitBehavior,
+} from "@/types/terminal-type-server";
+import type { TerminalSession, CreateSessionInput } from "@/types/session";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("TrashPlugin.Server");
+
+/**
+ * Metadata stored on a trash session.
+ *
+ * Intentionally empty for now — the trash view is stateless beyond the
+ * TrashContext it reads from. Kept as an explicit interface so future
+ * additions (e.g. filter state, selection) land in a typed shape.
+ */
+export interface TrashSessionMetadata {
+  /** Reserved for future state (filters, selection). */
+  reserved?: never;
+}
+
+/** Default trash server plugin instance */
+export const TrashServerPlugin: TerminalTypeServerPlugin = {
+  type: "trash",
+  priority: 50,
+  builtIn: true,
+  useTmux: false,
+
+  createSession(_input: CreateSessionInput): SessionConfig {
+    log.debug("Creating trash session");
+    const metadata: TrashSessionMetadata = {};
+    return {
+      shellCommand: null,
+      shellArgs: [],
+      environment: {},
+      useTmux: false,
+      metadata: metadata as unknown as Record<string, unknown>,
+    };
+  },
+
+  onSessionExit(): ExitBehavior {
+    return {
+      showExitScreen: false,
+      canRestart: false,
+      autoClose: true,
+    };
+  },
+
+  onSessionClose(session: TerminalSession): void {
+    log.debug("Closing trash session", { sessionId: session.id });
+  },
+
+  canHandle(session: TerminalSession): boolean {
+    return session.terminalType === "trash";
+  },
+};

--- a/src/types/terminal-type.ts
+++ b/src/types/terminal-type.ts
@@ -16,12 +16,12 @@ import type { AgentProviderType, TerminalSession, CreateSessionInput } from "./s
  * - file: Read/edit file without terminal (CLAUDE.md editor)
  * - Custom types can be added via plugin registration
  */
-export type TerminalType = "shell" | "agent" | "file" | "browser" | "settings" | "recordings" | "issues" | "prs" | "profiles" | "port-manager" | string;
+export type TerminalType = "shell" | "agent" | "file" | "browser" | "settings" | "recordings" | "issues" | "prs" | "profiles" | "port-manager" | "trash" | string;
 
 /**
  * Built-in terminal types (cannot be unregistered)
  */
-export const BUILT_IN_TERMINAL_TYPES: TerminalType[] = ["shell", "agent", "file", "browser", "loop", "settings", "recordings", "issues", "prs", "profiles", "port-manager"];
+export const BUILT_IN_TERMINAL_TYPES: TerminalType[] = ["shell", "agent", "file", "browser", "loop", "settings", "recordings", "issues", "prs", "profiles", "port-manager", "trash"];
 
 /**
  * Terminal types that render as user-global singletons in the sidebar,
@@ -40,6 +40,7 @@ export const GLOBAL_TERMINAL_TYPES: readonly TerminalType[] = [
   "recordings",
   "profiles",
   "port-manager",
+  "trash",
 ] as const;
 
 export function isGlobalTerminalType(type: TerminalType | null | undefined): boolean {

--- a/tests/lib/project-tree-session-utils.test.ts
+++ b/tests/lib/project-tree-session-utils.test.ts
@@ -128,9 +128,9 @@ describe("isGlobalTerminalType", () => {
     expect(isGlobalTerminalType(null)).toBe(false);
     expect(isGlobalTerminalType(undefined)).toBe(false);
   });
-  it("GLOBAL_TERMINAL_TYPES contains settings/recordings/profiles/port-manager", () => {
+  it("GLOBAL_TERMINAL_TYPES contains settings/recordings/profiles/port-manager/trash", () => {
     expect(new Set(GLOBAL_TERMINAL_TYPES)).toEqual(
-      new Set(["settings", "recordings", "profiles", "port-manager"]),
+      new Set(["settings", "recordings", "profiles", "port-manager", "trash"]),
     );
   });
 });


### PR DESCRIPTION
## Summary

Converts the Trash modal into a Global-section terminal-type plugin (`trash`). Follows the settings/recordings/profiles pattern — full-pane rendering, scope-key dedup.

## Changes

- New `trash-plugin-server.ts` + `trash-plugin-client.tsx` (icon: Trash2, title: Trash)
- Registered in `init-server`/`init-client`, added to `BUILT_IN_TERMINAL_TYPES` + `GLOBAL_TERMINAL_TYPES`
- `SessionManager` gains `openTrashSession()`; `onTrashOpen` wired through
- `RestoreDialog` + `DeleteConfirmDialog` remain as inner dialogs
- Deleted `TrashModal.tsx`

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test:run` — 722 passed (1 pre-existing mobile failure unrelated)
- [ ] Manual: open trash → list loads, restore/delete dialogs work, close returns cleanly