### PR TITLE
refactor(sidebar): unify session-row indent with sibling row pattern

### DIFF
--- a/src/components/session/ProjectTreeSidebar.tsx
+++ b/src/components/session/ProjectTreeSidebar.tsx
@@ -999,6 +999,7 @@ export const ProjectTreeSidebar = forwardRef<
                   setGlobalSectionCollapsed((v) => !v);
                 }
               }}
+              style={{ paddingLeft: "0px" }}
               className="group flex items-center gap-1.5 px-2 py-1 rounded-md hover:bg-accent/50 transition-all duration-150"
             >
               <button

--- a/src/components/session/project-tree/SessionRow.tsx
+++ b/src/components/session/project-tree/SessionRow.tsx
@@ -146,21 +146,20 @@ export function SessionRow({
     return <Icon className={cn("w-3.5 h-3.5 shrink-0", iconColor)} />;
   }
 
-  // Reserve horizontal space equivalent to the chevron column used by
-  // GroupRow/ProjectRow. Their chevron-button width (12px, `h-3 w-3`) plus
-  // sibling `gap-1.5` (6px) = 18px. However, GroupRow/ProjectRow apply their
-  // depth indent via inline `paddingLeft`, which overrides the row's `px-2`
-  // (8px) padding-left. SessionRow indents via `marginLeft`, so its `px-2`
-  // padding-left still applies on top. To make the icon land at the same X
-  // as a sibling project's icon, we subtract that 8px here:
-  //   chevron(12) + gap(6) - px-2 left(8) = 10px.
-  // Only applied when reserveChevronSpace is set (i.e. for top-level / under-
-  // group sessions). Sessions-under-projects intentionally indent LESS than
-  // their parent's icon and keep their current offset.
-  const chevronReservePx = reserveChevronSpace ? 10 : 0;
-  const totalIndentPx = depth * 12 + chevronReservePx;
+  // Indent with inline paddingLeft (matches GroupRow/ProjectRow). The inline
+  // paddingLeft overrides Tailwind `px-2`'s padding-left (inline > class),
+  // so the row's `px-2` only contributes its right padding. Two cases:
+  //   non-reserve: sessions-under-projects keep their historical visual
+  //     offset — when this row used `marginLeft` outside `px-2` the icon
+  //     sat at depth*12 + px-2-left(8). Reproducing that here means
+  //     padding-left = depth*12 + 8.
+  //   reserve: sessions-under-groups (incl. GLOBAL) align with sibling
+  //     ProjectRow / GroupRow ICONS at the same depth. Those rows put
+  //     their icon at depth*12 + chevron(12) + gap(6) = depth*12 + 18.
+  const indentBase = reserveChevronSpace ? 18 : 8;
+  const indentPx = depth * 12 + indentBase;
   const mergedInnerStyle: React.CSSProperties = {
-    marginLeft: totalIndentPx > 0 ? `${totalIndentPx}px` : undefined,
+    paddingLeft: `${indentPx}px`,
     ...(dragTranslateStyle ?? {}),
   };
 


### PR DESCRIPTION
## Summary
Make the GLOBAL section indent **defined consistently** with root groups (GroupRow) and root projects (ProjectRow). Follow-up to #207, which only patched the numeric offset.

- **SessionRow**: switch indent from `marginLeft` → `paddingLeft`, matching GroupRow/ProjectRow. Inline `paddingLeft` overrides Tailwind `px-2`'s left padding (inline > class), so `px-2` now contributes only its right padding. Indent base: 8px non-reserve, 18px reserve.
- **GLOBAL header** (in ProjectTreeSidebar): add `style={{ paddingLeft: "0px" }}` to match GroupRow at depth=0 (which sets the same to override `px-2`).

## Pixel arithmetic (verified)
- Non-reserve at depth=2: `depth*12 + 8 = 32px` from row border-left → **same as previous** `marginLeft(24) + px-2-left(8)`.
- Reserve at depth=1 (Ports under GLOBAL): `12 + 18 = 30px` → matches sibling ProjectRow at depth=1 (`paddingLeft(12) + chevron(12) + gap(6) = 30`).
- GLOBAL header chevron: now at 0px (matches Workspace's GroupRow chevron at 0px).

Fixes beads remote-dev-mpsm.

## Test plan
- [ ] Open the sidebar — GLOBAL chevron and Workspace chevron align horizontally at the very left.
- [ ] GLOBAL globe icon and Workspace folder icon align horizontally.
- [ ] Ports row icon under GLOBAL aligns with the briefcase icon on isaac-usage-menubar (depth=1 project under Workspace).
- [ ] Sessions under projects keep their existing offset (no visual change there).
- [ ] `bun run typecheck` clean.
- [ ] `bun run lint` clean.

This pull request and its description were written by Isaac.