### PR TITLE
fix(sidebar): align Global + group-prefs session rows with peer projects

### DIFF
--- a/src/components/session/ProjectTreeSidebar.tsx
+++ b/src/components/session/ProjectTreeSidebar.tsx
@@ -842,6 +842,7 @@ export const ProjectTreeSidebar = forwardRef<
               <SessionRow
                 session={s}
                 depth={depth}
+                reserveChevronSpace
                 dropIndicator={null}
                 isActive={s.id === activeSessionId}
                 isEditing={
@@ -1054,6 +1055,7 @@ export const ProjectTreeSidebar = forwardRef<
                         <SessionRow
                           session={s}
                           depth={1}
+                          reserveChevronSpace
                           dropIndicator={null}
                           isActive={s.id === activeSessionId}
                           isEditing={

--- a/src/components/session/project-tree/SessionRow.tsx
+++ b/src/components/session/project-tree/SessionRow.tsx
@@ -62,6 +62,12 @@ export interface SessionRowProps {
   // SessionMetadataBar, which hides itself when true. Defaults to false since
   // the new project tree does not yet expose a collapsed mode.
   isCollapsed?: boolean;
+  // When true, reserve extra left-margin equal to a chevron-button + gap so
+  // the row's icon lines up with sibling GroupRow/ProjectRow ICONS at the
+  // same depth, instead of with their chevron slots. Used for sessions that
+  // are direct children of a group-like header (Global section + group-prefs
+  // sessions) so they visually sit flush with peer project rows.
+  reserveChevronSpace?: boolean;
 }
 
 export function SessionRow({
@@ -91,6 +97,7 @@ export function SessionRow({
   onTouchMove,
   onTouchEnd,
   isCollapsed = false,
+  reserveChevronSpace = false,
 }: SessionRowProps) {
   const [local, setLocal] = useState(editValue ?? session.name);
   const committedRef = useRef(false);
@@ -139,8 +146,15 @@ export function SessionRow({
     return <Icon className={cn("w-3.5 h-3.5 shrink-0", iconColor)} />;
   }
 
+  // Chevron-button width (12px, `h-3 w-3`) + sibling `gap-1.5` (6px) = 18px.
+  // Matches the horizontal space GroupRow/ProjectRow spend on their chevron
+  // before the icon. Reserved only when `reserveChevronSpace` is set, so
+  // sessions-under-projects (which are intentionally indented LESS than their
+  // parent's icon) keep their current offset.
+  const chevronReservePx = reserveChevronSpace ? 18 : 0;
+  const totalIndentPx = depth * 12 + chevronReservePx;
   const mergedInnerStyle: React.CSSProperties = {
-    marginLeft: depth > 0 ? `${depth * 12}px` : undefined,
+    marginLeft: totalIndentPx > 0 ? `${totalIndentPx}px` : undefined,
     ...(dragTranslateStyle ?? {}),
   };
 


### PR DESCRIPTION
## Summary

Fixes the lingering sidebar alignment issue (bd remote-dev-nulu) that PR #195 did not fully resolve. After #195, Global-section session rows (Settings/Recordings/etc.) and group-prefs session rows still sat ~18px to the left of their sibling project/group rows.

## Root cause

- `SessionRow` lays out as `marginLeft = depth*12` + outer `px-2`; icon lands at the chevron slot (~20px at depth=1).
- `GroupRow`/`ProjectRow` lay out as `paddingLeft = depth*12` + `px-2` + chevron-button (12px) + `gap-1.5` (6px); icon lands ~18px further right (~38px at depth=1).
- PR #195 correctly put the Global header on `GroupRow`'s layout and Global sessions at `depth=1`, but since `SessionRow` has no chevron, "Settings" ended up peer-depth-but-shallower-indent — reads as an indent mistake, not a peer row.
- Same off-by-18px affected `renderGroupPrefsSessions` (children of a group header).

## Changes

- `SessionRow.tsx` — new optional `reserveChevronSpace` prop that adds 18px (chevron `h-3 w-3` + `gap-1.5`) to the inner `marginLeft`. Default off, so sessions nested under a project keep their intentionally-shallower indent.
- `ProjectTreeSidebar.tsx` — passes `reserveChevronSpace` at two call sites: Global-section session map, and `renderGroupPrefsSessions`.

No CSS vars or residual classes needed removing — PR #195 already scrubbed the legacy tree connector vars.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test:run` — 739 pass (1 pre-existing mobile failure unrelated)
- [ ] Manual: Global-section "Settings" / "Recordings" icons align horizontally with sibling project icons at depth 1
- [ ] Manual: group-prefs session rows align with child projects under the same group

Closes bd remote-dev-nulu.