### PR TITLE
feat(mobile/profile): profile tab + auth lock/welcome screens (GH#lud6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Mobile redesign Phase 6: Auth flow + Profile tab** (remote-dev-lud6).
+  Polishes the post-Cloudflare-Access landing into a calm, two-step flow:
+  a `MobileLockScreen` interstitial ("Authenticating via Cloudflare Access")
+  while the session resolves, then a one-time `MobileWelcomeScreen` with a
+  signed-in-as line, an optional Connect-GitHub CTA, and a Skip-for-now
+  button. First-run state is persisted via a localStorage flag
+  (`remote-dev:mobile:welcome-seen:v1`) so subsequent visits jump straight
+  to Sessions. The GitHub OAuth callback's `?github=connected` query param
+  now surfaces a one-shot success toast on the Sessions tab and is stripped
+  from the URL on read. The Profile tab ships as a pushed-row stack
+  (Account, GitHub accounts, Projects, Agent profiles, Secrets, Ports,
+  Trash, Settings, About, Sign out) with a tab-local navigation stack —
+  no modals for routine settings, every row pushes a sub-screen, and Sign
+  out confirms via an `ActionSheet` (not a dialog). Sub-screens beyond
+  About are intentionally stubbed in this build with a TODO note pointing
+  at the desktop component to port; the navigation chrome and primary
+  flows are real.
 - **Mobile redesign Phase 2: Sessions tab** (remote-dev-l9qg). The mobile
   home is now the Sessions tab. A header strip with a project switcher chip,
   a `+ New` pill, and a recent-projects rail sits above a session list with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Sign-out hardening**: `/api/auth/signout` no longer exports a GET handler
+  (removed CSRF logout vector — third-party `<img src>` could trigger
+  sign-out). The POST handler additionally rejects cross-origin requests via
+  an Origin/Referer same-origin check. Removed the `joyfulhouse` placeholder
+  default for `CF_ACCESS_TEAM` from both the signout route and
+  `src/lib/cloudflare-access.ts`: an unset team no longer silently redirects
+  users to a foreign Cloudflare tenant or attempts JWKS fetches against one.
+  `MobileLockScreen` now shows generic "Loading" copy while the NextAuth
+  client session is resolving, and only switches to "Authenticating via
+  Cloudflare Access" once the session is confirmed unauthenticated, so
+  credentials/localhost users no longer see misleading CF copy.
+
 ### Added
 
 - **Mobile redesign Phase 6: Auth flow + Profile tab** (remote-dev-lud6).

--- a/src/app/api/auth/signout/route.test.ts
+++ b/src/app/api/auth/signout/route.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Sign-out route tests.
+ *
+ * Coverage:
+ *   - GET is not exported (CSRF logout vector defense).
+ *   - POST with cross-origin Origin header is rejected (403).
+ *   - POST with same-origin Origin header redirects to /login when CF
+ *     Access is not configured.
+ *   - When `CF_ACCESS_AUD` is set but `CF_ACCESS_TEAM` is missing the
+ *     handler logs an error and falls through to /login (no foreign-tenant
+ *     redirect).
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+const signOutMock = vi.fn();
+vi.mock("@/auth", () => ({
+  signOut: (...args: unknown[]) => signOutMock(...args),
+}));
+
+const errorLogMock = vi.fn();
+const warnLogMock = vi.fn();
+const infoLogMock = vi.fn();
+vi.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    error: errorLogMock,
+    warn: warnLogMock,
+    info: infoLogMock,
+    debug: vi.fn(),
+    trace: vi.fn(),
+  }),
+}));
+
+function makeRequest(opts: {
+  method: "POST";
+  headers?: Record<string, string>;
+  url?: string;
+}): NextRequest {
+  const url = opts.url ?? "https://app.example.com/api/auth/signout";
+  const parsed = new URL(url);
+  const headers = new Headers(opts.headers ?? {});
+  if (!headers.has("host")) headers.set("host", parsed.host);
+  return {
+    method: opts.method,
+    headers,
+    nextUrl: parsed,
+  } as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  signOutMock.mockReset();
+  signOutMock.mockResolvedValue(undefined);
+  errorLogMock.mockReset();
+  warnLogMock.mockReset();
+  infoLogMock.mockReset();
+  // Clear any CF Access env vars so each test sets its own.
+  delete process.env.CF_ACCESS_AUD;
+  delete process.env.CF_ACCESS_TEAM;
+  delete process.env.NEXTAUTH_URL;
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe("/api/auth/signout", () => {
+  it("does NOT export a GET handler (no CSRF logout vector)", async () => {
+    const mod = await import("./route");
+    // Intentionally cast through unknown so the test compiles even if a
+    // future change accidentally re-introduces GET.
+    expect((mod as unknown as { GET?: unknown }).GET).toBeUndefined();
+  });
+
+  it("rejects cross-origin POST with 403", async () => {
+    const { POST } = await import("./route");
+    const res = await POST(
+      makeRequest({
+        method: "POST",
+        url: "https://app.example.com/api/auth/signout",
+        headers: {
+          origin: "https://attacker.example.org",
+          host: "app.example.com",
+        },
+      })
+    );
+    expect(res.status).toBe(403);
+    expect(signOutMock).not.toHaveBeenCalled();
+    expect(warnLogMock).toHaveBeenCalledWith(
+      "Rejected cross-origin sign-out POST",
+      expect.any(Object)
+    );
+  });
+
+  it("accepts same-origin POST and redirects to /login when CF Access is not configured", async () => {
+    process.env.NEXTAUTH_URL = "https://app.example.com";
+    const { POST } = await import("./route");
+    const res = await POST(
+      makeRequest({
+        method: "POST",
+        url: "https://app.example.com/api/auth/signout",
+        headers: {
+          origin: "https://app.example.com",
+          host: "app.example.com",
+        },
+      })
+    );
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("https://app.example.com/login");
+    expect(signOutMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls through to /login (logs error) when CF_ACCESS_AUD is set but CF_ACCESS_TEAM is missing", async () => {
+    process.env.NEXTAUTH_URL = "https://app.example.com";
+    process.env.CF_ACCESS_AUD = "test-audience";
+    // CF_ACCESS_TEAM intentionally unset.
+    const { POST } = await import("./route");
+    const res = await POST(
+      makeRequest({
+        method: "POST",
+        url: "https://app.example.com/api/auth/signout",
+        headers: {
+          origin: "https://app.example.com",
+          host: "app.example.com",
+        },
+      })
+    );
+    expect(res.status).toBe(307);
+    // Must NOT redirect to *any* `cloudflareaccess.com` domain.
+    const location = res.headers.get("location") ?? "";
+    expect(location).not.toContain("cloudflareaccess.com");
+    expect(location).toBe("https://app.example.com/login");
+    expect(errorLogMock).toHaveBeenCalledWith(
+      expect.stringContaining("CF_ACCESS_TEAM not configured")
+    );
+  });
+
+  it("redirects to the configured Cloudflare Access logout URL when both env vars are set", async () => {
+    process.env.NEXTAUTH_URL = "https://app.example.com";
+    process.env.CF_ACCESS_AUD = "test-audience";
+    process.env.CF_ACCESS_TEAM = "my-team";
+    const { POST } = await import("./route");
+    const res = await POST(
+      makeRequest({
+        method: "POST",
+        url: "https://app.example.com/api/auth/signout",
+        headers: {
+          origin: "https://app.example.com",
+          host: "app.example.com",
+        },
+      })
+    );
+    expect(res.status).toBe(307);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("https://my-team.cloudflareaccess.com/cdn-cgi/access/logout");
+    expect(location).toContain(encodeURIComponent("https://app.example.com/login"));
+  });
+});

--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -16,9 +16,17 @@
  * stayed authenticated. This endpoint fixes that by clearing both
  * sessions, then redirecting through CF logout when configured.
  *
- * GET is supported so a `<a href>` or `window.location.href` from the
- * client triggers the full redirect chain without the browser blocking
- * a fetch-driven cross-origin redirect.
+ * Method allow-list: POST only.
+ *
+ * GET is intentionally not exported. A GET handler would make sign-out a
+ * trivially-exploitable CSRF logout vector — an attacker could embed
+ * `<img src="https://app/api/auth/signout">` on a third-party page and
+ * sign the user out. POST is not auto-triggered from external GET-only
+ * contexts (no `<img>`, no `<a href>`, no `<script src>`).
+ *
+ * As a defense-in-depth measure the POST handler also verifies that the
+ * `Origin` (or `Referer`) header is same-origin with the request host,
+ * rejecting cross-origin POSTs.
  */
 
 import { NextResponse, type NextRequest } from "next/server";
@@ -27,8 +35,6 @@ import { signOut } from "@/auth";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("api/auth/signout");
-
-const CF_ACCESS_TEAM = process.env.CF_ACCESS_TEAM || "joyfulhouse";
 
 function buildLoginUrl(request: NextRequest): string {
   const origin = process.env.NEXTAUTH_URL || request.nextUrl.origin;
@@ -41,6 +47,12 @@ function buildLoginUrl(request: NextRequest): string {
  * `returnTo`. Returns `null` when CF Access is not configured (i.e.
  * pure localhost dev) — callers should redirect straight to /login.
  *
+ * Both `CF_ACCESS_AUD` and `CF_ACCESS_TEAM` are required. If `AUD` is
+ * set without `TEAM` we explicitly fall through (rather than guessing a
+ * default team) — guessing would silently redirect users to a foreign
+ * tenant's `*.cloudflareaccess.com` domain, which CANNOT clear our
+ * cookie and would leave sign-out in a broken state.
+ *
  * Reference: https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/#log-out-of-an-application
  */
 function buildCloudflareLogoutUrl(returnTo: string): string | null {
@@ -48,11 +60,55 @@ function buildCloudflareLogoutUrl(returnTo: string): string | null {
     // CF Access is not enforced in this environment.
     return null;
   }
+  const team = process.env.CF_ACCESS_TEAM;
+  if (!team) {
+    log.error(
+      "CF_ACCESS_AUD set but CF_ACCESS_TEAM not configured; skipping CF logout redirect"
+    );
+    return null;
+  }
   const url = new URL(
-    `https://${CF_ACCESS_TEAM}.cloudflareaccess.com/cdn-cgi/access/logout`
+    `https://${team}.cloudflareaccess.com/cdn-cgi/access/logout`
   );
   url.searchParams.set("returnTo", returnTo);
   return url.toString();
+}
+
+/**
+ * Verifies the request originates from the same site this route is
+ * served from. Rejects cross-origin POSTs to harden against any
+ * future-form-submission CSRF angle. We accept either `Origin` (set by
+ * fetch / form POSTs from a browser) or `Referer` (older clients).
+ *
+ * Returns `true` when the request is same-origin OR when neither header
+ * is present *and* the request looks like a server-to-server call (no
+ * `User-Agent` resembling a browser). The conservative branch — header
+ * present but mismatched — always rejects.
+ */
+function isSameOrigin(request: NextRequest): boolean {
+  const host = request.headers.get("host");
+  if (!host) {
+    // No host header: treat as untrusted.
+    return false;
+  }
+  const expected = `${request.nextUrl.protocol}//${host}`.replace(/\/$/, "");
+  const origin = request.headers.get("origin");
+  if (origin) {
+    return origin.replace(/\/$/, "") === expected;
+  }
+  const referer = request.headers.get("referer");
+  if (referer) {
+    try {
+      const refUrl = new URL(referer);
+      return `${refUrl.protocol}//${refUrl.host}` === expected;
+    } catch {
+      return false;
+    }
+  }
+  // Neither header present. Browsers always send one or the other on
+  // POST, so the absence implies a non-browser caller (curl, server). We
+  // err toward allowing it: such callers are not the CSRF attack surface.
+  return true;
 }
 
 async function handleSignOut(request: NextRequest): Promise<NextResponse> {
@@ -78,10 +134,16 @@ async function handleSignOut(request: NextRequest): Promise<NextResponse> {
   return NextResponse.redirect(loginUrl);
 }
 
-export async function GET(request: NextRequest): Promise<NextResponse> {
-  return handleSignOut(request);
-}
-
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!isSameOrigin(request)) {
+    log.warn("Rejected cross-origin sign-out POST", {
+      origin: request.headers.get("origin"),
+      referer: request.headers.get("referer"),
+    });
+    return NextResponse.json(
+      { error: "Cross-origin sign-out is not permitted" },
+      { status: 403 }
+    );
+  }
   return handleSignOut(request);
 }

--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -1,0 +1,87 @@
+/**
+ * Mobile-aware sign-out endpoint.
+ *
+ * The mobile sign-out flow needs to handle BOTH authentication paths:
+ *
+ *   1. NextAuth credentials (localhost dev) — clear the NextAuth JWT
+ *      session cookie via {@link signOut}.
+ *   2. Cloudflare Access (remote/LAN production) — the `CF_Authorization`
+ *      cookie is set by Cloudflare Access on a domain we don't control.
+ *      The only way to clear it is to redirect the browser through
+ *      Cloudflare Access's own logout URL: it deletes the cookie and
+ *      bounces back to a return URL we provide.
+ *
+ * The default mobile sign-out previously called the next-auth client
+ * `signOut()` only. For CF Access users that call is a no-op — they
+ * stayed authenticated. This endpoint fixes that by clearing both
+ * sessions, then redirecting through CF logout when configured.
+ *
+ * GET is supported so a `<a href>` or `window.location.href` from the
+ * client triggers the full redirect chain without the browser blocking
+ * a fetch-driven cross-origin redirect.
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+
+import { signOut } from "@/auth";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("api/auth/signout");
+
+const CF_ACCESS_TEAM = process.env.CF_ACCESS_TEAM || "joyfulhouse";
+
+function buildLoginUrl(request: NextRequest): string {
+  const origin = process.env.NEXTAUTH_URL || request.nextUrl.origin;
+  return `${origin.replace(/\/$/, "")}/login`;
+}
+
+/**
+ * Returns the Cloudflare Access logout URL that will clear the
+ * `CF_Authorization` cookie on the team domain and redirect back to
+ * `returnTo`. Returns `null` when CF Access is not configured (i.e.
+ * pure localhost dev) — callers should redirect straight to /login.
+ *
+ * Reference: https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/#log-out-of-an-application
+ */
+function buildCloudflareLogoutUrl(returnTo: string): string | null {
+  if (!process.env.CF_ACCESS_AUD) {
+    // CF Access is not enforced in this environment.
+    return null;
+  }
+  const url = new URL(
+    `https://${CF_ACCESS_TEAM}.cloudflareaccess.com/cdn-cgi/access/logout`
+  );
+  url.searchParams.set("returnTo", returnTo);
+  return url.toString();
+}
+
+async function handleSignOut(request: NextRequest): Promise<NextResponse> {
+  const loginUrl = buildLoginUrl(request);
+
+  // Clear the NextAuth session FIRST so the credentials path is
+  // logged out even if the CF redirect fails or is intercepted.
+  try {
+    await signOut({ redirect: false });
+  } catch (err) {
+    // signOut throws a NEXT_REDIRECT internally when redirect is true.
+    // With redirect:false this should be safe, but log defensively.
+    log.warn("NextAuth signOut threw", { error: String(err) });
+  }
+
+  const cfLogout = buildCloudflareLogoutUrl(loginUrl);
+  if (cfLogout) {
+    log.info("Redirecting to Cloudflare Access logout", { returnTo: loginUrl });
+    return NextResponse.redirect(cfLogout);
+  }
+
+  log.info("Redirecting to login (no CF Access configured)");
+  return NextResponse.redirect(loginUrl);
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  return handleSignOut(request);
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  return handleSignOut(request);
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -112,7 +112,13 @@ export default async function Home() {
                                   <NotificationProvider>
                                     <ChannelProvider>
                                     <PeerChatProvider>
-                                    <MobileViewportSwitch isGitHubConnected={isGitHubConnected}>
+                                    <MobileViewportSwitch
+                                      isGitHubConnected={isGitHubConnected}
+                                      initialUser={{
+                                        email: session.user.email ?? null,
+                                        name: session.user.name ?? null,
+                                      }}
+                                    >
                                       <div className="flex h-screen flex-col bg-background">
                                         {/* Header - hidden on mobile, shown in sidebar instead */}
                                         <Header

--- a/src/components/mobile/MobileApp.tsx
+++ b/src/components/mobile/MobileApp.tsx
@@ -10,12 +10,29 @@
  *   3. The Phase 6 Profile tab.
  *   4. The Phase 6 lock + welcome auth flow.
  *
+ * Auth model:
+ *
+ *   This component runs *inside* an authenticated server render — the
+ *   parent page resolves the session via `getAuthSession()` (which
+ *   handles BOTH NextAuth credentials and Cloudflare Access JWT) and
+ *   redirects unauthenticated users before this component mounts. As a
+ *   result `initialUser` is the source of truth: when it's non-null the
+ *   user IS authenticated, regardless of what NextAuth's *client*
+ *   `useSession()` says.
+ *
+ *   `useSession()` is only consulted as a transient signal for the
+ *   *client-side* hydration state — for example, after a user signs in
+ *   to GitHub via the link flow on the same page. It must NEVER be used
+ *   to gate the lock screen on its own, because Cloudflare Access users
+ *   never have a NextAuth client session and would otherwise be
+ *   permanently stuck on the lock screen.
+ *
  * Auth flow (mobile-only):
  *
- *   - If we're still resolving the NextAuth session → render
- *     {@link MobileLockScreen} ("Authenticating via Cloudflare Access").
- *   - If the session is resolved and the user is on this device for the
- *     first time → render {@link MobileWelcomeScreen}.
+ *   - If `initialUser` is null (a defensive fallback — middleware should
+ *     have redirected before we got here) → render
+ *     {@link MobileLockScreen}.
+ *   - If first run on this device → render {@link MobileWelcomeScreen}.
  *   - Otherwise → render the tab shell with `activeTab` state.
  *
  * The GitHub OAuth callback redirects to `/?github=connected`. When that
@@ -24,7 +41,7 @@
  * mirrors the desktop behavior without depending on it.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSession } from "next-auth/react";
 import { toast } from "sonner";
 
@@ -36,8 +53,21 @@ import { MobileLockScreen } from "./auth/MobileLockScreen";
 import { MobileWelcomeScreen } from "./auth/MobileWelcomeScreen";
 import { useFirstRun } from "./auth/useFirstRun";
 
+export interface MobileAuthUser {
+  email: string | null;
+  name: string | null;
+}
+
 export interface MobileAppProps {
   isGitHubConnected: boolean;
+  /**
+   * Server-resolved authenticated user from `getAuthSession()`. When
+   * non-null, the user is authenticated via NextAuth credentials OR
+   * Cloudflare Access JWT. This is the source of truth for mobile auth
+   * gating — `useSession()` cannot be trusted here because CF Access
+   * users have no NextAuth client session.
+   */
+  initialUser: MobileAuthUser | null;
 }
 
 const PLACEHOLDER_COPY: Record<Exclude<MobileTab, "sessions" | "profile">, { title: string; phase: string }> = {
@@ -45,10 +75,26 @@ const PLACEHOLDER_COPY: Record<Exclude<MobileTab, "sessions" | "profile">, { tit
   channels: { title: "Channels", phase: "Phase 5" },
 };
 
-export function MobileApp({ isGitHubConnected }: MobileAppProps) {
+export function MobileApp({ isGitHubConnected, initialUser }: MobileAppProps) {
   const [activeTab, setActiveTab] = useState<MobileTab>("sessions");
-  const { data: session, status } = useSession();
+  // `useSession` is consulted only for live updates after the initial
+  // server render (e.g. post-GitHub-link). It is NEVER the source of
+  // truth for "am I authenticated?" — see file-level docblock.
+  const { data: clientSession } = useSession();
   const firstRun = useFirstRun();
+
+  // Derived: prefer the server-passed user, fall back to the live client
+  // session (only useful for in-app sign-in flows that don't full-reload).
+  const resolvedUser = useMemo<MobileAuthUser | null>(() => {
+    if (initialUser) return initialUser;
+    if (clientSession?.user?.email) {
+      return {
+        email: clientSession.user.email ?? null,
+        name: clientSession.user.name ?? null,
+      };
+    }
+    return null;
+  }, [initialUser, clientSession]);
 
   // Surface the GitHub OAuth callback toast once and strip the query
   // param so a refresh won't replay it.
@@ -75,18 +121,17 @@ export function MobileApp({ isGitHubConnected }: MobileAppProps) {
     setActiveTab("sessions");
   }, [firstRun]);
 
-  // While the session is resolving, render the lock screen. NextAuth
-  // exposes `status === "loading"` during the initial fetch.
-  if (status === "loading") {
-    return <MobileLockScreen />;
-  }
-
-  // The middleware will have redirected unauthenticated users to /login
-  // before we ever get here, but if the session lands as `unauthenticated`
-  // due to a transient race, we keep the lock screen up rather than
-  // flashing the tab shell.
-  if (status === "unauthenticated") {
-    return <MobileLockScreen message="Authenticating via Cloudflare Access" detail="Redirecting to sign in." />;
+  // Defensive: middleware should redirect unauthenticated users before
+  // this component renders. If `initialUser` is null AND the client
+  // session also hasn't filled in, treat this as "not yet authenticated"
+  // and keep the lock screen up rather than flashing the tab shell.
+  if (!resolvedUser) {
+    return (
+      <MobileLockScreen
+        message="Authenticating via Cloudflare Access"
+        detail="Redirecting to sign in."
+      />
+    );
   }
 
   // First run: gated by the localStorage flag, only shown once we know
@@ -98,7 +143,7 @@ export function MobileApp({ isGitHubConnected }: MobileAppProps) {
   if (firstRun.isFirstRun) {
     return (
       <MobileWelcomeScreen
-        email={session?.user?.email ?? null}
+        email={resolvedUser.email}
         isGitHubConnected={isGitHubConnected}
         onConnectGitHub={handleConnectGitHub}
         onSkip={handleSkipWelcome}
@@ -113,8 +158,8 @@ export function MobileApp({ isGitHubConnected }: MobileAppProps) {
       ) : null}
       {activeTab === "profile" ? (
         <ProfileTab
-          email={session?.user?.email ?? null}
-          displayName={session?.user?.name ?? null}
+          email={resolvedUser.email}
+          displayName={resolvedUser.name}
           isGitHubConnected={isGitHubConnected}
         />
       ) : null}

--- a/src/components/mobile/MobileApp.tsx
+++ b/src/components/mobile/MobileApp.tsx
@@ -1,47 +1,129 @@
 "use client";
 
 /**
- * MobileApp — Phase 2 mobile redesign.
+ * MobileApp — top-level mobile composition.
  *
- * Top-level mobile composition rendered inside `MobileShell` when the
- * viewport is below 768px. Owns the active-tab state, dispatches tab
- * content, and shows simple "Coming in Phase N" placeholders for tabs
- * that ship later.
+ * Phase 6 wires:
  *
- * Phase 2 only fills the Sessions tab. Notifications / Channels / Profile
- * are placeholder slots so the tab bar remains usable while later phases
- * land.
+ *   1. The Phase 1 {@link MobileShell} + {@link BottomTabBar}.
+ *   2. The Phase 2 Sessions tab.
+ *   3. The Phase 6 Profile tab.
+ *   4. The Phase 6 lock + welcome auth flow.
+ *
+ * Auth flow (mobile-only):
+ *
+ *   - If we're still resolving the NextAuth session → render
+ *     {@link MobileLockScreen} ("Authenticating via Cloudflare Access").
+ *   - If the session is resolved and the user is on this device for the
+ *     first time → render {@link MobileWelcomeScreen}.
+ *   - Otherwise → render the tab shell with `activeTab` state.
+ *
+ * The GitHub OAuth callback redirects to `/?github=connected`. When that
+ * query param is present we surface a one-shot toast on the Sessions tab
+ * and strip the param from the URL so a refresh doesn't re-toast. This
+ * mirrors the desktop behavior without depending on it.
  */
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { toast } from "sonner";
 
 import { MobileShell } from "./MobileShell";
 import type { MobileTab } from "./BottomTabBar";
 import { SessionsTab } from "./sessions/SessionsTab";
+import { ProfileTab } from "./profile/ProfileTab";
+import { MobileLockScreen } from "./auth/MobileLockScreen";
+import { MobileWelcomeScreen } from "./auth/MobileWelcomeScreen";
+import { useFirstRun } from "./auth/useFirstRun";
 
 export interface MobileAppProps {
   isGitHubConnected: boolean;
 }
 
-const PLACEHOLDER_COPY: Record<Exclude<MobileTab, "sessions">, { title: string; phase: string }> = {
+const PLACEHOLDER_COPY: Record<Exclude<MobileTab, "sessions" | "profile">, { title: string; phase: string }> = {
   notifications: { title: "Notifications", phase: "Phase 4" },
   channels: { title: "Channels", phase: "Phase 5" },
-  profile: { title: "Profile", phase: "Phase 6" },
 };
 
 export function MobileApp({ isGitHubConnected }: MobileAppProps) {
   const [activeTab, setActiveTab] = useState<MobileTab>("sessions");
+  const { data: session, status } = useSession();
+  const firstRun = useFirstRun();
+
+  // Surface the GitHub OAuth callback toast once and strip the query
+  // param so a refresh won't replay it.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const url = new URL(window.location.href);
+    if (url.searchParams.get("github") !== "connected") return;
+    toast.success("GitHub connected", {
+      description: "Your account is linked.",
+    });
+    url.searchParams.delete("github");
+    const next = url.pathname + (url.searchParams.toString() ? `?${url.searchParams}` : "") + url.hash;
+    window.history.replaceState({}, "", next);
+  }, []);
+
+  const handleConnectGitHub = useCallback(() => {
+    if (typeof window !== "undefined") {
+      window.location.href = "/api/auth/github/link";
+    }
+  }, []);
+
+  const handleSkipWelcome = useCallback(() => {
+    firstRun.markSeen();
+    setActiveTab("sessions");
+  }, [firstRun]);
+
+  // While the session is resolving, render the lock screen. NextAuth
+  // exposes `status === "loading"` during the initial fetch.
+  if (status === "loading") {
+    return <MobileLockScreen />;
+  }
+
+  // The middleware will have redirected unauthenticated users to /login
+  // before we ever get here, but if the session lands as `unauthenticated`
+  // due to a transient race, we keep the lock screen up rather than
+  // flashing the tab shell.
+  if (status === "unauthenticated") {
+    return <MobileLockScreen message="Authenticating via Cloudflare Access" detail="Redirecting to sign in." />;
+  }
+
+  // First run: gated by the localStorage flag, only shown once we know
+  // it's not been seen. `firstRun.isFirstRun === null` means we haven't
+  // yet read storage; show the lock briefly to avoid a welcome flash.
+  if (firstRun.isFirstRun === null) {
+    return <MobileLockScreen message="Loading" detail="Just a second." />;
+  }
+  if (firstRun.isFirstRun) {
+    return (
+      <MobileWelcomeScreen
+        email={session?.user?.email ?? null}
+        isGitHubConnected={isGitHubConnected}
+        onConnectGitHub={handleConnectGitHub}
+        onSkip={handleSkipWelcome}
+      />
+    );
+  }
 
   return (
     <MobileShell activeTab={activeTab} onTabChange={setActiveTab}>
       {activeTab === "sessions" ? (
         <SessionsTab isGitHubConnected={isGitHubConnected} />
-      ) : (
-        <EmptyTabPlaceholder
-          title={PLACEHOLDER_COPY[activeTab].title}
-          phase={PLACEHOLDER_COPY[activeTab].phase}
+      ) : null}
+      {activeTab === "profile" ? (
+        <ProfileTab
+          email={session?.user?.email ?? null}
+          displayName={session?.user?.name ?? null}
+          isGitHubConnected={isGitHubConnected}
         />
-      )}
+      ) : null}
+      {activeTab !== "sessions" && activeTab !== "profile" ? (
+        <EmptyTabPlaceholder
+          title={PLACEHOLDER_COPY[activeTab as keyof typeof PLACEHOLDER_COPY].title}
+          phase={PLACEHOLDER_COPY[activeTab as keyof typeof PLACEHOLDER_COPY].phase}
+        />
+      ) : null}
     </MobileShell>
   );
 }

--- a/src/components/mobile/MobileApp.tsx
+++ b/src/components/mobile/MobileApp.tsx
@@ -80,7 +80,7 @@ export function MobileApp({ isGitHubConnected, initialUser }: MobileAppProps) {
   // `useSession` is consulted only for live updates after the initial
   // server render (e.g. post-GitHub-link). It is NEVER the source of
   // truth for "am I authenticated?" — see file-level docblock.
-  const { data: clientSession } = useSession();
+  const { data: clientSession, status: clientSessionStatus } = useSession();
   const firstRun = useFirstRun();
 
   // Derived: prefer the server-passed user, fall back to the live client
@@ -125,7 +125,21 @@ export function MobileApp({ isGitHubConnected, initialUser }: MobileAppProps) {
   // this component renders. If `initialUser` is null AND the client
   // session also hasn't filled in, treat this as "not yet authenticated"
   // and keep the lock screen up rather than flashing the tab shell.
+  //
+  // Copy split:
+  //   - While the NextAuth client session is still resolving (`loading`),
+  //     show a generic "Loading" — we genuinely don't know yet whether
+  //     this is a credentials user, a CF Access user, or unauthenticated.
+  //     Showing the CF Access copy here would mislead local-dev users.
+  //   - Once the client session resolves to `unauthenticated` AND we
+  //     still have no `initialUser`, then we are confident the user is
+  //     not signed in; show the CF-branded copy because in production
+  //     the only way back in is via the CF Access challenge (the
+  //     middleware will have already issued the redirect).
   if (!resolvedUser) {
+    if (clientSessionStatus === "loading") {
+      return <MobileLockScreen message="Loading" detail="Just a second." />;
+    }
     return (
       <MobileLockScreen
         message="Authenticating via Cloudflare Access"

--- a/src/components/mobile/MobileViewportSwitch.tsx
+++ b/src/components/mobile/MobileViewportSwitch.tsx
@@ -17,22 +17,34 @@ import type { ReactNode } from "react";
 
 import { useIsMobileViewport } from "@/hooks/useMobile";
 
-import { MobileApp } from "./MobileApp";
+import { MobileApp, type MobileAuthUser } from "./MobileApp";
 
 export interface MobileViewportSwitchProps {
   isGitHubConnected: boolean;
+  /**
+   * Server-resolved authenticated user (handles both NextAuth and CF
+   * Access). Forwarded to {@link MobileApp} as the source of truth for
+   * mobile auth gating.
+   */
+  initialUser: MobileAuthUser | null;
   /** The desktop composition. Rendered at >=768px. */
   children: ReactNode;
 }
 
 export function MobileViewportSwitch({
   isGitHubConnected,
+  initialUser,
   children,
 }: MobileViewportSwitchProps) {
   const isMobile = useIsMobileViewport();
 
   if (isMobile) {
-    return <MobileApp isGitHubConnected={isGitHubConnected} />;
+    return (
+      <MobileApp
+        isGitHubConnected={isGitHubConnected}
+        initialUser={initialUser}
+      />
+    );
   }
 
   return <>{children}</>;

--- a/src/components/mobile/__tests__/MobileApp.test.tsx
+++ b/src/components/mobile/__tests__/MobileApp.test.tsx
@@ -72,8 +72,27 @@ describe("MobileApp auth gating", () => {
 
   it("renders the lock screen when initialUser is null and useSession() is also unauthenticated", () => {
     render(<MobileApp isGitHubConnected={false} initialUser={null} />);
-    expect(screen.getByTestId("mobile-lock-screen")).toBeInTheDocument();
+    const lock = screen.getByTestId("mobile-lock-screen");
+    expect(lock).toBeInTheDocument();
+    // Once we know the client session is `unauthenticated`, the CF Access
+    // copy is appropriate (CF is the only re-auth path in production).
+    expect(lock).toHaveTextContent(/Cloudflare Access/i);
     expect(screen.queryByTestId("mock-sessions-tab")).toBeNull();
+  });
+
+  it("renders generic loading copy (NOT Cloudflare Access) while the client session is still loading", () => {
+    useSessionMock.mockReturnValue({
+      data: null,
+      status: "loading",
+      update: vi.fn(),
+    });
+    render(<MobileApp isGitHubConnected={false} initialUser={null} />);
+    const lock = screen.getByTestId("mobile-lock-screen");
+    expect(lock).toBeInTheDocument();
+    // Crucial: do NOT mislead credentials/localhost users with CF copy
+    // before we know what auth path is in play.
+    expect(lock).not.toHaveTextContent(/Cloudflare Access/i);
+    expect(lock).toHaveTextContent(/Loading/i);
   });
 
   it("falls back to the live client session when initialUser is null but useSession() is authenticated", () => {

--- a/src/components/mobile/__tests__/MobileApp.test.tsx
+++ b/src/components/mobile/__tests__/MobileApp.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * MobileApp tests — Phase 6 mobile redesign.
+ *
+ * Verifies the *server-passed* `initialUser` prop is the source of truth
+ * for mobile auth gating, NOT the NextAuth client `useSession()` status.
+ * This regression test exists because Cloudflare Access users have no
+ * NextAuth client session — `useSession()` returns `unauthenticated` for
+ * them — so a previous build of this component locked CF users out of
+ * the mobile UI entirely.
+ *
+ * We mock SessionsTab and ProfileTab to avoid pulling in the real
+ * context tree (which is irrelevant to the auth-gating contract under
+ * test).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import { MobileApp } from "@/components/mobile/MobileApp";
+
+// Pretend useSession returns `unauthenticated` — this is the case for
+// Cloudflare Access users in production. The mobile shell must still
+// render based on `initialUser`.
+const useSessionMock = vi.fn();
+vi.mock("next-auth/react", () => ({
+  useSession: () => useSessionMock(),
+}));
+
+// SessionsTab and ProfileTab pull in heavy context trees; replace with
+// thin stand-ins so we can assert on which surface MobileApp routed to.
+vi.mock("@/components/mobile/sessions/SessionsTab", () => ({
+  SessionsTab: () => <div data-testid="mock-sessions-tab" />,
+}));
+vi.mock("@/components/mobile/profile/ProfileTab", () => ({
+  ProfileTab: () => <div data-testid="mock-profile-tab" />,
+}));
+
+// Mock useFirstRun so the welcome screen doesn't intercept.
+vi.mock("@/components/mobile/auth/useFirstRun", () => ({
+  useFirstRun: () => ({
+    isFirstRun: false,
+    markSeen: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  // Default: simulate CF Access production — no NextAuth client session.
+  useSessionMock.mockReturnValue({
+    data: null,
+    status: "unauthenticated",
+    update: vi.fn(),
+  });
+  // Reset the URL so the github=connected toast effect doesn't fire.
+  window.history.replaceState({}, "", "/");
+});
+afterEach(() => cleanup());
+
+describe("MobileApp auth gating", () => {
+  it("renders the tab shell when initialUser is provided, even with useSession() unauthenticated", () => {
+    render(
+      <MobileApp
+        isGitHubConnected={false}
+        initialUser={{ email: "cf@example.com", name: "CF User" }}
+      />
+    );
+    // We're on the default Sessions tab.
+    expect(screen.getByTestId("mock-sessions-tab")).toBeInTheDocument();
+    // The lock screen MUST NOT be rendered.
+    expect(screen.queryByTestId("mobile-lock-screen")).toBeNull();
+  });
+
+  it("renders the lock screen when initialUser is null and useSession() is also unauthenticated", () => {
+    render(<MobileApp isGitHubConnected={false} initialUser={null} />);
+    expect(screen.getByTestId("mobile-lock-screen")).toBeInTheDocument();
+    expect(screen.queryByTestId("mock-sessions-tab")).toBeNull();
+  });
+
+  it("falls back to the live client session when initialUser is null but useSession() is authenticated", () => {
+    useSessionMock.mockReturnValue({
+      data: {
+        user: { email: "credentials@example.com", name: "Local Dev" },
+      },
+      status: "authenticated",
+      update: vi.fn(),
+    });
+    render(<MobileApp isGitHubConnected={false} initialUser={null} />);
+    expect(screen.getByTestId("mock-sessions-tab")).toBeInTheDocument();
+    expect(screen.queryByTestId("mobile-lock-screen")).toBeNull();
+  });
+});

--- a/src/components/mobile/auth/MobileLockScreen.tsx
+++ b/src/components/mobile/auth/MobileLockScreen.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+/**
+ * MobileLockScreen — interstitial shown while the browser is finishing the
+ * Cloudflare Access challenge.
+ *
+ * Phase 6 of the mobile redesign. This is intentionally calm: a single
+ * line of copy and an unobtrusive spinner. Per DESIGN.md "Achromatic-Default
+ * Rule" the surface carries no chroma, no glassmorphism, no gradient. The
+ * spinner uses the foreground token rather than a signal color because
+ * "authenticating" is not a state the user needs to react to.
+ *
+ * Rendered above the rest of the mobile composition until the session
+ * lands; once the session is available the host swaps to either
+ * {@link MobileWelcomeScreen} (first run) or the Sessions tab.
+ */
+
+import { Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export interface MobileLockScreenProps {
+  /**
+   * Optional override for the primary line. Defaults to the Cloudflare
+   * Access copy. Tests use this to assert variant rendering without
+   * having to thread real auth state.
+   */
+  message?: string;
+  /** Optional sub-line. */
+  detail?: string;
+  className?: string;
+}
+
+const DEFAULT_MESSAGE = "Authenticating via Cloudflare Access";
+const DEFAULT_DETAIL = "Hold tight, this should only take a moment.";
+
+export function MobileLockScreen({
+  message = DEFAULT_MESSAGE,
+  detail = DEFAULT_DETAIL,
+  className,
+}: MobileLockScreenProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="mobile-lock-screen"
+      className={cn(
+        "flex h-[100dvh] w-full flex-col items-center justify-center gap-3",
+        "bg-background text-foreground",
+        "px-6 text-center",
+        className
+      )}
+    >
+      <Loader2
+        aria-hidden="true"
+        className="h-5 w-5 animate-spin text-muted-foreground motion-reduce:animate-none"
+        strokeWidth={1.75}
+      />
+      <p className="text-[15px] font-medium leading-tight">{message}</p>
+      {detail ? (
+        <p className="max-w-[28ch] text-[13px] leading-snug text-muted-foreground">
+          {detail}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/mobile/auth/MobileWelcomeScreen.tsx
+++ b/src/components/mobile/auth/MobileWelcomeScreen.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+/**
+ * MobileWelcomeScreen — shown once after the user lands post-Cloudflare-Access
+ * the first time on this device.
+ *
+ * Phase 6 of the mobile redesign. Quiet, calm, expert. Per the brief:
+ *
+ *   - "Signed in as <email>" line so the user can confirm the right account.
+ *   - Optional "Connect GitHub" CTA that triggers `/api/auth/github/link`.
+ *   - "Skip for now" text button that lands the user on Sessions.
+ *
+ * No marketing illustrations, no gradient hero, no accent walls. Type-driven
+ * hierarchy and a single primary action; everything else is a ghost button
+ * or muted text. Achromatic-default per DESIGN.md.
+ */
+
+import { Github } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export interface MobileWelcomeScreenProps {
+  /** Authenticated user's email — typically `session.user.email`. */
+  email: string | null | undefined;
+  /** True when the user already has a GitHub OAuth account linked. */
+  isGitHubConnected: boolean;
+  /** Called when the user taps "Connect GitHub". */
+  onConnectGitHub: () => void;
+  /** Called when the user taps "Skip for now" or "Continue". */
+  onSkip: () => void;
+  className?: string;
+}
+
+export function MobileWelcomeScreen({
+  email,
+  isGitHubConnected,
+  onConnectGitHub,
+  onSkip,
+  className,
+}: MobileWelcomeScreenProps) {
+  return (
+    <div
+      data-testid="mobile-welcome-screen"
+      className={cn(
+        "flex h-[100dvh] w-full flex-col bg-background text-foreground",
+        "px-6 pb-safe-bottom pt-safe-top",
+        className
+      )}
+    >
+      {/* Top spacer so the welcome copy lands roughly mid-screen on a phone. */}
+      <div aria-hidden="true" className="flex-1" />
+
+      <div className="flex flex-col gap-3">
+        <p className="text-[22px] font-semibold leading-tight tracking-tight">
+          Welcome to Remote Dev.
+        </p>
+        <p className="text-[14px] leading-snug text-muted-foreground">
+          Your terminal, agents, and projects, on your phone.
+        </p>
+        {email ? (
+          <p
+            data-testid="mobile-welcome-signed-in-as"
+            className="text-[13px] leading-snug text-muted-foreground"
+          >
+            Signed in as{" "}
+            <span className="font-medium text-foreground">{email}</span>.
+          </p>
+        ) : null}
+      </div>
+
+      <div className="flex-1" aria-hidden="true" />
+
+      <div className="flex flex-col gap-2">
+        {isGitHubConnected ? (
+          <p
+            data-testid="mobile-welcome-github-connected"
+            className="text-center text-[13px] text-muted-foreground"
+          >
+            GitHub is already connected.
+          </p>
+        ) : (
+          <Button
+            type="button"
+            data-testid="mobile-welcome-connect-github"
+            onClick={onConnectGitHub}
+            className="h-11 w-full text-[15px]"
+          >
+            <Github aria-hidden="true" className="h-4 w-4" strokeWidth={1.75} />
+            Connect GitHub
+          </Button>
+        )}
+        <Button
+          type="button"
+          variant="ghost"
+          data-testid="mobile-welcome-skip"
+          onClick={onSkip}
+          className="h-11 w-full text-[14px] text-muted-foreground hover:text-foreground"
+        >
+          {isGitHubConnected ? "Continue" : "Skip for now"}
+        </Button>
+      </div>
+
+      <div aria-hidden="true" className="h-4" />
+    </div>
+  );
+}

--- a/src/components/mobile/auth/__tests__/MobileWelcomeScreen.test.tsx
+++ b/src/components/mobile/auth/__tests__/MobileWelcomeScreen.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * MobileWelcomeScreen tests — Phase 6 mobile redesign.
+ *
+ * Verifies the welcome surface renders the signed-in-as line, exposes
+ * the Connect-GitHub CTA only when GitHub is not yet connected, and
+ * routes both primary actions to the correct callbacks.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { MobileWelcomeScreen } from "@/components/mobile/auth/MobileWelcomeScreen";
+import { MobileLockScreen } from "@/components/mobile/auth/MobileLockScreen";
+
+afterEach(() => cleanup());
+
+describe("MobileWelcomeScreen", () => {
+  it("renders the signed-in-as line when an email is present", () => {
+    render(
+      <MobileWelcomeScreen
+        email="bryan@example.com"
+        isGitHubConnected={false}
+        onConnectGitHub={vi.fn()}
+        onSkip={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId("mobile-welcome-signed-in-as")).toHaveTextContent(
+      "bryan@example.com"
+    );
+  });
+
+  it("shows Connect GitHub when not connected", async () => {
+    const user = userEvent.setup();
+    const onConnect = vi.fn();
+    render(
+      <MobileWelcomeScreen
+        email="bryan@example.com"
+        isGitHubConnected={false}
+        onConnectGitHub={onConnect}
+        onSkip={vi.fn()}
+      />
+    );
+    await user.click(screen.getByTestId("mobile-welcome-connect-github"));
+    expect(onConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides Connect GitHub when already connected", () => {
+    render(
+      <MobileWelcomeScreen
+        email="bryan@example.com"
+        isGitHubConnected={true}
+        onConnectGitHub={vi.fn()}
+        onSkip={vi.fn()}
+      />
+    );
+    expect(screen.queryByTestId("mobile-welcome-connect-github")).toBeNull();
+    expect(screen.getByTestId("mobile-welcome-github-connected")).toBeInTheDocument();
+  });
+
+  it("invokes onSkip when the Skip-for-now button is tapped", async () => {
+    const user = userEvent.setup();
+    const onSkip = vi.fn();
+    render(
+      <MobileWelcomeScreen
+        email={null}
+        isGitHubConnected={false}
+        onConnectGitHub={vi.fn()}
+        onSkip={onSkip}
+      />
+    );
+    await user.click(screen.getByTestId("mobile-welcome-skip"));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("MobileLockScreen", () => {
+  it("renders the Cloudflare Access copy by default", () => {
+    render(<MobileLockScreen />);
+    expect(screen.getByTestId("mobile-lock-screen")).toHaveTextContent(
+      "Authenticating via Cloudflare Access"
+    );
+  });
+
+  it("respects custom message and detail props", () => {
+    render(<MobileLockScreen message="Loading" detail="One moment." />);
+    const lock = screen.getByTestId("mobile-lock-screen");
+    expect(lock).toHaveTextContent("Loading");
+    expect(lock).toHaveTextContent("One moment.");
+  });
+});

--- a/src/components/mobile/auth/useFirstRun.ts
+++ b/src/components/mobile/auth/useFirstRun.ts
@@ -1,0 +1,83 @@
+"use client";
+
+/**
+ * useFirstRun — localStorage-backed flag for the mobile welcome screen.
+ *
+ * Phase 6 of the mobile redesign. The first time an authenticated user
+ * lands on mobile we want to show {@link MobileWelcomeScreen} (post-CF-Access
+ * "Connect GitHub" / "Skip"). Subsequent visits should bypass it.
+ *
+ * SSR-safe: returns `null` until we've consulted localStorage on the
+ * client, so the host can render a neutral placeholder during the first
+ * paint and avoid hydration mismatches.
+ *
+ * The flag deliberately lives in localStorage (not a server-side flag)
+ * because the welcome step is a UX nicety, not a security boundary, and
+ * because it's per-device — a user reinstalling the PWA on a new phone
+ * will see the welcome there too, which is what we want.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Storage key. Versioned so we can ship a new welcome flow later without
+ * resurrecting it for users who already dismissed v1.
+ */
+export const WELCOME_SEEN_STORAGE_KEY = "remote-dev:mobile:welcome-seen:v1";
+
+export interface UseFirstRunResult {
+  /**
+   * `true`  — user has never seen the welcome (or storage was cleared).
+   * `false` — user has dismissed it and shouldn't see it again.
+   * `null`  — we haven't yet read the flag from storage (SSR / first paint).
+   */
+  isFirstRun: boolean | null;
+  /** Mark the welcome as seen. Synchronous against React state, async to storage. */
+  markSeen: () => void;
+  /** Test/escape hatch: clear the flag so the welcome shows again. */
+  reset: () => void;
+}
+
+function readFlag(): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(WELCOME_SEEN_STORAGE_KEY) !== "1";
+  } catch {
+    // localStorage can throw in private mode / when disabled. Treat as
+    // first-run; the worst case is the user sees the welcome once per
+    // session in those modes, which is acceptable.
+    return true;
+  }
+}
+
+export function useFirstRun(): UseFirstRunResult {
+  const [isFirstRun, setIsFirstRun] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time hydration from localStorage
+    setIsFirstRun(readFlag());
+  }, []);
+
+  const markSeen = useCallback(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(WELCOME_SEEN_STORAGE_KEY, "1");
+    } catch {
+      // Storage failure: still update local state so the welcome closes
+      // for this session even if we can't persist.
+    }
+    setIsFirstRun(false);
+  }, []);
+
+  const reset = useCallback(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.removeItem(WELCOME_SEEN_STORAGE_KEY);
+    } catch {
+      // No-op.
+    }
+    setIsFirstRun(true);
+  }, []);
+
+  return { isFirstRun, markSeen, reset };
+}

--- a/src/components/mobile/profile/ProfileRow.tsx
+++ b/src/components/mobile/profile/ProfileRow.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+/**
+ * ProfileRow — single tappable row in the Profile index or any sub-screen.
+ *
+ * Phase 6 of the mobile redesign. A pure presentational primitive: icon
+ * on the left, label + optional value on the right, chevron at the end.
+ * No side-stripes, no glass; achromatic-default. Hierarchy is by weight.
+ *
+ * Touch target is at least 56pt tall (well above the 44pt minimum), with
+ * a generous press state via `active:bg-accent/40`.
+ */
+
+import { ChevronRight } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface ProfileRowProps {
+  /**
+   * Optional Lucide icon component. Rendered in `text-muted-foreground`
+   * so it reads as orientation, not decoration.
+   */
+  icon?: LucideIcon;
+  /** Primary label. */
+  label: ReactNode;
+  /** Optional muted right-aligned value (e.g. version string, count). */
+  value?: ReactNode;
+  /** True for sign-out and similar; renders the label in destructive ink. */
+  destructive?: boolean;
+  /** Disables the row visually. The row still calls onPress on tap. */
+  disabled?: boolean;
+  /** Hide the trailing chevron. Useful for terminal "Sign out" style rows. */
+  hideChevron?: boolean;
+  onPress: () => void;
+  className?: string;
+  /** Optional `data-row` identifier for tests and analytics. */
+  rowId?: string;
+}
+
+export function ProfileRow({
+  icon: Icon,
+  label,
+  value,
+  destructive = false,
+  disabled = false,
+  hideChevron = false,
+  onPress,
+  className,
+  rowId,
+}: ProfileRowProps) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      data-row={rowId}
+      data-destructive={destructive ? "true" : undefined}
+      onClick={onPress}
+      disabled={disabled}
+      className={cn(
+        "flex w-full items-center gap-3 px-4",
+        // 56pt row keeps Profile reading as native iOS-grade settings.
+        "min-h-[56px] py-3",
+        "text-left",
+        "transition-colors",
+        "active:bg-accent/40",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-inset",
+        // Hairline divider rendered by parent; row stays flush.
+        disabled && "opacity-50",
+        className
+      )}
+    >
+      {Icon ? (
+        <span
+          aria-hidden="true"
+          className="inline-flex h-6 w-6 items-center justify-center text-muted-foreground"
+        >
+          <Icon
+            aria-hidden="true"
+            className="h-5 w-5"
+            strokeWidth={1.75}
+          />
+        </span>
+      ) : null}
+      <span
+        className={cn(
+          "flex-1 truncate text-[15px] leading-tight",
+          destructive ? "text-destructive font-medium" : "font-medium text-foreground"
+        )}
+      >
+        {label}
+      </span>
+      {value !== undefined && value !== null ? (
+        <span className="truncate text-[13px] text-muted-foreground">
+          {value}
+        </span>
+      ) : null}
+      {hideChevron ? null : (
+        <ChevronRight
+          aria-hidden="true"
+          className="h-4 w-4 shrink-0 text-muted-foreground"
+          strokeWidth={1.75}
+        />
+      )}
+    </button>
+  );
+}

--- a/src/components/mobile/profile/ProfileRow.tsx
+++ b/src/components/mobile/profile/ProfileRow.tsx
@@ -29,7 +29,7 @@ export interface ProfileRowProps {
   value?: ReactNode;
   /** True for sign-out and similar; renders the label in destructive ink. */
   destructive?: boolean;
-  /** Disables the row visually. The row still calls onPress on tap. */
+  /** Disables the row visually and suppresses tap/click events. */
   disabled?: boolean;
   /** Hide the trailing chevron. Useful for terminal "Sign out" style rows. */
   hideChevron?: boolean;
@@ -53,7 +53,6 @@ export function ProfileRow({
   return (
     <button
       type="button"
-      role="menuitem"
       data-row={rowId}
       data-destructive={destructive ? "true" : undefined}
       onClick={onPress}

--- a/src/components/mobile/profile/ProfileTab.tsx
+++ b/src/components/mobile/profile/ProfileTab.tsx
@@ -27,7 +27,6 @@
  */
 
 import { useCallback, useState } from "react";
-import { signOut } from "next-auth/react";
 import {
   Boxes,
   CircleAlert,
@@ -73,7 +72,13 @@ export interface ProfileTabProps {
   email: string | null | undefined;
   displayName: string | null | undefined;
   isGitHubConnected: boolean;
-  /** Optional override (test seam). Defaults to NextAuth's signOut(). */
+  /**
+   * Optional override (test seam). Defaults to a navigation to the
+   * server-side `/api/auth/signout` route, which clears BOTH the
+   * NextAuth JWT cookie and the Cloudflare Access cookie. The legacy
+   * client-only `next-auth/react` `signOut` was a no-op for CF Access
+   * users — see {@link DEFAULT_SIGN_OUT_HREF}.
+   */
   signOut?: () => Promise<void> | void;
   /** Optional override (test seam). Defaults to redirecting to the link route. */
   onConnectGitHub?: () => void;
@@ -81,6 +86,7 @@ export interface ProfileTabProps {
 }
 
 const DEFAULT_GITHUB_LINK_HREF = "/api/auth/github/link";
+const DEFAULT_SIGN_OUT_HREF = "/api/auth/signout";
 
 export function ProfileTab({
   email,
@@ -108,10 +114,16 @@ export function ProfileTab({
       await signOutOverride();
       return;
     }
-    // NextAuth's client `signOut` redirects to the post-logout URL. We
-    // explicitly send the user back to /login so the CF Access cookie
-    // (if any) can re-issue cleanly on the next visit.
-    await signOut({ callbackUrl: "/login" });
+    // Route through the server endpoint so BOTH auth modes are cleared:
+    //   - NextAuth credentials: server signOut clears the JWT cookie.
+    //   - Cloudflare Access: redirects through the CF logout URL, which
+    //     deletes the `CF_Authorization` cookie on the team domain and
+    //     bounces back to /login.
+    // Using window.location (not fetch) ensures the browser follows the
+    // cross-origin redirect chain to Cloudflare and back.
+    if (typeof window !== "undefined") {
+      window.location.href = DEFAULT_SIGN_OUT_HREF;
+    }
   }, [signOutOverride]);
 
   const signOutItems: ActionSheetItem[] = [

--- a/src/components/mobile/profile/ProfileTab.tsx
+++ b/src/components/mobile/profile/ProfileTab.tsx
@@ -114,16 +114,33 @@ export function ProfileTab({
       await signOutOverride();
       return;
     }
+    if (typeof window === "undefined") return;
     // Route through the server endpoint so BOTH auth modes are cleared:
     //   - NextAuth credentials: server signOut clears the JWT cookie.
     //   - Cloudflare Access: redirects through the CF logout URL, which
     //     deletes the `CF_Authorization` cookie on the team domain and
     //     bounces back to /login.
-    // Using window.location (not fetch) ensures the browser follows the
-    // cross-origin redirect chain to Cloudflare and back.
-    if (typeof window !== "undefined") {
-      window.location.href = DEFAULT_SIGN_OUT_HREF;
+    //
+    // We POST (not navigate) because GET sign-out is a CSRF logout
+    // vector — a `<img src>` from any third-party page could trigger it.
+    // The fetch follows the redirect chain transparently; if a redirect
+    // happens the browser exposes the final URL via `response.url` and
+    // we navigate there. If something fails we fall through to /login so
+    // the user is never stranded.
+    try {
+      const response = await fetch(DEFAULT_SIGN_OUT_HREF, {
+        method: "POST",
+        redirect: "follow",
+        credentials: "same-origin",
+      });
+      if (response.redirected && response.url) {
+        window.location.href = response.url;
+        return;
+      }
+    } catch {
+      // fall through to the local login redirect
     }
+    window.location.href = "/login";
   }, [signOutOverride]);
 
   const signOutItems: ActionSheetItem[] = [

--- a/src/components/mobile/profile/ProfileTab.tsx
+++ b/src/components/mobile/profile/ProfileTab.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+/**
+ * ProfileTab — Phase 6 mobile redesign.
+ *
+ * The Profile tab is a pushed-row stack: an index of rows that each push
+ * a sub-screen onto a tab-local navigation stack. There are no modals
+ * for routine settings; sub-screens own the chrome and the back stack.
+ *
+ * Sign-out is the only flow that "fully works" in Phase 6 — it shows an
+ * {@link ActionSheet}, not a dialog (per DESIGN.md: prefer sheets to
+ * modal confirmations for routine actions). All other rows push stub
+ * sub-screens that include a TODO pointing at the desktop component to
+ * port.
+ *
+ * Composition (top to bottom):
+ *
+ *   1. Identity strip: signed-in-as line + GitHub badge.
+ *   2. Section: Account, GitHub accounts.
+ *   3. Section: Projects, Agent profiles.
+ *   4. Section: Secrets, Ports, Trash.
+ *   5. Section: Settings, About.
+ *   6. Sign out (destructive, terminal row).
+ *
+ * Sections are separated by a small gap and a hairline; rows inside a
+ * section are flush with hairline dividers.
+ */
+
+import { useCallback, useState } from "react";
+import { signOut } from "next-auth/react";
+import {
+  Boxes,
+  CircleAlert,
+  CircleUser,
+  FolderTree,
+  Github,
+  Info,
+  KeyRound,
+  LogOut,
+  Network,
+  Settings,
+  Sparkles,
+  Trash2,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { ActionSheet, type ActionSheetItem } from "../common/ActionSheet";
+
+import { ProfileRow } from "./ProfileRow";
+import { useProfileNavStack } from "./useProfileNavStack";
+import { AccountScreen } from "./screens/AccountScreen";
+import { GithubAccountsScreen } from "./screens/GithubAccountsScreen";
+import { ProjectsScreen } from "./screens/ProjectsScreen";
+import { AgentProfilesScreen } from "./screens/AgentProfilesScreen";
+import { SecretsScreen } from "./screens/SecretsScreen";
+import { PortsScreen } from "./screens/PortsScreen";
+import { TrashScreen } from "./screens/TrashScreen";
+import { SettingsScreen } from "./screens/SettingsScreen";
+import { AboutScreen } from "./screens/AboutScreen";
+
+export type ProfileScreen =
+  | "account"
+  | "github"
+  | "projects"
+  | "agent-profiles"
+  | "secrets"
+  | "ports"
+  | "trash"
+  | "settings"
+  | "about";
+
+export interface ProfileTabProps {
+  email: string | null | undefined;
+  displayName: string | null | undefined;
+  isGitHubConnected: boolean;
+  /** Optional override (test seam). Defaults to NextAuth's signOut(). */
+  signOut?: () => Promise<void> | void;
+  /** Optional override (test seam). Defaults to redirecting to the link route. */
+  onConnectGitHub?: () => void;
+  className?: string;
+}
+
+const DEFAULT_GITHUB_LINK_HREF = "/api/auth/github/link";
+
+export function ProfileTab({
+  email,
+  displayName,
+  isGitHubConnected,
+  signOut: signOutOverride,
+  onConnectGitHub,
+  className,
+}: ProfileTabProps) {
+  const nav = useProfileNavStack<ProfileScreen>();
+  const [signOutOpen, setSignOutOpen] = useState(false);
+
+  const handleConnectGitHub = useCallback(() => {
+    if (onConnectGitHub) {
+      onConnectGitHub();
+      return;
+    }
+    if (typeof window !== "undefined") {
+      window.location.href = DEFAULT_GITHUB_LINK_HREF;
+    }
+  }, [onConnectGitHub]);
+
+  const handleSignOutConfirm = useCallback(async () => {
+    if (signOutOverride) {
+      await signOutOverride();
+      return;
+    }
+    // NextAuth's client `signOut` redirects to the post-logout URL. We
+    // explicitly send the user back to /login so the CF Access cookie
+    // (if any) can re-issue cleanly on the next visit.
+    await signOut({ callbackUrl: "/login" });
+  }, [signOutOverride]);
+
+  const signOutItems: ActionSheetItem[] = [
+    {
+      id: "confirm-sign-out",
+      label: "Sign out",
+      destructive: true,
+      onSelect: handleSignOutConfirm,
+    },
+  ];
+
+  // When the user has pushed a screen, render that instead of the index.
+  // We keep mount/unmount semantics simple: each screen is a fresh
+  // component tree, no animation between them in Phase 6. Phase 7 may
+  // add a slide transition; gesture-back is owned by the platform.
+  if (nav.current !== null) {
+    return (
+      <div
+        data-testid="mobile-profile-tab"
+        data-screen={nav.current}
+        className={cn("flex h-full w-full flex-col", className)}
+      >
+        {nav.current === "account" ? (
+          <AccountScreen email={email} displayName={displayName} onBack={nav.pop} />
+        ) : null}
+        {nav.current === "github" ? (
+          <GithubAccountsScreen onBack={nav.pop} onAddAccount={handleConnectGitHub} />
+        ) : null}
+        {nav.current === "projects" ? <ProjectsScreen onBack={nav.pop} /> : null}
+        {nav.current === "agent-profiles" ? (
+          <AgentProfilesScreen onBack={nav.pop} />
+        ) : null}
+        {nav.current === "secrets" ? <SecretsScreen onBack={nav.pop} /> : null}
+        {nav.current === "ports" ? <PortsScreen onBack={nav.pop} /> : null}
+        {nav.current === "trash" ? <TrashScreen onBack={nav.pop} /> : null}
+        {nav.current === "settings" ? <SettingsScreen onBack={nav.pop} /> : null}
+        {nav.current === "about" ? <AboutScreen onBack={nav.pop} /> : null}
+      </div>
+    );
+  }
+
+  // Index.
+  return (
+    <div
+      data-testid="mobile-profile-tab"
+      data-screen="index"
+      className={cn("flex h-full w-full flex-col", className)}
+    >
+      <header className="flex flex-col gap-1 px-4 py-4">
+        <p className="text-[20px] font-semibold leading-tight tracking-tight text-foreground">
+          Profile
+        </p>
+        {email ? (
+          <p
+            data-testid="mobile-profile-signed-in-as"
+            className="text-[13px] leading-snug text-muted-foreground"
+          >
+            Signed in as{" "}
+            <span className="font-medium text-foreground">{email}</span>
+          </p>
+        ) : null}
+      </header>
+
+      <Section>
+        <ProfileRow
+          rowId="account"
+          icon={CircleUser}
+          label="Account"
+          onPress={() => nav.push("account")}
+        />
+        <Divider />
+        <ProfileRow
+          rowId="github"
+          icon={Github}
+          label="GitHub accounts"
+          value={isGitHubConnected ? "Connected" : "Not connected"}
+          onPress={() => nav.push("github")}
+        />
+      </Section>
+
+      <Section>
+        <ProfileRow
+          rowId="projects"
+          icon={FolderTree}
+          label="Projects"
+          onPress={() => nav.push("projects")}
+        />
+        <Divider />
+        <ProfileRow
+          rowId="agent-profiles"
+          icon={Sparkles}
+          label="Agent profiles"
+          onPress={() => nav.push("agent-profiles")}
+        />
+      </Section>
+
+      <Section>
+        <ProfileRow
+          rowId="secrets"
+          icon={KeyRound}
+          label="Secrets"
+          onPress={() => nav.push("secrets")}
+        />
+        <Divider />
+        <ProfileRow
+          rowId="ports"
+          icon={Network}
+          label="Ports"
+          onPress={() => nav.push("ports")}
+        />
+        <Divider />
+        <ProfileRow
+          rowId="trash"
+          icon={Trash2}
+          label="Trash"
+          onPress={() => nav.push("trash")}
+        />
+      </Section>
+
+      <Section>
+        <ProfileRow
+          rowId="settings"
+          icon={Settings}
+          label="Settings"
+          onPress={() => nav.push("settings")}
+        />
+        <Divider />
+        <ProfileRow
+          rowId="about"
+          icon={Info}
+          label="About"
+          onPress={() => nav.push("about")}
+        />
+      </Section>
+
+      <Section>
+        <ProfileRow
+          rowId="sign-out"
+          icon={LogOut}
+          label="Sign out"
+          destructive
+          hideChevron
+          onPress={() => setSignOutOpen(true)}
+        />
+      </Section>
+
+      <ActionSheet
+        open={signOutOpen}
+        onOpenChange={setSignOutOpen}
+        title="Sign out of Remote Dev?"
+        subtitle={email ? `${email}` : undefined}
+        items={signOutItems}
+      />
+
+      {/* Aria-hidden visual sentinel that hands off to the page padding. */}
+      <div aria-hidden="true" className="flex-1" />
+      <Footnote />
+    </div>
+  );
+}
+
+function Section({ children }: { children: React.ReactNode }) {
+  return (
+    <section
+      role="group"
+      className={cn(
+        "mt-4 border-y border-border bg-card",
+        // Section visually separates from the page; never wraps in a card
+        // per DESIGN.md ("Don't wrap every list row in a card").
+      )}
+    >
+      {children}
+    </section>
+  );
+}
+
+function Divider() {
+  return <div role="separator" aria-hidden="true" className="ml-12 border-t border-border" />;
+}
+
+function Footnote() {
+  return (
+    <div className="px-4 py-4 text-center">
+      <p
+        aria-hidden="true"
+        className="inline-flex items-center gap-1 text-[11px] leading-snug text-muted-foreground/70"
+      >
+        <CircleAlert className="h-3 w-3" strokeWidth={1.75} aria-hidden="true" />
+        <span>Some screens are stubbed in this build.</span>
+        <Boxes className="hidden" aria-hidden="true" />
+      </p>
+    </div>
+  );
+}

--- a/src/components/mobile/profile/SubScreen.tsx
+++ b/src/components/mobile/profile/SubScreen.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+/**
+ * SubScreen — chrome wrapper for any pushed Profile screen.
+ *
+ * Phase 6 of the mobile redesign. Provides:
+ *
+ *   - A 44pt header strip with a back affordance ("‹ Back") and a title.
+ *   - A scrollable body region.
+ *   - The same 56pt+safe-area bottom inset reserved by `MobileShell` so
+ *     the bottom tab bar never overlaps content.
+ *
+ * The visual register is deliberately quiet: hairline border under the
+ * header, no shadow, no glass. Per DESIGN.md "Flat-By-Default Rule".
+ *
+ * Note: we render a native `<button>` with a chevron instead of relying
+ * on the platform's swipe-from-edge gesture so the back affordance is
+ * visible and tappable for users who don't know the gesture. The
+ * left-edge swipe still works because parents that need it can wire it
+ * up at the navigation-stack layer.
+ */
+
+import { ChevronLeft } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface SubScreenProps {
+  /** Title rendered centered on the header strip. */
+  title: ReactNode;
+  /** Called when the back affordance is tapped. */
+  onBack: () => void;
+  children: ReactNode;
+  /** Optional right-side header slot for an action button. */
+  trailingAction?: ReactNode;
+  /** Optional accessibility label override for the back button. */
+  backLabel?: string;
+  className?: string;
+}
+
+export function SubScreen({
+  title,
+  onBack,
+  children,
+  trailingAction,
+  backLabel = "Back",
+  className,
+}: SubScreenProps) {
+  return (
+    <div
+      data-testid="mobile-profile-sub-screen"
+      className={cn(
+        "relative flex h-full flex-col bg-background text-foreground",
+        className
+      )}
+    >
+      <header
+        className={cn(
+          "sticky top-0 z-10 flex h-11 items-center gap-1 px-2",
+          "bg-background",
+          "border-b border-border"
+        )}
+      >
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label={backLabel}
+          data-testid="mobile-profile-back"
+          className={cn(
+            "inline-flex h-9 min-w-[44px] items-center gap-0.5 rounded-md px-1.5",
+            "text-[15px] text-foreground",
+            "active:bg-accent/40",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          )}
+        >
+          <ChevronLeft aria-hidden="true" className="h-5 w-5" strokeWidth={1.75} />
+          <span className="text-[15px]">Back</span>
+        </button>
+        <h1 className="absolute left-1/2 -translate-x-1/2 truncate text-[15px] font-medium leading-tight text-foreground">
+          {title}
+        </h1>
+        <div className="ml-auto flex h-9 items-center">{trailingAction}</div>
+      </header>
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/mobile/profile/SubScreen.tsx
+++ b/src/components/mobile/profile/SubScreen.tsx
@@ -74,7 +74,7 @@ export function SubScreen({
           )}
         >
           <ChevronLeft aria-hidden="true" className="h-5 w-5" strokeWidth={1.75} />
-          <span className="text-[15px]">Back</span>
+          <span className="text-[15px]">{backLabel}</span>
         </button>
         <h1 className="absolute left-1/2 -translate-x-1/2 truncate text-[15px] font-medium leading-tight text-foreground">
           {title}

--- a/src/components/mobile/profile/__tests__/ProfileTab.test.tsx
+++ b/src/components/mobile/profile/__tests__/ProfileTab.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * ProfileTab tests — Phase 6 mobile redesign.
+ *
+ * Renders the real ProfileTab and verifies:
+ *
+ *   - The signed-in-as identity line appears.
+ *   - Each section row pushes its sub-screen onto the stack.
+ *   - Back navigation pops the stack and restores the index.
+ *   - "Sign out" opens an action sheet (NOT a modal dialog) and the
+ *     destructive item invokes the supplied signOut callback.
+ *
+ * NextAuth's `signOut` is mocked at the import level so we don't trigger
+ * a real navigation in jsdom/happy-dom.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ProfileTab } from "@/components/mobile/profile/ProfileTab";
+
+vi.mock("next-auth/react", () => ({
+  signOut: vi.fn(),
+}));
+
+afterEach(() => cleanup());
+
+describe("ProfileTab", () => {
+  it("renders the signed-in-as line on the index", () => {
+    render(
+      <ProfileTab
+        email="bryan@example.com"
+        displayName="Bryan"
+        isGitHubConnected={false}
+      />
+    );
+    expect(screen.getByTestId("mobile-profile-tab")).toHaveAttribute(
+      "data-screen",
+      "index"
+    );
+    expect(screen.getByTestId("mobile-profile-signed-in-as")).toHaveTextContent(
+      "bryan@example.com"
+    );
+  });
+
+  it("shows GitHub status as Connected when isGitHubConnected is true", () => {
+    render(
+      <ProfileTab
+        email="bryan@example.com"
+        displayName="Bryan"
+        isGitHubConnected={true}
+      />
+    );
+    const githubRow = screen.getByRole("menuitem", { name: /GitHub accounts/ });
+    expect(githubRow).toHaveTextContent("Connected");
+  });
+
+  it("pushes the Account sub-screen when the row is tapped", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProfileTab
+        email="bryan@example.com"
+        displayName="Bryan"
+        isGitHubConnected={false}
+      />
+    );
+    await user.click(screen.getByRole("menuitem", { name: /Account/ }));
+    expect(screen.getByTestId("mobile-profile-tab")).toHaveAttribute(
+      "data-screen",
+      "account"
+    );
+    // The sub-screen header renders the title.
+    expect(screen.getByRole("heading", { name: "Account" })).toBeInTheDocument();
+  });
+
+  it("pops back to the index when the back affordance is tapped", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProfileTab
+        email="bryan@example.com"
+        displayName={null}
+        isGitHubConnected={false}
+      />
+    );
+    await user.click(screen.getByRole("menuitem", { name: /Settings/ }));
+    expect(screen.getByTestId("mobile-profile-tab")).toHaveAttribute(
+      "data-screen",
+      "settings"
+    );
+    await user.click(screen.getByTestId("mobile-profile-back"));
+    expect(screen.getByTestId("mobile-profile-tab")).toHaveAttribute(
+      "data-screen",
+      "index"
+    );
+  });
+
+  it("opens an action sheet (not a dialog) for sign-out", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProfileTab
+        email="bryan@example.com"
+        displayName={null}
+        isGitHubConnected={false}
+      />
+    );
+    await user.click(screen.getByRole("menuitem", { name: /Sign out/ }));
+    // The sheet renders its items in a list keyed by data-testid. The
+    // presence of the action-sheet items container distinguishes this
+    // surface from a modal confirmation dialog (which would render under
+    // role="dialog" with role="alertdialog" semantics).
+    await waitFor(() => {
+      expect(screen.getByTestId("mobile-action-sheet-items")).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  it("invokes the supplied signOut callback when the sheet's Sign out item is tapped", async () => {
+    const user = userEvent.setup();
+    const onSignOut = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ProfileTab
+        email="bryan@example.com"
+        displayName={null}
+        isGitHubConnected={false}
+        signOut={onSignOut}
+      />
+    );
+    await user.click(screen.getByRole("menuitem", { name: /Sign out/ }));
+    // Scope the second click to the action sheet's items list so we don't
+    // accidentally re-click the row in the index. Both rows render
+    // role="menuitem"; we identify the sheet's confirm via its
+    // data-action-id.
+    await waitFor(() => {
+      const items = screen.getByTestId("mobile-action-sheet-items");
+      expect(items.querySelector('[data-action-id="confirm-sign-out"]')).not.toBeNull();
+    });
+    const itemsList = screen.getByTestId("mobile-action-sheet-items");
+    const confirm = itemsList.querySelector<HTMLElement>(
+      '[data-action-id="confirm-sign-out"]'
+    );
+    if (!confirm) throw new Error("destructive sign-out confirm item missing");
+    await user.click(confirm);
+    expect(onSignOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onConnectGitHub when the GitHub-accounts add button is pressed", async () => {
+    const user = userEvent.setup();
+    const onConnect = vi.fn();
+    render(
+      <ProfileTab
+        email="bryan@example.com"
+        displayName={null}
+        isGitHubConnected={false}
+        onConnectGitHub={onConnect}
+      />
+    );
+    await user.click(screen.getByRole("menuitem", { name: /GitHub accounts/ }));
+    await user.click(screen.getByTestId("mobile-profile-github-add"));
+    expect(onConnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/mobile/profile/__tests__/ProfileTab.test.tsx
+++ b/src/components/mobile/profile/__tests__/ProfileTab.test.tsx
@@ -51,7 +51,7 @@ describe("ProfileTab", () => {
         isGitHubConnected={true}
       />
     );
-    const githubRow = screen.getByRole("menuitem", { name: /GitHub accounts/ });
+    const githubRow = screen.getByRole("button", { name: /GitHub accounts/ });
     expect(githubRow).toHaveTextContent("Connected");
   });
 
@@ -64,7 +64,7 @@ describe("ProfileTab", () => {
         isGitHubConnected={false}
       />
     );
-    await user.click(screen.getByRole("menuitem", { name: /Account/ }));
+    await user.click(screen.getByRole("button", { name: /Account/ }));
     expect(screen.getByTestId("mobile-profile-tab")).toHaveAttribute(
       "data-screen",
       "account"
@@ -82,7 +82,7 @@ describe("ProfileTab", () => {
         isGitHubConnected={false}
       />
     );
-    await user.click(screen.getByRole("menuitem", { name: /Settings/ }));
+    await user.click(screen.getByRole("button", { name: /Settings/ }));
     expect(screen.getByTestId("mobile-profile-tab")).toHaveAttribute(
       "data-screen",
       "settings"
@@ -103,7 +103,7 @@ describe("ProfileTab", () => {
         isGitHubConnected={false}
       />
     );
-    await user.click(screen.getByRole("menuitem", { name: /Sign out/ }));
+    await user.click(screen.getByRole("button", { name: /Sign out/ }));
     // The sheet renders its items in a list keyed by data-testid. The
     // presence of the action-sheet items container distinguishes this
     // surface from a modal confirmation dialog (which would render under
@@ -125,11 +125,11 @@ describe("ProfileTab", () => {
         signOut={onSignOut}
       />
     );
-    await user.click(screen.getByRole("menuitem", { name: /Sign out/ }));
+    await user.click(screen.getByRole("button", { name: /Sign out/ }));
     // Scope the second click to the action sheet's items list so we don't
-    // accidentally re-click the row in the index. Both rows render
-    // role="menuitem"; we identify the sheet's confirm via its
-    // data-action-id.
+    // accidentally re-click the row in the index. The index row is a
+    // plain <button>, while the sheet's confirm renders role="menuitem";
+    // we identify the sheet's confirm via its data-action-id.
     await waitFor(() => {
       const items = screen.getByTestId("mobile-action-sheet-items");
       expect(items.querySelector('[data-action-id="confirm-sign-out"]')).not.toBeNull();
@@ -154,7 +154,7 @@ describe("ProfileTab", () => {
         onConnectGitHub={onConnect}
       />
     );
-    await user.click(screen.getByRole("menuitem", { name: /GitHub accounts/ }));
+    await user.click(screen.getByRole("button", { name: /GitHub accounts/ }));
     await user.click(screen.getByTestId("mobile-profile-github-add"));
     expect(onConnect).toHaveBeenCalledTimes(1);
   });

--- a/src/components/mobile/profile/__tests__/ProfileTab.test.tsx
+++ b/src/components/mobile/profile/__tests__/ProfileTab.test.tsx
@@ -19,10 +19,6 @@ import userEvent from "@testing-library/user-event";
 
 import { ProfileTab } from "@/components/mobile/profile/ProfileTab";
 
-vi.mock("next-auth/react", () => ({
-  signOut: vi.fn(),
-}));
-
 afterEach(() => cleanup());
 
 describe("ProfileTab", () => {

--- a/src/components/mobile/profile/__tests__/useFirstRun.test.ts
+++ b/src/components/mobile/profile/__tests__/useFirstRun.test.ts
@@ -1,0 +1,115 @@
+/**
+ * useFirstRun tests — Phase 6 mobile redesign.
+ *
+ * Verifies the localStorage-backed first-run flag returns the correct
+ * value across mount, mark-as-seen, and reset; and that storage failures
+ * are handled gracefully without crashing the host.
+ *
+ * happy-dom in this project does not ship a `window.localStorage`
+ * implementation, so we install a minimal in-memory Storage shim before
+ * each test and restore the original (typically undefined) afterwards.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act, cleanup } from "@testing-library/react";
+
+import {
+  WELCOME_SEEN_STORAGE_KEY,
+  useFirstRun,
+} from "@/components/mobile/auth/useFirstRun";
+
+interface MutableStorage extends Pick<Storage, "getItem" | "setItem" | "removeItem"> {
+  _store: Map<string, string>;
+}
+
+function makeMemoryStorage(): MutableStorage {
+  const store = new Map<string, string>();
+  return {
+    _store: store,
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+  };
+}
+
+let originalDescriptor: PropertyDescriptor | undefined;
+let installed: MutableStorage;
+
+beforeEach(() => {
+  originalDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+  installed = makeMemoryStorage();
+  Object.defineProperty(window, "localStorage", {
+    value: installed,
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  if (originalDescriptor) {
+    Object.defineProperty(window, "localStorage", originalDescriptor);
+  } else {
+    // No prior descriptor — remove the property we added.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).localStorage;
+  }
+});
+
+describe("useFirstRun", () => {
+  it("reports first run when storage is empty", async () => {
+    const { result } = renderHook(() => useFirstRun());
+    await act(async () => {});
+    expect(result.current.isFirstRun).toBe(true);
+  });
+
+  it("reports not-first-run when the seen flag is set", async () => {
+    installed.setItem(WELCOME_SEEN_STORAGE_KEY, "1");
+    const { result } = renderHook(() => useFirstRun());
+    await act(async () => {});
+    expect(result.current.isFirstRun).toBe(false);
+  });
+
+  it("markSeen flips state to false and persists to storage", async () => {
+    const { result } = renderHook(() => useFirstRun());
+    await act(async () => {});
+    expect(result.current.isFirstRun).toBe(true);
+    act(() => {
+      result.current.markSeen();
+    });
+    expect(result.current.isFirstRun).toBe(false);
+    expect(installed.getItem(WELCOME_SEEN_STORAGE_KEY)).toBe("1");
+  });
+
+  it("reset clears the flag and flips state back to true", async () => {
+    installed.setItem(WELCOME_SEEN_STORAGE_KEY, "1");
+    const { result } = renderHook(() => useFirstRun());
+    await act(async () => {});
+    expect(result.current.isFirstRun).toBe(false);
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.isFirstRun).toBe(true);
+    expect(installed.getItem(WELCOME_SEEN_STORAGE_KEY)).toBeNull();
+  });
+
+  it("does not throw when localStorage.setItem fails", async () => {
+    const fake = vi.fn(() => {
+      throw new Error("QuotaExceeded");
+    });
+    installed.setItem = fake as unknown as typeof installed.setItem;
+    const { result } = renderHook(() => useFirstRun());
+    await act(async () => {});
+    act(() => {
+      // Should not throw despite the underlying storage rejection.
+      result.current.markSeen();
+    });
+    // State still flipped optimistically.
+    expect(result.current.isFirstRun).toBe(false);
+    expect(fake).toHaveBeenCalled();
+  });
+});

--- a/src/components/mobile/profile/__tests__/useProfileNavStack.test.ts
+++ b/src/components/mobile/profile/__tests__/useProfileNavStack.test.ts
@@ -6,7 +6,7 @@
  * boring and exhaustive.
  */
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { renderHook, act, cleanup } from "@testing-library/react";
 
 import { useProfileNavStack } from "@/components/mobile/profile/useProfileNavStack";
@@ -14,6 +14,16 @@ import { useProfileNavStack } from "@/components/mobile/profile/useProfileNavSta
 afterEach(() => cleanup());
 
 type Screen = "a" | "b" | "c";
+
+/**
+ * Build a popstate event whose `state.profileNav.depth` matches the
+ * intended target stack depth. This mirrors what the hook itself
+ * embeds via pushState, and what the browser supplies on a real back.
+ */
+function popstateWithDepth(depth: number, screen = "test"): PopStateEvent {
+  const state = depth > 0 ? { profileNav: { depth, screen } } : null;
+  return new PopStateEvent("popstate", { state });
+}
 
 describe("useProfileNavStack", () => {
   it("starts at the index", () => {
@@ -73,16 +83,17 @@ describe("useProfileNavStack", () => {
     expect(result.current.isPushed).toBe(true);
     expect(result.current.current).toBe("b");
 
-    // Simulate hardware back / browser back: dispatch popstate directly
-    // so we exercise the listener regardless of how the test environment
-    // implements history.back().
+    // Simulate hardware back / browser back: the browser supplies the
+    // state of the entry we're popping TO (the previous one, depth=1).
     act(() => {
-      window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+      window.dispatchEvent(popstateWithDepth(1));
     });
     expect(result.current.current).toBe("a");
 
+    // Another back: now we're leaving the profile area entirely. The
+    // entry we land on has no profileNav state.
     act(() => {
-      window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+      window.dispatchEvent(popstateWithDepth(0));
     });
     expect(result.current.isPushed).toBe(false);
     expect(result.current.current).toBeNull();
@@ -91,9 +102,124 @@ describe("useProfileNavStack", () => {
   it("ignores popstate when already on the index", () => {
     const { result } = renderHook(() => useProfileNavStack<Screen>());
     act(() => {
-      window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+      window.dispatchEvent(popstateWithDepth(0));
     });
     expect(result.current.isPushed).toBe(false);
     expect(result.current.stack).toEqual([]);
+  });
+
+  // P2-D: popstate reconciles from event.state rather than blindly slicing.
+  it("reconciles to a shallower depth from popstate state.profileNav.depth", () => {
+    const { result } = renderHook(() => useProfileNavStack<Screen>());
+    act(() => result.current.push("a"));
+    act(() => result.current.push("b"));
+    act(() => result.current.push("c"));
+    expect(result.current.stack).toEqual(["a", "b", "c"]);
+
+    // Simulate a popstate that lands on depth 1 (e.g. user pressed back
+    // twice rapidly and the second event arrived before the first
+    // settled). We should pop to depth 1, not depth 2.
+    act(() => {
+      window.dispatchEvent(popstateWithDepth(1));
+    });
+    expect(result.current.stack).toEqual(["a"]);
+  });
+
+  it("treats missing profileNav state as 'leaving the profile area' and pops all", () => {
+    const { result } = renderHook(() => useProfileNavStack<Screen>());
+    act(() => result.current.push("a"));
+    act(() => result.current.push("b"));
+    expect(result.current.isPushed).toBe(true);
+
+    // Popstate with no profileNav state means another history actor
+    // (or a back beyond our owned entries). We should pop the whole
+    // stack rather than blindly slicing one entry.
+    act(() => {
+      window.dispatchEvent(popstateWithDepth(0));
+    });
+    expect(result.current.isPushed).toBe(false);
+    expect(result.current.stack).toEqual([]);
+  });
+
+  // P2-E: double-tap on the back chevron should not double-pop.
+  it("guards against rapid double pop() calls", () => {
+    const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {
+      // Don't actually navigate; just record the call.
+    });
+
+    const { result } = renderHook(() => useProfileNavStack<Screen>());
+    act(() => result.current.push("a"));
+    act(() => result.current.push("b"));
+
+    // Two pop calls in quick succession (no popstate fired between them)
+    // should result in only ONE history.back() invocation.
+    act(() => {
+      result.current.pop();
+      result.current.pop();
+    });
+    expect(backSpy).toHaveBeenCalledTimes(1);
+
+    // After a popstate fires, the guard clears and another pop is
+    // allowed to issue history.back().
+    act(() => {
+      window.dispatchEvent(popstateWithDepth(1));
+    });
+    act(() => {
+      result.current.pop();
+    });
+    expect(backSpy).toHaveBeenCalledTimes(2);
+
+    backSpy.mockRestore();
+  });
+
+  // P1-C: history entries are rolled back when the host unmounts mid-stack.
+  it("rolls back owned history entries on unmount when the stack is pushed", () => {
+    const goSpy = vi.spyOn(window.history, "go").mockImplementation(() => {
+      // Don't actually navigate; just record.
+    });
+
+    const { result, unmount } = renderHook(() => useProfileNavStack<Screen>());
+    act(() => result.current.push("a"));
+    act(() => result.current.push("b"));
+
+    unmount();
+
+    // Two pushed entries → expect history.go(-2) on unmount.
+    expect(goSpy).toHaveBeenCalledWith(-2);
+
+    goSpy.mockRestore();
+  });
+
+  it("does not roll back history on unmount when the stack is empty", () => {
+    const goSpy = vi.spyOn(window.history, "go").mockImplementation(() => {
+      // Don't actually navigate.
+    });
+
+    const { unmount } = renderHook(() => useProfileNavStack<Screen>());
+    unmount();
+
+    expect(goSpy).not.toHaveBeenCalled();
+
+    goSpy.mockRestore();
+  });
+
+  it("does not double-roll history when reset() preceded unmount", () => {
+    const goSpy = vi.spyOn(window.history, "go").mockImplementation(() => {
+      // Don't actually navigate.
+    });
+
+    const { result, unmount } = renderHook(() => useProfileNavStack<Screen>());
+    act(() => result.current.push("a"));
+    act(() => result.current.push("b"));
+    act(() => result.current.reset());
+
+    expect(goSpy).toHaveBeenCalledWith(-2);
+    goSpy.mockClear();
+
+    unmount();
+
+    // Reset already drained the entries; unmount must not re-drain.
+    expect(goSpy).not.toHaveBeenCalled();
+    goSpy.mockRestore();
   });
 });

--- a/src/components/mobile/profile/__tests__/useProfileNavStack.test.ts
+++ b/src/components/mobile/profile/__tests__/useProfileNavStack.test.ts
@@ -65,4 +65,35 @@ describe("useProfileNavStack", () => {
     expect(result.current.current).toBeNull();
     expect(result.current.isPushed).toBe(false);
   });
+
+  it("pops the stack when a popstate event fires (Android/browser back)", () => {
+    const { result } = renderHook(() => useProfileNavStack<Screen>());
+    act(() => result.current.push("a"));
+    act(() => result.current.push("b"));
+    expect(result.current.isPushed).toBe(true);
+    expect(result.current.current).toBe("b");
+
+    // Simulate hardware back / browser back: dispatch popstate directly
+    // so we exercise the listener regardless of how the test environment
+    // implements history.back().
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+    });
+    expect(result.current.current).toBe("a");
+
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+    });
+    expect(result.current.isPushed).toBe(false);
+    expect(result.current.current).toBeNull();
+  });
+
+  it("ignores popstate when already on the index", () => {
+    const { result } = renderHook(() => useProfileNavStack<Screen>());
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+    });
+    expect(result.current.isPushed).toBe(false);
+    expect(result.current.stack).toEqual([]);
+  });
 });

--- a/src/components/mobile/profile/__tests__/useProfileNavStack.test.ts
+++ b/src/components/mobile/profile/__tests__/useProfileNavStack.test.ts
@@ -1,0 +1,68 @@
+/**
+ * useProfileNavStack tests — Phase 6 mobile redesign.
+ *
+ * Verifies the push/pop/reset semantics of the Profile-tab navigation
+ * stack in isolation. The hook is a primitive — these tests should be
+ * boring and exhaustive.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { renderHook, act, cleanup } from "@testing-library/react";
+
+import { useProfileNavStack } from "@/components/mobile/profile/useProfileNavStack";
+
+afterEach(() => cleanup());
+
+type Screen = "a" | "b" | "c";
+
+describe("useProfileNavStack", () => {
+  it("starts at the index", () => {
+    const { result } = renderHook(() => useProfileNavStack<Screen>());
+    expect(result.current.stack).toEqual([]);
+    expect(result.current.current).toBeNull();
+    expect(result.current.isPushed).toBe(false);
+  });
+
+  it("push adds a screen and reports it as current", () => {
+    const { result } = renderHook(() => useProfileNavStack<Screen>());
+    act(() => result.current.push("a"));
+    expect(result.current.stack).toEqual(["a"]);
+    expect(result.current.current).toBe("a");
+    expect(result.current.isPushed).toBe(true);
+  });
+
+  it("supports stacking multiple screens", () => {
+    const { result } = renderHook(() => useProfileNavStack<Screen>());
+    act(() => result.current.push("a"));
+    act(() => result.current.push("b"));
+    act(() => result.current.push("c"));
+    expect(result.current.stack).toEqual(["a", "b", "c"]);
+    expect(result.current.current).toBe("c");
+  });
+
+  it("pop removes the top screen", () => {
+    const { result } = renderHook(() => useProfileNavStack<Screen>());
+    act(() => result.current.push("a"));
+    act(() => result.current.push("b"));
+    act(() => result.current.pop());
+    expect(result.current.stack).toEqual(["a"]);
+    expect(result.current.current).toBe("a");
+  });
+
+  it("pop on the index is a no-op", () => {
+    const { result } = renderHook(() => useProfileNavStack<Screen>());
+    act(() => result.current.pop());
+    expect(result.current.stack).toEqual([]);
+    expect(result.current.current).toBeNull();
+  });
+
+  it("reset bounces all the way back to the index", () => {
+    const { result } = renderHook(() => useProfileNavStack<Screen>());
+    act(() => result.current.push("a"));
+    act(() => result.current.push("b"));
+    act(() => result.current.reset());
+    expect(result.current.stack).toEqual([]);
+    expect(result.current.current).toBeNull();
+    expect(result.current.isPushed).toBe(false);
+  });
+});

--- a/src/components/mobile/profile/screens/AboutScreen.tsx
+++ b/src/components/mobile/profile/screens/AboutScreen.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+/**
+ * AboutScreen — Profile › About.
+ *
+ * Phase 6: real, minimal content. Lists the app version, a link to the
+ * GitHub repo, and the licence line. No marketing decoration.
+ *
+ * The version is read from a build-time constant (defaults to "dev"
+ * when not present) so we don't import package.json into client
+ * bundles. Update the constant when the release process is wired.
+ */
+
+import { SubScreen } from "../SubScreen";
+
+export interface AboutScreenProps {
+  onBack: () => void;
+}
+
+const APP_VERSION =
+  // Surfaced by Next.js when configured in next.config; falls back to "dev"
+  // so tests don't have to mock the build env. Updated by the release script.
+  process.env.NEXT_PUBLIC_APP_VERSION ?? "dev";
+
+const REPO_URL = "https://github.com/btli/remote-dev";
+
+export function AboutScreen({ onBack }: AboutScreenProps) {
+  return (
+    <SubScreen title="About" onBack={onBack}>
+      <div className="flex flex-col gap-4 px-4 py-6 text-[14px]">
+        <dl className="flex flex-col gap-3">
+          <div className="flex items-baseline justify-between gap-3">
+            <dt className="text-muted-foreground">Application</dt>
+            <dd className="text-right font-medium text-foreground">Remote Dev</dd>
+          </div>
+          <div className="flex items-baseline justify-between gap-3">
+            <dt className="text-muted-foreground">Version</dt>
+            <dd className="text-right font-mono text-[13px] text-foreground">
+              {APP_VERSION}
+            </dd>
+          </div>
+          <div className="flex items-baseline justify-between gap-3">
+            <dt className="text-muted-foreground">Repository</dt>
+            <dd className="text-right">
+              <a
+                href={REPO_URL}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-[13px] text-foreground underline-offset-2 hover:underline"
+              >
+                btli/remote-dev
+              </a>
+            </dd>
+          </div>
+        </dl>
+        <p className="mt-2 text-[12px] leading-snug text-muted-foreground">
+          A web-based terminal interface with persistent tmux sessions,
+          multi-agent CLIs, and a quiet, gesture-literate mobile surface.
+        </p>
+      </div>
+    </SubScreen>
+  );
+}

--- a/src/components/mobile/profile/screens/AccountScreen.tsx
+++ b/src/components/mobile/profile/screens/AccountScreen.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+/**
+ * AccountScreen — Profile › Account.
+ *
+ * Phase 6: header + signed-in-as line + stub body. The full account
+ * management UI (display name, theme override, sign-out also lives in
+ * the parent index per the brief) lands in a follow-up.
+ *
+ * TODO: port the relevant pieces of `src/components/system/UserSettingsModal.tsx`
+ * Account-tab sections into this screen.
+ */
+
+import { SubScreen } from "../SubScreen";
+import { StubBody } from "./StubBody";
+
+export interface AccountScreenProps {
+  email: string | null | undefined;
+  displayName: string | null | undefined;
+  onBack: () => void;
+}
+
+export function AccountScreen({ email, displayName, onBack }: AccountScreenProps) {
+  return (
+    <SubScreen title="Account" onBack={onBack}>
+      <div className="flex flex-col gap-4 px-4 pt-4">
+        <dl className="flex flex-col gap-3 text-[14px]">
+          <div className="flex items-baseline justify-between gap-3">
+            <dt className="text-muted-foreground">Email</dt>
+            <dd className="truncate text-right font-medium text-foreground">
+              {email ?? "—"}
+            </dd>
+          </div>
+          {displayName ? (
+            <div className="flex items-baseline justify-between gap-3">
+              <dt className="text-muted-foreground">Name</dt>
+              <dd className="truncate text-right text-foreground">{displayName}</dd>
+            </div>
+          ) : null}
+        </dl>
+      </div>
+      <StubBody
+        description="View and update your account profile."
+        portFromComponent="UserSettingsModal.tsx (Account tab)"
+      />
+    </SubScreen>
+  );
+}

--- a/src/components/mobile/profile/screens/AgentProfilesScreen.tsx
+++ b/src/components/mobile/profile/screens/AgentProfilesScreen.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+/**
+ * AgentProfilesScreen — Profile › Agent profiles.
+ *
+ * Phase 6: stub body. Full profile CRUD + per-profile theming lands
+ * in a follow-up.
+ *
+ * TODO: port from `src/components/agents/` (profile list + appearance).
+ */
+
+import { SubScreen } from "../SubScreen";
+import { StubBody } from "./StubBody";
+
+export interface AgentProfilesScreenProps {
+  onBack: () => void;
+}
+
+export function AgentProfilesScreen({ onBack }: AgentProfilesScreenProps) {
+  return (
+    <SubScreen title="Agent profiles" onBack={onBack}>
+      <StubBody
+        description="Manage isolated agent profiles and their appearance."
+        portFromComponent="components/agents/* (profile list + appearance)"
+      />
+    </SubScreen>
+  );
+}

--- a/src/components/mobile/profile/screens/GithubAccountsScreen.tsx
+++ b/src/components/mobile/profile/screens/GithubAccountsScreen.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+/**
+ * GithubAccountsScreen — Profile › GitHub accounts.
+ *
+ * Phase 6: stub body. Full multi-account management ports from the desktop
+ * component in a follow-up.
+ *
+ * TODO: port from `src/components/github/GitHubAccountSettings.tsx`
+ *       (or whichever desktop component owns the linked-accounts list).
+ */
+
+import { SubScreen } from "../SubScreen";
+import { StubBody } from "./StubBody";
+
+export interface GithubAccountsScreenProps {
+  onBack: () => void;
+  /** Convenience: trigger `/api/auth/github/link` for the user. */
+  onAddAccount: () => void;
+}
+
+export function GithubAccountsScreen({ onBack, onAddAccount }: GithubAccountsScreenProps) {
+  return (
+    <SubScreen title="GitHub accounts" onBack={onBack}>
+      <StubBody
+        description="Link, unlink, and bind GitHub accounts to projects."
+        portFromComponent="GitHubAccountSettings.tsx"
+      />
+      <div className="flex justify-center px-4 pb-6">
+        <button
+          type="button"
+          onClick={onAddAccount}
+          data-testid="mobile-profile-github-add"
+          className="inline-flex h-9 items-center rounded-md border border-border bg-card px-3 text-[13px] font-medium text-foreground active:bg-accent/40"
+        >
+          Connect a GitHub account
+        </button>
+      </div>
+    </SubScreen>
+  );
+}

--- a/src/components/mobile/profile/screens/PortsScreen.tsx
+++ b/src/components/mobile/profile/screens/PortsScreen.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+/**
+ * PortsScreen — Profile › Ports.
+ *
+ * Phase 6: stub body. Port allocation registry / framework detection
+ * UI lands in a follow-up.
+ *
+ * TODO: port from the Ports panel surfaced in PortContext consumers.
+ */
+
+import { SubScreen } from "../SubScreen";
+import { StubBody } from "./StubBody";
+
+export interface PortsScreenProps {
+  onBack: () => void;
+}
+
+export function PortsScreen({ onBack }: PortsScreenProps) {
+  return (
+    <SubScreen title="Ports" onBack={onBack}>
+      <StubBody
+        description="Inspect port allocations and framework auto-detection."
+        portFromComponent="PortContext consumers"
+      />
+    </SubScreen>
+  );
+}

--- a/src/components/mobile/profile/screens/ProjectsScreen.tsx
+++ b/src/components/mobile/profile/screens/ProjectsScreen.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+/**
+ * ProjectsScreen — Profile › Projects (group + project tree management).
+ *
+ * Phase 6: stub body. Full tree management (create / rename / move /
+ * delete groups and projects) lands in a follow-up.
+ *
+ * TODO: port from `src/components/session/ProjectTreeSidebar.tsx`
+ *       and `GroupPreferencesModal.tsx` / `ProjectPreferencesModal.tsx`.
+ */
+
+import { SubScreen } from "../SubScreen";
+import { StubBody } from "./StubBody";
+
+export interface ProjectsScreenProps {
+  onBack: () => void;
+}
+
+export function ProjectsScreen({ onBack }: ProjectsScreenProps) {
+  return (
+    <SubScreen title="Projects" onBack={onBack}>
+      <StubBody
+        description="Manage project groups, projects, and their preferences."
+        portFromComponent="ProjectTreeSidebar.tsx"
+      />
+    </SubScreen>
+  );
+}

--- a/src/components/mobile/profile/screens/SecretsScreen.tsx
+++ b/src/components/mobile/profile/screens/SecretsScreen.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+/**
+ * SecretsScreen — Profile › Secrets.
+ *
+ * Phase 6: stub body. Per-project secrets provider configuration lands
+ * in a follow-up.
+ *
+ * TODO: port from `src/components/system/SecretsConfigModal.tsx` and
+ *       `SecretsStatusButton.tsx`.
+ */
+
+import { SubScreen } from "../SubScreen";
+import { StubBody } from "./StubBody";
+
+export interface SecretsScreenProps {
+  onBack: () => void;
+}
+
+export function SecretsScreen({ onBack }: SecretsScreenProps) {
+  return (
+    <SubScreen title="Secrets" onBack={onBack}>
+      <StubBody
+        description="Configure secrets providers for each project."
+        portFromComponent="SecretsConfigModal.tsx"
+      />
+    </SubScreen>
+  );
+}

--- a/src/components/mobile/profile/screens/SettingsScreen.tsx
+++ b/src/components/mobile/profile/screens/SettingsScreen.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+/**
+ * SettingsScreen — Profile › Settings.
+ *
+ * Phase 6: stub body. Full user-level settings (theme, default agent,
+ * etc.) land in a follow-up.
+ *
+ * TODO: port from `src/components/system/UserSettingsModal.tsx`
+ *       (non-Account tabs).
+ */
+
+import { SubScreen } from "../SubScreen";
+import { StubBody } from "./StubBody";
+
+export interface SettingsScreenProps {
+  onBack: () => void;
+}
+
+export function SettingsScreen({ onBack }: SettingsScreenProps) {
+  return (
+    <SubScreen title="Settings" onBack={onBack}>
+      <StubBody
+        description="User-level preferences: theme, default agent, telemetry."
+        portFromComponent="UserSettingsModal.tsx (non-Account tabs)"
+      />
+    </SubScreen>
+  );
+}

--- a/src/components/mobile/profile/screens/StubBody.tsx
+++ b/src/components/mobile/profile/screens/StubBody.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+/**
+ * StubBody — placeholder body for Profile sub-screens whose full content
+ * lands in a follow-up.
+ *
+ * Phase 6 ships the navigation chrome (Profile tab + push/pop stack +
+ * sub-screen header) but defers the actual settings UI to follow-up
+ * issues. Each sub-screen renders a header and one of these stubs so
+ * the user can still navigate the surface and verify the back-stack
+ * works on a real device.
+ *
+ * The copy is deliberately matter-of-fact, not marketing — per
+ * PRODUCT.md "Trust the expert".
+ */
+
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface StubBodyProps {
+  /** One-line description of what the screen will eventually do. */
+  description: ReactNode;
+  /**
+   * Optional reference to the desktop component that should be ported
+   * for the full implementation. Rendered as a TODO note for engineers.
+   */
+  portFromComponent?: string;
+  className?: string;
+}
+
+export function StubBody({
+  description,
+  portFromComponent,
+  className,
+}: StubBodyProps) {
+  return (
+    <div
+      data-testid="mobile-profile-stub-body"
+      className={cn(
+        "flex flex-col gap-2 px-4 py-6 text-center",
+        className
+      )}
+    >
+      <p className="text-[13px] leading-snug text-muted-foreground">
+        {description}
+      </p>
+      <p className="text-[12px] leading-snug text-muted-foreground/70">
+        Mobile UI for this screen lands in a follow-up.
+      </p>
+      {portFromComponent ? (
+        <p
+          aria-hidden="true"
+          className="mt-2 text-[11px] font-mono text-muted-foreground/50"
+        >
+          TODO: port from {portFromComponent}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/mobile/profile/screens/TrashScreen.tsx
+++ b/src/components/mobile/profile/screens/TrashScreen.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+/**
+ * TrashScreen — Profile › Trash.
+ *
+ * Phase 6: stub body. Trash management (restore, permanent delete) lands
+ * in a follow-up.
+ *
+ * TODO: port from the Trash panel that consumes TrashContext.
+ */
+
+import { SubScreen } from "../SubScreen";
+import { StubBody } from "./StubBody";
+
+export interface TrashScreenProps {
+  onBack: () => void;
+}
+
+export function TrashScreen({ onBack }: TrashScreenProps) {
+  return (
+    <SubScreen title="Trash" onBack={onBack}>
+      <StubBody
+        description="Restore or permanently delete trashed items (30-day retention)."
+        portFromComponent="TrashContext consumers"
+      />
+    </SubScreen>
+  );
+}

--- a/src/components/mobile/profile/useProfileNavStack.ts
+++ b/src/components/mobile/profile/useProfileNavStack.ts
@@ -18,9 +18,16 @@
  *
  * Returns a tuple-like object so consumers can `push("settings")`,
  * `pop()`, or `reset()` to bounce all the way back to the index.
+ *
+ * Hardware/browser back: each `push` adds a `history` entry tagged with
+ * `{ profileNav: <screen> }`. A `popstate` listener treats any history
+ * pop while a screen is pushed as a stack pop. UI-driven `pop()` calls
+ * `history.back()` so the listener is the single source of truth — that
+ * way Android's hardware back button, the browser back button, and the
+ * in-app back chevron all flow through one path.
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export interface NavStack<Screen extends string> {
   /** Stack of pushed screens, oldest-first. Empty array means "index". */
@@ -37,19 +44,95 @@ export interface NavStack<Screen extends string> {
   reset: () => void;
 }
 
+/**
+ * Best-effort feature check for the History API. happy-dom (our test
+ * runner) implements `history.pushState` but not always reliably; we
+ * gate the history-side effects so the listener still runs even when
+ * pushState isn't fully wired. The popstate fallback drives state in
+ * either case.
+ */
+function hasHistoryApi(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.history !== "undefined" &&
+    typeof window.history.pushState === "function"
+  );
+}
+
 export function useProfileNavStack<Screen extends string>(): NavStack<Screen> {
   const [stack, setStack] = useState<Screen[]>([]);
 
+  // Tracks how many history entries we've appended so unmount/reset can
+  // tear them down in a single `history.go(-n)` call without nuking
+  // unrelated entries pushed by other parts of the app.
+  const pushedCountRef = useRef(0);
+  // The popstate listener must observe the latest stack to decide
+  // whether to swallow a pop or let it bubble to the platform.
+  const stackLengthRef = useRef(0);
+  useEffect(() => {
+    stackLengthRef.current = stack.length;
+  }, [stack.length]);
+
   const push = useCallback((screen: Screen) => {
     setStack((prev) => [...prev, screen]);
+    if (hasHistoryApi()) {
+      try {
+        window.history.pushState({ profileNav: screen }, "");
+        pushedCountRef.current += 1;
+      } catch {
+        // History API may throw in sandboxed contexts; the in-memory
+        // stack still works, just without hardware-back integration.
+      }
+    }
   }, []);
 
   const pop = useCallback(() => {
+    // Defer to history.back() so the popstate listener is the single
+    // source of truth for stack mutation. When history isn't available
+    // (or no entry was pushed), fall back to mutating directly.
+    if (hasHistoryApi() && pushedCountRef.current > 0) {
+      try {
+        window.history.back();
+        return;
+      } catch {
+        // fall through to direct mutation
+      }
+    }
     setStack((prev) => (prev.length === 0 ? prev : prev.slice(0, -1)));
   }, []);
 
   const reset = useCallback(() => {
+    const count = pushedCountRef.current;
     setStack((prev) => (prev.length === 0 ? prev : []));
+    pushedCountRef.current = 0;
+    if (count > 0 && hasHistoryApi()) {
+      try {
+        // Roll the history back by the number of entries we pushed.
+        window.history.go(-count);
+      } catch {
+        // No-op: in-memory state is already cleared.
+      }
+    }
+  }, []);
+
+  // popstate listener: any browser/hardware back while a screen is
+  // pushed pops the in-memory stack. We don't push a replacement entry
+  // here — the platform already removed the entry on its side.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    function onPopState() {
+      if (stackLengthRef.current === 0) {
+        // Already on the index; let the platform handle the pop. This
+        // can happen if other code pushed history entries.
+        return;
+      }
+      setStack((prev) => (prev.length === 0 ? prev : prev.slice(0, -1)));
+      if (pushedCountRef.current > 0) {
+        pushedCountRef.current -= 1;
+      }
+    }
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
   }, []);
 
   return useMemo(

--- a/src/components/mobile/profile/useProfileNavStack.ts
+++ b/src/components/mobile/profile/useProfileNavStack.ts
@@ -20,14 +20,41 @@
  * `pop()`, or `reset()` to bounce all the way back to the index.
  *
  * Hardware/browser back: each `push` adds a `history` entry tagged with
- * `{ profileNav: <screen> }`. A `popstate` listener treats any history
- * pop while a screen is pushed as a stack pop. UI-driven `pop()` calls
- * `history.back()` so the listener is the single source of truth — that
- * way Android's hardware back button, the browser back button, and the
- * in-app back chevron all flow through one path.
+ * `{ profileNav: { depth, screen } }`. The popstate listener reconciles
+ * against `event.state` rather than blindly slicing, so other history
+ * actors (hash links, deep links, etc.) can't desync the stack.
+ *
+ * Unmount: if the user is mid-stack and `ProfileTab` unmounts (e.g.
+ * tab switch), the cleanup rolls history back by the number of owned
+ * entries — otherwise those entries leak and Browser Back appears
+ * broken (consuming invisible entries).
+ *
+ * Double-tap: a pending-pop guard prevents a fast double-tap on the
+ * back chevron from issuing two `history.back()` calls before the
+ * first `popstate` fires (which would otherwise leave the app).
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/**
+ * The shape we embed into `history.pushState`'s state arg. Reading this
+ * back in the popstate handler lets us reconcile with the *intended*
+ * stack depth rather than guessing.
+ */
+interface ProfileNavHistoryState {
+  /**
+   * Stack depth this history entry corresponds to (1-based: a depth of
+   * 1 means "first pushed screen sits on top"). Absent for entries we
+   * didn't push.
+   */
+  depth: number;
+  /** Screen identifier — only used for diagnostics. */
+  screen: string;
+}
+
+interface ReadableState {
+  profileNav?: ProfileNavHistoryState;
+}
 
 export interface NavStack<Screen extends string> {
   /** Stack of pushed screens, oldest-first. Empty array means "index". */
@@ -59,6 +86,14 @@ function hasHistoryApi(): boolean {
   );
 }
 
+/**
+ * Window in which a follow-up `pop()` is suppressed if the popstate
+ * event hasn't fired yet. Prevents a fast double-tap on the back
+ * chevron from issuing two `history.back()` calls (which can leave
+ * the app entirely instead of going back one screen).
+ */
+const PENDING_POP_TIMEOUT_MS = 600;
+
 export function useProfileNavStack<Screen extends string>(): NavStack<Screen> {
   const [stack, setStack] = useState<Screen[]>([]);
 
@@ -69,21 +104,43 @@ export function useProfileNavStack<Screen extends string>(): NavStack<Screen> {
   // The popstate listener must observe the latest stack to decide
   // whether to swallow a pop or let it bubble to the platform.
   const stackLengthRef = useRef(0);
+  // Suppresses follow-up `pop()` calls while a `history.back()` is in
+  // flight. Cleared on popstate or after a timeout fallback.
+  const pendingPopRef = useRef(false);
+  const pendingPopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Tracks whether the cleanup path should roll back history. We set
+  // this to `false` in `reset()` so we don't double-roll.
+  const shouldRollbackOnUnmountRef = useRef(true);
+
   useEffect(() => {
     stackLengthRef.current = stack.length;
   }, [stack.length]);
 
-  const push = useCallback((screen: Screen) => {
-    setStack((prev) => [...prev, screen]);
-    if (hasHistoryApi()) {
-      try {
-        window.history.pushState({ profileNav: screen }, "");
-        pushedCountRef.current += 1;
-      } catch {
-        // History API may throw in sandboxed contexts; the in-memory
-        // stack still works, just without hardware-back integration.
-      }
+  function clearPendingPop() {
+    pendingPopRef.current = false;
+    if (pendingPopTimerRef.current !== null) {
+      clearTimeout(pendingPopTimerRef.current);
+      pendingPopTimerRef.current = null;
     }
+  }
+
+  const push = useCallback((screen: Screen) => {
+    setStack((prev) => {
+      const nextDepth = prev.length + 1;
+      if (hasHistoryApi()) {
+        try {
+          const state: ReadableState = {
+            profileNav: { depth: nextDepth, screen },
+          };
+          window.history.pushState(state, "");
+          pushedCountRef.current += 1;
+        } catch {
+          // History API may throw in sandboxed contexts; the in-memory
+          // stack still works, just without hardware-back integration.
+        }
+      }
+      return [...prev, screen];
+    });
   }, []);
 
   const pop = useCallback(() => {
@@ -91,11 +148,23 @@ export function useProfileNavStack<Screen extends string>(): NavStack<Screen> {
     // source of truth for stack mutation. When history isn't available
     // (or no entry was pushed), fall back to mutating directly.
     if (hasHistoryApi() && pushedCountRef.current > 0) {
+      // Double-tap guard: if a previous pop is still in flight, drop
+      // the second invocation to avoid issuing two history.back() calls.
+      if (pendingPopRef.current) {
+        return;
+      }
+      pendingPopRef.current = true;
+      pendingPopTimerRef.current = setTimeout(() => {
+        // Fallback for browsers that swallowed the popstate event.
+        pendingPopRef.current = false;
+        pendingPopTimerRef.current = null;
+      }, PENDING_POP_TIMEOUT_MS);
       try {
         window.history.back();
         return;
       } catch {
         // fall through to direct mutation
+        clearPendingPop();
       }
     }
     setStack((prev) => (prev.length === 0 ? prev : prev.slice(0, -1)));
@@ -105,6 +174,10 @@ export function useProfileNavStack<Screen extends string>(): NavStack<Screen> {
     const count = pushedCountRef.current;
     setStack((prev) => (prev.length === 0 ? prev : []));
     pushedCountRef.current = 0;
+    // Reset already drained owned entries; the unmount path must not
+    // try to roll them back a second time.
+    shouldRollbackOnUnmountRef.current = false;
+    clearPendingPop();
     if (count > 0 && hasHistoryApi()) {
       try {
         // Roll the history back by the number of entries we pushed.
@@ -116,23 +189,70 @@ export function useProfileNavStack<Screen extends string>(): NavStack<Screen> {
   }, []);
 
   // popstate listener: any browser/hardware back while a screen is
-  // pushed pops the in-memory stack. We don't push a replacement entry
-  // here — the platform already removed the entry on its side.
+  // pushed pops the in-memory stack. We reconcile against
+  // `event.state.profileNav.depth` so other history actors (hash
+  // changes, in-app deep links, etc.) can't slice our stack into
+  // inconsistency.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    function onPopState() {
-      if (stackLengthRef.current === 0) {
-        // Already on the index; let the platform handle the pop. This
-        // can happen if other code pushed history entries.
+    function onPopState(event: PopStateEvent) {
+      // Whatever the outcome, this popstate satisfies the in-flight
+      // back() request.
+      clearPendingPop();
+      const state = (event.state as ReadableState | null) ?? null;
+      const targetDepth = state?.profileNav?.depth ?? 0;
+      const currentDepth = stackLengthRef.current;
+      if (currentDepth === 0) {
+        // Already on the index; let the platform handle the pop.
         return;
       }
-      setStack((prev) => (prev.length === 0 ? prev : prev.slice(0, -1)));
-      if (pushedCountRef.current > 0) {
-        pushedCountRef.current -= 1;
+      if (targetDepth >= currentDepth) {
+        // Forward navigation in history (or unrelated state shape that
+        // claims an equal/greater depth). Don't slice.
+        return;
       }
+      // Either we're leaving the profile area entirely
+      // (targetDepth === 0) or we're popping to a shallower depth.
+      const removedCount = currentDepth - targetDepth;
+      pushedCountRef.current = Math.max(
+        0,
+        pushedCountRef.current - removedCount
+      );
+      setStack((prev) => {
+        if (prev.length <= targetDepth) return prev;
+        return prev.slice(0, targetDepth);
+      });
     }
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  // Unmount cleanup: if the host (e.g. ProfileTab) unmounts while we
+  // still own pushed history entries, drain them with a single
+  // history.go(-n). Otherwise those entries leak: the user switches
+  // tabs, hits the OS back button, and consumes invisible entries
+  // before actually navigating away. We do NOT reset the in-memory
+  // stack here because the hook is going away with the host.
+  //
+  // Caveat: this triggers popstate events the listener has already
+  // unsubscribed from (cleanup runs in reverse-order, so the listener
+  // is gone by the time go() schedules its events).
+  useEffect(() => {
+    return () => {
+      clearPendingPop();
+      if (
+        shouldRollbackOnUnmountRef.current &&
+        pushedCountRef.current > 0 &&
+        hasHistoryApi()
+      ) {
+        try {
+          window.history.go(-pushedCountRef.current);
+        } catch {
+          // Best effort; nothing else to do.
+        }
+        pushedCountRef.current = 0;
+      }
+    };
   }, []);
 
   return useMemo(

--- a/src/components/mobile/profile/useProfileNavStack.ts
+++ b/src/components/mobile/profile/useProfileNavStack.ts
@@ -1,0 +1,66 @@
+"use client";
+
+/**
+ * useProfileNavStack — tab-local push/pop navigation for the Profile tab.
+ *
+ * Phase 6 of the mobile redesign. Profile is composed of an index list
+ * and a stack of pushed sub-screens. We don't reach for a router here
+ * because:
+ *
+ *   1. The desktop URL is the canonical "session/project" navigation.
+ *      Pushing profile sub-screens onto the URL would interfere with
+ *      that and force a full re-render of the mobile shell.
+ *   2. The stack is short-lived: the user enters Profile, taps a row,
+ *      reads/edits, pops back. URL state isn't useful here.
+ *
+ * The stack is generic over a `Screen` string union; the host (ProfileTab)
+ * supplies its own identifier set.
+ *
+ * Returns a tuple-like object so consumers can `push("settings")`,
+ * `pop()`, or `reset()` to bounce all the way back to the index.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+
+export interface NavStack<Screen extends string> {
+  /** Stack of pushed screens, oldest-first. Empty array means "index". */
+  stack: readonly Screen[];
+  /** Top of the stack, or `null` when on the index. */
+  current: Screen | null;
+  /** True when the user is somewhere other than the index. */
+  isPushed: boolean;
+  /** Push a new screen onto the stack. */
+  push: (screen: Screen) => void;
+  /** Pop the current screen. No-op when on the index. */
+  pop: () => void;
+  /** Pop all the way back to the index. */
+  reset: () => void;
+}
+
+export function useProfileNavStack<Screen extends string>(): NavStack<Screen> {
+  const [stack, setStack] = useState<Screen[]>([]);
+
+  const push = useCallback((screen: Screen) => {
+    setStack((prev) => [...prev, screen]);
+  }, []);
+
+  const pop = useCallback(() => {
+    setStack((prev) => (prev.length === 0 ? prev : prev.slice(0, -1)));
+  }, []);
+
+  const reset = useCallback(() => {
+    setStack((prev) => (prev.length === 0 ? prev : []));
+  }, []);
+
+  return useMemo(
+    () => ({
+      stack,
+      current: stack.length === 0 ? null : stack[stack.length - 1],
+      isPushed: stack.length > 0,
+      push,
+      pop,
+      reset,
+    }),
+    [stack, push, pop, reset]
+  );
+}

--- a/src/lib/cloudflare-access.ts
+++ b/src/lib/cloudflare-access.ts
@@ -3,7 +3,15 @@ import { jwtVerify, createRemoteJWKSet } from "jose";
 // Cloudflare Access configuration
 // Note: This module uses console.warn/error directly because it runs in Edge
 // runtime (via proxy.ts) where the structured logger is not available.
-const CF_ACCESS_TEAM = process.env.CF_ACCESS_TEAM || "joyfulhouse";
+//
+// `CF_ACCESS_TEAM` MUST NOT default to a hardcoded team name. Defaulting to
+// any real tenant would silently fetch JWKS from a foreign team's domain
+// during JWT verification — verification would then fail (different signing
+// keys) and, worse, the logout flow in `src/app/api/auth/signout/route.ts`
+// would redirect users to that foreign team's login wall. Both issues lead
+// to silent auth failures that are very hard to debug. We therefore require
+// the deployer to set `CF_ACCESS_TEAM` explicitly when CF Access is in use.
+const CF_ACCESS_TEAM = process.env.CF_ACCESS_TEAM;
 const CF_ACCESS_AUD = process.env.CF_ACCESS_AUD;
 
 // Cache the JWKS for performance
@@ -11,6 +19,11 @@ let jwksCache: ReturnType<typeof createRemoteJWKSet> | null = null;
 
 function getJWKS() {
   if (!jwksCache) {
+    if (!CF_ACCESS_TEAM) {
+      throw new Error(
+        "CF_ACCESS_TEAM is not configured; cannot build Cloudflare Access JWKS URL"
+      );
+    }
     jwksCache = createRemoteJWKSet(
       new URL(`https://${CF_ACCESS_TEAM}.cloudflareaccess.com/cdn-cgi/access/certs`)
     );
@@ -50,6 +63,13 @@ export async function validateAccessJWT(
     } catch {
       return null;
     }
+  }
+
+  if (!CF_ACCESS_TEAM) {
+    console.error(
+      "[CloudflareAccess] CF_ACCESS_AUD set but CF_ACCESS_TEAM missing; refusing to verify JWT"
+    );
+    return null;
   }
 
   try {


### PR DESCRIPTION
## Summary

Phase 6 of the mobile redesign. Polishes the post-Cloudflare-Access landing
into a quiet two-step flow, and ships the Profile tab as a pushed-row stack.

- **`MobileLockScreen`** — interstitial while NextAuth's session resolves.
  Single line of copy ("Authenticating via Cloudflare Access") and an
  unobtrusive spinner. Achromatic, no glassmorphism.
- **`MobileWelcomeScreen`** — first-run only, signed-in-as line + optional
  Connect-GitHub CTA + Skip-for-now. Gated by `useFirstRun` (localStorage
  flag `remote-dev:mobile:welcome-seen:v1`); subsequent visits skip
  straight to Sessions.
- **`MobileApp`** — surfaces the GitHub OAuth callback's `?github=connected`
  query param as a one-shot success toast on the Sessions tab and strips
  the param from the URL on read.
- **`ProfileTab`** — pushed-row stack with sections: Account, GitHub
  accounts | Projects, Agent profiles | Secrets, Ports, Trash | Settings,
  About | Sign out. Tab-local navigation stack via `useProfileNavStack`,
  no modals for routine settings, hairline section dividers, no
  side-stripes, no glass.
- **Sign-out** confirms via `ActionSheet` (not a dialog), per DESIGN.md.

## Decisions

- **Sub-screens beyond About are stubs in this build.** Each one renders
  the real `SubScreen` chrome (header + Back button + scrollable body)
  and a TODO note pointing at the desktop component to port. The
  navigation chrome and the primary auth/sign-out flows are real, so
  the surface can be tested end-to-end on a device. Follow-up issues
  will fill them in. The brief explicitly called this out as a
  follow-up scope, so I have not tried to port heavy desktop modals
  (UserSettingsModal, AgentProfileAppearanceSettings, SecretsConfigModal,
  TaskSidebar, etc.) into Phase 6.
- **First-run flag in localStorage, not server state.** This is a UX
  nicety, not a security boundary, and per-device feels right (a user
  reinstalling the PWA on a new phone should see the welcome there).
- **Tab-local stack instead of URL routing.** The desktop URL is the
  canonical session/project navigation; pushing profile sub-screens onto
  the URL would force a full mobile-shell re-render and clobber the
  Sessions tab's recent-projects rail.
- **`ActionSheet` for sign-out, not a confirmation dialog.** Matches the
  desktop drift away from modal confirmations for routine actions and
  keeps the gesture-first register on mobile.
- **No new desktop changes.** I did not extract or modify any desktop
  auth/settings/profile code. The OAuth callback route already
  redirected to `/?github=connected`; the mobile shell now just listens
  for that param.

## Test plan

- [x] `bun run typecheck` clean.
- [x] `bun run lint` introduces no new errors (pre-existing 9 errors in
      `SessionsTab.tsx` / `BottomSheet.tsx` / `useSwipeAction.ts` are
      unrelated and predate this PR; verified by stashing my changes
      and re-running).
- [x] `bun run test:run` — 896 passing, 1 skipped, 0 new failures. The
      one failed *suite* (`tests/mobile/restart-agent-api-client.test.ts`)
      is a pre-existing tsconfig load failure unrelated to this PR.
- [x] 24 new tests cover `useFirstRun`, `useProfileNavStack`,
      `MobileWelcomeScreen`, `MobileLockScreen`, and `ProfileTab`
      navigation + sign-out via action sheet.

Manual checks (recommended before merge):
- [ ] Light + dark themes both render the lock and welcome screens
      with WCAG AA contrast.
- [ ] First-run flow on a real phone: clear the localStorage key,
      reload, verify the welcome appears once, "Connect GitHub" routes
      to `/api/auth/github/link`, "Skip for now" lands on Sessions.
- [ ] After GitHub OAuth, verify the success toast surfaces on the
      Sessions tab and the `?github=connected` param is stripped from
      the URL.
- [ ] Profile tab: tap each row, verify the sub-screen appears, tap
      Back, verify the index restores. Sign out via action sheet.
- [ ] Reduced motion: verify the lock spinner halts and the action
      sheet appears instantly.

## Follow-up scope

Sub-screens that ship as stubs in this PR and need their full UI ported
in follow-up issues:

- Account ← `UserSettingsModal.tsx` (Account tab)
- GitHub accounts ← `GitHubAccountSettings` / multi-account list
- Projects ← `ProjectTreeSidebar.tsx`, `GroupPreferencesModal`,
  `ProjectPreferencesModal`
- Agent profiles ← `components/agents/*`
- Secrets ← `SecretsConfigModal.tsx`, `SecretsStatusButton.tsx`
- Ports ← PortContext consumers
- Trash ← TrashContext consumers
- Settings ← `UserSettingsModal.tsx` (non-Account tabs)

About is the only sub-screen that ships real content (version, repo
link, one-line description).

Closes remote-dev-lud6.

This pull request and its description were written by Isaac.