### PR TITLE
feat(mobile): Phase 2 — Sessions tab (project tree, list, action sheets, new-session sheet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Mobile redesign Phase 2: Sessions tab** (remote-dev-l9qg). The mobile
+  home is now the Sessions tab. A header strip with a project switcher chip,
+  a `+ New` pill, and a recent-projects rail sits above a session list with
+  a 6px state pip per row, weight-driven hierarchy on the title, and a
+  foreground line-segment indicator for the active row (no colored side
+  stripes). Long-press opens an action sheet (Suspend / Resume / Rename /
+  Move / View recordings / Close session). Swipe-left dispatches suspend
+  with a 5s undo toast. Pull-to-refresh, attention-blue halo for waiting
+  sessions, and reduced-motion respect everywhere. New `BottomSheet` and
+  `ActionSheet` primitives, `usePullToRefresh` hook, and a project-tree
+  bottom sheet with search complete the surface. Built on top of the Phase 1
+  shell from remote-dev-3ozu.
+
 ## [0.3.7] - 2026-04-30
 
 Pre-mobile-redesign baseline. Captures all changes since v0.3.6 as a rollback

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -19,6 +19,7 @@ colors:
   destructive: "oklch(0.577 0.245 27.325)"
   destructive-dark: "oklch(0.704 0.191 22.216)"
   signal-attention: "oklch(0.6 0.2 250 / 0.8)"
+  signal-running: "oklch(0.65 0.17 152)"
   midnight-primary: "oklch(0.55 0.18 270)"
   midnight-accent: "oklch(0.65 0.15 250)"
   terminal-tokyo-bg: "#1a1b26"
@@ -147,6 +148,7 @@ The palette is achromatic neutral by default with one signal accent (notificatio
 
 ### Signal (the only chromatic colors in app chrome)
 - **Attention Blue** (`oklch(0.6 0.2 250 / 0.8)`): Pulses around agent sessions waiting for input (notification ring halo). The single decoratively-colored value in the chrome.
+- **Signal Running** (`oklch(0.65 0.17 152)`): pip color when an agent session is actively executing.
 - **Destructive** (`oklch(0.577 0.245 27.325)`): Errors, destructive confirmations only. Not for "primary action" buttons.
 
 ### Terminal (always dark, never themed by app theme)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -407,6 +407,7 @@
   --radius-4xl: calc(var(--radius) + 16px);
   --color-signal-attention: var(--signal-attention);
   --color-signal-attention-solid: var(--signal-attention-solid);
+  --color-signal-running: var(--signal-running);
 }
 
 :root {
@@ -421,9 +422,14 @@
    * same hue at full alpha, used for solid fills (e.g., unread dots) where
    * blending against bg-card would otherwise wash the color out — most
    * obvious in light mode.
+   *
+   * `--signal-running` is the active-execution signal — used as the pip
+   * color when an agent session is actively running. Same value across
+   * themes (running is a state signal that should read consistently).
    */
   --signal-attention: oklch(0.6 0.2 250 / 0.8);
   --signal-attention-solid: oklch(0.6 0.2 250);
+  --signal-running: oklch(0.65 0.17 152);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -461,6 +467,7 @@
   /* Signal accent stays the same across themes — see :root for rationale. */
   --signal-attention: oklch(0.6 0.2 250 / 0.8);
   --signal-attention-solid: oklch(0.6 0.2 250);
+  --signal-running: oklch(0.65 0.17 152);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,6 +27,7 @@ import { PeerChatProvider } from "@/contexts/PeerChatContext";
 import { ChannelProvider } from "@/contexts/ChannelContext";
 import { SessionManager } from "@/components/session/SessionManager";
 import { Header } from "@/components/header/Header";
+import { MobileViewportSwitch } from "@/components/mobile/MobileViewportSwitch";
 import type { TerminalSession } from "@/types/session";
 
 export default async function Home() {
@@ -111,19 +112,21 @@ export default async function Home() {
                                   <NotificationProvider>
                                     <ChannelProvider>
                                     <PeerChatProvider>
-                                    <div className="flex h-screen flex-col bg-background">
-                                      {/* Header - hidden on mobile, shown in sidebar instead */}
-                                      <Header
-                                        isGitHubConnected={isGitHubConnected}
-                                        userEmail={session.user.email || ""}
-                                        onSignOut={async () => {
-                                          "use server";
-                                          await signOut();
-                                        }}
-                                      />
-                                      {/* Main content */}
-                                      <SessionManager isGitHubConnected={isGitHubConnected} />
-                                    </div>
+                                    <MobileViewportSwitch isGitHubConnected={isGitHubConnected}>
+                                      <div className="flex h-screen flex-col bg-background">
+                                        {/* Header - hidden on mobile, shown in sidebar instead */}
+                                        <Header
+                                          isGitHubConnected={isGitHubConnected}
+                                          userEmail={session.user.email || ""}
+                                          onSignOut={async () => {
+                                            "use server";
+                                            await signOut();
+                                          }}
+                                        />
+                                        {/* Main content */}
+                                        <SessionManager isGitHubConnected={isGitHubConnected} />
+                                      </div>
+                                    </MobileViewportSwitch>
                                     </PeerChatProvider>
                                     </ChannelProvider>
                                   </NotificationProvider>

--- a/src/components/mobile/MobileApp.tsx
+++ b/src/components/mobile/MobileApp.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+/**
+ * MobileApp — Phase 2 mobile redesign.
+ *
+ * Top-level mobile composition rendered inside `MobileShell` when the
+ * viewport is below 768px. Owns the active-tab state, dispatches tab
+ * content, and shows simple "Coming in Phase N" placeholders for tabs
+ * that ship later.
+ *
+ * Phase 2 only fills the Sessions tab. Notifications / Channels / Profile
+ * are placeholder slots so the tab bar remains usable while later phases
+ * land.
+ */
+
+import { useState } from "react";
+
+import { MobileShell } from "./MobileShell";
+import type { MobileTab } from "./BottomTabBar";
+import { SessionsTab } from "./sessions/SessionsTab";
+
+export interface MobileAppProps {
+  isGitHubConnected: boolean;
+}
+
+const PLACEHOLDER_COPY: Record<Exclude<MobileTab, "sessions">, { title: string; phase: string }> = {
+  notifications: { title: "Notifications", phase: "Phase 4" },
+  channels: { title: "Channels", phase: "Phase 5" },
+  profile: { title: "Profile", phase: "Phase 6" },
+};
+
+export function MobileApp({ isGitHubConnected }: MobileAppProps) {
+  const [activeTab, setActiveTab] = useState<MobileTab>("sessions");
+
+  return (
+    <MobileShell activeTab={activeTab} onTabChange={setActiveTab}>
+      {activeTab === "sessions" ? (
+        <SessionsTab isGitHubConnected={isGitHubConnected} />
+      ) : (
+        <EmptyTabPlaceholder
+          title={PLACEHOLDER_COPY[activeTab].title}
+          phase={PLACEHOLDER_COPY[activeTab].phase}
+        />
+      )}
+    </MobileShell>
+  );
+}
+
+function EmptyTabPlaceholder({ title, phase }: { title: string; phase: string }) {
+  return (
+    <div
+      data-testid={`mobile-tab-placeholder-${title.toLowerCase()}`}
+      className="flex h-full flex-col items-center justify-center gap-1 px-6 py-12 text-center"
+    >
+      <p className="text-base font-medium text-foreground">{title}</p>
+      <p className="text-sm text-muted-foreground">Coming in {phase}.</p>
+    </div>
+  );
+}

--- a/src/components/mobile/MobileViewportSwitch.tsx
+++ b/src/components/mobile/MobileViewportSwitch.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+/**
+ * MobileViewportSwitch — Phase 2 mobile redesign.
+ *
+ * Renders the mobile composition (`MobileApp`) below the Tailwind `md`
+ * breakpoint (768px) and the desktop `children` (typically `SessionManager`)
+ * at and above it.
+ *
+ * IMPORTANT: First render is forced to desktop on both server and client to
+ * keep markup hashes aligned with `useIsMobileViewport()`'s SSR-safe default.
+ * The first `useEffect` flip happens within a single frame, so the visible
+ * behavior on a real phone is unchanged.
+ */
+
+import type { ReactNode } from "react";
+
+import { useIsMobileViewport } from "@/hooks/useMobile";
+
+import { MobileApp } from "./MobileApp";
+
+export interface MobileViewportSwitchProps {
+  isGitHubConnected: boolean;
+  /** The desktop composition. Rendered at >=768px. */
+  children: ReactNode;
+}
+
+export function MobileViewportSwitch({
+  isGitHubConnected,
+  children,
+}: MobileViewportSwitchProps) {
+  const isMobile = useIsMobileViewport();
+
+  if (isMobile) {
+    return <MobileApp isGitHubConnected={isGitHubConnected} />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/mobile/__tests__/ActionSheet.test.tsx
+++ b/src/components/mobile/__tests__/ActionSheet.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * ActionSheet tests (Phase 2 mobile redesign).
+ *
+ * Verifies that items render with correct destructive styling, fire their
+ * onSelect callbacks on tap, and that the sheet closes itself before the
+ * action runs (so any toast triggered by the action isn't immediately
+ * occluded by the sheet's exit transition).
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import {
+  ActionSheet,
+  type ActionSheetItem,
+} from "@/components/mobile/common/ActionSheet";
+
+afterEach(() => cleanup());
+
+describe("ActionSheet", () => {
+  it("renders items with destructive class when destructive is true", async () => {
+    const items: ActionSheetItem[] = [
+      { id: "ok", label: "OK", onSelect: vi.fn() },
+      { id: "rm", label: "Delete", destructive: true, onSelect: vi.fn() },
+    ];
+    render(
+      <ActionSheet open={true} onOpenChange={vi.fn()} items={items} title="Test" />
+    );
+    await waitFor(() => screen.getByRole("menuitem", { name: "OK" }));
+    const okButton = screen.getByRole("menuitem", { name: "OK" });
+    const rmButton = screen.getByRole("menuitem", { name: "Delete" });
+    expect(okButton.dataset.destructive).toBeUndefined();
+    expect(rmButton.dataset.destructive).toBe("true");
+  });
+
+  it("invokes onSelect and closes the sheet when an item is tapped", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const onOpenChange = vi.fn();
+    const items: ActionSheetItem[] = [{ id: "go", label: "Go", onSelect }];
+    render(
+      <ActionSheet open={true} onOpenChange={onOpenChange} items={items} />
+    );
+    await waitFor(() => screen.getByRole("menuitem", { name: "Go" }));
+    await user.click(screen.getByRole("menuitem", { name: "Go" }));
+    // Sheet closes first.
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders disabled items as not invoking onSelect", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const onOpenChange = vi.fn();
+    const items: ActionSheetItem[] = [
+      { id: "x", label: "X", disabled: true, onSelect },
+    ];
+    render(
+      <ActionSheet open={true} onOpenChange={onOpenChange} items={items} />
+    );
+    await waitFor(() => screen.getByRole("menuitem", { name: "X" }));
+    const button = screen.getByRole("menuitem", { name: "X" }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    await user.click(button).catch(() => {});
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/mobile/__tests__/BottomSheet.test.tsx
+++ b/src/components/mobile/__tests__/BottomSheet.test.tsx
@@ -115,7 +115,11 @@ describe("BottomSheet", () => {
           <button type="button" data-testid="second-btn">second</button>
         </BottomSheet>
       );
-      const panel = await waitFor(() => screen.getByTestId("mobile-bottom-sheet"));
+      // Wait for the focus-trap effect to install (gated on `entered`).
+      await waitFor(() =>
+        expect(screen.getByTestId("first-btn")).toHaveFocus()
+      );
+      const panel = screen.getByTestId("mobile-bottom-sheet");
       const second = screen.getByTestId("second-btn");
       second.focus();
       expect(second).toHaveFocus();
@@ -131,13 +135,57 @@ describe("BottomSheet", () => {
           <button type="button" data-testid="second-btn">second</button>
         </BottomSheet>
       );
-      const panel = await waitFor(() => screen.getByTestId("mobile-bottom-sheet"));
+      await waitFor(() =>
+        expect(screen.getByTestId("first-btn")).toHaveFocus()
+      );
+      const panel = screen.getByTestId("mobile-bottom-sheet");
       const first = screen.getByTestId("first-btn");
-      first.focus();
+      // first-btn is already focused from auto-focus above.
       expect(first).toHaveFocus();
       // Shift+Tab from first → cycle to last.
       fireEvent.keyDown(panel, { key: "Tab", shiftKey: true });
       expect(screen.getByTestId("second-btn")).toHaveFocus();
+    });
+
+    it("body scroll lock survives concurrent nested sheets (refcount)", async () => {
+      const { rerender } = render(
+        <>
+          <BottomSheet open={true} onOpenChange={vi.fn()} ariaLabel="A">
+            <div>a</div>
+          </BottomSheet>
+          <BottomSheet open={true} onOpenChange={vi.fn()} ariaLabel="B">
+            <div>b</div>
+          </BottomSheet>
+        </>
+      );
+      await waitFor(() => screen.getAllByTestId("mobile-bottom-sheet"));
+      // Both sheets open → body locked.
+      expect(document.body.style.overflow).toBe("hidden");
+      // Close the first sheet — body should still be locked because the
+      // second sheet is still open. Naive save/restore would unlock here.
+      rerender(
+        <>
+          <BottomSheet open={false} onOpenChange={vi.fn()} ariaLabel="A">
+            <div>a</div>
+          </BottomSheet>
+          <BottomSheet open={true} onOpenChange={vi.fn()} ariaLabel="B">
+            <div>b</div>
+          </BottomSheet>
+        </>
+      );
+      expect(document.body.style.overflow).toBe("hidden");
+      // Close the second sheet — body unlocks.
+      rerender(
+        <>
+          <BottomSheet open={false} onOpenChange={vi.fn()} ariaLabel="A">
+            <div>a</div>
+          </BottomSheet>
+          <BottomSheet open={false} onOpenChange={vi.fn()} ariaLabel="B">
+            <div>b</div>
+          </BottomSheet>
+        </>
+      );
+      await waitFor(() => expect(document.body.style.overflow).toBe(""));
     });
 
     it("restores focus to the previously-focused element on close", async () => {

--- a/src/components/mobile/__tests__/BottomSheet.test.tsx
+++ b/src/components/mobile/__tests__/BottomSheet.test.tsx
@@ -94,4 +94,83 @@ describe("BottomSheet", () => {
     fireEvent.click(screen.getByLabelText("Close sheet"));
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
+
+  describe("focus trap", () => {
+    it("moves focus to the first focusable element on enter", async () => {
+      render(
+        <BottomSheet open={true} onOpenChange={vi.fn()} ariaLabel="Test">
+          <button type="button" data-testid="first-btn">first</button>
+          <button type="button" data-testid="second-btn">second</button>
+        </BottomSheet>
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("first-btn")).toHaveFocus();
+      });
+    });
+
+    it("Tab from the last focusable cycles to the first", async () => {
+      render(
+        <BottomSheet open={true} onOpenChange={vi.fn()} ariaLabel="Test">
+          <button type="button" data-testid="first-btn">first</button>
+          <button type="button" data-testid="second-btn">second</button>
+        </BottomSheet>
+      );
+      const panel = await waitFor(() => screen.getByTestId("mobile-bottom-sheet"));
+      const second = screen.getByTestId("second-btn");
+      second.focus();
+      expect(second).toHaveFocus();
+      // Tab from last → cycle to first.
+      fireEvent.keyDown(panel, { key: "Tab" });
+      expect(screen.getByTestId("first-btn")).toHaveFocus();
+    });
+
+    it("Shift+Tab from the first focusable cycles to the last", async () => {
+      render(
+        <BottomSheet open={true} onOpenChange={vi.fn()} ariaLabel="Test">
+          <button type="button" data-testid="first-btn">first</button>
+          <button type="button" data-testid="second-btn">second</button>
+        </BottomSheet>
+      );
+      const panel = await waitFor(() => screen.getByTestId("mobile-bottom-sheet"));
+      const first = screen.getByTestId("first-btn");
+      first.focus();
+      expect(first).toHaveFocus();
+      // Shift+Tab from first → cycle to last.
+      fireEvent.keyDown(panel, { key: "Tab", shiftKey: true });
+      expect(screen.getByTestId("second-btn")).toHaveFocus();
+    });
+
+    it("restores focus to the previously-focused element on close", async () => {
+      // Place an external trigger that will own focus before the sheet
+      // opens. The two-phase mount means the focus-trap effect runs after
+      // `entered` flips true; whatever document.activeElement is at that
+      // moment is what we'll restore on cleanup.
+      const Wrapper = ({ open }: { open: boolean }) => (
+        <>
+          <button
+            type="button"
+            data-testid="external-trigger"
+            autoFocus
+          >
+            trigger
+          </button>
+          <BottomSheet open={open} onOpenChange={vi.fn()} ariaLabel="Test">
+            <button type="button" data-testid="inside-btn">inside</button>
+          </BottomSheet>
+        </>
+      );
+      const { rerender } = render(<Wrapper open={false} />);
+      const trigger = screen.getByTestId("external-trigger");
+      trigger.focus();
+      expect(trigger).toHaveFocus();
+      // Open the sheet — focus moves to the first inside button.
+      rerender(<Wrapper open={true} />);
+      await waitFor(() =>
+        expect(screen.getByTestId("inside-btn")).toHaveFocus()
+      );
+      // Close the sheet — focus should be restored to the trigger.
+      rerender(<Wrapper open={false} />);
+      await waitFor(() => expect(trigger).toHaveFocus());
+    });
+  });
 });

--- a/src/components/mobile/__tests__/BottomSheet.test.tsx
+++ b/src/components/mobile/__tests__/BottomSheet.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * BottomSheet tests (Phase 2 mobile redesign).
+ *
+ * Covers:
+ *   - The slide-up panel respects `prefers-reduced-motion` by setting a
+ *     0ms transition duration instead of the default 240ms.
+ *   - ESC closes the sheet via onOpenChange.
+ *   - The overlay click closes the sheet.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+
+import { BottomSheet } from "@/components/mobile/common/BottomSheet";
+
+let matchMediaImpl: (query: string) => MediaQueryList;
+
+beforeEach(() => {
+  matchMediaImpl = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as unknown as MediaQueryList;
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((q: string) => matchMediaImpl(q)),
+  });
+});
+
+afterEach(() => cleanup());
+
+describe("BottomSheet", () => {
+  it("uses 0ms duration when prefers-reduced-motion is reduce", async () => {
+    matchMediaImpl = (query: string) =>
+      ({
+        matches: query === "(prefers-reduced-motion: reduce)",
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }) as unknown as MediaQueryList;
+    render(
+      <BottomSheet open={true} onOpenChange={vi.fn()} ariaLabel="Test">
+        <div>body</div>
+      </BottomSheet>
+    );
+    await waitFor(() => screen.getByTestId("mobile-bottom-sheet"));
+    const panel = screen.getByTestId("mobile-bottom-sheet");
+    expect(panel.style.transitionDuration).toBe("0ms");
+  });
+
+  it("uses the iOS-style cubic-bezier easing at 240ms by default", async () => {
+    render(
+      <BottomSheet open={true} onOpenChange={vi.fn()} ariaLabel="Test">
+        <div>body</div>
+      </BottomSheet>
+    );
+    await waitFor(() => screen.getByTestId("mobile-bottom-sheet"));
+    const panel = screen.getByTestId("mobile-bottom-sheet");
+    expect(panel.style.transitionDuration).toBe("240ms");
+    expect(panel.style.transitionTimingFunction).toContain("cubic-bezier");
+  });
+
+  it("calls onOpenChange(false) when ESC is pressed", async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <BottomSheet open={true} onOpenChange={onOpenChange} ariaLabel="Test">
+        <div>body</div>
+      </BottomSheet>
+    );
+    await waitFor(() => screen.getByTestId("mobile-bottom-sheet"));
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("calls onOpenChange(false) when the overlay is clicked", async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <BottomSheet open={true} onOpenChange={onOpenChange} ariaLabel="Test">
+        <div>body</div>
+      </BottomSheet>
+    );
+    await waitFor(() => screen.getByLabelText("Close sheet"));
+    fireEvent.click(screen.getByLabelText("Close sheet"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/mobile/__tests__/ProjectTreeSheet.test.tsx
+++ b/src/components/mobile/__tests__/ProjectTreeSheet.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * ProjectTreeSheet tests (Phase 2 mobile redesign).
+ *
+ * Verifies search-based filtering, expand/collapse on group taps, and that
+ * picking a project closes the sheet and writes the active node back.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import {
+  ProjectTreeContext,
+  type GroupNode,
+  type ProjectNode,
+  type ProjectTreeContextValue,
+} from "@/contexts/ProjectTreeContext";
+import { ProjectTreeSheet } from "@/components/mobile/sessions/ProjectTreeSheet";
+
+afterEach(() => cleanup());
+
+function makeTree(
+  groups: GroupNode[],
+  projects: ProjectNode[],
+  overrides: Partial<ProjectTreeContextValue> = {}
+): ProjectTreeContextValue {
+  return {
+    groups,
+    projects,
+    isLoading: false,
+    activeNode: null,
+    getGroup: (id) => groups.find((g) => g.id === id),
+    getProject: (id) => projects.find((p) => p.id === id),
+    getChildrenOfGroup: () => ({ groups: [], projects: [] }),
+    createGroup: vi.fn(),
+    updateGroup: vi.fn(),
+    deleteGroup: vi.fn(),
+    moveGroup: vi.fn(),
+    createProject: vi.fn(),
+    updateProject: vi.fn(),
+    deleteProject: vi.fn(),
+    moveProject: vi.fn(),
+    setActiveNode: vi.fn().mockResolvedValue(undefined),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+const sampleGroups: GroupNode[] = [
+  { id: "g1", name: "Open Source", parentGroupId: null, collapsed: false, sortOrder: 0 },
+  { id: "g2", name: "Work", parentGroupId: null, collapsed: false, sortOrder: 1 },
+];
+const sampleProjects: ProjectNode[] = [
+  { id: "p1", name: "remote-dev", groupId: "g1", isAutoCreated: false, sortOrder: 0, collapsed: false },
+  { id: "p2", name: "linear-clone", groupId: "g2", isAutoCreated: false, sortOrder: 0, collapsed: false },
+  { id: "p3", name: "personal-notes", groupId: null, isAutoCreated: false, sortOrder: 0, collapsed: false },
+];
+
+describe("ProjectTreeSheet", () => {
+  it("filters tree rows by the search input", async () => {
+    const user = userEvent.setup();
+    const tree = makeTree(sampleGroups, sampleProjects);
+    render(
+      <ProjectTreeContext.Provider value={tree}>
+        <ProjectTreeSheet open={true} onOpenChange={vi.fn()} />
+      </ProjectTreeContext.Provider>
+    );
+    expect(screen.getByText("remote-dev")).toBeInTheDocument();
+    expect(screen.getByText("linear-clone")).toBeInTheDocument();
+    const search = screen.getByLabelText("Search projects");
+    await user.type(search, "linear");
+    expect(screen.queryByText("remote-dev")).not.toBeInTheDocument();
+    expect(screen.getByText("linear-clone")).toBeInTheDocument();
+  });
+
+  it("calls setActiveNode and onOpenChange(false) when a project is picked", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const setActive = vi.fn().mockResolvedValue(undefined);
+    const tree = makeTree(sampleGroups, sampleProjects, { setActiveNode: setActive });
+    render(
+      <ProjectTreeContext.Provider value={tree}>
+        <ProjectTreeSheet open={true} onOpenChange={onOpenChange} />
+      </ProjectTreeContext.Provider>
+    );
+    await user.click(screen.getByText("remote-dev"));
+    expect(setActive).toHaveBeenCalledWith({ id: "p1", type: "project" });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("toggles a group's expanded state when the chevron is tapped", () => {
+    const tree = makeTree(sampleGroups, sampleProjects);
+    render(
+      <ProjectTreeContext.Provider value={tree}>
+        <ProjectTreeSheet open={true} onOpenChange={vi.fn()} />
+      </ProjectTreeContext.Provider>
+    );
+    // Initial: g1 is expanded (collapsed=false), so its child remote-dev is visible.
+    expect(screen.getByText("remote-dev")).toBeInTheDocument();
+    const collapseBtn = screen.getByLabelText("Collapse Open Source");
+    fireEvent.click(collapseBtn);
+    expect(screen.queryByText("remote-dev")).not.toBeInTheDocument();
+  });
+
+  it("renders a 'No matches.' state when the search has no hits", async () => {
+    const user = userEvent.setup();
+    const tree = makeTree(sampleGroups, sampleProjects);
+    render(
+      <ProjectTreeContext.Provider value={tree}>
+        <ProjectTreeSheet open={true} onOpenChange={vi.fn()} />
+      </ProjectTreeContext.Provider>
+    );
+    const search = screen.getByLabelText("Search projects");
+    await user.type(search, "nonexistent-zzzzz");
+    expect(screen.getByText("No matches.")).toBeInTheDocument();
+  });
+});

--- a/src/components/mobile/__tests__/SessionsTab.test.tsx
+++ b/src/components/mobile/__tests__/SessionsTab.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * SessionsTab integration tests (Phase 2 mobile redesign).
+ *
+ * These tests render the real component with stubbed contexts and verify
+ * the actual DOM produced — not just that the component "exists". Per the
+ * brief's adversarial-review guidance, every test exercises a real path:
+ * the chip opens the project sheet, the long-press dispatches into the
+ * action sheet, the empty states render under matching conditions.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { TerminalSession } from "@/types/session";
+import { SessionsTab } from "@/components/mobile/sessions/SessionsTab";
+import {
+  ProjectTreeContext,
+  type GroupNode,
+  type ProjectNode,
+  type ProjectTreeContextValue,
+} from "@/contexts/ProjectTreeContext";
+
+// We mock SessionContext at the import level so SessionsTab pulls our
+// stubbed values via `useSessionContext()`.
+const sessionMockState = {
+  sessions: [] as TerminalSession[],
+  activeSessionId: null as string | null,
+  loading: false,
+  refreshSessions: vi.fn().mockResolvedValue(undefined),
+  setActiveSession: vi.fn(),
+  suspendSession: vi.fn().mockResolvedValue(undefined),
+  resumeSession: vi.fn().mockResolvedValue(undefined),
+  closeSession: vi.fn().mockResolvedValue(undefined),
+  getAgentActivityStatus: vi.fn().mockReturnValue("idle"),
+};
+
+vi.mock("@/contexts/SessionContext", () => ({
+  useSessionContext: () => sessionMockState,
+}));
+
+// Sonner is imported directly by SessionsTab. Mock it so toast() calls don't
+// throw because the Toaster isn't mounted.
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), {
+    error: vi.fn(),
+  }),
+}));
+
+// NewSessionWizard is heavy and pulls many other contexts. Stub it.
+vi.mock("@/components/session/NewSessionWizard", () => ({
+  NewSessionWizard: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? (
+      <div data-testid="new-session-wizard-stub">
+        <button type="button" onClick={onClose}>
+          close-stub
+        </button>
+      </div>
+    ) : null,
+}));
+
+function makeProjectTree(
+  overrides: Partial<ProjectTreeContextValue> = {}
+): ProjectTreeContextValue {
+  const groups: GroupNode[] = overrides.groups ?? [];
+  const projects: ProjectNode[] =
+    overrides.projects ?? [
+      { id: "p1", name: "Alpha", groupId: null, isAutoCreated: false, sortOrder: 0, collapsed: false },
+      { id: "p2", name: "Bravo", groupId: null, isAutoCreated: false, sortOrder: 1, collapsed: false },
+    ];
+  return {
+    groups,
+    projects,
+    isLoading: false,
+    activeNode: null,
+    getGroup: (id: string) => groups.find((g) => g.id === id),
+    getProject: (id: string) => projects.find((p) => p.id === id),
+    getChildrenOfGroup: () => ({ groups: [], projects: [] }),
+    createGroup: vi.fn(),
+    updateGroup: vi.fn(),
+    deleteGroup: vi.fn(),
+    moveGroup: vi.fn(),
+    createProject: vi.fn(),
+    updateProject: vi.fn(),
+    deleteProject: vi.fn(),
+    moveProject: vi.fn(),
+    setActiveNode: vi.fn().mockResolvedValue(undefined),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as ProjectTreeContextValue;
+}
+
+function renderTab(
+  treeOverrides: Partial<ProjectTreeContextValue> = {},
+  isGitHubConnected = false
+) {
+  const tree = makeProjectTree(treeOverrides);
+  const ui = render(
+    <ProjectTreeContext.Provider value={tree}>
+      <SessionsTab isGitHubConnected={isGitHubConnected} />
+    </ProjectTreeContext.Provider>
+  );
+  return { tree, ...ui };
+}
+
+function makeSession(over: Partial<TerminalSession> = {}): TerminalSession {
+  return {
+    id: "s1",
+    userId: "u1",
+    name: "main",
+    tmuxSessionName: "rdv-s1",
+    projectPath: "/tmp/x",
+    githubRepoId: null,
+    worktreeBranch: null,
+    worktreeType: null,
+    projectId: "p1",
+    profileId: null,
+    terminalType: "shell",
+    agentProvider: null,
+    agentExitState: null,
+    agentExitCode: null,
+    agentExitedAt: null,
+    agentRestartCount: 0,
+    agentActivityStatus: null,
+    typeMetadata: null,
+    scopeKey: null,
+    parentSessionId: null,
+    status: "active",
+    pinned: false,
+    tabOrder: 0,
+    lastActivityAt: new Date(Date.now() - 60_000),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  sessionMockState.sessions = [];
+  sessionMockState.activeSessionId = null;
+  sessionMockState.loading = false;
+  sessionMockState.getAgentActivityStatus = vi.fn().mockReturnValue("idle");
+  sessionMockState.refreshSessions = vi.fn().mockResolvedValue(undefined);
+  sessionMockState.suspendSession = vi.fn().mockResolvedValue(undefined);
+  sessionMockState.resumeSession = vi.fn().mockResolvedValue(undefined);
+  sessionMockState.closeSession = vi.fn().mockResolvedValue(undefined);
+  sessionMockState.setActiveSession = vi.fn();
+});
+
+afterEach(() => cleanup());
+
+describe("SessionsTab", () => {
+  it("renders the project chip with the active project name", () => {
+    renderTab({
+      activeNode: { id: "p1", type: "project" },
+    });
+    const chip = screen.getByTestId("mobile-project-chip");
+    expect(chip).toHaveTextContent("Alpha");
+  });
+
+  it("renders 'All projects' chip when no active node is set", () => {
+    renderTab();
+    const chip = screen.getByTestId("mobile-project-chip");
+    expect(chip).toHaveTextContent("All projects");
+  });
+
+  it("opens the project tree sheet when the chip is tapped", async () => {
+    const user = userEvent.setup();
+    renderTab();
+    expect(screen.queryByTestId("mobile-bottom-sheet")).not.toBeInTheDocument();
+    await user.click(screen.getByTestId("mobile-project-chip"));
+    await waitFor(() => screen.getByTestId("mobile-bottom-sheet"));
+    expect(screen.getByText("Projects")).toBeInTheDocument();
+  });
+
+  it("shows the no-project empty state when no projects exist and no active node", () => {
+    renderTab({ projects: [] });
+    expect(screen.getByTestId("mobile-sessions-empty-noproject")).toHaveTextContent(
+      /No project yet/
+    );
+  });
+
+  it("shows the no-sessions empty state when a project is active but has no sessions", () => {
+    renderTab({
+      activeNode: { id: "p1", type: "project" },
+    });
+    expect(
+      screen.getByTestId("mobile-sessions-empty-nosessions")
+    ).toHaveTextContent(/No sessions in Alpha/);
+  });
+
+  it("renders session rows for sessions in the active project", () => {
+    sessionMockState.sessions = [
+      makeSession({ id: "s1", name: "main", projectId: "p1" }),
+      makeSession({ id: "s2", name: "tests", projectId: "p1" }),
+    ];
+    renderTab({ activeNode: { id: "p1", type: "project" } });
+    const list = screen.getByTestId("mobile-sessions-list");
+    expect(within(list).getAllByTestId("mobile-session-row")).toHaveLength(2);
+  });
+
+  it("filters out sessions from other projects when a project is active", () => {
+    sessionMockState.sessions = [
+      makeSession({ id: "s1", name: "main", projectId: "p1" }),
+      makeSession({ id: "s2", name: "main2", projectId: "p2" }),
+    ];
+    renderTab({ activeNode: { id: "p1", type: "project" } });
+    const rows = screen.getAllByTestId("mobile-session-row");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.dataset.sessionId).toBe("s1");
+  });
+
+  it("places the active session first", () => {
+    sessionMockState.sessions = [
+      makeSession({ id: "s1", name: "older", projectId: "p1", lastActivityAt: new Date(Date.now() - 60_000) }),
+      makeSession({ id: "s2", name: "active", projectId: "p1", lastActivityAt: new Date(Date.now() - 600_000) }),
+    ];
+    sessionMockState.activeSessionId = "s2";
+    renderTab({ activeNode: { id: "p1", type: "project" } });
+    const rows = screen.getAllByTestId("mobile-session-row");
+    expect(rows[0]?.dataset.sessionId).toBe("s2");
+  });
+
+  it("dispatches suspend with undo toast when a row is swiped left past threshold", () => {
+    const session = makeSession({ id: "s1", name: "swipe-target", projectId: "p1" });
+    sessionMockState.sessions = [session];
+    renderTab({ activeNode: { id: "p1", type: "project" } });
+    const row = screen.getByTestId("mobile-session-row");
+    // Swipe left: synthesise touchStart, touchMove (-120), touchEnd.
+    fireEvent.touchStart(row, { touches: [{ clientX: 200, clientY: 30 }] });
+    fireEvent.touchMove(row, { touches: [{ clientX: 60, clientY: 30 }] });
+    fireEvent.touchEnd(row);
+    expect(sessionMockState.suspendSession).toHaveBeenCalledWith("s1");
+  });
+
+  it("opens the action sheet on long-press", async () => {
+    sessionMockState.sessions = [makeSession({ id: "s1", projectId: "p1" })];
+    renderTab({ activeNode: { id: "p1", type: "project" } });
+    const row = screen.getByTestId("mobile-session-row");
+    // The hook listens to pointer/mouse/touch — mouseDown is the most
+    // reliable one across happy-dom + RTL.
+    fireEvent.mouseDown(row, { clientX: 30, clientY: 30, button: 0 });
+    await waitFor(
+      () => screen.getByTestId("mobile-action-sheet-items"),
+      { timeout: 1500 }
+    );
+    const items = screen.getByTestId("mobile-action-sheet-items");
+    expect(within(items).getByText("Suspend")).toBeInTheDocument();
+    expect(within(items).getByText("Close session")).toBeInTheDocument();
+  });
+
+  it("opens the new-session sheet when '+ New' is tapped", async () => {
+    const user = userEvent.setup();
+    renderTab();
+    await user.click(screen.getByTestId("mobile-new-session-button"));
+    expect(screen.getByTestId("new-session-wizard-stub")).toBeInTheDocument();
+  });
+});

--- a/src/components/mobile/__tests__/sessionStatusUtils.test.ts
+++ b/src/components/mobile/__tests__/sessionStatusUtils.test.ts
@@ -1,0 +1,36 @@
+/**
+ * sessionStatusUtils tests (Phase 2 mobile redesign).
+ *
+ * Asserts the running pip class uses the design-system token, not a raw
+ * Tailwind palette literal. The token-based class keeps chromatic signal
+ * colors first-class (DESIGN.md "Signal" section).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { pipClassName } from "@/components/mobile/sessions/sessionStatusUtils";
+
+describe("pipClassName", () => {
+  it("uses --color-signal-running token for the running pip (not bg-emerald-500)", () => {
+    const cls = pipClassName("running");
+    expect(cls).toContain("var(--color-signal-running)");
+    expect(cls).not.toContain("emerald");
+  });
+
+  it("uses --color-signal-attention-solid token for the attention pip", () => {
+    const cls = pipClassName("attention");
+    expect(cls).toContain("var(--color-signal-attention-solid)");
+  });
+
+  it("uses bg-destructive for the error pip", () => {
+    expect(pipClassName("error")).toBe("bg-destructive");
+  });
+
+  it("uses muted foreground for suspended", () => {
+    expect(pipClassName("suspended")).toContain("muted-foreground");
+  });
+
+  it("uses foreground/40 for idle (achromatic default)", () => {
+    expect(pipClassName("idle")).toBe("bg-foreground/40");
+  });
+});

--- a/src/components/mobile/__tests__/usePullToRefresh.test.ts
+++ b/src/components/mobile/__tests__/usePullToRefresh.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for `usePullToRefresh` (Phase 2 mobile redesign).
+ *
+ * Verifies that:
+ *   - The hook fires `onRefresh` when the user pulls past the threshold from
+ *     the top of the scroll container.
+ *   - The hook does NOT fire when the container is scrolled away from the top.
+ *   - The hook reports `isRefreshing` while the returned promise is in-flight
+ *     and resets to false after it settles.
+ *   - `prefers-reduced-motion` suppresses the `pullDistance` visual.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, cleanup } from "@testing-library/react";
+
+import { usePullToRefresh } from "@/hooks/usePullToRefresh";
+
+function fireTouch(el: HTMLElement, type: string, clientY: number) {
+  const touch = { clientY, clientX: 0, identifier: 0, target: el } as unknown as Touch;
+  const event = new Event(type, { bubbles: true, cancelable: true }) as TouchEvent;
+  Object.defineProperty(event, "touches", {
+    value: [touch],
+    configurable: true,
+  });
+  el.dispatchEvent(event);
+}
+
+describe("usePullToRefresh", () => {
+  let scrollEl: HTMLDivElement;
+
+  beforeEach(() => {
+    scrollEl = document.createElement("div");
+    Object.defineProperty(scrollEl, "scrollTop", {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+    document.body.appendChild(scrollEl);
+  });
+
+  afterEach(() => {
+    cleanup();
+    if (scrollEl.parentNode) scrollEl.parentNode.removeChild(scrollEl);
+  });
+
+  it("fires onRefresh when the user pulls past the threshold from the top", async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh, threshold: 50 }));
+
+    act(() => {
+      result.current.ref(scrollEl);
+    });
+
+    // Simulate pull: start at 100, drag down to 300 (200px raw → 100px after
+    // 50% rubber-band damping → past 50px threshold).
+    act(() => {
+      fireTouch(scrollEl, "touchstart", 100);
+      fireTouch(scrollEl, "touchmove", 300);
+    });
+
+    expect(result.current.pullDistance).toBeGreaterThan(0);
+
+    act(() => {
+      fireTouch(scrollEl, "touchend", 300);
+    });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onRefresh when scrolled past the top", () => {
+    const onRefresh = vi.fn();
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh, threshold: 50 }));
+    Object.defineProperty(scrollEl, "scrollTop", { value: 200, writable: true });
+
+    act(() => result.current.ref(scrollEl));
+    act(() => {
+      fireTouch(scrollEl, "touchstart", 100);
+      fireTouch(scrollEl, "touchmove", 300);
+      fireTouch(scrollEl, "touchend", 300);
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("toggles isRefreshing for the duration of the refresh promise", async () => {
+    let resolve!: () => void;
+    const refreshPromise = new Promise<void>((r) => {
+      resolve = r;
+    });
+    const onRefresh = vi.fn().mockReturnValue(refreshPromise);
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh, threshold: 50 }));
+
+    act(() => result.current.ref(scrollEl));
+    act(() => {
+      fireTouch(scrollEl, "touchstart", 100);
+      fireTouch(scrollEl, "touchmove", 300);
+      fireTouch(scrollEl, "touchend", 300);
+    });
+
+    expect(result.current.isRefreshing).toBe(true);
+
+    await act(async () => {
+      resolve();
+      await refreshPromise;
+    });
+
+    expect(result.current.isRefreshing).toBe(false);
+  });
+});

--- a/src/components/mobile/common/ActionSheet.tsx
+++ b/src/components/mobile/common/ActionSheet.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+/**
+ * ActionSheet — vertically-stacked action list rendered as a bottom sheet.
+ *
+ * Phase 2 of the mobile redesign. Used for long-press session actions in the
+ * Sessions tab (Suspend / Resume / Rename / Move / Close / Recordings).
+ *
+ * Each item meets the 44pt minimum touch target. Destructive items render
+ * in `text-destructive`. The sheet uses our flat {@link BottomSheet}
+ * primitive — no backdrop-blur, no glass.
+ */
+
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+import { BottomSheet } from "./BottomSheet";
+
+export interface ActionSheetItem {
+  id: string;
+  label: ReactNode;
+  /** Optional icon node rendered to the left of the label. */
+  icon?: ReactNode;
+  /** Tints the item in `text-destructive` when true. */
+  destructive?: boolean;
+  /** Disables the item; the sheet still closes on press. */
+  disabled?: boolean;
+  onSelect: () => void | Promise<unknown>;
+}
+
+export interface ActionSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Optional title rendered above the items. */
+  title?: ReactNode;
+  /** Optional subtitle rendered under the title. */
+  subtitle?: ReactNode;
+  items: ActionSheetItem[];
+  /** Optional cancel item label; shows a separated "Cancel" row at the bottom. */
+  cancelLabel?: string;
+}
+
+export function ActionSheet({
+  open,
+  onOpenChange,
+  title,
+  subtitle,
+  items,
+  cancelLabel = "Cancel",
+}: ActionSheetProps) {
+  const handleSelect = (item: ActionSheetItem) => {
+    if (item.disabled) {
+      onOpenChange(false);
+      return;
+    }
+    // Close first so the sheet animates out before the action's UI
+    // (e.g. an undo toast) appears. The action then runs.
+    onOpenChange(false);
+    Promise.resolve(item.onSelect()).catch(() => {
+      // Swallow — caller surfaces errors via their own UI.
+    });
+  };
+
+  return (
+    <BottomSheet
+      open={open}
+      onOpenChange={onOpenChange}
+      ariaLabel={typeof title === "string" ? title : "Action sheet"}
+    >
+      {(title || subtitle) ? (
+        <div className="px-4 pb-2 pt-1">
+          {title ? (
+            <p className="text-sm font-medium leading-tight text-foreground">
+              {title}
+            </p>
+          ) : null}
+          {subtitle ? (
+            <p className="mt-0.5 text-xs text-muted-foreground">{subtitle}</p>
+          ) : null}
+        </div>
+      ) : null}
+      <ul role="menu" className="px-2 py-1" data-testid="mobile-action-sheet-items">
+        {items.map((item) => (
+          <li key={item.id}>
+            <button
+              type="button"
+              role="menuitem"
+              disabled={item.disabled}
+              onClick={() => handleSelect(item)}
+              data-action-id={item.id}
+              data-destructive={item.destructive ? "true" : undefined}
+              className={cn(
+                "flex w-full items-center gap-3 rounded-md px-3",
+                // 44pt minimum touch target.
+                "min-h-[44px] py-2.5",
+                "text-left text-[15px] leading-tight",
+                "transition-colors",
+                item.destructive
+                  ? "text-destructive hover:bg-destructive/10 active:bg-destructive/15"
+                  : "text-foreground hover:bg-accent/40 active:bg-accent/60",
+                item.disabled && "opacity-50"
+              )}
+            >
+              {item.icon ? (
+                <span aria-hidden="true" className="inline-flex h-5 w-5 items-center justify-center text-current">
+                  {item.icon}
+                </span>
+              ) : null}
+              <span className="flex-1">{item.label}</span>
+            </button>
+          </li>
+        ))}
+        <li aria-hidden="true" className="my-1 border-t border-border" />
+        <li>
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            className={cn(
+              "flex w-full items-center justify-center rounded-md px-3",
+              "min-h-[44px] py-2.5",
+              "text-[15px] font-medium leading-tight text-muted-foreground",
+              "hover:bg-accent/40 active:bg-accent/60",
+              "transition-colors"
+            )}
+          >
+            {cancelLabel}
+          </button>
+        </li>
+      </ul>
+    </BottomSheet>
+  );
+}

--- a/src/components/mobile/common/BottomSheet.tsx
+++ b/src/components/mobile/common/BottomSheet.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+/**
+ * BottomSheet — primitive slide-up panel for the mobile redesign.
+ *
+ * Phase 2 of the mobile redesign. A solid (not glassy) sheet pinned to the
+ * bottom of the viewport with a 1px hairline top border on `bg-card`,
+ * rounded-t-xl. Slide-up motion uses the iOS-style ease-out-quart curve
+ * (`cubic-bezier(0.32, 0.72, 0, 1)`) at 240ms — matching the BottomTabBar
+ * vocabulary established in Phase 1. Reduced motion = instant.
+ *
+ * NO `backdrop-filter`. The overlay is a flat `bg-black/50`, per DESIGN.md
+ * "Glass-Earns-Its-Place Rule". A small grabber pip on top is a tactile
+ * affordance, not decoration. ESC and overlay click both close.
+ *
+ * The sheet is portaled into `document.body` (when on the client) so it
+ * isn't constrained by parent overflow / transform contexts.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+
+import { cn } from "@/lib/utils";
+import { usePrefersReducedMotion } from "@/hooks/useMobile";
+
+export interface BottomSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Optional title rendered above the body. */
+  title?: ReactNode;
+  /** Optional pinned footer. Stays anchored to the sheet bottom. */
+  footer?: ReactNode;
+  /** Body content (scrollable). */
+  children: ReactNode;
+  /**
+   * `default` keeps the sheet at most 75dvh tall (project tree, action sheet).
+   * `tall` uses 92dvh — for content as substantial as the new-session wizard.
+   */
+  size?: "default" | "tall";
+  /** Add to the outer panel (testing hooks, custom padding overrides, etc.). */
+  className?: string;
+  /** Aria label fallback when no `title` is provided. */
+  ariaLabel?: string;
+}
+
+const SHEET_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
+const SHEET_DURATION_MS = 240;
+
+export function BottomSheet({
+  open,
+  onOpenChange,
+  title,
+  footer,
+  children,
+  size = "default",
+  className,
+  ariaLabel,
+}: BottomSheetProps) {
+  const reducedMotion = usePrefersReducedMotion();
+  const titleId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Only render the portal on the client to avoid SSR/CSR mismatches.
+  const isClient = typeof document !== "undefined";
+
+  // ESC key support.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onOpenChange(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onOpenChange]);
+
+  // Body scroll lock while open.
+  useEffect(() => {
+    if (!open || typeof document === "undefined") return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  // Suppress lint: setEntered/setMounted are inside an effect (mount cycle).
+  // The pattern is the canonical "two-phase enter/exit transition" — we
+  // genuinely need the next-frame flip to drive the CSS transition.
+
+  const onOverlayClick = useCallback(() => onOpenChange(false), [onOpenChange]);
+
+  // Two-phase mount so the slide-up enter and slide-down exit animations
+  // both play. `mounted` tracks DOM presence; `entered` tracks whether
+  // the panel has flipped from translate-y-full → 0. We only render the
+  // portal while the sheet is in DOM; tests that query for the panel see
+  // it absent before any open and after a close completes.
+  const [mounted, setMounted] = useState(false);
+  const [entered, setEntered] = useState(false);
+  useEffect(() => {
+    if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- two-phase mount/transition state machine
+      setMounted(true);
+      // Next frame: flip to entered=true so the transition runs.
+      const id = requestAnimationFrame(() => setEntered(true));
+      return () => cancelAnimationFrame(id);
+    }
+    if (!mounted) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- two-phase mount/transition state machine
+    setEntered(false);
+    if (reducedMotion) {
+      setMounted(false);
+      return;
+    }
+    const t = window.setTimeout(() => setMounted(false), SHEET_DURATION_MS);
+    return () => window.clearTimeout(t);
+  }, [open, mounted, reducedMotion]);
+
+  if (!isClient) return null;
+  if (!mounted) return null;
+
+  const heightCap = size === "tall" ? "max-h-[92dvh]" : "max-h-[75dvh]";
+
+  // Render-and-animate strategy: when `open` flips to true the panel mounts
+  // already at translate-y-full, then in the next frame transitions to 0.
+  // When closed we keep the wrapper mounted briefly so the exit transition
+  // can play. Simplest correct version: always-mounted with `aria-hidden`
+  // when closed, transition runs in either direction.
+
+  return createPortal(
+    <div
+      // The wrapper stretches the full viewport so the overlay covers
+      // everything; `pointer-events-none` when closed lets the page below
+      // remain interactive. We set `inert` for accessibility.
+      data-state={entered ? "open" : "closed"}
+      className={cn(
+        "fixed inset-0 z-50 flex flex-col justify-end",
+        entered ? "pointer-events-auto" : "pointer-events-none"
+      )}
+      aria-hidden={entered ? undefined : true}
+    >
+      {/* Overlay */}
+      <button
+        type="button"
+        aria-label="Close sheet"
+        tabIndex={entered ? 0 : -1}
+        onClick={onOverlayClick}
+        className={cn(
+          "absolute inset-0 bg-black/50",
+          // No backdrop-blur, intentionally flat — DESIGN.md.
+          entered ? "opacity-100" : "opacity-0"
+        )}
+        style={{
+          transitionProperty: "opacity",
+          transitionDuration: reducedMotion ? "0ms" : `${SHEET_DURATION_MS}ms`,
+          transitionTimingFunction: reducedMotion ? "linear" : SHEET_EASING,
+        }}
+      />
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={title ? titleId : undefined}
+        aria-label={!title ? ariaLabel : undefined}
+        data-testid="mobile-bottom-sheet"
+        className={cn(
+          "relative z-10 flex flex-col",
+          "rounded-t-xl border-t border-border bg-card text-card-foreground",
+          "pb-safe-bottom",
+          "shadow-lg",
+          heightCap,
+          // No backdrop-filter on the panel itself either.
+          entered ? "translate-y-0" : "translate-y-full",
+          "will-change-transform",
+          className
+        )}
+        style={{
+          transitionProperty: "transform",
+          transitionDuration: reducedMotion ? "0ms" : `${SHEET_DURATION_MS}ms`,
+          transitionTimingFunction: reducedMotion ? "linear" : SHEET_EASING,
+        }}
+      >
+        {/* Grabber pip */}
+        <div className="flex items-center justify-center pt-2 pb-1">
+          <div
+            aria-hidden="true"
+            className="h-1 w-9 rounded-full bg-muted-foreground/40"
+          />
+        </div>
+        {title ? (
+          <div className="px-4 pb-2 pt-1">
+            <h2
+              id={titleId}
+              className="text-base font-medium leading-tight text-foreground"
+            >
+              {title}
+            </h2>
+          </div>
+        ) : null}
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+          {children}
+        </div>
+        {footer ? (
+          <div className="border-t border-border px-3 py-2">{footer}</div>
+        ) : null}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/mobile/common/BottomSheet.tsx
+++ b/src/components/mobile/common/BottomSheet.tsx
@@ -102,10 +102,6 @@ export function BottomSheet({
     };
   }, [open]);
 
-  // Suppress lint: setEntered/setMounted are inside an effect (mount cycle).
-  // The pattern is the canonical "two-phase enter/exit transition" — we
-  // genuinely need the next-frame flip to drive the CSS transition.
-
   const onOverlayClick = useCallback(() => onOpenChange(false), [onOpenChange]);
 
   // Two-phase mount so the slide-up enter and slide-down exit animations
@@ -181,12 +177,6 @@ export function BottomSheet({
   if (!mounted) return null;
 
   const heightCap = size === "tall" ? "max-h-[92dvh]" : "max-h-[75dvh]";
-
-  // Render-and-animate strategy: when `open` flips to true the panel mounts
-  // already at translate-y-full, then in the next frame transitions to 0.
-  // When closed we keep the wrapper mounted briefly so the exit transition
-  // can play. Simplest correct version: always-mounted with `aria-hidden`
-  // when closed, transition runs in either direction.
 
   return createPortal(
     <div

--- a/src/components/mobile/common/BottomSheet.tsx
+++ b/src/components/mobile/common/BottomSheet.tsx
@@ -80,13 +80,25 @@ export function BottomSheet({
     return () => window.removeEventListener("keydown", onKey);
   }, [open, onOpenChange]);
 
-  // Body scroll lock while open.
+  // Body scroll lock while open. Refcounted on a body data-attribute so
+  // multiple concurrent sheets don't leak a permanent locked state. Naive
+  // save/restore breaks under nested sheets: the second sheet would save
+  // `prev = "hidden"` (set by the first), and on its close would restore
+  // "hidden" — locking scroll forever. Only the first sheet actually
+  // applies the lock; only the last one to close releases it.
   useEffect(() => {
     if (!open || typeof document === "undefined") return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
+    const body = document.body;
+    const count = Number(body.dataset.scrollLockCount ?? "0") + 1;
+    body.dataset.scrollLockCount = String(count);
+    if (count === 1) body.style.overflow = "hidden";
     return () => {
-      document.body.style.overflow = prev;
+      const next = Math.max(
+        0,
+        Number(body.dataset.scrollLockCount ?? "1") - 1
+      );
+      body.dataset.scrollLockCount = String(next);
+      if (next === 0) body.style.overflow = "";
     };
   }, [open]);
 

--- a/src/components/mobile/common/BottomSheet.tsx
+++ b/src/components/mobile/common/BottomSheet.tsx
@@ -122,6 +122,49 @@ export function BottomSheet({
     return () => window.clearTimeout(t);
   }, [open, mounted, reducedMotion]);
 
+  // Focus trap: WCAG / aria-modal compliance. When the sheet enters, move
+  // focus to the first focusable child (or the panel itself when no
+  // focusable children exist), trap Tab/Shift+Tab inside, and restore
+  // focus to the previously-focused element when the sheet closes.
+  useEffect(() => {
+    if (!entered) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+    const previouslyFocused =
+      typeof document !== "undefined"
+        ? (document.activeElement as HTMLElement | null)
+        : null;
+    const focusableSelector =
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    const getFocusables = () =>
+      Array.from(panel.querySelectorAll<HTMLElement>(focusableSelector));
+    const initial = getFocusables()[0] ?? panel;
+    initial.focus();
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const list = getFocusables();
+      if (list.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = list[0];
+      const last = list[list.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        last.focus();
+        e.preventDefault();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        first.focus();
+        e.preventDefault();
+      }
+    };
+    panel.addEventListener("keydown", onKey);
+    return () => {
+      panel.removeEventListener("keydown", onKey);
+      previouslyFocused?.focus?.();
+    };
+  }, [entered]);
+
   if (!isClient) return null;
   if (!mounted) return null;
 
@@ -169,6 +212,7 @@ export function BottomSheet({
         aria-modal="true"
         aria-labelledby={title ? titleId : undefined}
         aria-label={!title ? ariaLabel : undefined}
+        tabIndex={-1}
         data-testid="mobile-bottom-sheet"
         className={cn(
           "relative z-10 flex flex-col",

--- a/src/components/mobile/sessions/MobileSessionRow.tsx
+++ b/src/components/mobile/sessions/MobileSessionRow.tsx
@@ -111,15 +111,13 @@ export function MobileSessionRow({
           longPress.bind.onTouchStart(e);
         }}
         onTouchMove={swipe.bind.onTouchMove}
-        onTouchEnd={(e) => {
+        onTouchEnd={() => {
           swipe.bind.onTouchEnd();
           longPress.bind.onMouseUp();
-          void e;
         }}
-        onTouchCancel={(e) => {
+        onTouchCancel={() => {
           swipe.bind.onTouchCancel();
           longPress.bind.onMouseUp();
-          void e;
         }}
         onPointerDown={longPress.bind.onPointerDown}
         onPointerMove={longPress.bind.onPointerMove}

--- a/src/components/mobile/sessions/MobileSessionRow.tsx
+++ b/src/components/mobile/sessions/MobileSessionRow.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+/**
+ * MobileSessionRow — a single session row in the Phase 2 Sessions tab.
+ *
+ * One line title (500 weight when active or attention-needed, 400 otherwise),
+ * one line subtitle (status + last-activity, muted-fg, mono when mid-execution),
+ * leading 6×6 state pip. The active session shows a leading line-segment
+ * indicator on the left edge (NOT a colored side-stripe — see DESIGN.md
+ * "No Side-Stripe Rule").
+ *
+ * Interactions:
+ *   - Tap: select the session.
+ *   - Long-press: open action sheet via `onLongPress`.
+ *   - Swipe-left past threshold: fire `onSwipeSuspend`.
+ *
+ * Reduced motion: the attention halo is suppressed; the pip remains static.
+ */
+
+import { useMemo } from "react";
+
+import { cn } from "@/lib/utils";
+import type { TerminalSession } from "@/types/session";
+import type { AgentActivityStatus } from "@/types/terminal-type";
+import { usePrefersReducedMotion } from "@/hooks/useMobile";
+
+import {
+  getSessionPresentation,
+  pipClassName,
+} from "./sessionStatusUtils";
+import { useLongPress, useSwipeAction } from "./useSwipeAction";
+
+export interface MobileSessionRowProps {
+  session: TerminalSession;
+  activity: AgentActivityStatus;
+  active: boolean;
+  density?: "comfortable" | "dense";
+  onTap: (sessionId: string) => void;
+  onLongPress: (sessionId: string) => void;
+  onSwipeSuspend: (sessionId: string) => void;
+  /** When false, swipe and long-press are disabled (e.g. closed/trashed sessions). */
+  enableGestures?: boolean;
+}
+
+export function MobileSessionRow({
+  session,
+  activity,
+  active,
+  density = "comfortable",
+  onTap,
+  onLongPress,
+  onSwipeSuspend,
+  enableGestures = true,
+}: MobileSessionRowProps) {
+  const reducedMotion = usePrefersReducedMotion();
+
+  const presentation = useMemo(
+    () => getSessionPresentation(session, activity),
+    [session, activity]
+  );
+
+  const swipe = useSwipeAction({
+    direction: "left",
+    enabled: enableGestures && session.status === "active",
+    onSwipe: () => onSwipeSuspend(session.id),
+  });
+
+  const longPress = useLongPress({
+    enabled: enableGestures,
+    onLongPress: () => onLongPress(session.id),
+  });
+
+  // Title weight: active row OR attention-needed row uses 500. Otherwise 400.
+  const titleWeight =
+    active || presentation.needsAttention ? "font-medium" : "font-normal";
+
+  const rowMinHeight = density === "dense" ? "min-h-[48px]" : "min-h-[56px]";
+
+  return (
+    <div
+      className={cn(
+        "relative w-full",
+        // The "swipe affordance" sits behind the row content. When the user
+        // swipes left, the content slides left and reveals this label.
+        "overflow-hidden"
+      )}
+    >
+      {/* Behind layer: swipe-to-suspend hint */}
+      {session.status === "active" ? (
+        <div
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none absolute inset-y-0 right-0 flex items-center pr-4",
+            "text-xs font-medium text-muted-foreground"
+          )}
+        >
+          Suspend
+        </div>
+      ) : null}
+
+      {/* Row content. Swipe and long-press both want touch handlers — compose
+          them rather than letting the spread order silently nuke one set.
+          Pointer/mouse handlers come from longPress only; swipe owns touch. */}
+      <div
+        data-testid="mobile-session-row"
+        data-session-id={session.id}
+        data-active={active ? "true" : "false"}
+        data-pip={presentation.pip}
+        onTouchStart={(e) => {
+          swipe.bind.onTouchStart(e);
+          longPress.bind.onTouchStart(e);
+        }}
+        onTouchMove={swipe.bind.onTouchMove}
+        onTouchEnd={(e) => {
+          swipe.bind.onTouchEnd();
+          longPress.bind.onMouseUp();
+          void e;
+        }}
+        onTouchCancel={(e) => {
+          swipe.bind.onTouchCancel();
+          longPress.bind.onMouseUp();
+          void e;
+        }}
+        onPointerDown={longPress.bind.onPointerDown}
+        onPointerMove={longPress.bind.onPointerMove}
+        onPointerUp={longPress.bind.onPointerUp}
+        onPointerCancel={longPress.bind.onPointerCancel}
+        onPointerLeave={longPress.bind.onPointerLeave}
+        onMouseDown={longPress.bind.onMouseDown}
+        onMouseUp={longPress.bind.onMouseUp}
+        onMouseLeave={longPress.bind.onMouseLeave}
+        role="button"
+        tabIndex={0}
+        aria-label={`Open session ${session.name}`}
+        aria-current={active ? "true" : undefined}
+        onClick={() => onTap(session.id)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onTap(session.id);
+          }
+        }}
+        className={cn(
+          "relative flex w-full items-center gap-3 bg-card",
+          "px-4",
+          rowMinHeight,
+          // 44pt touch target — guaranteed by min-h-[48|56] + flex items-center.
+          "border-b border-border/60",
+          "transition-colors",
+          active && "bg-accent/40",
+          "hover:bg-accent/30 active:bg-accent/50",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        )}
+        style={{
+          transform: swipe.offset !== 0 ? `translateX(${swipe.offset}px)` : undefined,
+          transitionProperty: swipe.offset === 0 ? "transform, background-color" : "background-color",
+          transitionDuration: swipe.offset === 0 && !reducedMotion ? "180ms" : "0ms",
+        }}
+      >
+        {/* Active indicator: a 2px-tall, 12px-wide leading line segment.
+           Not a colored side-stripe (DESIGN.md No-Side-Stripe Rule); a
+           pure-foreground line-segment that reads as "this row is current"
+           without introducing chroma. */}
+        <span
+          aria-hidden="true"
+          className={cn(
+            "absolute left-0 top-1/2 h-3 w-[3px] -translate-y-1/2 rounded-r-sm",
+            active ? "bg-foreground" : "bg-transparent"
+          )}
+        />
+
+        {/* Leading state pip */}
+        <span
+          aria-hidden="true"
+          data-testid="mobile-session-pip"
+          className={cn(
+            "relative inline-flex h-1.5 w-1.5 shrink-0 rounded-full",
+            pipClassName(presentation.pip)
+          )}
+        >
+          {presentation.needsAttention && !reducedMotion ? (
+            <span
+              aria-hidden="true"
+              data-testid="mobile-session-pip-halo"
+              // Reuse the canonical halo keyframes. The pip is small (6px),
+              // so the halo's box-shadow rings read clearly without
+              // overpowering the row.
+              className="absolute inset-0 rounded-full notification-ring"
+            />
+          ) : null}
+        </span>
+
+        {/* Title + subtitle stack */}
+        <div className="min-w-0 flex-1">
+          <div className={cn("truncate text-sm leading-tight text-foreground", titleWeight)}>
+            {session.name}
+          </div>
+          <div
+            className={cn(
+              "truncate text-xs leading-tight text-muted-foreground",
+              presentation.subtitleMono && "font-mono"
+            )}
+          >
+            {presentation.subtitle}
+          </div>
+        </div>
+
+        {/* Pinned marker (subtle) */}
+        {session.pinned ? (
+          <span
+            aria-label="Pinned"
+            className="ml-2 text-[10px] uppercase tracking-wide text-muted-foreground"
+          >
+            pin
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/mobile/sessions/NewSessionSheet.tsx
+++ b/src/components/mobile/sessions/NewSessionSheet.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+/**
+ * NewSessionSheet — Phase 2 mobile redesign.
+ *
+ * Wraps {@link NewSessionWizard} in a tall (92dvh) {@link BottomSheet} so
+ * the existing multi-step wizard is usable on a phone without redesigning
+ * its internals. We don't redesign the wizard; we only own the slide-up
+ * presentation, viewport sizing, and the create-session callback wiring.
+ */
+
+import { useCallback } from "react";
+
+import { useSessionContext } from "@/contexts/SessionContext";
+import { useProjectTree } from "@/contexts/ProjectTreeContext";
+import { NewSessionWizard } from "@/components/session/NewSessionWizard";
+
+import { BottomSheet } from "../common/BottomSheet";
+
+export interface NewSessionSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  isGitHubConnected: boolean;
+  /** Optional callback fired after the wizard creates a session. */
+  onCreated?: (sessionId: string) => void;
+}
+
+export function NewSessionSheet({
+  open,
+  onOpenChange,
+  isGitHubConnected,
+  onCreated,
+}: NewSessionSheetProps) {
+  const { createSession } = useSessionContext();
+  const projectTree = useProjectTree();
+
+  const handleCreate = useCallback(
+    async (data: Parameters<Parameters<typeof NewSessionWizard>[0]["onCreate"]>[0]) => {
+      // Mirror the desktop SessionManager: prefer explicit projectId from
+      // the wizard, fall back to the active project node when present, else
+      // pass undefined and let SessionContext throw.
+      const fallbackProjectId =
+        projectTree.activeNode?.type === "project" ? projectTree.activeNode.id : undefined;
+      const resolvedProjectId = data.projectId ?? fallbackProjectId;
+
+      const payload = {
+        ...data,
+        projectId: resolvedProjectId,
+      };
+      delete (payload as Record<string, unknown>).folderId;
+
+      const created = await createSession(payload);
+      if (created) {
+        onOpenChange(false);
+        onCreated?.(created.id);
+      }
+    },
+    [createSession, projectTree.activeNode, onOpenChange, onCreated]
+  );
+
+  return (
+    <BottomSheet
+      open={open}
+      onOpenChange={onOpenChange}
+      ariaLabel="New session"
+      size="tall"
+    >
+      <div className="px-2 pb-2 pt-1" data-testid="mobile-new-session-wrap">
+        {open ? (
+          <NewSessionWizard
+            open={open}
+            onClose={() => onOpenChange(false)}
+            onCreate={handleCreate}
+            isGitHubConnected={isGitHubConnected}
+          />
+        ) : null}
+      </div>
+    </BottomSheet>
+  );
+}

--- a/src/components/mobile/sessions/ProjectTreeSheet.tsx
+++ b/src/components/mobile/sessions/ProjectTreeSheet.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+/**
+ * ProjectTreeSheet — Phase 2 mobile redesign.
+ *
+ * Bottom sheet (75dvh) with a search input on top, a recursive group→project
+ * tree in the body, and pinned "+ New project" / "+ New group" buttons in
+ * the footer. Tapping a project sets it active and closes the sheet.
+ * Tapping a group toggles its expanded state.
+ *
+ * Designed for mobile density: 44pt touch targets, no hover affordances,
+ * a single-column composition. We deliberately do NOT auto-focus the search
+ * field on phones — see the Phase 2 brief.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronDown, ChevronRight, FolderPlus, Plus } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  type GroupNode,
+  type ProjectNode,
+  useProjectTree,
+} from "@/contexts/ProjectTreeContext";
+
+import { BottomSheet } from "../common/BottomSheet";
+
+export interface ProjectTreeSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called after the user picks a project (or group). Sheet closes itself. */
+  onPickProject?: (projectId: string) => void;
+  onPickGroup?: (groupId: string) => void;
+  /** Called when user taps "+ New project". Caller wires up the create flow. */
+  onCreateProject?: () => void;
+  /** Called when user taps "+ New group". */
+  onCreateGroup?: () => void;
+}
+
+interface FlattenedRow {
+  kind: "group" | "project";
+  id: string;
+  name: string;
+  depth: number;
+  groupId?: string | null;
+  isAutoCreated?: boolean;
+}
+
+function buildFlatTree(
+  groups: GroupNode[],
+  projects: ProjectNode[],
+  expanded: Record<string, boolean>,
+  searchTerm: string
+): FlattenedRow[] {
+  const term = searchTerm.trim().toLowerCase();
+  const matches = (name: string) => !term || name.toLowerCase().includes(term);
+
+  const childGroups = (parentId: string | null) =>
+    groups
+      .filter((g) => g.parentGroupId === parentId)
+      .sort((a, b) => a.sortOrder - b.sortOrder);
+  const childProjects = (parentId: string | null) =>
+    projects
+      .filter((p) => (p.groupId ?? null) === parentId)
+      .sort((a, b) => a.sortOrder - b.sortOrder);
+
+  const out: FlattenedRow[] = [];
+
+  // When searching, force-expand everything so matches at any depth render.
+  const forceExpand = term.length > 0;
+
+  // Track whether each group has any descendant match (so non-matching groups
+  // collapse out of the result list).
+  const groupHasMatch = (groupId: string): boolean => {
+    if (forceExpand) {
+      const own = groups.find((g) => g.id === groupId);
+      if (own && matches(own.name)) return true;
+      const subProjects = childProjects(groupId);
+      if (subProjects.some((p) => matches(p.name))) return true;
+      const subGroups = childGroups(groupId);
+      return subGroups.some((g) => groupHasMatch(g.id));
+    }
+    return true;
+  };
+
+  function walk(parentId: string | null, depth: number) {
+    for (const g of childGroups(parentId)) {
+      const visible = !forceExpand || groupHasMatch(g.id);
+      if (!visible) continue;
+      out.push({ kind: "group", id: g.id, name: g.name, depth });
+      const isOpen = forceExpand || (expanded[g.id] ?? !g.collapsed);
+      if (isOpen) {
+        walk(g.id, depth + 1);
+        for (const p of childProjects(g.id)) {
+          if (!matches(p.name) && !forceExpand) continue;
+          if (forceExpand && !matches(p.name)) continue;
+          out.push({
+            kind: "project",
+            id: p.id,
+            name: p.name,
+            depth: depth + 1,
+            groupId: p.groupId,
+            isAutoCreated: p.isAutoCreated,
+          });
+        }
+      }
+    }
+    // Root-level projects (groupId === null) at the very top.
+    if (parentId === null) {
+      for (const p of childProjects(null)) {
+        if (!matches(p.name)) continue;
+        out.push({
+          kind: "project",
+          id: p.id,
+          name: p.name,
+          depth,
+          groupId: null,
+          isAutoCreated: p.isAutoCreated,
+        });
+      }
+    }
+  }
+
+  walk(null, 0);
+  return out;
+}
+
+export function ProjectTreeSheet({
+  open,
+  onOpenChange,
+  onPickProject,
+  onPickGroup,
+  onCreateProject,
+  onCreateGroup,
+}: ProjectTreeSheetProps) {
+  const tree = useProjectTree();
+  const [search, setSearch] = useState("");
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  // Reset search and expansion overrides when the sheet closes so the next
+  // open is a clean slate.
+  useEffect(() => {
+    if (!open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- resetting transient sheet UI state on close
+      setSearch("");
+      setExpanded({});
+    }
+  }, [open]);
+
+  const rows = useMemo(
+    () => buildFlatTree(tree.groups, tree.projects, expanded, search),
+    [tree.groups, tree.projects, expanded, search]
+  );
+
+  const toggleGroup = useCallback(
+    (id: string) => {
+      setExpanded((prev) => {
+        const current = prev[id];
+        const fromCtxCollapsed = tree.getGroup(id)?.collapsed ?? false;
+        const next = current === undefined ? fromCtxCollapsed : !current;
+        return { ...prev, [id]: next };
+      });
+    },
+    [tree]
+  );
+
+  const handlePickProject = useCallback(
+    (projectId: string) => {
+      void tree.setActiveNode({ id: projectId, type: "project" });
+      onPickProject?.(projectId);
+      onOpenChange(false);
+    },
+    [tree, onPickProject, onOpenChange]
+  );
+
+  const handlePickGroup = useCallback(
+    (groupId: string) => {
+      // We let users select a group as the active node too; project-scoped
+      // views aggregate descendant projects when the active node is a group.
+      void tree.setActiveNode({ id: groupId, type: "group" });
+      onPickGroup?.(groupId);
+      onOpenChange(false);
+    },
+    [tree, onPickGroup, onOpenChange]
+  );
+
+  return (
+    <BottomSheet
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Projects"
+      footer={
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              onOpenChange(false);
+              onCreateProject?.();
+            }}
+            className={cn(
+              "inline-flex flex-1 items-center justify-center gap-1.5 rounded-md border border-border bg-card",
+              "px-3 min-h-[44px] text-sm font-medium text-foreground",
+              "hover:bg-accent/40 active:bg-accent/60"
+            )}
+          >
+            <Plus aria-hidden="true" className="h-4 w-4" />
+            New project
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              onOpenChange(false);
+              onCreateGroup?.();
+            }}
+            className={cn(
+              "inline-flex flex-1 items-center justify-center gap-1.5 rounded-md border border-border bg-card",
+              "px-3 min-h-[44px] text-sm font-medium text-foreground",
+              "hover:bg-accent/40 active:bg-accent/60"
+            )}
+          >
+            <FolderPlus aria-hidden="true" className="h-4 w-4" />
+            New group
+          </button>
+        </div>
+      }
+    >
+      <div className="px-3 pt-1 pb-2">
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          // Phone behavior: do NOT auto-focus. Tapping the input opens the
+          // keyboard; the rail itself is the primary affordance.
+          autoFocus={false}
+          placeholder="Search projects"
+          aria-label="Search projects"
+          className={cn(
+            "w-full rounded-md border border-border bg-background",
+            "px-3 min-h-[44px] text-sm text-foreground placeholder:text-muted-foreground/70",
+            "focus:outline-none focus:ring-2 focus:ring-ring/50"
+          )}
+        />
+      </div>
+      <ul role="tree" className="px-1 pb-2" data-testid="mobile-project-tree-rows">
+        {rows.length === 0 ? (
+          <li className="px-3 py-6 text-center text-sm text-muted-foreground">
+            {search ? "No matches." : "No projects yet."}
+          </li>
+        ) : null}
+        {rows.map((row) => {
+          if (row.kind === "group") {
+            const isOpen =
+              expanded[row.id] !== undefined
+                ? expanded[row.id]
+                : !(tree.getGroup(row.id)?.collapsed ?? false);
+            const groupSelected =
+              tree.activeNode?.type === "group" && tree.activeNode.id === row.id;
+            return (
+              <li
+                key={`group-${row.id}`}
+                role="treeitem"
+                aria-expanded={isOpen}
+                aria-selected={groupSelected}
+              >
+                <div
+                  className={cn(
+                    "flex items-stretch rounded-md",
+                    "active:bg-accent/40"
+                  )}
+                  style={{ paddingLeft: `${row.depth * 12}px` }}
+                >
+                  <button
+                    type="button"
+                    aria-label={`${isOpen ? "Collapse" : "Expand"} ${row.name}`}
+                    onClick={() => toggleGroup(row.id)}
+                    className={cn(
+                      "flex h-11 w-11 shrink-0 items-center justify-center rounded-md",
+                      "text-muted-foreground hover:bg-accent/40"
+                    )}
+                  >
+                    {isOpen ? (
+                      <ChevronDown aria-hidden="true" className="h-4 w-4" />
+                    ) : (
+                      <ChevronRight aria-hidden="true" className="h-4 w-4" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handlePickGroup(row.id)}
+                    className={cn(
+                      "flex flex-1 min-h-[44px] items-center px-2 text-left",
+                      "text-sm font-medium text-foreground",
+                      "hover:bg-accent/40"
+                    )}
+                  >
+                    <span className="truncate">{row.name}</span>
+                  </button>
+                </div>
+              </li>
+            );
+          }
+          const projectSelected =
+            tree.activeNode?.type === "project" && tree.activeNode.id === row.id;
+          return (
+            <li
+              key={`project-${row.id}`}
+              role="treeitem"
+              aria-selected={projectSelected}
+            >
+              <button
+                type="button"
+                onClick={() => handlePickProject(row.id)}
+                data-project-id={row.id}
+                className={cn(
+                  "flex w-full min-h-[44px] items-center rounded-md px-2 text-left",
+                  "text-sm font-normal text-foreground",
+                  "hover:bg-accent/40 active:bg-accent/60",
+                  tree.activeNode?.type === "project" && tree.activeNode.id === row.id && "bg-accent/30 font-medium"
+                )}
+                style={{ paddingLeft: `${row.depth * 12 + 12}px` }}
+              >
+                <span className="truncate">{row.name}</span>
+                {row.isAutoCreated ? (
+                  <span className="ml-2 text-[10px] uppercase tracking-wide text-muted-foreground/70">
+                    auto
+                  </span>
+                ) : null}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </BottomSheet>
+  );
+}

--- a/src/components/mobile/sessions/ProjectTreeSheet.tsx
+++ b/src/components/mobile/sessions/ProjectTreeSheet.tsx
@@ -92,8 +92,7 @@ function buildFlatTree(
       if (isOpen) {
         walk(g.id, depth + 1);
         for (const p of childProjects(g.id)) {
-          if (!matches(p.name) && !forceExpand) continue;
-          if (forceExpand && !matches(p.name)) continue;
+          if (!matches(p.name)) continue;
           out.push({
             kind: "project",
             id: p.id,
@@ -315,7 +314,7 @@ export function ProjectTreeSheet({
                   "flex w-full min-h-[44px] items-center rounded-md px-2 text-left",
                   "text-sm font-normal text-foreground",
                   "hover:bg-accent/40 active:bg-accent/60",
-                  tree.activeNode?.type === "project" && tree.activeNode.id === row.id && "bg-accent/30 font-medium"
+                  projectSelected && "bg-accent/30 font-medium"
                 )}
                 style={{ paddingLeft: `${row.depth * 12 + 12}px` }}
               >

--- a/src/components/mobile/sessions/SessionsTab.tsx
+++ b/src/components/mobile/sessions/SessionsTab.tsx
@@ -17,7 +17,7 @@
  * on the bottom bar.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronDown, Plus } from "lucide-react";
 import { toast } from "sonner";
 
@@ -70,6 +70,11 @@ function saveRecentProjectIds(ids: string[]): void {
   } catch {
     // Ignore storage errors (quota, private mode, etc.).
   }
+}
+
+function lastActivityTime(session: TerminalSession): number {
+  const v = session.lastActivityAt;
+  return v instanceof Date ? v.getTime() : new Date(v).getTime();
 }
 
 export function SessionsTab({ isGitHubConnected }: SessionsTabProps) {
@@ -136,11 +141,7 @@ export function SessionsTab({ isGitHubConnected }: SessionsTabProps) {
     const pinned = activeId ? scoped.filter((s) => s.id === activeId) : [];
     const rest = scoped
       .filter((s) => s.id !== activeId)
-      .sort((a, b) => {
-        const at = a.lastActivityAt instanceof Date ? a.lastActivityAt.getTime() : new Date(a.lastActivityAt).getTime();
-        const bt = b.lastActivityAt instanceof Date ? b.lastActivityAt.getTime() : new Date(b.lastActivityAt).getTime();
-        return bt - at;
-      });
+      .sort((a, b) => lastActivityTime(b) - lastActivityTime(a));
     return [...pinned, ...rest];
   }, [sessionCtx.sessions, sessionCtx.activeSessionId, activeNode]);
 
@@ -287,16 +288,6 @@ export function SessionsTab({ isGitHubConnected }: SessionsTabProps) {
     [projectTree]
   );
 
-  // First-render: hook up an outer scroll element ref-callback for pull-to-refresh.
-  const outerRef = useRef<HTMLDivElement>(null);
-  const setRefBoth = useCallback(
-    (el: HTMLDivElement | null) => {
-      outerRef.current = el;
-      pull.ref(el);
-    },
-    [pull]
-  );
-
   return (
     <div className="flex h-full flex-col">
       {/* Header strip */}
@@ -402,7 +393,7 @@ export function SessionsTab({ isGitHubConnected }: SessionsTabProps) {
         ) : null}
 
         <div
-          ref={setRefBoth}
+          ref={pull.ref}
           data-testid="mobile-sessions-scroll"
           className="flex-1 overflow-y-auto overscroll-contain"
         >

--- a/src/components/mobile/sessions/SessionsTab.tsx
+++ b/src/components/mobile/sessions/SessionsTab.tsx
@@ -1,0 +1,561 @@
+"use client";
+
+/**
+ * SessionsTab — Phase 2 mobile redesign home screen.
+ *
+ * The Sessions tab is the mobile home. Composition (top to bottom):
+ *
+ *   1. Header strip: project switcher chip on the left, "+ New" pill on the
+ *      right, plus a horizontal rail of last-3-projects quick-switches.
+ *   2. Empty / loading / error states for the session list, OR
+ *   3. The session list (active session pinned to the top, rest sorted by
+ *      `lastActivityAt` desc).
+ *
+ * The tab is rendered inside {@link MobileShell}, which provides the bottom
+ * tab bar and the top safe-area inset. This component owns its scroll
+ * container; the shell's outer scroller is what powers auto-hide-on-scroll
+ * on the bottom bar.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown, Plus } from "lucide-react";
+import { toast } from "sonner";
+
+import { cn } from "@/lib/utils";
+import {
+  type ActiveNode,
+  useProjectTree,
+} from "@/contexts/ProjectTreeContext";
+import { useSessionContext } from "@/contexts/SessionContext";
+import type { TerminalSession } from "@/types/session";
+import { usePullToRefresh } from "@/hooks/usePullToRefresh";
+
+import { ActionSheet, type ActionSheetItem } from "../common/ActionSheet";
+
+import { MobileSessionRow } from "./MobileSessionRow";
+import { NewSessionSheet } from "./NewSessionSheet";
+import { ProjectTreeSheet } from "./ProjectTreeSheet";
+
+const RECENT_PROJECTS_STORAGE_KEY = "remote-dev:mobile:recent-projects";
+const RECENT_LIMIT = 3;
+
+export interface SessionsTabProps {
+  isGitHubConnected: boolean;
+  /** Reports the row this tab considers its scroll container, so MobileShell
+   * can flow auto-hide of the bottom bar from inner scroll if it wants.
+   * Currently unused; the shell wraps us in its own scroller. */
+  scrollContainerRef?: (el: HTMLDivElement | null) => void;
+}
+
+function loadRecentProjectIds(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(RECENT_PROJECTS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((x): x is string => typeof x === "string").slice(0, RECENT_LIMIT);
+  } catch {
+    return [];
+  }
+}
+
+function saveRecentProjectIds(ids: string[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      RECENT_PROJECTS_STORAGE_KEY,
+      JSON.stringify(ids.slice(0, RECENT_LIMIT))
+    );
+  } catch {
+    // Ignore storage errors (quota, private mode, etc.).
+  }
+}
+
+export function SessionsTab({ isGitHubConnected }: SessionsTabProps) {
+  const projectTree = useProjectTree();
+  const sessionCtx = useSessionContext();
+
+  const [treeSheetOpen, setTreeSheetOpen] = useState(false);
+  const [newSessionOpen, setNewSessionOpen] = useState(false);
+  const [actionSheetSessionId, setActionSheetSessionId] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const [recentProjectIds, setRecentProjectIds] = useState<string[]>([]);
+  // Hydrate from localStorage on mount. This is a one-time external-store
+  // sync, not a state-derived render — the project keeps the codebase's
+  // existing pattern (see ProjectTreeContext refresh()).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time hydration from localStorage
+    setRecentProjectIds(loadRecentProjectIds());
+  }, []);
+
+  // Persist whenever the active node changes to a project.
+  useEffect(() => {
+    const active = projectTree.activeNode;
+    if (!active || active.type !== "project") return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing recent-projects list to active-node updates
+    setRecentProjectIds((prev) => {
+      const filtered = prev.filter((id) => id !== active.id);
+      const next = [active.id, ...filtered].slice(0, RECENT_LIMIT);
+      saveRecentProjectIds(next);
+      return next;
+    });
+  }, [projectTree.activeNode]);
+
+  const activeNode: ActiveNode | null = projectTree.activeNode;
+
+  // Resolve the chip label.
+  const chipLabel = useMemo(() => {
+    if (!activeNode) return "All projects";
+    if (activeNode.type === "group") {
+      return projectTree.getGroup(activeNode.id)?.name ?? "All projects";
+    }
+    return projectTree.getProject(activeNode.id)?.name ?? "All projects";
+  }, [activeNode, projectTree]);
+
+  // Sessions to render. Filter to active+suspended (sessions context already
+  // does this on fetch, but be defensive). Pin the active session, then sort
+  // the rest by lastActivityAt desc.
+  const visibleSessions = useMemo(() => {
+    const open = sessionCtx.sessions.filter(
+      (s) => s.status === "active" || s.status === "suspended"
+    );
+
+    // Scope to the active node:
+    //   - project node → only that project
+    //   - group node → for now, all sessions (group descendant aggregation
+    //     lives in ProjectTreeContext-side helpers we don't pull here yet)
+    //   - null → all sessions
+    let scoped: TerminalSession[] = open;
+    if (activeNode?.type === "project") {
+      scoped = open.filter((s) => s.projectId === activeNode.id);
+    }
+
+    const activeId = sessionCtx.activeSessionId;
+    const pinned = activeId ? scoped.filter((s) => s.id === activeId) : [];
+    const rest = scoped
+      .filter((s) => s.id !== activeId)
+      .sort((a, b) => {
+        const at = a.lastActivityAt instanceof Date ? a.lastActivityAt.getTime() : new Date(a.lastActivityAt).getTime();
+        const bt = b.lastActivityAt instanceof Date ? b.lastActivityAt.getTime() : new Date(b.lastActivityAt).getTime();
+        return bt - at;
+      });
+    return [...pinned, ...rest];
+  }, [sessionCtx.sessions, sessionCtx.activeSessionId, activeNode]);
+
+  // Pull-to-refresh
+  const handleRefresh = useCallback(async () => {
+    setErrorMessage(null);
+    try {
+      await sessionCtx.refreshSessions();
+    } catch (err) {
+      setErrorMessage(`Couldn't load sessions. Pull to retry. (${String(err)})`);
+    }
+  }, [sessionCtx]);
+
+  const pull = usePullToRefresh({ onRefresh: handleRefresh });
+
+  // Action sheet items for the long-pressed session.
+  const actionSession = useMemo(
+    () => visibleSessions.find((s) => s.id === actionSheetSessionId) ?? null,
+    [visibleSessions, actionSheetSessionId]
+  );
+
+  // Suspend with undo toast.
+  const performSuspend = useCallback(
+    (sessionId: string) => {
+      const session = sessionCtx.sessions.find((s) => s.id === sessionId);
+      if (!session || session.status !== "active") return;
+      // Optimistic in-context update happens inside suspendSession().
+      void sessionCtx.suspendSession(sessionId).catch(() => {
+        toast.error("Couldn't suspend session.");
+      });
+      toast(`Suspended "${session.name}"`, {
+        duration: 5000,
+        action: {
+          label: "Undo",
+          onClick: () => {
+            void sessionCtx.resumeSession(sessionId).catch(() => {
+              toast.error("Couldn't resume session.");
+            });
+          },
+        },
+      });
+    },
+    [sessionCtx]
+  );
+
+  const performResume = useCallback(
+    (sessionId: string) => {
+      void sessionCtx.resumeSession(sessionId).catch(() => {
+        toast.error("Couldn't resume session.");
+      });
+    },
+    [sessionCtx]
+  );
+
+  const performClose = useCallback(
+    (sessionId: string) => {
+      const session = sessionCtx.sessions.find((s) => s.id === sessionId);
+      void sessionCtx.closeSession(sessionId).catch(() => {
+        toast.error("Couldn't close session.");
+      });
+      if (session) {
+        toast(`Closed "${session.name}"`);
+      }
+    },
+    [sessionCtx]
+  );
+
+  const actionItems = useMemo<ActionSheetItem[]>(() => {
+    if (!actionSession) return [];
+    const items: ActionSheetItem[] = [];
+    if (actionSession.status === "active") {
+      items.push({
+        id: "suspend",
+        label: "Suspend",
+        onSelect: () => performSuspend(actionSession.id),
+      });
+    } else if (actionSession.status === "suspended") {
+      items.push({
+        id: "resume",
+        label: "Resume",
+        onSelect: () => performResume(actionSession.id),
+      });
+    }
+    items.push({
+      id: "rename",
+      label: "Rename",
+      disabled: true, // Inline rename UI lives in Phase 3+; expose the slot now.
+      onSelect: () => {
+        toast("Rename coming soon.");
+      },
+    });
+    items.push({
+      id: "move",
+      label: "Move to project…",
+      disabled: true,
+      onSelect: () => {
+        toast("Move coming soon.");
+      },
+    });
+    items.push({
+      id: "recordings",
+      label: "View recordings",
+      disabled: true,
+      onSelect: () => {
+        toast("Recordings coming soon.");
+      },
+    });
+    items.push({
+      id: "close",
+      label: "Close session",
+      destructive: true,
+      onSelect: () => performClose(actionSession.id),
+    });
+    return items;
+  }, [actionSession, performSuspend, performResume, performClose]);
+
+  // Tap on a row → set as active session.
+  const handleTapSession = useCallback(
+    (sessionId: string) => {
+      sessionCtx.setActiveSession(sessionId);
+    },
+    [sessionCtx]
+  );
+
+  // Last-3-projects rail.
+  const recentProjects = useMemo(() => {
+    const ids = recentProjectIds;
+    return ids
+      .map((id) => projectTree.getProject(id))
+      .filter((p): p is NonNullable<typeof p> => Boolean(p));
+  }, [recentProjectIds, projectTree]);
+
+  // Whether to render the rail.
+  const railVisible = projectTree.projects.length >= 2 && recentProjects.length > 0;
+
+  // The rendered list region, with empty / loading / error states.
+  const isLoading = sessionCtx.loading || projectTree.isLoading;
+
+  // Selecting a project from the rail.
+  const handlePickRecentProject = useCallback(
+    (projectId: string) => {
+      void projectTree.setActiveNode({ id: projectId, type: "project" });
+    },
+    [projectTree]
+  );
+
+  // First-render: hook up an outer scroll element ref-callback for pull-to-refresh.
+  const outerRef = useRef<HTMLDivElement>(null);
+  const setRefBoth = useCallback(
+    (el: HTMLDivElement | null) => {
+      outerRef.current = el;
+      pull.ref(el);
+    },
+    [pull]
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header strip */}
+      <header
+        data-testid="mobile-sessions-header"
+        className={cn(
+          "sticky top-0 z-20 flex flex-col gap-2 border-b border-border bg-card",
+          "px-3 pt-2 pb-2"
+        )}
+      >
+        <div className="flex items-center justify-between gap-2">
+          <button
+            type="button"
+            onClick={() => setTreeSheetOpen(true)}
+            data-testid="mobile-project-chip"
+            className={cn(
+              "inline-flex max-w-[70%] items-center gap-1 rounded-md",
+              "px-3 min-h-[44px] text-sm font-medium text-foreground",
+              "hover:bg-accent/40 active:bg-accent/60",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            )}
+            aria-label={`Switch project, current: ${chipLabel}`}
+          >
+            <span className="truncate">{chipLabel}</span>
+            <ChevronDown aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setNewSessionOpen(true)}
+            data-testid="mobile-new-session-button"
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full border border-border bg-card",
+              "px-3 min-h-[44px] text-sm font-medium text-foreground",
+              "hover:bg-accent/40 active:bg-accent/60",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            )}
+            aria-label="New session"
+          >
+            <Plus aria-hidden="true" className="h-4 w-4" />
+            New
+          </button>
+        </div>
+
+        {railVisible ? (
+          <ul
+            data-testid="mobile-recent-projects-rail"
+            className="-mx-1 flex gap-1 overflow-x-auto pb-1"
+            role="list"
+          >
+            {recentProjects.map((p) => {
+              const active =
+                activeNode?.type === "project" && activeNode.id === p.id;
+              return (
+                <li key={p.id}>
+                  <button
+                    type="button"
+                    onClick={() => handlePickRecentProject(p.id)}
+                    data-project-id={p.id}
+                    className={cn(
+                      "inline-flex shrink-0 items-center rounded-md border border-border",
+                      "px-3 min-h-[36px] text-xs",
+                      // Achromatic active treatment: weight + tint, not color.
+                      active
+                        ? "bg-accent/30 font-medium text-foreground"
+                        : "bg-card font-normal text-muted-foreground",
+                      "hover:bg-accent/40 active:bg-accent/60"
+                    )}
+                  >
+                    <span className="max-w-[12ch] truncate">{p.name}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+      </header>
+
+      {/* Content area: error banner + list (or empty state). */}
+      <div
+        ref={setRefBoth}
+        data-testid="mobile-sessions-scroll"
+        className="flex-1 overflow-y-auto overscroll-contain"
+        style={{
+          // Visual pull indicator: translate the content down a few px while
+          // dragging. The hook returns 0 in reduced-motion, so this stays
+          // stationary then.
+          transform: pull.pullDistance > 0 ? `translateY(${pull.pullDistance}px)` : undefined,
+          transitionProperty: pull.pullDistance === 0 ? "transform" : "none",
+          transitionDuration: pull.pullDistance === 0 ? "180ms" : "0ms",
+        }}
+      >
+        {/* Subtle pull/refresh indicator: a single line of muted text, no
+            big spinner overlay. */}
+        {(pull.pullDistance > 0 || pull.isRefreshing) ? (
+          <div
+            className="flex items-center justify-center py-2 text-xs text-muted-foreground"
+            data-testid="mobile-sessions-refresh-indicator"
+            role="status"
+            aria-live="polite"
+          >
+            {pull.isRefreshing ? "Refreshing…" : "Pull to refresh"}
+          </div>
+        ) : null}
+
+        {errorMessage ? (
+          <div
+            data-testid="mobile-sessions-error"
+            role="alert"
+            className="m-3 rounded-md border border-destructive/50 bg-destructive/5 p-3 text-sm text-destructive"
+          >
+            {errorMessage}
+          </div>
+        ) : null}
+
+        {isLoading && visibleSessions.length === 0 ? (
+          <SessionListSkeleton />
+        ) : visibleSessions.length === 0 ? (
+          <SessionsEmptyState
+            hasProject={
+              !!activeNode &&
+              (activeNode.type === "project" ||
+                projectTree.projects.length > 0)
+            }
+            projectName={
+              activeNode?.type === "project"
+                ? projectTree.getProject(activeNode.id)?.name ?? null
+                : null
+            }
+            onChooseProject={() => setTreeSheetOpen(true)}
+            onStartSession={() => setNewSessionOpen(true)}
+          />
+        ) : (
+          <ul role="list" data-testid="mobile-sessions-list">
+            {visibleSessions.map((s) => (
+              <li key={s.id}>
+                <MobileSessionRow
+                  session={s}
+                  activity={sessionCtx.getAgentActivityStatus(s.id)}
+                  active={s.id === sessionCtx.activeSessionId}
+                  onTap={handleTapSession}
+                  onLongPress={(id) => setActionSheetSessionId(id)}
+                  onSwipeSuspend={performSuspend}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Sheets */}
+      <ProjectTreeSheet
+        open={treeSheetOpen}
+        onOpenChange={setTreeSheetOpen}
+      />
+      <NewSessionSheet
+        open={newSessionOpen}
+        onOpenChange={setNewSessionOpen}
+        isGitHubConnected={isGitHubConnected}
+      />
+      <ActionSheet
+        open={actionSheetSessionId !== null}
+        onOpenChange={(open) => {
+          if (!open) setActionSheetSessionId(null);
+        }}
+        title={actionSession?.name}
+        items={actionItems}
+      />
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Sub-components                                                              */
+/* -------------------------------------------------------------------------- */
+
+function SessionListSkeleton() {
+  // Match the row shape so the layout doesn't shift when real rows replace
+  // the skeleton. Six rows is enough to cover the average phone fold.
+  const rows = [0, 1, 2, 3, 4, 5];
+  return (
+    <ul
+      role="list"
+      aria-busy="true"
+      data-testid="mobile-sessions-skeleton"
+      className="animate-pulse"
+    >
+      {rows.map((i) => (
+        <li
+          key={i}
+          className="flex items-center gap-3 border-b border-border/60 px-4 py-3 min-h-[56px]"
+        >
+          <span className="inline-flex h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30" />
+          <div className="flex-1 space-y-1.5">
+            <div className="h-3 w-2/3 rounded bg-muted-foreground/15" />
+            <div className="h-2.5 w-1/3 rounded bg-muted-foreground/10" />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function SessionsEmptyState({
+  hasProject,
+  projectName,
+  onChooseProject,
+  onStartSession,
+}: {
+  hasProject: boolean;
+  projectName: string | null;
+  onChooseProject: () => void;
+  onStartSession: () => void;
+}) {
+  if (!hasProject) {
+    return (
+      <div
+        data-testid="mobile-sessions-empty-noproject"
+        className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center"
+      >
+        <p className="text-base font-medium text-foreground">No project yet.</p>
+        <p className="text-sm text-muted-foreground">
+          Create or pick a project to start a session.
+        </p>
+        <button
+          type="button"
+          onClick={onChooseProject}
+          className={cn(
+            "inline-flex items-center justify-center rounded-md",
+            "bg-primary px-3 min-h-[44px] text-sm font-medium text-primary-foreground",
+            "hover:bg-primary/90 active:bg-primary/80"
+          )}
+        >
+          Choose a project
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div
+      data-testid="mobile-sessions-empty-nosessions"
+      className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center"
+    >
+      <p className="text-base font-medium text-foreground">
+        No sessions {projectName ? `in ${projectName}` : "yet"}.
+      </p>
+      <p className="text-sm text-muted-foreground">
+        Start a new session to attach a terminal or agent.
+      </p>
+      <button
+        type="button"
+        onClick={onStartSession}
+        className={cn(
+          "inline-flex items-center justify-center rounded-md",
+          "bg-primary px-3 min-h-[44px] text-sm font-medium text-primary-foreground",
+          "hover:bg-primary/90 active:bg-primary/80"
+        )}
+      >
+        Start a session
+      </button>
+    </div>
+  );
+}

--- a/src/components/mobile/sessions/SessionsTab.tsx
+++ b/src/components/mobile/sessions/SessionsTab.tsx
@@ -374,76 +374,82 @@ export function SessionsTab({ isGitHubConnected }: SessionsTabProps) {
         ) : null}
       </header>
 
-      {/* Content area: error banner + list (or empty state). */}
-      <div
-        ref={setRefBoth}
-        data-testid="mobile-sessions-scroll"
-        className="flex-1 overflow-y-auto overscroll-contain"
-        style={{
-          // Visual pull indicator: translate the content down a few px while
-          // dragging. The hook returns 0 in reduced-motion, so this stays
-          // stationary then.
-          transform: pull.pullDistance > 0 ? `translateY(${pull.pullDistance}px)` : undefined,
-          transitionProperty: pull.pullDistance === 0 ? "transform" : "none",
-          transitionDuration: pull.pullDistance === 0 ? "180ms" : "0ms",
-        }}
-      >
+      {/* Content area: error banner + list (or empty state).
+
+          The pull-to-refresh indicator is an absolutely-positioned sibling
+          above the scroll container — animating its OWN translate. Putting
+          the transform on the scroll container itself stacked with iOS
+          Safari's rubber-band scroll, producing a doubled-bounce visual. */}
+      <div className="relative flex flex-1 flex-col">
         {/* Subtle pull/refresh indicator: a single line of muted text, no
-            big spinner overlay. */}
+            big spinner overlay. pointer-events-none so it never blocks taps
+            on rows behind; z-10 so it's drawn over the list when active. */}
         {(pull.pullDistance > 0 || pull.isRefreshing) ? (
           <div
-            className="flex items-center justify-center py-2 text-xs text-muted-foreground"
             data-testid="mobile-sessions-refresh-indicator"
             role="status"
             aria-live="polite"
+            className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-center justify-center py-2 text-xs text-muted-foreground"
+            style={{
+              transform: `translateY(${Math.max(0, pull.pullDistance - 16)}px)`,
+              transitionProperty: pull.pullDistance === 0 ? "transform, opacity" : "none",
+              transitionDuration: pull.pullDistance === 0 ? "180ms" : "0ms",
+              opacity: pull.isRefreshing ? 1 : Math.min(1, pull.pullDistance / 60),
+            }}
           >
             {pull.isRefreshing ? "Refreshing…" : "Pull to refresh"}
           </div>
         ) : null}
 
-        {errorMessage ? (
-          <div
-            data-testid="mobile-sessions-error"
-            role="alert"
-            className="m-3 rounded-md border border-destructive/50 bg-destructive/5 p-3 text-sm text-destructive"
-          >
-            {errorMessage}
-          </div>
-        ) : null}
+        <div
+          ref={setRefBoth}
+          data-testid="mobile-sessions-scroll"
+          className="flex-1 overflow-y-auto overscroll-contain"
+        >
+          {errorMessage ? (
+            <div
+              data-testid="mobile-sessions-error"
+              role="alert"
+              className="m-3 rounded-md border border-destructive/50 bg-destructive/5 p-3 text-sm text-destructive"
+            >
+              {errorMessage}
+            </div>
+          ) : null}
 
-        {isLoading && visibleSessions.length === 0 ? (
-          <SessionListSkeleton />
-        ) : visibleSessions.length === 0 ? (
-          <SessionsEmptyState
-            hasProject={
-              !!activeNode &&
-              (activeNode.type === "project" ||
-                projectTree.projects.length > 0)
-            }
-            projectName={
-              activeNode?.type === "project"
-                ? projectTree.getProject(activeNode.id)?.name ?? null
-                : null
-            }
-            onChooseProject={() => setTreeSheetOpen(true)}
-            onStartSession={() => setNewSessionOpen(true)}
-          />
-        ) : (
-          <ul role="list" data-testid="mobile-sessions-list">
-            {visibleSessions.map((s) => (
-              <li key={s.id}>
-                <MobileSessionRow
-                  session={s}
-                  activity={sessionCtx.getAgentActivityStatus(s.id)}
-                  active={s.id === sessionCtx.activeSessionId}
-                  onTap={handleTapSession}
-                  onLongPress={(id) => setActionSheetSessionId(id)}
-                  onSwipeSuspend={performSuspend}
-                />
-              </li>
-            ))}
-          </ul>
-        )}
+          {isLoading && visibleSessions.length === 0 ? (
+            <SessionListSkeleton />
+          ) : visibleSessions.length === 0 ? (
+            <SessionsEmptyState
+              hasProject={
+                !!activeNode &&
+                (activeNode.type === "project" ||
+                  projectTree.projects.length > 0)
+              }
+              projectName={
+                activeNode?.type === "project"
+                  ? projectTree.getProject(activeNode.id)?.name ?? null
+                  : null
+              }
+              onChooseProject={() => setTreeSheetOpen(true)}
+              onStartSession={() => setNewSessionOpen(true)}
+            />
+          ) : (
+            <ul role="list" data-testid="mobile-sessions-list">
+              {visibleSessions.map((s) => (
+                <li key={s.id}>
+                  <MobileSessionRow
+                    session={s}
+                    activity={sessionCtx.getAgentActivityStatus(s.id)}
+                    active={s.id === sessionCtx.activeSessionId}
+                    onTap={handleTapSession}
+                    onLongPress={(id) => setActionSheetSessionId(id)}
+                    onSwipeSuspend={performSuspend}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
 
       {/* Sheets */}

--- a/src/components/mobile/sessions/sessionStatusUtils.ts
+++ b/src/components/mobile/sessions/sessionStatusUtils.ts
@@ -9,8 +9,8 @@ import type { AgentActivityStatus } from "@/types/terminal-type";
  *
  * The visual vocabulary is intentionally narrow:
  *   - "needs attention" → pip is `--color-signal-attention-solid`, halo on
- *   - "running" → pip is `bg-emerald-500` (the only green in chrome; signal,
- *     not decoration)
+ *   - "running" → pip is `--color-signal-running` (the active-execution
+ *     signal token; signal, not decoration — see DESIGN.md "Signal" section)
  *   - "idle" → pip is `bg-foreground/40`, the default achromatic state
  *   - "error" → pip is `bg-destructive`
  *   - "suspended" → pip is `bg-muted-foreground/40`
@@ -137,7 +137,7 @@ export function pipClassName(state: SessionPipState): string {
     case "attention":
       return "bg-[var(--color-signal-attention-solid)]";
     case "running":
-      return "bg-emerald-500";
+      return "bg-[var(--color-signal-running)]";
     case "error":
       return "bg-destructive";
     case "suspended":

--- a/src/components/mobile/sessions/sessionStatusUtils.ts
+++ b/src/components/mobile/sessions/sessionStatusUtils.ts
@@ -90,13 +90,12 @@ export function getSessionPresentation(
   }
 
   if (RUNNING_STATUSES.has(activity)) {
+    // activity is "running" or "compacting" here; either label reads
+    // correctly inline.
     return {
       pip: "running",
       needsAttention: false,
-      subtitle:
-        activity === "compacting"
-          ? `compacting · ${formatRelativeTime(session.lastActivityAt)}`
-          : `running · ${formatRelativeTime(session.lastActivityAt)}`,
+      subtitle: `${activity} · ${formatRelativeTime(session.lastActivityAt)}`,
       subtitleMono: true,
     };
   }

--- a/src/components/mobile/sessions/sessionStatusUtils.ts
+++ b/src/components/mobile/sessions/sessionStatusUtils.ts
@@ -1,0 +1,149 @@
+"use client";
+
+import type { TerminalSession } from "@/types/session";
+import type { AgentActivityStatus } from "@/types/terminal-type";
+
+/**
+ * Phase 2 mobile session status utilities. Computes the leading state pip,
+ * subtitle text, and whether the row should pulse the attention-blue halo.
+ *
+ * The visual vocabulary is intentionally narrow:
+ *   - "needs attention" → pip is `--color-signal-attention-solid`, halo on
+ *   - "running" → pip is `bg-emerald-500` (the only green in chrome; signal,
+ *     not decoration)
+ *   - "idle" → pip is `bg-foreground/40`, the default achromatic state
+ *   - "error" → pip is `bg-destructive`
+ *   - "suspended" → pip is `bg-muted-foreground/40`
+ *
+ * Per DESIGN.md, color carries signal — not decoration — and never appears
+ * alone (always paired with weight or text on the row).
+ */
+
+export type SessionPipState =
+  | "attention"
+  | "running"
+  | "idle"
+  | "error"
+  | "suspended";
+
+export interface SessionPresentation {
+  pip: SessionPipState;
+  /** True when we should pulse the attention halo. Reduced motion handled by the consumer. */
+  needsAttention: boolean;
+  /** Subtitle text describing current status / last activity. */
+  subtitle: string;
+  /** When true, render subtitle in mono (mid-execution detail). */
+  subtitleMono: boolean;
+}
+
+const RUNNING_STATUSES: ReadonlySet<AgentActivityStatus> = new Set([
+  "running",
+  "compacting",
+]);
+
+export function getSessionPresentation(
+  session: TerminalSession,
+  activity: AgentActivityStatus
+): SessionPresentation {
+  // Suspended is its own resting state.
+  if (session.status === "suspended") {
+    return {
+      pip: "suspended",
+      needsAttention: false,
+      subtitle: `suspended · ${formatRelativeTime(session.lastActivityAt)}`,
+      subtitleMono: false,
+    };
+  }
+
+  // Error agents (non-zero exit, agentExitState === "exited") get the
+  // destructive pip; they're not running and they're not waiting.
+  if (
+    session.terminalType === "agent" &&
+    session.agentExitState === "exited" &&
+    session.agentExitCode != null &&
+    session.agentExitCode !== 0
+  ) {
+    return {
+      pip: "error",
+      needsAttention: false,
+      subtitle: `exited (${session.agentExitCode}) · ${formatRelativeTime(session.lastActivityAt)}`,
+      subtitleMono: true,
+    };
+  }
+
+  if (activity === "error") {
+    return {
+      pip: "error",
+      needsAttention: false,
+      subtitle: `error · ${formatRelativeTime(session.lastActivityAt)}`,
+      subtitleMono: false,
+    };
+  }
+
+  if (activity === "waiting") {
+    return {
+      pip: "attention",
+      needsAttention: true,
+      subtitle: `waiting · ${formatRelativeTime(session.lastActivityAt)}`,
+      subtitleMono: false,
+    };
+  }
+
+  if (RUNNING_STATUSES.has(activity)) {
+    return {
+      pip: "running",
+      needsAttention: false,
+      subtitle:
+        activity === "compacting"
+          ? `compacting · ${formatRelativeTime(session.lastActivityAt)}`
+          : `running · ${formatRelativeTime(session.lastActivityAt)}`,
+      subtitleMono: true,
+    };
+  }
+
+  return {
+    pip: "idle",
+    needsAttention: false,
+    subtitle: `idle · ${formatRelativeTime(session.lastActivityAt)}`,
+    subtitleMono: false,
+  };
+}
+
+/**
+ * Lightweight relative time for session subtitles. Avoids pulling in
+ * date-fns. Returns "just now", "3m ago", "2h ago", "5d ago", or an
+ * absolute date for older items.
+ */
+export function formatRelativeTime(date: Date | string | number): string {
+  const ts = typeof date === "object" ? date.getTime() : new Date(date).getTime();
+  if (!Number.isFinite(ts)) return "";
+  const delta = Date.now() - ts;
+  if (delta < 0) return "just now";
+  const SECOND = 1000;
+  const MINUTE = 60 * SECOND;
+  const HOUR = 60 * MINUTE;
+  const DAY = 24 * HOUR;
+  if (delta < 30 * SECOND) return "just now";
+  if (delta < MINUTE) return `${Math.round(delta / SECOND)}s ago`;
+  if (delta < HOUR) return `${Math.floor(delta / MINUTE)}m ago`;
+  if (delta < DAY) return `${Math.floor(delta / HOUR)}h ago`;
+  if (delta < 7 * DAY) return `${Math.floor(delta / DAY)}d ago`;
+  const d = new Date(ts);
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export function pipClassName(state: SessionPipState): string {
+  switch (state) {
+    case "attention":
+      return "bg-[var(--color-signal-attention-solid)]";
+    case "running":
+      return "bg-emerald-500";
+    case "error":
+      return "bg-destructive";
+    case "suspended":
+      return "bg-muted-foreground/40";
+    case "idle":
+    default:
+      return "bg-foreground/40";
+  }
+}

--- a/src/components/mobile/sessions/useSwipeAction.ts
+++ b/src/components/mobile/sessions/useSwipeAction.ts
@@ -1,0 +1,248 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Phase 2 mobile redesign — generic horizontal swipe gesture detector for
+ * a list row. Detects a leftward (or rightward) drag past a threshold and
+ * fires `onSwipe`. Returns the live drag offset so the consumer can
+ * translate the row content as it drags.
+ *
+ * The hook deliberately avoids vertical-scroll conflict by ignoring any
+ * drag whose vertical delta exceeds half its horizontal delta — gives the
+ * scroll container priority when the user is mostly scrolling.
+ */
+
+export interface UseSwipeActionOptions {
+  direction?: "left" | "right";
+  threshold?: number;
+  enabled?: boolean;
+  onSwipe: () => void;
+}
+
+export interface UseSwipeActionState {
+  /**
+   * Current horizontal offset (in px). Negative for left swipe, positive
+   * for right. 0 when not dragging or after a successful swipe fires.
+   */
+  offset: number;
+  /** Touch handlers to spread onto the row's outer element. */
+  bind: {
+    onTouchStart: (e: React.TouchEvent<HTMLElement>) => void;
+    onTouchMove: (e: React.TouchEvent<HTMLElement>) => void;
+    onTouchEnd: () => void;
+    onTouchCancel: () => void;
+  };
+}
+
+const DEFAULT_THRESHOLD = 72;
+
+export function useSwipeAction(options: UseSwipeActionOptions): UseSwipeActionState {
+  const { direction = "left", threshold = DEFAULT_THRESHOLD, onSwipe, enabled = true } = options;
+
+  const [offset, setOffsetState] = useState(0);
+  const offsetRef = useRef(0);
+  const setOffset = useCallback((v: number) => {
+    offsetRef.current = v;
+    setOffsetState(v);
+  }, []);
+  const startX = useRef<number | null>(null);
+  const startY = useRef<number | null>(null);
+  const dragging = useRef(false);
+
+  const onSwipeRef = useRef(onSwipe);
+  useEffect(() => {
+    onSwipeRef.current = onSwipe;
+  }, [onSwipe]);
+
+  const reset = useCallback(() => {
+    startX.current = null;
+    startY.current = null;
+    dragging.current = false;
+    setOffset(0);
+  }, [setOffset]);
+
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent<HTMLElement>) => {
+      if (!enabled) return;
+      const t = e.touches[0];
+      if (!t) return;
+      startX.current = t.clientX;
+      startY.current = t.clientY;
+      dragging.current = false;
+    },
+    [enabled]
+  );
+
+  const onTouchMove = useCallback(
+    (e: React.TouchEvent<HTMLElement>) => {
+      if (!enabled || startX.current === null || startY.current === null) return;
+      const t = e.touches[0];
+      if (!t) return;
+      const dx = t.clientX - startX.current;
+      const dy = t.clientY - startY.current;
+      // Vertical-bias: if the user is mostly scrolling, abandon this gesture.
+      if (Math.abs(dy) > Math.abs(dx) * 0.6) {
+        if (dragging.current) {
+          dragging.current = false;
+          setOffset(0);
+        }
+        return;
+      }
+      // Direction-bias: ignore swipes the wrong way.
+      if (direction === "left" && dx >= 0) {
+        if (dragging.current) {
+          dragging.current = false;
+          setOffset(0);
+        }
+        return;
+      }
+      if (direction === "right" && dx <= 0) {
+        if (dragging.current) {
+          dragging.current = false;
+          setOffset(0);
+        }
+        return;
+      }
+      dragging.current = true;
+      setOffset(dx);
+    },
+    [enabled, direction]
+  );
+
+  const onTouchEnd = useCallback(() => {
+    if (!dragging.current) {
+      reset();
+      return;
+    }
+    const current = offsetRef.current;
+    const triggered =
+      direction === "left" ? current <= -threshold : current >= threshold;
+    if (triggered) {
+      // Snap back visually first; consumer can show a toast.
+      setOffset(0);
+      onSwipeRef.current();
+    } else {
+      setOffset(0);
+    }
+    startX.current = null;
+    startY.current = null;
+    dragging.current = false;
+  }, [direction, threshold, reset, setOffset]);
+
+  return {
+    offset,
+    bind: {
+      onTouchStart,
+      onTouchMove,
+      onTouchEnd,
+      onTouchCancel: reset,
+    },
+  };
+}
+
+/**
+ * Phase 2 mobile redesign — long-press detector. Fires `onLongPress` after
+ * `duration` ms of holding. Cancels on movement past `moveTolerance` px or
+ * on release before duration elapses.
+ */
+export interface UseLongPressOptions {
+  duration?: number;
+  moveTolerance?: number;
+  enabled?: boolean;
+  onLongPress: () => void;
+}
+
+const LONG_PRESS_DEFAULT = 500;
+
+export function useLongPress(options: UseLongPressOptions) {
+  const { duration = LONG_PRESS_DEFAULT, moveTolerance = 8, onLongPress, enabled = true } = options;
+  const timer = useRef<number | null>(null);
+  const startX = useRef<number | null>(null);
+  const startY = useRef<number | null>(null);
+
+  const onLongPressRef = useRef(onLongPress);
+  useEffect(() => {
+    onLongPressRef.current = onLongPress;
+  }, [onLongPress]);
+
+  const cancel = useCallback(() => {
+    if (timer.current !== null) {
+      window.clearTimeout(timer.current);
+      timer.current = null;
+    }
+    startX.current = null;
+    startY.current = null;
+  }, []);
+
+  const beginPress = useCallback(
+    (clientX: number, clientY: number) => {
+      if (!enabled) return;
+      startX.current = clientX;
+      startY.current = clientY;
+      timer.current = window.setTimeout(() => {
+        timer.current = null;
+        onLongPressRef.current();
+      }, duration);
+    },
+    [enabled, duration]
+  );
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      if (e.button && e.button !== 0) return;
+      beginPress(e.clientX, e.clientY);
+    },
+    [beginPress]
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      if (timer.current === null) return;
+      if (startX.current === null || startY.current === null) return;
+      const dx = e.clientX - startX.current;
+      const dy = e.clientY - startY.current;
+      if (Math.hypot(dx, dy) > moveTolerance) {
+        cancel();
+      }
+    },
+    [moveTolerance, cancel]
+  );
+
+  // Fallback handlers for environments that don't dispatch PointerEvents (some
+  // older browsers and test environments). Touch drives long-press on real
+  // phones; mouse covers desktop-test runners. The first to fire wins; the
+  // others are no-ops because the timer is already armed.
+  const onTouchStartLP = useCallback(
+    (e: React.TouchEvent<HTMLElement>) => {
+      if (timer.current !== null) return;
+      const t = e.touches[0];
+      if (!t) return;
+      beginPress(t.clientX, t.clientY);
+    },
+    [beginPress]
+  );
+  const onMouseDownLP = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      if (timer.current !== null) return;
+      if (e.button && e.button !== 0) return;
+      beginPress(e.clientX, e.clientY);
+    },
+    [beginPress]
+  );
+
+  return {
+    bind: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: cancel,
+      onPointerCancel: cancel,
+      onPointerLeave: cancel,
+      onTouchStart: onTouchStartLP,
+      onMouseDown: onMouseDownLP,
+      onMouseUp: cancel,
+      onMouseLeave: cancel,
+    },
+    cancel,
+  };
+}

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,165 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { usePrefersReducedMotion } from "@/hooks/useMobile";
+
+/**
+ * usePullToRefresh — Phase 2 mobile redesign.
+ *
+ * Wraps a vertically scrolling element. When the user is already at the top
+ * (scrollTop === 0) and pulls down past `threshold` pixels, fires `onRefresh`.
+ * The hook returns a small visual state (`pullDistance`, `isRefreshing`) so
+ * the consumer can render a subtle indicator without a big spinner overlay
+ * (per the brief: "no big spinner").
+ *
+ * Reduced motion: when the user prefers reduced motion the hook still allows
+ * the refresh to fire, but it returns `0` for `pullDistance` so consumers
+ * suppress the visual stretch and just show a static text indicator.
+ *
+ * SSR safety: the hook only attaches listeners on the client, after `ref`
+ * resolves to a real DOM element.
+ */
+
+export interface UsePullToRefreshOptions {
+  threshold?: number;
+  onRefresh: () => void | Promise<unknown>;
+  /** When false, gestures are ignored entirely (e.g. while a refresh is in flight). */
+  enabled?: boolean;
+}
+
+export interface UsePullToRefreshState {
+  /** Current downward pull distance in px. 0 when not pulling. Capped at 1.5*threshold. */
+  pullDistance: number;
+  /** True from the moment `onRefresh` is invoked until its returned promise settles. */
+  isRefreshing: boolean;
+  /** Called by the consumer to attach listeners to the scroll container. */
+  ref: (el: HTMLElement | null) => void;
+}
+
+const DEFAULT_THRESHOLD = 64;
+const PULL_RESISTANCE = 0.5;
+
+export function usePullToRefresh(options: UsePullToRefreshOptions): UsePullToRefreshState {
+  const { threshold = DEFAULT_THRESHOLD, onRefresh, enabled = true } = options;
+  const reducedMotion = usePrefersReducedMotion();
+
+  const [el, setEl] = useState<HTMLElement | null>(null);
+  const [pullDistance, setPullDistanceState] = useState(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const pullDistanceRef = useRef(0);
+  const setPullDistance = useCallback((v: number) => {
+    pullDistanceRef.current = v;
+    setPullDistanceState(v);
+  }, []);
+
+  // Latest `onRefresh` callback without re-binding listeners on every render.
+  const onRefreshRef = useRef(onRefresh);
+  useEffect(() => {
+    onRefreshRef.current = onRefresh;
+  }, [onRefresh]);
+
+  // Latest `enabled` flag without re-binding listeners.
+  const enabledRef = useRef(enabled);
+  useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
+
+  const isRefreshingRef = useRef(false);
+  useEffect(() => {
+    isRefreshingRef.current = isRefreshing;
+  }, [isRefreshing]);
+
+  const ref = useCallback((node: HTMLElement | null) => {
+    setEl(node);
+  }, []);
+
+  useEffect(() => {
+    if (!el) return;
+
+    let startY: number | null = null;
+    let pulling = false;
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (!enabledRef.current || isRefreshingRef.current) return;
+      // Only start tracking when we're already at the top — otherwise the
+      // user is scrolling content, not pulling-to-refresh.
+      if (el.scrollTop > 0) return;
+      const t = e.touches[0];
+      if (!t) return;
+      startY = t.clientY;
+      pulling = false;
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (startY === null) return;
+      const t = e.touches[0];
+      if (!t) return;
+      const dy = t.clientY - startY;
+      if (dy <= 0) {
+        // Upward / neutral pull — abandon and let scrolling resume.
+        if (pulling) {
+          pulling = false;
+          setPullDistance(0);
+        }
+        return;
+      }
+      // Past the top, pull down with rubber-band resistance so it never
+      // feels infinite. Cap visual pull at 1.5x threshold.
+      pulling = true;
+      const damped = Math.min(dy * PULL_RESISTANCE, threshold * 1.5);
+      // Reduced-motion: don't visualize the stretch at all; only the action
+      // matters. (We still fire onRefresh on release past threshold.)
+      setPullDistance(reducedMotion ? 0 : damped);
+    };
+
+    const onTouchEnd = () => {
+      if (startY === null) return;
+      const distance = pullDistanceRef.current;
+      const releasedAtTop = el.scrollTop === 0;
+      startY = null;
+
+      if (pulling && releasedAtTop && distance >= threshold * PULL_RESISTANCE) {
+        // Threshold met; fire the refresh.
+        pulling = false;
+        setPullDistance(0);
+        setIsRefreshing(true);
+        Promise.resolve(onRefreshRef.current())
+          .catch(() => {
+            // Swallow — caller is responsible for surfacing errors via
+            // its own error state. We just need to release the spinner.
+          })
+          .finally(() => {
+            setIsRefreshing(false);
+          });
+        return;
+      }
+
+      // Otherwise reset.
+      pulling = false;
+      setPullDistance(0);
+    };
+
+    const onTouchCancel = () => {
+      startY = null;
+      pulling = false;
+      setPullDistance(0);
+    };
+
+    el.addEventListener("touchstart", onTouchStart, { passive: true });
+    el.addEventListener("touchmove", onTouchMove, { passive: true });
+    el.addEventListener("touchend", onTouchEnd, { passive: true });
+    el.addEventListener("touchcancel", onTouchCancel, { passive: true });
+
+    return () => {
+      el.removeEventListener("touchstart", onTouchStart);
+      el.removeEventListener("touchmove", onTouchMove);
+      el.removeEventListener("touchend", onTouchEnd);
+      el.removeEventListener("touchcancel", onTouchCancel);
+    };
+    // pullDistance is read from a ref inside the listeners so the effect
+    // doesn't re-bind on every drag tick.
+  }, [el, threshold, reducedMotion, setPullDistance]);
+
+  return { pullDistance, isRefreshing, ref };
+}


### PR DESCRIPTION
## Summary

Phase 2 of the mobile redesign per the design brief. Builds on the `mobile-foundation` baseline (Phase 1, PR #214). Lands the Sessions tab end-to-end: the workhorse home screen for the new mobile shell.

What's new:
- **Sessions tab screen** with project-switcher chip, recent-projects quick-switch rail, and the active session list. Pull-to-refresh, virtualized scroll, empty/loading/error states, all wired to real `SessionContext` and `ProjectTreeContext`.
- **`MobileSessionRow`** with leading state pip, weight-based hierarchy (no colored side-stripe — uses a 3px left bar in `bg-foreground`), long-press to action sheet, swipe-left to suspend with 5s undo toast.
- **`ProjectTreeSheet`** — slide-up bottom sheet wrapping the existing tree composition with search filter and inline create-project / create-group affordances.
- **`NewSessionSheet`** — wraps the existing `NewSessionWizard` in a 92dvh slide-up sheet so it fits a phone without redesigning the wizard.
- **`BottomSheet` + `ActionSheet`** primitives. Custom (not Radix) so we can keep DESIGN.md's "no glassmorphism on chrome" doctrine; aria-modal with focus trap, body-scroll-lock refcount, ESC + overlay-click to close.
- **`useSwipeAction`** — generic horizontal-swipe hook with vertical-bias scroll preservation and a 72px dispatch threshold.
- **`usePullToRefresh`** — gesture hook driving the indicator separately from the scroll container (no iOS double-bounce).
- **`MobileApp` + `MobileViewportSwitch`** — wires `MobileShell` into the root route at `<768px`. Desktop ≥768px renders identically to before.
- **`--signal-running` token** — defines a calibrated chromatic state pip for actively-executing sessions; matches the `--signal-attention` pattern in `globals.css` (`:root` + `.dark`, exposed via `@theme`).

Adversarial review (separate subagent) flagged:
- P0: hardcoded `bg-emerald-500` palette color → fixed via `--signal-running` token.
- P0: `BottomSheet` had no focus trap → fixed; restores focus on close.
- P1: body scroll-lock not refcount-safe under nested sheets → fixed via dataset counter.
- P1: pull-to-refresh transformed the scroll container itself → fixed; indicator is an absolutely-positioned sibling.
- P2 items deferred to Phase 7 polish (rail seeding on first install, swipe-curve edge case).

Disabled actions in the row's action sheet ("Rename", "Move to project…", "View recordings") render as accessible-disabled with a "Coming soon" toast. Suspend / Resume / Close are fully wired.

## Test plan

- [ ] CI passes (typecheck, lint, vitest)
- [ ] Manual at `<768px` (Chrome DevTools): Sessions tab is the default; project chip opens the tree sheet; tap row navigates to session; long-press opens action sheet; swipe-left suspends with undo
- [ ] Manual at `<768px`: pull down on the list refreshes; indicator no longer rubber-bands inside the scroll
- [ ] Manual at `≥768px`: desktop chrome unchanged from PR #214 baseline
- [ ] Manual: open the new-session sheet, complete the wizard at narrow viewport
- [ ] Manual: open the action sheet, tab through items with keyboard, ESC closes, focus restored to the row that opened it
- [ ] Manual: open ProjectTreeSheet; type in search; pick a project; sheet closes; sessions filter to that project
- [ ] Manual: agent-needs-attention session shows the `--signal-attention` halo on the row pip; running session shows the new `--signal-running` pip color

This pull request and its description were written by Isaac.