### PR TITLE
fix(sidebar): align Global section + remove tree connector bars

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -677,31 +677,6 @@
   @apply h-7 text-[11px] px-2.5;
 }
 
-/* ============================================================================
-   Sidebar Tree View Lines - Vertical lines only
-   ============================================================================ */
-
-:root {
-  --tree-line-color: oklch(1 0 0 / 12%);
-}
-
-/* Tree item container */
-.tree-item {
-  position: relative;
-}
-
-/* Vertical line - full height */
-.tree-item::before {
-  content: '';
-  position: absolute;
-  left: var(--tree-connector-left);
-  top: 0;
-  width: 1px;
-  height: 100%;
-  background: var(--tree-line-color);
-  pointer-events: none;
-}
-
 /* Agent activity breathing animation */
 @keyframes agent-breathing {
   0%, 100% { opacity: 1; }

--- a/src/components/session/ProjectTreeSidebar.tsx
+++ b/src/components/session/ProjectTreeSidebar.tsx
@@ -893,97 +893,137 @@ export const ProjectTreeSidebar = forwardRef<
       }}
     >
       {globalSessionList.length > 0 && (
-        <div data-testid="global-section" className="mb-1">
-          <button
-            type="button"
-            aria-expanded={!globalSectionCollapsed}
-            aria-label="Toggle global section"
-            onClick={() => setGlobalSectionCollapsed((v) => !v)}
-            className="flex w-full items-center gap-1 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors"
-          >
-            {globalSectionCollapsed ? (
-              <ChevronRight className="h-3 w-3" aria-hidden />
-            ) : (
-              <ChevronDown className="h-3 w-3" aria-hidden />
-            )}
-            <Globe className="h-3 w-3" aria-hidden />
-            <span>Global</span>
-            <span className="ml-auto text-[10px] font-normal text-muted-foreground">
-              {globalSessionList.length}
-            </span>
-          </button>
-          {!globalSectionCollapsed && (
-            <div data-testid="global-section-list">
-              {globalSessionList.map((s, i) => (
-                <TreeConnector
-                  key={s.id}
-                  depth={0}
-                  isLastChild={i === globalSessionList.length - 1}
-                >
-                  <SessionContextMenu
-                    session={s}
-                    projects={projectOptions}
-                    onStartEdit={() => setEditingNode({ id: s.id, type: "session" })}
-                    onTogglePin={() => props.onSessionTogglePin(s.id)}
-                    onMove={(targetProjectId) => {
-                      props.onSessionMove(s.id, targetProjectId);
-                    }}
-                    onSchedule={
-                      props.onSessionSchedule
-                        ? () => props.onSessionSchedule!(s.id)
-                        : undefined
-                    }
-                    onClose={() => props.onSessionClose(s.id)}
-                  >
-                    <div>
-                      <SessionRow
-                        session={s}
-                        depth={0}
-                        dropIndicator={null}
-                        isActive={s.id === activeSessionId}
-                        isEditing={
-                          editingNode?.id === s.id &&
-                          editingNode?.type === "session"
-                        }
-                        hasUnread={(sessionUnread.get(s.id) ?? 0) > 0}
-                        agentStatus={null}
-                        scheduleCount={0}
-                        dragTranslateStyle={swipe.getRowStyle(s.id)}
-                        swipeRevealed={swipe.swipedSessionId === s.id}
-                        onTouchStart={(e) => swipe.handleTouchStart(e, s.id)}
-                        onTouchMove={swipe.handleTouchMove}
-                        onTouchEnd={swipe.handleTouchEnd}
-                        onClick={() => {
-                // Tap on the row dismisses a committed swipe instead of
-                // activating the session. Gives the user an escape hatch
-                // when they swiped by accident and don't want to close.
-                if (swipe.swipedSessionId === s.id) {
-                  swipe.clearSwipe();
-                  return;
+        <TreeConnector
+          depth={0}
+          isLastChild={
+            rootOrdered.length === 0 && creating?.parentGroupId !== null
+          }
+        >
+          <div data-testid="global-section" className="relative space-y-0.5">
+            {/*
+              Global header. Structurally mirrors GroupRow at depth=0 so it
+              lines up with other top-level containers: same `px-2 py-1
+              rounded-md` shell, same chevron + icon layout, same right-side
+              count slot (a single min-w 24px span to match the session-count
+              column in GroupRow). Only the icon (Globe) and the uppercase
+              label style distinguish it visually. Child sessions render at
+              depth=1, matching how GroupRow's subtree renders a depth=1
+              project under a depth=0 group.
+            */}
+            <div
+              role="button"
+              tabIndex={0}
+              aria-expanded={!globalSectionCollapsed}
+              aria-label="Toggle global section"
+              onClick={() => setGlobalSectionCollapsed((v) => !v)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setGlobalSectionCollapsed((v) => !v);
                 }
-                props.onSessionClick(s.id);
               }}
-                        onClose={() => {
-                          props.onSessionClose(s.id);
-                          swipe.clearSwipe();
-                        }}
-                        onStartEdit={() => {
-                          props.onSessionStartEdit(s.id);
-                          setEditingNode({ id: s.id, type: "session" });
-                        }}
-                        onSaveEdit={(name) => {
-                          props.onSessionRename(s.id, name);
-                          setEditingNode(null);
-                        }}
-                        onCancelEdit={() => setEditingNode(null)}
-                      />
-                    </div>
-                  </SessionContextMenu>
-                </TreeConnector>
-              ))}
+              className="group flex items-center gap-1.5 px-2 py-1 rounded-md hover:bg-accent/50 transition-all duration-150"
+            >
+              <button
+                type="button"
+                aria-label="Toggle global section"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setGlobalSectionCollapsed((v) => !v);
+                }}
+                className="shrink-0 text-muted-foreground hover:text-foreground"
+              >
+                {globalSectionCollapsed ? (
+                  <ChevronRight className="h-3 w-3" />
+                ) : (
+                  <ChevronDown className="h-3 w-3" />
+                )}
+              </button>
+              <Globe className="w-3.5 h-3.5 shrink-0 text-primary" />
+              <div className="flex-1 min-w-0 flex items-center gap-1">
+                <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground truncate">
+                  Global
+                </span>
+              </div>
+              <div className="flex items-center gap-1 shrink-0 ml-auto">
+                <span className="flex items-center gap-0.5 justify-end text-[9px] text-muted-foreground min-w-[24px]">
+                  {globalSessionList.length}
+                </span>
+              </div>
             </div>
-          )}
-        </div>
+            {!globalSectionCollapsed && (
+              <div data-testid="global-section-list">
+                {globalSessionList.map((s, i) => (
+                  <TreeConnector
+                    key={s.id}
+                    depth={1}
+                    isLastChild={i === globalSessionList.length - 1}
+                  >
+                    <SessionContextMenu
+                      session={s}
+                      projects={projectOptions}
+                      onStartEdit={() => setEditingNode({ id: s.id, type: "session" })}
+                      onTogglePin={() => props.onSessionTogglePin(s.id)}
+                      onMove={(targetProjectId) => {
+                        props.onSessionMove(s.id, targetProjectId);
+                      }}
+                      onSchedule={
+                        props.onSessionSchedule
+                          ? () => props.onSessionSchedule!(s.id)
+                          : undefined
+                      }
+                      onClose={() => props.onSessionClose(s.id)}
+                    >
+                      <div>
+                        <SessionRow
+                          session={s}
+                          depth={1}
+                          dropIndicator={null}
+                          isActive={s.id === activeSessionId}
+                          isEditing={
+                            editingNode?.id === s.id &&
+                            editingNode?.type === "session"
+                          }
+                          hasUnread={(sessionUnread.get(s.id) ?? 0) > 0}
+                          agentStatus={null}
+                          scheduleCount={0}
+                          dragTranslateStyle={swipe.getRowStyle(s.id)}
+                          swipeRevealed={swipe.swipedSessionId === s.id}
+                          onTouchStart={(e) => swipe.handleTouchStart(e, s.id)}
+                          onTouchMove={swipe.handleTouchMove}
+                          onTouchEnd={swipe.handleTouchEnd}
+                          onClick={() => {
+                            // Tap on the row dismisses a committed swipe instead of
+                            // activating the session. Gives the user an escape hatch
+                            // when they swiped by accident and don't want to close.
+                            if (swipe.swipedSessionId === s.id) {
+                              swipe.clearSwipe();
+                              return;
+                            }
+                            props.onSessionClick(s.id);
+                          }}
+                          onClose={() => {
+                            props.onSessionClose(s.id);
+                            swipe.clearSwipe();
+                          }}
+                          onStartEdit={() => {
+                            props.onSessionStartEdit(s.id);
+                            setEditingNode({ id: s.id, type: "session" });
+                          }}
+                          onSaveEdit={(name) => {
+                            props.onSessionRename(s.id, name);
+                            setEditingNode(null);
+                          }}
+                          onCancelEdit={() => setEditingNode(null)}
+                        />
+                      </div>
+                    </SessionContextMenu>
+                  </TreeConnector>
+                ))}
+              </div>
+            )}
+          </div>
+        </TreeConnector>
       )}
       {rootOrdered.map((entry, i) => {
         const isLast =

--- a/src/components/session/project-tree/TreeConnector.tsx
+++ b/src/components/session/project-tree/TreeConnector.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { type ReactNode, type CSSProperties } from "react";
+import { type ReactNode } from "react";
 
 interface Props {
   depth: number;
@@ -7,14 +7,19 @@ interface Props {
   children: ReactNode;
 }
 
-export function TreeConnector({ depth, isLastChild, children }: Props) {
-  const left = depth * 12 + 8 + 7;
-  const style: CSSProperties & Record<string, string> = {
-    "--tree-connector-left": `${left}px`,
-    "--tree-connector-width": "8px",
-  };
+/**
+ * Wrapper for tree rows. Previously rendered vertical nesting guide bars via
+ * CSS custom properties consumed by a `.tree-item::before` pseudo-element.
+ * The bars were removed (they didn't align reliably with parent rows and the
+ * user preferred plain indentation), so this component is now a thin wrapper
+ * that preserves the last-child data attribute for potential styling hooks.
+ * `depth` is retained in the API because call-sites pass it through, but it
+ * no longer drives any layout — indentation is owned by the individual row
+ * components via `paddingLeft` / `marginLeft`.
+ */
+export function TreeConnector({ depth: _depth, isLastChild, children }: Props) {
   return (
-    <div className="tree-item" data-tree-last={isLastChild ? "true" : undefined} style={style}>
+    <div data-tree-last={isLastChild ? "true" : undefined}>
       {children}
     </div>
   );

--- a/tests/components/project-tree/TreeConnector.test.tsx
+++ b/tests/components/project-tree/TreeConnector.test.tsx
@@ -30,15 +30,17 @@ describe("TreeConnector", () => {
     expect(container.firstElementChild).not.toHaveAttribute("data-tree-last");
   });
 
-  it("sets --tree-connector-left based on depth", () => {
+  it("does not render the legacy vertical nesting bar CSS variables", () => {
+    // The `.tree-item::before` pseudo-element was removed along with its
+    // driving CSS variables. Asserting their absence pins the behavior so a
+    // regression would be caught here rather than via manual QA.
     const { container } = render(
       <TreeConnector depth={3} isLastChild={false}>
         <span />
       </TreeConnector>
     );
-    // depth*12 + 8 + 7 = 51 for depth 3
     const el = container.firstElementChild as HTMLElement;
-    expect(el.style.getPropertyValue("--tree-connector-left")).toBe("51px");
-    expect(el.style.getPropertyValue("--tree-connector-width")).toBe("8px");
+    expect(el.style.getPropertyValue("--tree-connector-left")).toBe("");
+    expect(el.style.getPropertyValue("--tree-connector-width")).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

Fixes two sidebar regressions reported via screenshots:
1. Global section header was mis-aligned with other tree rows (different padding/icon layout).
2. Vertical nesting bars were rendering inconsistently and added visual noise without clarifying hierarchy.

## Changes

- Deleted `.tree-item::before` rules + `--tree-line-color` CSS variable (globals.css)
- `TreeConnector` stripped to a thin `data-tree-last` wrapper; no more CSS custom-property wiring
- Global section header restructured to mirror `GroupRow` exactly (px-2 py-1, chevron, Globe icon, right-aligned count)
- Sessions under Global now render at `depth=1` to match spec
- Test updated to pin absence of legacy CSS custom props

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] Tree tests 281/281 pass
- [x] Full suite 722 pass (1 pre-existing mobile failure unrelated)
- [ ] Manual: Global section header aligns with project rows; no vertical bars