### PR TITLE
chore: release v0.3.7 (pre-mobile-redesign baseline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-04-30
+
+Pre-mobile-redesign baseline. Captures all changes since v0.3.6 as a rollback
+point ahead of the gesture-first PWA redesign.
+
 ### Removed
 
 - **Legacy `IssueDetailModal` dialog**: The Dialog-based issue detail view is

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-dev",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Web-based terminal interface with persistent tmux sessions and GitHub integration",
   "author": "Remote Dev Team",
   "private": true,


### PR DESCRIPTION
## Summary

- Cuts v0.3.7 as a versioned baseline before the upcoming gesture-first PWA mobile redesign.
- Bumps `package.json` from 0.3.6 to 0.3.7 and converts the `[Unreleased]` CHANGELOG section into a dated `[0.3.7] - 2026-04-30` heading with a one-line note explaining the baseline intent. A fresh empty `[Unreleased]` section sits above it for the redesign work.
- Companion to the lightweight `pre-mobile-redesign` annotated tag already pushed at the previous HEAD (`823e5ab`). Either tag works as a rollback point; this PR adds the formal version tag.

After merge: tag the merge commit as `v0.3.7` and push.

## Test plan

- [ ] CI passes (typecheck, lint, vitest)
- [ ] Verify CHANGELOG.md renders cleanly on the GitHub release page after tagging
- [ ] Confirm `bun run dev` starts and the version footer (if any) reads 0.3.7
- [ ] Sanity check that `git checkout pre-mobile-redesign` and `git checkout v0.3.7` (post-merge tag) both produce a runnable build

This pull request and its description were written by Isaac.