### PR TITLE
fix(sidebar): align global footer buttons and add close affordance for Ports panel

### DIFF
--- a/src/components/session/Sidebar.tsx
+++ b/src/components/session/Sidebar.tsx
@@ -523,18 +523,18 @@ export function Sidebar({
 
       {/* Footer - hide when collapsed */}
       {!collapsed && (
-        <div className="px-3 py-1.5 border-t border-border space-y-1">
+        <div className="px-1 py-1.5 border-t border-border space-y-0.5">
           {/* Profiles button */}
           {onProfilesOpen && (
             <button
               onClick={onProfilesOpen}
               className={cn(
-                "w-full flex items-center gap-2 px-2 py-1.5 rounded-md",
+                "w-full flex items-center gap-1.5 px-2 py-1 rounded-md",
                 "text-xs text-muted-foreground hover:text-foreground",
                 "hover:bg-muted/50 transition-colors"
               )}
             >
-              <Fingerprint className="w-3.5 h-3.5" />
+              <Fingerprint className="w-3.5 h-3.5 shrink-0" />
               <span>Profiles</span>
               {profileCount > 0 && (
                 <span className="ml-auto text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
@@ -548,12 +548,12 @@ export function Sidebar({
             <button
               onClick={onPortsOpen}
               className={cn(
-                "w-full flex items-center gap-2 px-2 py-1.5 rounded-md",
+                "w-full flex items-center gap-1.5 px-2 py-1 rounded-md",
                 "text-xs text-muted-foreground hover:text-foreground",
                 "hover:bg-muted/50 transition-colors"
               )}
             >
-              <Network className="w-3.5 h-3.5" />
+              <Network className="w-3.5 h-3.5 shrink-0" />
               <span>Ports</span>
               {allocations.length > 0 && (
                 <span className={cn(
@@ -576,12 +576,12 @@ export function Sidebar({
               <button
                 onClick={onTrashOpen}
                 className={cn(
-                  "w-full flex items-center gap-2 px-2 py-1.5 rounded-md",
+                  "w-full flex items-center gap-1.5 px-2 py-1 rounded-md",
                   "text-xs text-muted-foreground hover:text-foreground",
                   "hover:bg-muted/50 transition-colors"
                 )}
               >
-                <Trash2 className="w-3.5 h-3.5" />
+                <Trash2 className="w-3.5 h-3.5 shrink-0" />
                 <span>Trash</span>
                 <span className="ml-auto text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
                   {trashCount}
@@ -589,7 +589,7 @@ export function Sidebar({
               </button>
             </TrashButtonContextMenu>
           )}
-          <div className="flex items-center justify-between text-[10px] text-muted-foreground">
+          <div className="flex items-center justify-between px-2 pt-1 text-[10px] text-muted-foreground">
             <span>New session</span>
             <kbd className="px-1 py-0.5 bg-muted rounded">⌘↵</kbd>
           </div>

--- a/src/components/session/Sidebar.tsx
+++ b/src/components/session/Sidebar.tsx
@@ -43,6 +43,13 @@ const MAX_SIDEBAR_WIDTH = 400;
 const DEFAULT_SIDEBAR_WIDTH = 220;
 const COLLAPSED_SIDEBAR_WIDTH = 48;
 
+// Shared className for the footer action buttons (Profiles / Ports / Trash).
+const FOOTER_BUTTON_CLASS = cn(
+  "w-full flex items-center gap-1.5 px-2 py-1 rounded-md",
+  "text-xs text-muted-foreground hover:text-foreground",
+  "hover:bg-muted/50 transition-colors"
+);
+
 // Folder repo stats returned by getFolderRepoStats
 export interface FolderRepoStats {
   prCount: number;
@@ -528,11 +535,7 @@ export function Sidebar({
           {onProfilesOpen && (
             <button
               onClick={onProfilesOpen}
-              className={cn(
-                "w-full flex items-center gap-1.5 px-2 py-1 rounded-md",
-                "text-xs text-muted-foreground hover:text-foreground",
-                "hover:bg-muted/50 transition-colors"
-              )}
+              className={FOOTER_BUTTON_CLASS}
             >
               <Fingerprint className="w-3.5 h-3.5 shrink-0" />
               <span>Profiles</span>
@@ -547,11 +550,7 @@ export function Sidebar({
           {onPortsOpen && (
             <button
               onClick={onPortsOpen}
-              className={cn(
-                "w-full flex items-center gap-1.5 px-2 py-1 rounded-md",
-                "text-xs text-muted-foreground hover:text-foreground",
-                "hover:bg-muted/50 transition-colors"
-              )}
+              className={FOOTER_BUTTON_CLASS}
             >
               <Network className="w-3.5 h-3.5 shrink-0" />
               <span>Ports</span>
@@ -575,11 +574,7 @@ export function Sidebar({
             >
               <button
                 onClick={onTrashOpen}
-                className={cn(
-                  "w-full flex items-center gap-1.5 px-2 py-1 rounded-md",
-                  "text-xs text-muted-foreground hover:text-foreground",
-                  "hover:bg-muted/50 transition-colors"
-                )}
+                className={FOOTER_BUTTON_CLASS}
               >
                 <Trash2 className="w-3.5 h-3.5 shrink-0" />
                 <span>Trash</span>

--- a/src/lib/terminal-plugins/plugins/port-manager-plugin-client.tsx
+++ b/src/lib/terminal-plugins/plugins/port-manager-plugin-client.tsx
@@ -18,6 +18,7 @@ import {
   Cpu,
   RefreshCw,
   Loader2,
+  X,
 } from "lucide-react";
 import type {
   TerminalTypeClientPlugin,
@@ -68,7 +69,11 @@ function PortManagerTabContent({ session }: TerminalTypeClientComponentProps) {
     checkPortsNow,
     refreshAllocations,
   } = usePortContext();
-  const { updateSession } = useSessionContext();
+  const { updateSession, closeSession } = useSessionContext();
+
+  const handleClose = useCallback(() => {
+    void closeSession(session.id);
+  }, [closeSession, session.id]);
 
   const metadata = (session.typeMetadata ?? null) as PortManagerMetadata | null;
   const activeTab = normalizeTab(metadata?.activeTab);
@@ -118,13 +123,26 @@ function PortManagerTabContent({ session }: TerminalTypeClientComponentProps) {
     <div className="flex flex-col h-full min-h-0 overflow-hidden bg-background">
       {/* Header */}
       <div className="shrink-0 border-b border-border/50 px-6 py-4">
-        <div className="flex items-center gap-2 text-foreground text-base font-semibold">
-          <Network className="w-5 h-5 text-primary" />
-          Port Manager
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <div className="flex items-center gap-2 text-foreground text-base font-semibold">
+              <Network className="w-5 h-5 text-primary" />
+              Port Manager
+            </div>
+            <p className="text-sm text-muted-foreground mt-1">
+              View and manage port allocations across folders
+            </p>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleClose}
+            aria-label="Close Port Manager"
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+          >
+            <X className="w-4 h-4" />
+          </Button>
         </div>
-        <p className="text-sm text-muted-foreground mt-1">
-          View and manage port allocations across folders
-        </p>
       </div>
 
       {/* Quick Stats Bar */}


### PR DESCRIPTION
## Summary
- Aligns the sidebar footer (Profiles / Ports / Trash) with project tree rows above — matches `px-1`/`gap-1.5`/`py-1` metrics, adds `shrink-0` to icons.
- Adds a visible close (X) button to the Port Manager singleton tab header so the panel can be dismissed from inside.
- Extracts the repeated footer button className into a shared `FOOTER_BUTTON_CLASS` constant.

Fixes beads remote-dev-msu9.

## Key decisions
- Used X-in-header for the Port Manager close (more discoverable than Trash's footer button); did not retrofit Trash to match — out of scope.
- Did NOT rename internal `folder` → `project` in port-manager copy: the data model still uses `folderId`, so a UI-only rename would create a model/UI mismatch. Belongs in a dedicated rename PR.

## Test plan
- [ ] Open the sidebar — Profiles, Ports, Trash buttons line up horizontally with project/group rows above.
- [ ] Click Ports → panel opens with X in top-right of its header; clicking X closes the tab.
- [ ] Verify collapsed sidebar still hides the footer.
- [ ] `bun run typecheck` clean.
- [ ] `bun run lint` clean.

This pull request and its description were written by Isaac.