### PR TITLE
fix(terminal): mobile swipe sends mouse-wheel reports to TUI apps (GH#178 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,18 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Mobile web terminal: swipe now scrolls in TUI apps like Claude Code, vim,
-  less** (GH#178, remote-dev-61c1, follow-up to PR #209): the synthetic
-  `WheelEvent` approach shipped in PR #209 didn't actually scroll inside
-  alt-screen TUIs because xterm v6's `CoreBrowserTerminal.ts:818-820`
-  collapses every wheel event to a single `ESC[A`/`ESC[B`, and
-  `consumeWheelEvent` rate-limits small per-frame deltas to zero. Touch
-  handler now bypasses xterm's wheel pipeline entirely. Two paths gated on
-  the live buffer state: normal buffer (shell with scrollback) calls
-  `terminal.scrollLines(±N)` directly per cell-height of finger travel; alt
-  buffer (Claude Code, vim, less, htop) emits `ESC[A`/`ESC[B` (or the SS3
-  forms when `applicationCursorKeysMode` is set) per cell-height via the
-  existing input WebSocket channel. Buffer type and DECCKM are re-read on
+- **Mobile web terminal: swipe now actually scrolls Claude Code / vim / less
+  / lazygit chat history** (GH#178, remote-dev-61c1, follow-up to PR #210):
+  PR #210 sent arrow keys (`ESC[A`/`ESC[B`) to alt-buffer apps, which TUIs
+  with mouse-wheel reporting interpret as cursor movement, not scroll —
+  visible regression in Claude Code, vim with `mouse=a`, less -m, lazygit,
+  tmux mouse mode. Fixed by detecting `terminal.modes.mouseTrackingMode` and
+  routing accordingly: when the app negotiated wheel reporting (vt200, drag,
+  any), emit SGR mouse-wheel reports (`CSI < 64;1;1 M` back, `CSI < 65;1;1
+  M` forward) per cell-height of finger travel — the same bytes desktop
+  wheel produces. Falls through to scrollback (normal buffer) or arrow
+  keys (alt buffer with no mouse mode, rare) when the app doesn't accept
+  wheel reports. Buffer type, mouse mode, and DECCKM are re-read on
   every flush so DECSET 1049 transitions and vim mode toggles mid-swipe
   behave correctly. (Earlier PR #209 also fixed the latent "Latest" pill
   always-hidden bug and the wrong-element cell-height read; those remain.)

--- a/src/components/terminal/Terminal.touch-scroll.test.ts
+++ b/src/components/terminal/Terminal.touch-scroll.test.ts
@@ -17,11 +17,16 @@ import { createTouchScrollHandlers, TOUCH_SCROLL_ACTIVATION_PX } from "./touch-s
 const CELL_HEIGHT = 16;
 const ROWS = 24;
 
+type MouseTrackingMode = "none" | "x10" | "vt200" | "drag" | "any";
+
 interface XtermStub {
   rows: number;
   scrollLines: (n: number) => void;
   buffer: { active: { type: "normal" | "alternate" } };
-  modes: { applicationCursorKeysMode: boolean };
+  modes: {
+    applicationCursorKeysMode: boolean;
+    mouseTrackingMode: MouseTrackingMode;
+  };
 }
 
 interface Harness {
@@ -33,6 +38,7 @@ interface Harness {
   feedTouchSequence: (yPositions: number[]) => void;
   setBufferType: (t: "normal" | "alternate") => void;
   setApplicationCursorKeys: (v: boolean) => void;
+  setMouseTrackingMode: (m: MouseTrackingMode) => void;
 }
 
 function makeHarness(opts: { withScrollEl?: boolean; bufferType?: "normal" | "alternate" } = {}): Harness {
@@ -56,7 +62,7 @@ function makeHarness(opts: { withScrollEl?: boolean; bufferType?: "normal" | "al
     rows: ROWS,
     scrollLines: (n: number) => scrollLinesCalls.push(n),
     buffer: { active: { type: bufferType } },
-    modes: { applicationCursorKeysMode: false },
+    modes: { applicationCursorKeysMode: false, mouseTrackingMode: "none" },
   };
 
   let nowValue = 0;
@@ -92,6 +98,9 @@ function makeHarness(opts: { withScrollEl?: boolean; bufferType?: "normal" | "al
     },
     setApplicationCursorKeys: (v) => {
       xterm.modes.applicationCursorKeysMode = v;
+    },
+    setMouseTrackingMode: (m) => {
+      xterm.modes.mouseTrackingMode = m;
     },
     feedTouchSequence: (yPositions: number[]) => {
       if (yPositions.length === 0) return;
@@ -148,7 +157,49 @@ describe("touch-scroll: normal buffer (scrollback)", () => {
   });
 });
 
-describe("touch-scroll: alt buffer (TUI apps)", () => {
+describe("touch-scroll: app has mouse-wheel reporting (Claude Code, vim with mouse, less -m, lazygit)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  for (const mode of ["vt200", "drag", "any"] as const) {
+    it(`(${mode}) emits SGR wheel-DOWN report (CSI < 65;1;1 M) per cell when finger swipes up (forward)`, () => {
+      const h = makeHarness({ bufferType: "alternate" });
+      h.setMouseTrackingMode(mode);
+      h.feedTouchSequence([500, 480, 460, 440, 420, 400]);
+      expect(h.scrollLinesCalls).toEqual([]);
+      expect(h.inputBytes.join("")).toBe("\x1b[<65;1;1M".repeat(6));
+    });
+
+    it(`(${mode}) emits SGR wheel-UP report (CSI < 64;1;1 M) per cell when finger swipes down (back)`, () => {
+      const h = makeHarness({ bufferType: "alternate" });
+      h.setMouseTrackingMode(mode);
+      h.feedTouchSequence([100, 120, 140, 160, 180, 200]);
+      expect(h.inputBytes.join("")).toBe("\x1b[<64;1;1M".repeat(6));
+    });
+  }
+
+  it("(x10) does NOT use the wheel-report path — falls through to scrollback / arrow keys", () => {
+    const h = makeHarness({ bufferType: "alternate" });
+    h.setMouseTrackingMode("x10");
+    h.feedTouchSequence([500, 480, 460, 440, 420, 400]);
+    // x10 doesn't carry wheel events, so we fall through to the alt-buffer
+    // arrow-key path.
+    expect(h.inputBytes.join("")).toBe("\x1b[B".repeat(6));
+  });
+
+  it("wheel-report path takes precedence over buffer type (mouse mode in normal buffer)", () => {
+    const h = makeHarness({ bufferType: "normal" });
+    h.setMouseTrackingMode("vt200");
+    h.feedTouchSequence([500, 480, 460, 440, 420, 400]);
+    // The app is the source of truth — we forward the wheel even though we
+    // *could* scroll xterm's scrollback.
+    expect(h.scrollLinesCalls).toEqual([]);
+    expect(h.inputBytes.join("")).toBe("\x1b[<65;1;1M".repeat(6));
+  });
+});
+
+describe("touch-scroll: alt buffer fallback (no mouse reporting)", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
   });
@@ -157,33 +208,28 @@ describe("touch-scroll: alt buffer (TUI apps)", () => {
     const h = makeHarness({ bufferType: "alternate" });
     h.feedTouchSequence([500, 480, 460, 440, 420, 400]);
     expect(h.scrollLinesCalls).toEqual([]);
-    const joined = h.inputBytes.join("");
-    expect(joined).toBe("\x1b[B".repeat(6));
+    expect(h.inputBytes.join("")).toBe("\x1b[B".repeat(6));
   });
 
   it("emits ESC[A per cell-height when finger swipes down (older)", () => {
     const h = makeHarness({ bufferType: "alternate" });
     h.feedTouchSequence([100, 120, 140, 160, 180, 200]);
-    const joined = h.inputBytes.join("");
-    expect(joined).toBe("\x1b[A".repeat(6));
+    expect(h.inputBytes.join("")).toBe("\x1b[A".repeat(6));
   });
 
   it("uses ESC O A / ESC O B (SS3) when applicationCursorKeysMode is on", () => {
     const h = makeHarness({ bufferType: "alternate" });
     h.setApplicationCursorKeys(true);
     h.feedTouchSequence([500, 480, 460, 440, 420, 400]);
-    const joined = h.inputBytes.join("");
-    expect(joined).toBe("\x1bOB".repeat(6));
+    expect(h.inputBytes.join("")).toBe("\x1bOB".repeat(6));
   });
 
   it("re-reads buffer type per flush (DECSET 1049 mid-gesture switches paths)", () => {
     const h = makeHarness({ bufferType: "normal" });
-    // First gesture in normal buffer: ~40 px upward = 2 cells of scrollback.
     h.feedTouchSequence([500, 480, 460]);
     expect(h.scrollLinesCalls.reduce((a, b) => a + b, 0)).toBe(2);
     expect(h.inputBytes).toEqual([]);
 
-    // App enters alt screen between gestures.
     h.setBufferType("alternate");
     h.feedTouchSequence([460, 440, 420]);
     expect(h.inputBytes.join("")).toBe("\x1b[B\x1b[B");

--- a/src/components/terminal/touch-scroll.ts
+++ b/src/components/terminal/touch-scroll.ts
@@ -2,26 +2,31 @@
 //
 // xterm v6 was not designed for touch (upstream confirmation:
 // https://github.com/xtermjs/xterm.js/issues/5377). Its wheel pipeline
-// collapses each WheelEvent into at most ONE up/down sequence in the
-// alt-screen path (CoreBrowserTerminal.ts:818-820: "simply send a single
-// up or down sequence"). Synthetic 60Hz WheelEvent dispatch therefore
-// produces ~5–7 arrow keys for a full thumb swipe regardless of deltaY
-// magnitude — looks broken in TUIs like Claude Code, vim, less.
+// collapses each WheelEvent into at most ONE wheel/up/down event regardless
+// of magnitude. Synthetic 60Hz WheelEvent dispatch therefore looks broken.
 //
-// We bypass xterm's wheel pipeline entirely. Two paths gated on the live
-// buffer state:
+// We bypass xterm's wheel pipeline and choose the right path per flush
+// based on what the running app actually negotiated:
 //
-//   1. Normal buffer (shell at prompt with scrollback): call
-//      terminal.scrollLines(±N) directly for each cell-height of
-//      accumulated finger travel.
+//   1. App enabled mouse-wheel reporting (mouseTrackingMode is
+//      vt200/drag/any — Claude Code, vim with `mouse=a`, less -m, lazygit,
+//      tmux mouse on): emit SGR mouse-wheel reports (`CSI < 64;1;1 M`
+//      back, `CSI < 65;1;1 M` forward) directly via the input WebSocket.
+//      Each report is one "wheel click" the app interprets as scroll.
+//      Modern TUIs negotiate SGR encoding (DECSET 1006) alongside
+//      tracking; SGR is what we send.
 //
-//   2. Alt buffer (Claude Code, vim, less, htop): emit ESC[A / ESC[B
-//      (or ESC O A / ESC O B when DECCKM is set) per cell-height directly
-//      via the existing input WebSocket channel — same bytes the keyboard
-//      already sends.
+//   2. Normal buffer with scrollback, no mouse reporting (shell at
+//      prompt): call terminal.scrollLines(±N) directly. App doesn't see
+//      the gesture; xterm's scrollback moves under the user.
 //
-// Buffer type and DECCKM are read on every flush (not cached at gesture
-// start) so DECSET 1049 transitions and vim mode toggles mid-swipe behave
+//   3. Alt buffer, no mouse reporting (rare — vim with `mouse=`, htop
+//      without mouse): emit ESC[A / ESC[B (or ESC O A / ESC O B under
+//      DECCKM) per cell. Mirrors what xterm's own outer wheel listener
+//      (CoreBrowserTerminal.ts:838) does for desktop wheel in this state.
+//
+// Buffer type, mouse-tracking mode, and DECCKM are re-read on every
+// flush so DECSET 1049 / mouse-mode / vim mode toggles mid-swipe behave
 // correctly.
 
 // Pixel slop a single-touch swipe must exceed before we treat it as a scroll
@@ -39,7 +44,10 @@ export interface XTermSlice {
   readonly rows: number;
   scrollLines(amount: number): void;
   readonly buffer: { readonly active: { readonly type: "normal" | "alternate" } };
-  readonly modes: { readonly applicationCursorKeysMode: boolean };
+  readonly modes: {
+    readonly applicationCursorKeysMode: boolean;
+    readonly mouseTrackingMode: "none" | "x10" | "vt200" | "drag" | "any";
+  };
 }
 
 export interface TouchScrollDeps {
@@ -114,26 +122,41 @@ export function createTouchScrollHandlers(deps: TouchScrollDeps): TouchScrollHan
     if (lines === 0) return;
     accumPx -= lines * cellHeight;
 
-    const buf = xterm.buffer.active;
-    if (buf.type === "normal") {
-      // Scrollback: positive lines = view moves down through buffer = newer
-      // content; negative = older. xterm's scrollLines(N) uses the same sign.
+    // Sign convention (consistent across all three paths below):
+    //   accumPx > 0  → finger moved up overall → user wants newer content
+    //                  → forward (wheel-down / ESC[B / scrollLines(+N))
+    //   accumPx < 0  → finger moved down → user wants older content
+    //                  → back (wheel-up / ESC[A / scrollLines(-N))
+    const forward = lines > 0;
+    const count = Math.abs(lines);
+
+    // Path 1 — app accepts mouse-wheel reports. We emit one SGR wheel report
+    // per line of finger travel; the app handles internal scroll itself
+    // (Claude Code chat history, vim with mouse, less, lazygit, tmux mouse).
+    const tracking = xterm.modes.mouseTrackingMode;
+    if (tracking === "vt200" || tracking === "drag" || tracking === "any") {
+      // SGR mouse-wheel: ESC[<{code};{col};{row}M
+      // code = 64 (WHEEL bit) | action (0=UP/back, 1=DOWN/forward).
+      // (col, row) = (1, 1) — apps that scroll on wheel don't gate on coords.
+      const code = forward ? 65 : 64;
+      sendInput(`\x1b[<${code};1;1M`.repeat(count));
+      return;
+    }
+
+    // Path 2 — normal buffer, no mouse reporting: move xterm scrollback.
+    if (xterm.buffer.active.type === "normal") {
       xterm.scrollLines(lines);
       return;
     }
 
-    // Alt buffer: emit |lines| arrow keys. Sign maps swipe direction to the
-    // user's expectation:
-    //   accumPx > 0  → finger moved up overall → user wants to advance
-    //                  (newer / down-arrow / ESC[B)
-    //   accumPx < 0  → finger moved down → user wants to go back
-    //                  (older / up-arrow / ESC[A)
-    // DECCKM (applicationCursorKeysMode) swaps CSI for SS3.
+    // Path 3 — alt buffer, no mouse reporting (rare). Mirror xterm's own
+    // outer wheel listener at CoreBrowserTerminal.ts:838: emit one arrow
+    // key per line. DECCKM (applicationCursorKeysMode) swaps CSI for SS3.
     const appCursor = xterm.modes.applicationCursorKeysMode;
-    const seq = lines > 0
+    const seq = forward
       ? (appCursor ? "\x1bOB" : "\x1b[B")
       : (appCursor ? "\x1bOA" : "\x1b[A");
-    sendInput(seq.repeat(Math.abs(lines)));
+    sendInput(seq.repeat(count));
   };
 
   const cancelMomentum = (): void => {


### PR DESCRIPTION
## Summary

Follow-up to PR #210. PR #210 sent `ESC[A`/`ESC[B` (arrow keys) to alt-buffer apps. TUIs with mouse-wheel reporting interpret arrow keys as cursor movement, not scroll — visible regression in Claude Code, vim with `mouse=a`, less -m, lazygit, tmux mouse mode. User report: "It's sending up and down events to the TUI instead of actual scroll."

## Root cause (re-traced again)

Desktop wheel works in Claude Code because xterm's wheel handler at `CoreBrowserTerminal.ts:751–757` (the dynamically-attached `eventListeners.wheel`) routes wheel events to `coreMouseService.triggerMouseEvent` → SGR mouse-wheel report → app's own scroll handler.

I had assumed earlier that the alt-buffer arrow-key path (`:806–842`) was what apps wanted. It is — but only when the app has NOT enabled mouse-wheel reporting. When it has (Claude Code does), `requestedEvents.wheel` is set, the outer listener returns early, and the `eventListeners.wheel` mouse-report listener takes over. Sending arrow keys to a mouse-mode-aware app does the wrong thing.

## Fix

Touch handler now reads `terminal.modes.mouseTrackingMode` per flush:

- **`vt200` / `drag` / `any`**: emit one SGR mouse-wheel report per cell-height of finger travel directly via the input WebSocket — `CSI < 64;1;1 M` (back) for finger-down, `CSI < 65;1;1 M` (forward) for finger-up. Modern TUIs negotiate SGR encoding (DECSET 1006) alongside tracking; SGR is what we send. Apps interpret as scroll, exactly like desktop wheel.
- **otherwise + normal buffer**: `terminal.scrollLines(±N)` for xterm's own scrollback.
- **otherwise + alt buffer**: `ESC[A`/`ESC[B` (or SS3 under DECCKM) — mirrors xterm's own outer-wheel-listener fallback at `CoreBrowserTerminal.ts:838`.

Buffer type, mouse mode, and DECCKM are re-read on every flush so DECSET 1049 / mouse-mode toggles / vim mode changes mid-swipe behave correctly. Sign convention unchanged: finger-up = forward; finger-down = back.

## Why this is the right primitive

When you scroll Claude Code on desktop with a mouse wheel, here's exactly what happens:
1. Browser dispatches `WheelEvent` on `.xterm`.
2. xterm's `eventListeners.wheel` (`CoreBrowserTerminal.ts:710–713`) fires.
3. `sendEvent(ev)` → `coreMouseService.triggerMouseEvent({ button: WHEEL, action: deltaY < 0 ? UP : DOWN, ... })`.
4. CoreMouseService SGR encoder (`CoreMouseService.ts:143–146`) emits `\x1b[<{64|action};{col};{row}M`.
5. Bytes flow to Claude Code via the PTY; Claude Code interprets and scrolls.

Our fix bypasses steps 1-4 and emits step 5 bytes directly. Step 4 is the only stage that would have varied (DEFAULT vs SGR encoding), and modern TUIs use SGR.

## Tests

`Terminal.touch-scroll.test.ts` rewritten — 18 tests covering:
- All three mouse-wheel-reporting modes (`vt200`, `drag`, `any`) emit correct SGR bytes for both swipe directions.
- `x10` (no wheel events) falls through to alt-buffer arrow keys.
- Wheel-report mode takes precedence over buffer type — mouse-mode-on apps own scrolling regardless of normal vs alt buffer.
- Normal-buffer scrollback path (PR #210 behavior preserved when no mouse mode).
- Alt-buffer arrow-key fallback (rare — apps without mouse mode).
- DECCKM SS3 forms.
- Mid-gesture buffer-type switch.
- Activation threshold + sub-cell residue carry.
- Multi-touch bailout.

`bun run lint` clean. `bun run typecheck` clean. `bun run test:run`: 820 passed / 1 skipped.

## Test plan

- [ ] iOS Safari: open Claude Code, swipe up/down — chat history scrolls.
- [ ] iOS Safari: open vim, run `:set mouse=a`, swipe — vim's view scrolls.
- [ ] iOS Safari: open `less file`, swipe — less scrolls (it negotiates mouse).
- [ ] Plain shell prompt: swipe — xterm scrollback moves (regression).
- [ ] vim with `:set mouse=` (off): swipe — emits arrow keys to vim (vim's normal mode scrolls cursor; expected).
- [ ] Pinch-zoom unaffected.
- [ ] Desktop wheel/trackpad behavior unchanged.

This pull request and its description were written by Isaac.