### PR TITLE
Mobile redesign Phase 5: Channels tab with thread takeover

### DIFF
--- a/src/components/channels/ChannelView.tsx
+++ b/src/components/channels/ChannelView.tsx
@@ -9,6 +9,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Hash, MessageSquare, Users } from "lucide-react";
+import { toast } from "sonner";
 import { useChannelContext } from "@/contexts/ChannelContext";
 import { usePeerChatContext } from "@/contexts/PeerChatContext";
 import { ChannelMessageRow } from "./ChannelMessageRow";
@@ -66,9 +67,12 @@ export function ChannelView({ folderId }: ChannelViewProps) {
   }, []);
 
   const handleSend = useCallback(
-    (text: string) => {
+    async (text: string) => {
       setIsUserScrolled(false);
-      sendMessage(text);
+      const result = await sendMessage(text);
+      if (!result.ok) {
+        toast.error("Failed to send message");
+      }
     },
     [sendMessage]
   );

--- a/src/components/channels/ThreadPanel.tsx
+++ b/src/components/channels/ThreadPanel.tsx
@@ -9,6 +9,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { X, MessageSquare } from "lucide-react";
+import { toast } from "sonner";
 import { useChannelContext } from "@/contexts/ChannelContext";
 import { usePeerChatContext } from "@/contexts/PeerChatContext";
 import { ChannelMessageRow } from "./ChannelMessageRow";
@@ -48,10 +49,13 @@ export function ThreadPanel() {
   }, []);
 
   const handleSend = useCallback(
-    (text: string) => {
+    async (text: string) => {
       if (!openThreadId) return;
       setIsUserScrolled(false);
-      sendMessage(text, openThreadId);
+      const result = await sendMessage(text, openThreadId);
+      if (!result.ok) {
+        toast.error("Failed to send message");
+      }
     },
     [openThreadId, sendMessage]
   );

--- a/src/components/channels/__tests__/ChannelView.test.tsx
+++ b/src/components/channels/__tests__/ChannelView.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * ChannelView tests — desktop send-failure feedback.
+ *
+ * Verifies that when `sendMessage` resolves with `{ ok: false }`, the
+ * desktop ChannelView surfaces a sonner error toast so silent send
+ * failures aren't invisible to the user.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { error: (msg: string) => toastError(msg) },
+}));
+
+const sendMessage = vi.fn();
+const channelContextValue = {
+  groups: [
+    {
+      id: "g1",
+      name: "Channels",
+      kind: "channels" as const,
+      channels: [
+        {
+          id: "c1",
+          name: "general",
+          displayName: "general",
+          topic: null,
+          kind: "channel" as const,
+        },
+      ],
+    },
+  ],
+  activeChannelId: "c1",
+  activeChannelMessages: [],
+  loading: false,
+  sendMessage,
+  markChannelRead: vi.fn(),
+  openThread: vi.fn(),
+  openThreadId: null,
+};
+
+vi.mock("@/contexts/ChannelContext", () => ({
+  useChannelContext: () => channelContextValue,
+}));
+
+vi.mock("@/contexts/PeerChatContext", () => ({
+  usePeerChatContext: () => ({
+    peers: [],
+    peerNameMap: new Map(),
+  }),
+}));
+
+// Avoid pulling in the ThreadPanel tree (which has its own context deps).
+vi.mock("../ThreadPanel", () => ({
+  ThreadPanel: () => null,
+}));
+
+import { ChannelView } from "../ChannelView";
+
+beforeEach(() => {
+  toastError.mockReset();
+  sendMessage.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function typeAndSend(text: string) {
+  const textarea = screen.getByPlaceholderText(
+    /Message #general/i
+  ) as HTMLTextAreaElement;
+  fireEvent.change(textarea, { target: { value: text } });
+  fireEvent.keyDown(textarea, { key: "Enter" });
+}
+
+describe("ChannelView.handleSend", () => {
+  it("shows a toast when sendMessage returns { ok: false }", async () => {
+    sendMessage.mockResolvedValue({ ok: false, error: "boom" });
+    render(<ChannelView folderId="f1" folderName="Folder" />);
+    typeAndSend("hello");
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith("hello");
+      expect(toastError).toHaveBeenCalledWith("Failed to send message");
+    });
+  });
+
+  it("does not toast when sendMessage returns { ok: true }", async () => {
+    sendMessage.mockResolvedValue({ ok: true });
+    render(<ChannelView folderId="f1" folderName="Folder" />);
+    typeAndSend("hi");
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith("hi");
+    });
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/channels/__tests__/ThreadPanel.test.tsx
+++ b/src/components/channels/__tests__/ThreadPanel.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * ThreadPanel tests — desktop thread send-failure feedback.
+ *
+ * Verifies that when `sendMessage` resolves with `{ ok: false }` while
+ * replying in a thread, the panel surfaces a sonner error toast.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { error: (msg: string) => toastError(msg) },
+}));
+
+const sendMessage = vi.fn();
+const parentMessage = {
+  id: "p1",
+  channelId: "c1",
+  parentMessageId: null,
+  authorSessionId: "s1",
+  body: "parent",
+  createdAt: new Date().toISOString(),
+  replyCount: 0,
+};
+
+const channelContextValue = {
+  activeChannelMessages: [parentMessage],
+  openThreadId: "p1",
+  closeThread: vi.fn(),
+  threadMessages: [],
+  sendMessage,
+};
+
+vi.mock("@/contexts/ChannelContext", () => ({
+  useChannelContext: () => channelContextValue,
+}));
+
+vi.mock("@/contexts/PeerChatContext", () => ({
+  usePeerChatContext: () => ({
+    peerNameMap: new Map(),
+  }),
+}));
+
+// Replace the message row with a stub so we don't pull in markdown deps.
+vi.mock("../ChannelMessageRow", () => ({
+  ChannelMessageRow: () => null,
+}));
+
+import { ThreadPanel } from "../ThreadPanel";
+
+beforeEach(() => {
+  toastError.mockReset();
+  sendMessage.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function typeAndSend(text: string) {
+  const textarea = screen.getByPlaceholderText(
+    /Reply in thread/i
+  ) as HTMLTextAreaElement;
+  fireEvent.change(textarea, { target: { value: text } });
+  fireEvent.keyDown(textarea, { key: "Enter" });
+}
+
+describe("ThreadPanel.handleSend", () => {
+  it("shows a toast when sendMessage returns { ok: false }", async () => {
+    sendMessage.mockResolvedValue({ ok: false, error: "boom" });
+    render(<ThreadPanel />);
+    typeAndSend("reply");
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith("reply", "p1");
+      expect(toastError).toHaveBeenCalledWith("Failed to send message");
+    });
+  });
+
+  it("does not toast when sendMessage returns { ok: true }", async () => {
+    sendMessage.mockResolvedValue({ ok: true });
+    render(<ThreadPanel />);
+    typeAndSend("reply ok");
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith("reply ok", "p1");
+    });
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/mobile/MobileApp.tsx
+++ b/src/components/mobile/MobileApp.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 /**
- * MobileApp — Phase 2 mobile redesign.
+ * MobileApp — mobile composition root.
  *
  * Top-level mobile composition rendered inside `MobileShell` when the
  * viewport is below 768px. Owns the active-tab state, dispatches tab
  * content, and shows simple "Coming in Phase N" placeholders for tabs
  * that ship later.
  *
- * Phase 2 only fills the Sessions tab. Notifications / Channels / Profile
- * are placeholder slots so the tab bar remains usable while later phases
- * land.
+ * Phases 2 + 5 are wired: Sessions tab and Channels tab. Notifications and
+ * Profile remain placeholders for later phases.
  */
 
 import { useState } from "react";
@@ -18,24 +17,39 @@ import { useState } from "react";
 import { MobileShell } from "./MobileShell";
 import type { MobileTab } from "./BottomTabBar";
 import { SessionsTab } from "./sessions/SessionsTab";
+import { ChannelsTab } from "./channels/ChannelsTab";
+import { useChannelContextOptional } from "@/contexts/ChannelContext";
 
 export interface MobileAppProps {
   isGitHubConnected: boolean;
 }
 
-const PLACEHOLDER_COPY: Record<Exclude<MobileTab, "sessions">, { title: string; phase: string }> = {
+const PLACEHOLDER_COPY: Record<
+  Exclude<MobileTab, "sessions" | "channels">,
+  { title: string; phase: string }
+> = {
   notifications: { title: "Notifications", phase: "Phase 4" },
-  channels: { title: "Channels", phase: "Phase 5" },
   profile: { title: "Profile", phase: "Phase 6" },
 };
 
 export function MobileApp({ isGitHubConnected }: MobileAppProps) {
   const [activeTab, setActiveTab] = useState<MobileTab>("sessions");
 
+  // Pull the channels unread count for the bottom-tab badge. The provider
+  // is optional so the tab works even when channels haven't loaded yet.
+  const channels = useChannelContextOptional();
+  const channelsBadge = channels?.totalUnreadCount ?? 0;
+
   return (
-    <MobileShell activeTab={activeTab} onTabChange={setActiveTab}>
+    <MobileShell
+      activeTab={activeTab}
+      onTabChange={setActiveTab}
+      badges={channelsBadge > 0 ? { channels: channelsBadge } : undefined}
+    >
       {activeTab === "sessions" ? (
         <SessionsTab isGitHubConnected={isGitHubConnected} />
+      ) : activeTab === "channels" ? (
+        <ChannelsTab />
       ) : (
         <EmptyTabPlaceholder
           title={PLACEHOLDER_COPY[activeTab].title}

--- a/src/components/mobile/MobileApp.tsx
+++ b/src/components/mobile/MobileApp.tsx
@@ -12,7 +12,7 @@
  * Profile remain placeholders for later phases.
  */
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import { MobileShell } from "./MobileShell";
 import type { MobileTab } from "./BottomTabBar";
@@ -40,10 +40,31 @@ export function MobileApp({ isGitHubConnected }: MobileAppProps) {
   const channels = useChannelContextOptional();
   const channelsBadge = channels?.totalUnreadCount ?? 0;
 
+  // While a thread takeover is open inside the Channels tab the bottom tab
+  // bar would otherwise paint over the reply composer (both render at z-40
+  // before the takeover bumped to z-50). Force the bar hidden so the modal
+  // stack reads top-to-bottom: takeover > channel view > shell. We also
+  // dismiss the thread on tab change so it doesn't get stranded behind a
+  // sibling tab.
+  const openThreadId = channels?.openThreadId ?? null;
+  const closeThread = channels?.closeThread;
+  const tabBarForceHidden = activeTab === "channels" && openThreadId != null;
+
+  const handleTabChange = useCallback(
+    (tab: MobileTab) => {
+      if (tab !== activeTab && openThreadId && closeThread) {
+        closeThread();
+      }
+      setActiveTab(tab);
+    },
+    [activeTab, openThreadId, closeThread]
+  );
+
   return (
     <MobileShell
       activeTab={activeTab}
-      onTabChange={setActiveTab}
+      onTabChange={handleTabChange}
+      forceHidden={tabBarForceHidden}
       badges={channelsBadge > 0 ? { channels: channelsBadge } : undefined}
     >
       {activeTab === "sessions" ? (

--- a/src/components/mobile/__tests__/BottomSheet.test.tsx
+++ b/src/components/mobile/__tests__/BottomSheet.test.tsx
@@ -9,7 +9,12 @@
  */
 
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { act, render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+
+const flushFrame = () =>
+  act(async () => {
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+  });
 
 import { BottomSheet } from "@/components/mobile/common/BottomSheet";
 
@@ -79,6 +84,9 @@ describe("BottomSheet", () => {
       </BottomSheet>
     );
     await waitFor(() => screen.getByTestId("mobile-bottom-sheet"));
+    // The two-phase mount flips `entered` on the next animation frame;
+    // useDialogPolish's ESC + stack registration runs at that point.
+    await flushFrame();
     fireEvent.keyDown(window, { key: "Escape" });
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
@@ -159,6 +167,7 @@ describe("BottomSheet", () => {
         </>
       );
       await waitFor(() => screen.getAllByTestId("mobile-bottom-sheet"));
+      await flushFrame();
       // Both sheets open → body locked.
       expect(document.body.style.overflow).toBe("hidden");
       // Close the first sheet — body should still be locked because the
@@ -186,6 +195,31 @@ describe("BottomSheet", () => {
         </>
       );
       await waitFor(() => expect(document.body.style.overflow).toBe(""));
+    });
+
+    it("ESC only closes the topmost dialog when sheets are stacked", async () => {
+      // Render two BottomSheets sequentially. The second one mounted is
+      // on top of the modal stack — pressing ESC must close ONLY it,
+      // leaving the underlying sheet open. Without the modal-stack
+      // sentinel both layers' window-level handlers would fire and the
+      // user would lose context of the underlying surface.
+      const onCloseA = vi.fn();
+      const onCloseB = vi.fn();
+      render(
+        <>
+          <BottomSheet open={true} onOpenChange={onCloseA} ariaLabel="A">
+            <div>a</div>
+          </BottomSheet>
+          <BottomSheet open={true} onOpenChange={onCloseB} ariaLabel="B">
+            <div>b</div>
+          </BottomSheet>
+        </>
+      );
+      await waitFor(() => screen.getAllByTestId("mobile-bottom-sheet"));
+      await flushFrame();
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(onCloseB).toHaveBeenCalledWith(false);
+      expect(onCloseA).not.toHaveBeenCalled();
     });
 
     it("restores focus to the previously-focused element on close", async () => {

--- a/src/components/mobile/__tests__/MobileApp.test.tsx
+++ b/src/components/mobile/__tests__/MobileApp.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * MobileApp tests — verifies the mobile composition root coordinates
+ * the bottom tab bar with the thread takeover state.
+ *
+ * Specifically:
+ *  - When a thread is open inside the Channels tab, the BottomTabBar is
+ *    forced hidden so it doesn't paint over the reply composer.
+ *  - Switching tabs while a thread is open dismisses the thread so it
+ *    doesn't get stranded behind a sibling tab.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+
+import type { ReactNode } from "react";
+
+const channelState = {
+  totalUnreadCount: 0,
+  openThreadId: null as string | null,
+  closeThread: vi.fn(),
+};
+
+vi.mock("@/contexts/ChannelContext", () => ({
+  useChannelContextOptional: () => channelState,
+}));
+
+vi.mock("@/hooks/useMobile", () => ({
+  useIsMobileViewport: () => true,
+  usePrefersReducedMotion: () => true,
+}));
+
+// Stub out the heavy tab content modules — we only care about MobileApp
+// wiring forceHidden + onTabChange to MobileShell here.
+vi.mock("../sessions/SessionsTab", () => ({
+  SessionsTab: () => <div data-testid="stub-sessions-tab" />,
+}));
+vi.mock("../channels/ChannelsTab", () => ({
+  ChannelsTab: () => <div data-testid="stub-channels-tab" />,
+}));
+
+// Capture the props MobileShell receives so we can assert on them.
+const shellProps: { current: { forceHidden?: boolean; onTabChange?: (t: string) => void } } = {
+  current: {},
+};
+vi.mock("../MobileShell", () => ({
+  MobileShell: ({
+    children,
+    onTabChange,
+    forceHidden,
+  }: {
+    children: ReactNode;
+    onTabChange: (t: string) => void;
+    forceHidden?: boolean;
+  }) => {
+    shellProps.current = { forceHidden, onTabChange };
+    return (
+      <div
+        data-testid="stub-mobile-shell"
+        data-force-hidden={forceHidden ? "true" : "false"}
+      >
+        <button
+          type="button"
+          data-testid="stub-tab-channels"
+          onClick={() => onTabChange("channels")}
+        />
+        <button
+          type="button"
+          data-testid="stub-tab-sessions"
+          onClick={() => onTabChange("sessions")}
+        />
+        {children}
+      </div>
+    );
+  },
+}));
+
+import { MobileApp } from "../MobileApp";
+
+beforeEach(() => {
+  channelState.openThreadId = null;
+  channelState.totalUnreadCount = 0;
+  channelState.closeThread.mockClear();
+  shellProps.current = {};
+});
+
+afterEach(() => cleanup());
+
+describe("MobileApp", () => {
+  it("forces the bottom tab bar hidden while a thread is open in Channels", () => {
+    channelState.openThreadId = "m1";
+    const { getByTestId } = render(<MobileApp isGitHubConnected={false} />);
+    // Default tab is sessions — forceHidden stays false even with a thread
+    // open in the (currently inactive) Channels tab.
+    expect(getByTestId("stub-mobile-shell").dataset.forceHidden).toBe("false");
+
+    // Switch to channels — now the takeover would render and the bar must
+    // hide so it doesn't cover the composer.
+    fireEvent.click(getByTestId("stub-tab-channels"));
+    expect(getByTestId("stub-mobile-shell").dataset.forceHidden).toBe("true");
+  });
+
+  it("closes any open thread when switching tabs", () => {
+    channelState.openThreadId = "m1";
+    const { getByTestId } = render(<MobileApp isGitHubConnected={false} />);
+    // From sessions → channels: thread is still open, but we still close
+    // it on the way out so it doesn't get stranded behind another tab.
+    fireEvent.click(getByTestId("stub-tab-channels"));
+    expect(channelState.closeThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call closeThread when the tab does not change", () => {
+    channelState.openThreadId = "m1";
+    const { getByTestId } = render(<MobileApp isGitHubConnected={false} />);
+    fireEvent.click(getByTestId("stub-tab-sessions"));
+    expect(channelState.closeThread).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/mobile/channels/ChannelsTab.tsx
+++ b/src/components/mobile/channels/ChannelsTab.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+/**
+ * ChannelsTab — Phase 5 mobile redesign.
+ *
+ * Top-level Channels tab. Drives a two-pane router:
+ *   - "list" → {@link MobileChannelList} (channel groups + unread badges)
+ *   - "view" → {@link MobileChannelView} (message stream + composer)
+ *
+ * The thread takeover ({@link MobileThreadTakeover}) is rendered above the
+ * view as a fixed full-screen layer when `openThreadId` is set in context.
+ *
+ * The DM creation FAB sits above the bottom tab bar (per the brief:
+ * `bottom-[calc(56px+env(safe-area-inset-bottom)+16px)]`) and only shows on
+ * the channel list (not while reading a channel).
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { MessageSquarePlus } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useChannelContextOptional } from "@/contexts/ChannelContext";
+import { usePreferencesContext } from "@/contexts/PreferencesContext";
+import { useProjectTree } from "@/contexts/ProjectTreeContext";
+
+import { MobileChannelList } from "./MobileChannelList";
+import { MobileChannelView } from "./MobileChannelView";
+import { MobileThreadTakeover } from "./MobileThreadTakeover";
+import { DmPickerSheet } from "./DmPickerSheet";
+
+type Pane = "list" | "view";
+
+export function ChannelsTab() {
+  const channels = useChannelContextOptional();
+  const { activeProject } = usePreferencesContext();
+  const projectTree = useProjectTree();
+
+  const [pane, setPane] = useState<Pane>("list");
+  const [dmSheetOpen, setDmSheetOpen] = useState(false);
+
+  const projectName =
+    activeProject.folderId
+      ? projectTree.getProject(activeProject.folderId)?.name ?? null
+      : null;
+
+  // Pull values out as nullable so hooks below stay unconditional. The early
+  // return for "no provider" comes after all hooks have run.
+  const activeChannelId = channels?.activeChannelId ?? null;
+  const setActiveChannelId = channels?.setActiveChannelId;
+  const openThreadId = channels?.openThreadId ?? null;
+  const closeThread = channels?.closeThread;
+
+  const handleOpenChannel = useCallback(
+    (channelId: string) => {
+      setActiveChannelId?.(channelId);
+      setPane("view");
+    },
+    [setActiveChannelId]
+  );
+
+  const handleBackToList = useCallback(() => {
+    // Closing a thread that's still open should also collapse it so the
+    // takeover doesn't reappear on the next channel-view entry.
+    if (openThreadId && closeThread) closeThread();
+    setPane("list");
+  }, [openThreadId, closeThread]);
+
+  const handleOpenThread = useCallback(() => {
+    // ChannelView already opens the thread in context; we don't need to do
+    // anything here — the takeover renders off `openThreadId`.
+  }, []);
+
+  const handleDmOpened = useCallback(() => {
+    // The picker already calls setActiveChannelId; route into the view.
+    setPane("view");
+  }, []);
+
+  // If the user navigates away from the tab and back, we want to keep their
+  // last pane. We only force back to list if the active channel disappears
+  // (e.g. archived from the desktop while we weren't looking).
+  useEffect(() => {
+    if (pane === "view" && !activeChannelId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- recover when active channel disappears externally
+      setPane("list");
+    }
+  }, [pane, activeChannelId]);
+
+  // If there's no ChannelProvider mounted (defensive — page.tsx mounts it),
+  // render a calm empty state. This keeps the tab usable in tests and in
+  // edge-case routes where channels haven't loaded yet. All hooks above
+  // already ran so the order stays stable across renders.
+  if (!channels || !closeThread) {
+    return (
+      <div
+        data-testid="mobile-channels-no-provider"
+        className="flex h-full flex-col items-center justify-center gap-2 px-6 py-12 text-center"
+      >
+        <p className="text-base font-medium text-foreground">Channels unavailable.</p>
+        <p className="text-sm text-muted-foreground">
+          Pick a project from the Sessions tab to load channels.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative flex h-full flex-col" data-testid="mobile-channels-tab">
+      {pane === "list" ? (
+        <>
+          <header className="border-b border-border bg-card px-3 py-2">
+            <h2 className="text-sm font-medium text-foreground">
+              Channels{projectName ? ` · ${projectName}` : ""}
+            </h2>
+          </header>
+          <div className="flex-1 overflow-y-auto overscroll-contain">
+            <MobileChannelList onOpen={handleOpenChannel} projectName={projectName} />
+          </div>
+          {/* DM creation FAB. Sits above the 56pt bottom tab bar + safe area. */}
+          <button
+            type="button"
+            onClick={() => setDmSheetOpen(true)}
+            aria-label="New direct message"
+            data-testid="mobile-channels-dm-fab"
+            className={cn(
+              "fixed right-4 z-30",
+              // Anchored above the tab bar (56) + safe area + 16px breathing room.
+              "bottom-[calc(56px+env(safe-area-inset-bottom)+16px)]",
+              "inline-flex h-12 w-12 items-center justify-center rounded-full",
+              // Achromatic primary, no neon. Per Achromatic-Default Rule.
+              "bg-foreground text-background shadow-lg",
+              "hover:bg-foreground/90 active:bg-foreground/80",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            )}
+          >
+            <MessageSquarePlus aria-hidden="true" className="h-5 w-5" />
+          </button>
+        </>
+      ) : (
+        <MobileChannelView onBack={handleBackToList} onOpenThread={handleOpenThread} />
+      )}
+
+      {/* Thread takeover layer — full-screen, rendered when a thread is open. */}
+      <MobileThreadTakeover open={!!openThreadId} onClose={closeThread} />
+
+      {/* DM picker bottom sheet */}
+      <DmPickerSheet
+        open={dmSheetOpen}
+        onOpenChange={setDmSheetOpen}
+        onOpenDm={handleDmOpened}
+      />
+    </div>
+  );
+}

--- a/src/components/mobile/channels/DmPickerSheet.tsx
+++ b/src/components/mobile/channels/DmPickerSheet.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+/**
+ * DmPickerSheet — Phase 5 mobile redesign.
+ *
+ * BottomSheet that lists project peers (active agent sessions) and lets the
+ * user open a direct-message channel with one. DM creation in Remote Dev is
+ * inherently between two sessions in the same project, so the sheet picks:
+ *   - target: the peer the user taps
+ *   - from:   the user's currently-active session, if it lives in the same
+ *             project as the target
+ *
+ * If no eligible "from" session exists in the active project, the sheet
+ * surfaces a single, calm explanation row instead of an actionable list.
+ * Per DESIGN.md "Trust the Expert" we don't lecture — just say what's
+ * needed.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { Bot, MessageSquarePlus } from "lucide-react";
+import { toast } from "sonner";
+
+import { cn } from "@/lib/utils";
+import { useChannelContext } from "@/contexts/ChannelContext";
+import { usePeerChatContext } from "@/contexts/PeerChatContext";
+import { useSessionContext } from "@/contexts/SessionContext";
+import { usePreferencesContext } from "@/contexts/PreferencesContext";
+import type { Channel } from "@/types/channels";
+
+import { BottomSheet } from "../common/BottomSheet";
+
+export interface DmPickerSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Fired with the resolved channel id once the DM has been opened. */
+  onOpenDm: (channelId: string) => void;
+}
+
+export function DmPickerSheet({ open, onOpenChange, onOpenDm }: DmPickerSheetProps) {
+  const { activeProject } = usePreferencesContext();
+  const projectId = activeProject.folderId;
+  const { peers } = usePeerChatContext();
+  const { sessions, activeSessionId } = useSessionContext();
+  const { setActiveChannelId, addChannel } = useChannelContext();
+
+  const [pendingTargetId, setPendingTargetId] = useState<string | null>(null);
+
+  // Find the user's "from" session: prefer the active session if it's in this
+  // project, otherwise the first session in the project.
+  const fromSessionId = useMemo<string | null>(() => {
+    if (!projectId) return null;
+    const inProject = sessions.filter((s) => s.projectId === projectId && s.status !== "closed");
+    if (inProject.length === 0) return null;
+    const active = inProject.find((s) => s.id === activeSessionId);
+    if (active) return active.id;
+    return inProject[0].id;
+  }, [sessions, activeSessionId, projectId]);
+
+  // Filter peers down to those that aren't the user's own from-session.
+  const eligiblePeers = useMemo(
+    () => peers.filter((p) => p.sessionId !== fromSessionId),
+    [peers, fromSessionId]
+  );
+
+  const handlePick = useCallback(
+    async (targetSessionId: string) => {
+      if (!projectId || !fromSessionId) return;
+      setPendingTargetId(targetSessionId);
+      try {
+        const resp = await fetch("/api/channels/dm", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            projectId,
+            targetSessionId,
+            fromSessionId,
+          }),
+        });
+        if (!resp.ok) {
+          const data = (await resp.json().catch(() => ({}))) as { error?: string };
+          throw new Error(data.error ?? "Failed to open DM");
+        }
+        const data = (await resp.json()) as { channel: Channel };
+        // Make the channel show up immediately in the list & become active.
+        addChannel(data.channel);
+        setActiveChannelId(data.channel.id);
+        onOpenChange(false);
+        onOpenDm(data.channel.id);
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to open DM");
+      } finally {
+        setPendingTargetId(null);
+      }
+    },
+    [projectId, fromSessionId, addChannel, setActiveChannelId, onOpenChange, onOpenDm]
+  );
+
+  const sheetTitle = "Direct message";
+
+  // Three states: no project, no from-session, peer list.
+  return (
+    <BottomSheet open={open} onOpenChange={onOpenChange} title={sheetTitle}>
+      {!projectId ? (
+        <DmEmpty
+          headline="Pick a project first."
+          body="Direct messages are scoped to a project. Choose one from the Sessions tab."
+        />
+      ) : !fromSessionId ? (
+        <DmEmpty
+          headline="Open a session in this project first."
+          body="DMs always have a from-session. Start any session in this project, then come back."
+        />
+      ) : eligiblePeers.length === 0 ? (
+        <DmEmpty
+          headline="No peers online."
+          body="Direct messages are between two agents in the same project. When another agent comes online here it will show up."
+        />
+      ) : (
+        <ul role="list" className="px-2 py-1" data-testid="dm-picker-sheet-items">
+          {eligiblePeers.map((peer) => {
+            const pending = pendingTargetId === peer.sessionId;
+            return (
+              <li key={peer.sessionId}>
+                <button
+                  type="button"
+                  onClick={() => handlePick(peer.sessionId)}
+                  disabled={pending}
+                  data-testid="dm-picker-sheet-row"
+                  data-session-id={peer.sessionId}
+                  className={cn(
+                    "flex w-full items-center gap-3 rounded-md px-3",
+                    "min-h-[44px] py-2.5 text-left",
+                    "transition-colors",
+                    "hover:bg-accent/40 active:bg-accent/60",
+                    pending && "opacity-60"
+                  )}
+                >
+                  <span
+                    aria-hidden="true"
+                    className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted"
+                  >
+                    <Bot className="h-3.5 w-3.5 text-muted-foreground" />
+                  </span>
+                  <span className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate text-sm font-medium text-foreground">
+                      {peer.name}
+                    </span>
+                    {peer.peerSummary ? (
+                      <span className="truncate text-xs text-muted-foreground">
+                        {peer.peerSummary}
+                      </span>
+                    ) : peer.agentProvider ? (
+                      <span className="truncate text-xs text-muted-foreground">
+                        {peer.agentProvider}
+                      </span>
+                    ) : null}
+                  </span>
+                  {pending ? (
+                    <span className="text-[11px] text-muted-foreground">Opening…</span>
+                  ) : (
+                    <MessageSquarePlus
+                      aria-hidden="true"
+                      className="h-4 w-4 text-muted-foreground"
+                    />
+                  )}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </BottomSheet>
+  );
+}
+
+function DmEmpty({ headline, body }: { headline: string; body: string }) {
+  return (
+    <div className="flex flex-col items-start gap-1 px-4 py-4 text-left">
+      <p className="text-sm font-medium text-foreground">{headline}</p>
+      <p className="text-xs text-muted-foreground">{body}</p>
+    </div>
+  );
+}

--- a/src/components/mobile/channels/DmPickerSheet.tsx
+++ b/src/components/mobile/channels/DmPickerSheet.tsx
@@ -16,7 +16,7 @@
  * needed.
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Bot, MessageSquarePlus } from "lucide-react";
 import { toast } from "sonner";
 
@@ -25,7 +25,6 @@ import { useChannelContext } from "@/contexts/ChannelContext";
 import { usePeerChatContext } from "@/contexts/PeerChatContext";
 import { useSessionContext } from "@/contexts/SessionContext";
 import { usePreferencesContext } from "@/contexts/PreferencesContext";
-import type { Channel } from "@/types/channels";
 
 import { BottomSheet } from "../common/BottomSheet";
 
@@ -41,9 +40,14 @@ export function DmPickerSheet({ open, onOpenChange, onOpenDm }: DmPickerSheetPro
   const projectId = activeProject.folderId;
   const { peers } = usePeerChatContext();
   const { sessions, activeSessionId } = useSessionContext();
-  const { setActiveChannelId, addChannel } = useChannelContext();
+  const { setActiveChannelId, refreshChannels } = useChannelContext();
 
   const [pendingTargetId, setPendingTargetId] = useState<string | null>(null);
+  // Per-request AbortController so that closing the sheet mid-request
+  // cancels the in-flight POST. Without this, a stale resolution would
+  // call setActiveChannelId/onOpenDm AFTER the user dismissed the picker
+  // and yank them into a DM they no longer wanted to open.
+  const controllerRef = useRef<AbortController | null>(null);
 
   // Find the user's "from" session: prefer the active session if it's in this
   // project, otherwise the first session in the project.
@@ -62,9 +66,30 @@ export function DmPickerSheet({ open, onOpenChange, onOpenDm }: DmPickerSheetPro
     [peers, fromSessionId]
   );
 
+  // Cancel any in-flight DM POST when the sheet closes (or the component
+  // unmounts). The success/failure paths below also bail out when the
+  // signal is aborted to avoid mutating channel state after the user
+  // dismissed the picker.
+  useEffect(() => {
+    if (!open && controllerRef.current) {
+      controllerRef.current.abort();
+      controllerRef.current = null;
+    }
+  }, [open]);
+  useEffect(() => {
+    return () => {
+      controllerRef.current?.abort();
+      controllerRef.current = null;
+    };
+  }, []);
+
   const handlePick = useCallback(
     async (targetSessionId: string) => {
       if (!projectId || !fromSessionId) return;
+      // Abort any earlier in-flight request (rapid double-tap).
+      controllerRef.current?.abort();
+      const controller = new AbortController();
+      controllerRef.current = controller;
       setPendingTargetId(targetSessionId);
       try {
         const resp = await fetch("/api/channels/dm", {
@@ -75,24 +100,42 @@ export function DmPickerSheet({ open, onOpenChange, onOpenDm }: DmPickerSheetPro
             targetSessionId,
             fromSessionId,
           }),
+          signal: controller.signal,
         });
+        if (controller.signal.aborted) return;
         if (!resp.ok) {
           const data = (await resp.json().catch(() => ({}))) as { error?: string };
           throw new Error(data.error ?? "Failed to open DM");
         }
-        const data = (await resp.json()) as { channel: Channel };
-        // Make the channel show up immediately in the list & become active.
-        addChannel(data.channel);
+        const data = (await resp.json()) as { channel: { id: string } };
+        if (controller.signal.aborted) return;
+        // Refresh the full channel list so the new DM lands in the right
+        // group with a normalized shape (unreadCount, folderId, etc.).
+        // The /api/channels/dm endpoint returns the raw DB row which is
+        // missing those fields — passing it directly into addChannel would
+        // produce a NaN totalUnreadCount and a "Channel unavailable" route
+        // when the Direct Messages group hasn't been hydrated yet.
+        await refreshChannels();
+        if (controller.signal.aborted) return;
         setActiveChannelId(data.channel.id);
         onOpenChange(false);
         onOpenDm(data.channel.id);
       } catch (err) {
+        if (
+          (err instanceof DOMException && err.name === "AbortError") ||
+          controller.signal.aborted
+        ) {
+          return;
+        }
         toast.error(err instanceof Error ? err.message : "Failed to open DM");
       } finally {
+        if (controllerRef.current === controller) {
+          controllerRef.current = null;
+        }
         setPendingTargetId(null);
       }
     },
-    [projectId, fromSessionId, addChannel, setActiveChannelId, onOpenChange, onOpenDm]
+    [projectId, fromSessionId, refreshChannels, setActiveChannelId, onOpenChange, onOpenDm]
   );
 
   const sheetTitle = "Direct message";

--- a/src/components/mobile/channels/MobileChannelComposer.tsx
+++ b/src/components/mobile/channels/MobileChannelComposer.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+/**
+ * MobileChannelComposer — autocorrect-ON prose composer for the mobile
+ * Channels tab.
+ *
+ * Same external shape as the terminal {@link MobileInputBar} (textarea +
+ * trailing send button, long-press = insert without firing) but tuned for
+ * prose: autocorrect / autocapitalize / spellcheck on, no terminal modifier
+ * machinery, plain `\n` newlines (Shift+Enter), and an `enterkeyhint="send"`
+ * hint so soft keyboards show a Send affordance.
+ *
+ * Long-press semantics:
+ *   - tap send  → submit current value, clear
+ *   - hold 400ms→ "insert without sending" — keeps the text in the textarea so
+ *     the user can edit and follow up before posting. Mirrors the terminal
+ *     bar's "compose-without-execute" gesture so muscle memory carries.
+ *
+ * No `backdrop-filter` / glass — solid `bg-card` with a single hairline top
+ * border per DESIGN.md "Flat-By-Default Rule".
+ */
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import { Send } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const LONG_PRESS_MS = 400;
+const PEEK_DURATION_MS = 600;
+
+export interface MobileChannelComposerProps {
+  /** Submit handler. Receives trimmed body. Returning a promise blocks input. */
+  onSubmit: (text: string) => void | Promise<unknown>;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+  /** Reflects the post status — when true the composer is locked to prevent
+   * double-submits. */
+  busy?: boolean;
+}
+
+export const MobileChannelComposer = forwardRef<
+  HTMLTextAreaElement,
+  MobileChannelComposerProps
+>(function MobileChannelComposer(
+  { onSubmit, disabled = false, placeholder = "Message", className, busy = false },
+  ref
+) {
+  const [value, setValue] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  useImperativeHandle(ref, () => textareaRef.current!, []);
+
+  const valueRef = useRef(value);
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
+
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressFiredRef = useRef(false);
+  const [longPressActive, setLongPressActive] = useState(false);
+
+  const clearLongPressTimer = useCallback(() => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearLongPressTimer, [clearLongPressTimer]);
+
+  const resetHeight = useCallback(() => {
+    const ta = textareaRef.current;
+    if (ta) ta.style.height = "auto";
+  }, []);
+
+  const submit = useCallback(() => {
+    if (disabled || busy) return;
+    const trimmed = valueRef.current.trim();
+    if (!trimmed) return;
+    setValue("");
+    resetHeight();
+    void Promise.resolve(onSubmit(trimmed)).catch(() => {
+      // Caller surfaces errors; we don't restore the draft because the
+      // failure path normally produces a toast plus removed optimistic row.
+    });
+  }, [disabled, busy, onSubmit, resetHeight]);
+
+  const handleFormSubmit = useCallback(
+    (e?: FormEvent) => {
+      e?.preventDefault();
+      // Long-press fires its own action and pre-empts the click; gate here too
+      // so a fast-tap right after a long-press doesn't double-post.
+      if (longPressFiredRef.current) {
+        longPressFiredRef.current = false;
+        return;
+      }
+      submit();
+    },
+    [submit]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.nativeEvent.isComposing) return;
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        submit();
+      }
+    },
+    [submit]
+  );
+
+  const handleInput = useCallback((e: FormEvent<HTMLTextAreaElement>) => {
+    const ta = e.currentTarget;
+    ta.style.height = "auto";
+    ta.style.height = `${ta.scrollHeight}px`;
+  }, []);
+
+  const handleSendPointerDown = useCallback(() => {
+    if (disabled || busy) return;
+    longPressFiredRef.current = false;
+    longPressTimerRef.current = setTimeout(() => {
+      longPressFiredRef.current = true;
+      // Long-press = "insert without send": keep the value in the textarea
+      // so the author can edit further. We just give a brief visual ack.
+      if (!valueRef.current.trim()) return;
+      setLongPressActive(true);
+      window.setTimeout(() => setLongPressActive(false), PEEK_DURATION_MS);
+    }, LONG_PRESS_MS);
+  }, [disabled, busy]);
+
+  const handleSendPointerUp = useCallback(
+    (e: ReactPointerEvent) => {
+      clearLongPressTimer();
+      if (longPressFiredRef.current) {
+        // Don't let the click bubble into a submit.
+        e.preventDefault();
+      }
+    },
+    [clearLongPressTimer]
+  );
+
+  const handleSendClick = useCallback((e: MouseEvent) => {
+    if (longPressFiredRef.current) {
+      e.preventDefault();
+      longPressFiredRef.current = false;
+    }
+  }, []);
+
+  const canSend = value.trim().length > 0 && !busy && !disabled;
+
+  return (
+    <form
+      onSubmit={handleFormSubmit}
+      data-testid="mobile-channel-composer"
+      className={cn(
+        // Solid bg-card per DESIGN.md "Flat-By-Default Rule" + "Glass-Earns-Its-Place".
+        "flex items-end gap-1.5 border-t border-border bg-card px-2 py-1.5",
+        className
+      )}
+    >
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onInput={handleInput}
+        placeholder={placeholder}
+        disabled={disabled || busy}
+        rows={1}
+        // Autocorrect ON for prose. Mirrors mail / chat clients.
+        autoComplete="on"
+        autoCorrect="on"
+        autoCapitalize="sentences"
+        spellCheck
+        enterKeyHint="send"
+        data-testid="mobile-channel-composer-textarea"
+        className={cn(
+          "flex-1 min-h-[2.25rem] max-h-32 resize-none rounded-lg px-3 py-2",
+          "bg-muted/50 text-foreground text-sm leading-snug",
+          "placeholder:text-muted-foreground/60",
+          "focus:outline-none focus:ring-1 focus:ring-ring/60",
+          "overflow-y-auto",
+          (disabled || busy) && "opacity-50 cursor-not-allowed"
+        )}
+      />
+
+      <button
+        type="submit"
+        disabled={!canSend && !longPressActive}
+        onPointerDown={handleSendPointerDown}
+        onPointerUp={handleSendPointerUp}
+        onPointerCancel={clearLongPressTimer}
+        onClick={handleSendClick}
+        onContextMenu={(e) => e.preventDefault()}
+        aria-label="Send message (hold to keep editing)"
+        data-testid="mobile-channel-composer-send"
+        className={cn(
+          "relative shrink-0 rounded-md p-2 touch-manipulation",
+          "min-h-[44px] min-w-[44px] flex items-center justify-center",
+          "transition-colors duration-200",
+          !canSend && !longPressActive && "text-muted-foreground/40",
+          canSend && !longPressActive && "text-foreground active:bg-accent/40",
+          longPressActive && "text-foreground bg-accent/30"
+        )}
+      >
+        <Send className="h-4 w-4" />
+        {longPressActive ? (
+          <span
+            role="status"
+            className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-md border border-border bg-card px-2 py-1 text-xs text-muted-foreground shadow-sm"
+          >
+            Kept for editing
+          </span>
+        ) : null}
+      </button>
+    </form>
+  );
+});

--- a/src/components/mobile/channels/MobileChannelComposer.tsx
+++ b/src/components/mobile/channels/MobileChannelComposer.tsx
@@ -33,6 +33,7 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import { Send } from "lucide-react";
+import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
 
@@ -40,7 +41,13 @@ const LONG_PRESS_MS = 400;
 const PEEK_DURATION_MS = 600;
 
 export interface MobileChannelComposerProps {
-  /** Submit handler. Receives trimmed body. Returning a promise blocks input. */
+  /**
+   * Submit handler. Receives the trimmed body. The composer optimistically
+   * clears the textarea before awaiting the result, but if the returned
+   * promise REJECTS the draft is restored and an error toast is shown so
+   * the user can retry without retyping. Returning normally (or resolving
+   * a non-rejection) is treated as success.
+   */
   onSubmit: (text: string) => void | Promise<unknown>;
   disabled?: boolean;
   placeholder?: string;
@@ -88,11 +95,23 @@ export const MobileChannelComposer = forwardRef<
     if (disabled || busy) return;
     const trimmed = valueRef.current.trim();
     if (!trimmed) return;
+    // Optimistically clear the input so the keyboard/textarea reflects a
+    // clean send, but remember the draft so we can restore it if the
+    // submit rejects. Without restoration the user loses what they typed
+    // when the network or server fails.
+    const draft = valueRef.current;
     setValue("");
     resetHeight();
     void Promise.resolve(onSubmit(trimmed)).catch(() => {
-      // Caller surfaces errors; we don't restore the draft because the
-      // failure path normally produces a toast plus removed optimistic row.
+      setValue(draft);
+      // Resize back to the draft's content height on the next paint.
+      requestAnimationFrame(() => {
+        const ta = textareaRef.current;
+        if (!ta) return;
+        ta.style.height = "auto";
+        ta.style.height = `${ta.scrollHeight}px`;
+      });
+      toast.error("Failed to send. Try again.");
     });
   }, [disabled, busy, onSubmit, resetHeight]);
 

--- a/src/components/mobile/channels/MobileChannelList.tsx
+++ b/src/components/mobile/channels/MobileChannelList.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+/**
+ * MobileChannelList — Phase 5 mobile redesign.
+ *
+ * Renders the {@link useChannelContext} groups as a scrolling list of section
+ * headers with channel rows underneath. Each row shows the channel name, the
+ * (optional) topic, and a right-aligned unread badge when `unreadCount > 0`.
+ *
+ * Selecting a row sets it as the active channel via context AND fires
+ * `onOpen(channelId)` so the parent can route to the channel view.
+ *
+ * The unread badge is achromatic (foreground / background tokens). Per
+ * DESIGN.md "One Voice Rule", color enters chrome only as signal — and
+ * unread-count is a *quantity*, not a state-attention signal.
+ */
+
+import { useCallback } from "react";
+import { Hash, Lock, MessageCircle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useChannelContext } from "@/contexts/ChannelContext";
+import type { Channel } from "@/types/channels";
+
+export interface MobileChannelListProps {
+  /** Called after the row's tap selects the channel. */
+  onOpen: (channelId: string) => void;
+  /** Stable id for the active project (for empty-state copy). May be null. */
+  projectName?: string | null;
+}
+
+export function MobileChannelList({ onOpen, projectName }: MobileChannelListProps) {
+  const { groups, activeChannelId, setActiveChannelId, loading } = useChannelContext();
+
+  const handleSelect = useCallback(
+    (channelId: string) => {
+      setActiveChannelId(channelId);
+      onOpen(channelId);
+    },
+    [setActiveChannelId, onOpen]
+  );
+
+  const totalChannels = groups.reduce((n, g) => n + g.channels.length, 0);
+
+  if (loading && totalChannels === 0) {
+    return <ChannelListSkeleton />;
+  }
+
+  if (totalChannels === 0) {
+    return (
+      <div
+        data-testid="mobile-channels-empty"
+        className="flex h-full flex-col items-center justify-center gap-2 px-6 py-12 text-center"
+      >
+        <MessageCircle aria-hidden="true" className="h-6 w-6 text-muted-foreground/60" />
+        <p className="text-base font-medium text-foreground">
+          No channels{projectName ? ` in ${projectName}` : ""} yet.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Channels appear here when agents in this project start a conversation.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul
+      role="list"
+      data-testid="mobile-channel-list"
+      className="flex flex-col"
+    >
+      {groups.map((group) => (
+        <li key={group.id}>
+          <h3
+            className={cn(
+              "sticky top-0 z-10 border-b border-border bg-card",
+              "px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
+            )}
+          >
+            {group.name}
+          </h3>
+          <ul role="list" className="flex flex-col">
+            {group.channels.map((channel) => (
+              <li key={channel.id}>
+                <ChannelRow
+                  channel={channel}
+                  active={channel.id === activeChannelId}
+                  onSelect={handleSelect}
+                />
+              </li>
+            ))}
+            {group.channels.length === 0 ? (
+              <li className="px-4 py-3 text-xs text-muted-foreground">
+                No channels in this group.
+              </li>
+            ) : null}
+          </ul>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ChannelRow({
+  channel,
+  active,
+  onSelect,
+}: {
+  channel: Channel;
+  active: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const Icon = channel.type === "dm" ? Lock : Hash;
+  const display = channel.displayName || channel.name;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(channel.id)}
+      aria-current={active ? "page" : undefined}
+      data-testid="mobile-channel-row"
+      data-channel-id={channel.id}
+      className={cn(
+        "flex w-full items-center gap-3 border-b border-border/60 px-4 text-left",
+        "min-h-[56px] py-2 transition-colors",
+        // Selection treatment: tint, no side-stripe (DESIGN.md "No Side-Stripe").
+        active ? "bg-accent/40" : "bg-card",
+        "hover:bg-accent/30 active:bg-accent/50",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      )}
+    >
+      <Icon aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span
+          className={cn(
+            "truncate text-sm",
+            // Weight contrast for unread (Weight-Over-Size Rule).
+            channel.unreadCount > 0 ? "font-semibold text-foreground" : "font-normal text-foreground"
+          )}
+        >
+          {display}
+        </span>
+        {channel.topic ? (
+          <span className="truncate text-xs text-muted-foreground">
+            {channel.topic}
+          </span>
+        ) : null}
+      </div>
+      {channel.unreadCount > 0 ? (
+        <span
+          aria-label={`${channel.unreadCount} unread`}
+          data-testid="mobile-channel-row-unread"
+          className={cn(
+            "ml-2 inline-flex h-5 min-w-[20px] items-center justify-center rounded-full",
+            "bg-foreground px-1.5 text-[11px] font-medium leading-none text-background"
+          )}
+        >
+          {channel.unreadCount > 99 ? "99+" : channel.unreadCount}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function ChannelListSkeleton() {
+  const rows = [0, 1, 2, 3, 4];
+  return (
+    <ul
+      role="list"
+      aria-busy="true"
+      data-testid="mobile-channel-list-skeleton"
+      className="animate-pulse"
+    >
+      {rows.map((i) => (
+        <li
+          key={i}
+          className="flex items-center gap-3 border-b border-border/60 px-4 py-3 min-h-[56px]"
+        >
+          <span className="inline-flex h-3.5 w-3.5 shrink-0 rounded-full bg-muted-foreground/20" />
+          <div className="flex-1 space-y-1.5">
+            <div className="h-3 w-1/2 rounded bg-muted-foreground/15" />
+            <div className="h-2.5 w-1/3 rounded bg-muted-foreground/10" />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/mobile/channels/MobileChannelView.tsx
+++ b/src/components/mobile/channels/MobileChannelView.tsx
@@ -70,11 +70,25 @@ export function MobileChannelView({ onBack, onOpenThread }: MobileChannelViewPro
   }, [activeChannelMessages, isUserScrolled]);
 
   // Mark the channel read when we see new messages and we're not viewing
-  // an optimistic placeholder. Mirrors ChannelView's behaviour.
+  // an optimistic placeholder. Mirrors ChannelView's behaviour. Gated on a
+  // ref tracking the last-marked id so unrelated context updates (which
+  // produce a new `activeChannelMessages` reference but the same trailing
+  // message) don't refire the request on every render.
+  const lastMarkedRef = useRef<string | null>(null);
+  useEffect(() => {
+    // Reset the tracker when the user switches channels so the new channel
+    // gets its first read mark even if the message id happens to collide.
+    lastMarkedRef.current = null;
+  }, [activeChannelId]);
   useEffect(() => {
     if (!activeChannelId || activeChannelMessages.length === 0) return;
     const last = activeChannelMessages[activeChannelMessages.length - 1];
-    if (last && !last.id.startsWith("opt-")) {
+    if (
+      last &&
+      !last.id.startsWith("opt-") &&
+      last.id !== lastMarkedRef.current
+    ) {
+      lastMarkedRef.current = last.id;
       void markChannelRead(activeChannelId, last.id);
     }
   }, [activeChannelId, activeChannelMessages, markChannelRead]);

--- a/src/components/mobile/channels/MobileChannelView.tsx
+++ b/src/components/mobile/channels/MobileChannelView.tsx
@@ -20,15 +20,19 @@
  *    big illustrated empty state.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronLeft, Hash, Lock } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { ChevronLeft, Copy, Hash, Lock, MessageSquare } from "lucide-react";
+import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
 import { useChannelContext } from "@/contexts/ChannelContext";
 import { usePeerChatContext } from "@/contexts/PeerChatContext";
 import { ChannelMessageRow } from "@/components/channels/ChannelMessageRow";
+import type { ChannelMessage } from "@/types/channels";
 
 import { MobileChannelComposer } from "./MobileChannelComposer";
+import { ActionSheet } from "../common/ActionSheet";
+import { useLongPress } from "../sessions/useSwipeAction";
 
 const SCROLL_THRESHOLD_PX = 50;
 
@@ -53,6 +57,11 @@ export function MobileChannelView({ onBack, onOpenThread }: MobileChannelViewPro
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isUserScrolled, setIsUserScrolled] = useState(false);
+  // Long-press surfaces an ActionSheet ("Reply in thread", "Copy") since
+  // ChannelMessageRow's hover-only reply chip is unreachable on touch
+  // devices. We track the target message rather than just its id so the
+  // sheet can offer message-aware actions (Copy uses the body).
+  const [actionMessage, setActionMessage] = useState<ChannelMessage | null>(null);
 
   const activeChannel = useMemo(
     () =>
@@ -103,7 +112,13 @@ export function MobileChannelView({ onBack, onOpenThread }: MobileChannelViewPro
   const handleSend = useCallback(
     async (text: string) => {
       setIsUserScrolled(false);
-      await sendMessage(text);
+      const result = await sendMessage(text);
+      // Reject so the composer can restore the user's draft + toast.
+      if (!result.ok) {
+        throw result.error instanceof Error
+          ? result.error
+          : new Error("Failed to send");
+      }
     },
     [sendMessage]
   );
@@ -116,6 +131,29 @@ export function MobileChannelView({ onBack, onOpenThread }: MobileChannelViewPro
     },
     [openThread, onOpenThread]
   );
+
+  const handleLongPressMessage = useCallback((message: ChannelMessage) => {
+    setActionMessage(message);
+  }, []);
+
+  const handleCopyMessage = useCallback(async () => {
+    const body = actionMessage?.body;
+    if (!body) return;
+    try {
+      if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(body);
+      }
+    } catch {
+      // Clipboard access can fail on insecure contexts; surface a toast
+      // rather than silently swallow.
+      toast.error("Couldn't copy to clipboard");
+    }
+  }, [actionMessage]);
+
+  const handleReplyFromAction = useCallback(() => {
+    if (!actionMessage) return;
+    handleReplyClick(actionMessage.id);
+  }, [actionMessage, handleReplyClick]);
 
   if (!activeChannel) {
     // Defensive: parent shouldn't render us without an active channel, but if
@@ -168,13 +206,18 @@ export function MobileChannelView({ onBack, onOpenThread }: MobileChannelViewPro
         data-testid="mobile-channel-view-stream"
       >
         {activeChannelMessages.map((msg) => (
-          <ChannelMessageRow
+          <LongPressMessage
             key={msg.id}
             message={msg}
-            peerNameMap={peerNameMap}
-            onReplyClick={handleReplyClick}
-            isThreadReply={false}
-          />
+            onLongPress={handleLongPressMessage}
+          >
+            <ChannelMessageRow
+              message={msg}
+              peerNameMap={peerNameMap}
+              onReplyClick={handleReplyClick}
+              isThreadReply={false}
+            />
+          </LongPressMessage>
         ))}
         <div ref={messagesEndRef} />
       </div>
@@ -202,6 +245,55 @@ export function MobileChannelView({ onBack, onOpenThread }: MobileChannelViewPro
           placeholder={`Message ${display}`}
         />
       </div>
+
+      <ActionSheet
+        open={actionMessage != null}
+        onOpenChange={(open) => {
+          if (!open) setActionMessage(null);
+        }}
+        title="Message actions"
+        items={[
+          {
+            id: "reply",
+            label: "Reply in thread",
+            icon: <MessageSquare className="h-4 w-4" />,
+            onSelect: handleReplyFromAction,
+          },
+          {
+            id: "copy",
+            label: "Copy message",
+            icon: <Copy className="h-4 w-4" />,
+            onSelect: handleCopyMessage,
+          },
+        ]}
+      />
+    </div>
+  );
+}
+
+/**
+ * Wrap a message row in a long-press surface so touch users can open the
+ * message-actions sheet without relying on the hover-only Reply chip baked
+ * into {@link ChannelMessageRow}. We use a <div> shell so the press doesn't
+ * interfere with markdown links / code blocks inside the row — those still
+ * receive their own click events.
+ */
+function LongPressMessage({
+  message,
+  onLongPress,
+  children,
+}: {
+  message: ChannelMessage;
+  onLongPress: (message: ChannelMessage) => void;
+  children: ReactNode;
+}) {
+  const longPress = useLongPress({
+    duration: 450,
+    onLongPress: () => onLongPress(message),
+  });
+  return (
+    <div data-testid="mobile-channel-message-wrap" {...longPress.bind}>
+      {children}
     </div>
   );
 }

--- a/src/components/mobile/channels/MobileChannelView.tsx
+++ b/src/components/mobile/channels/MobileChannelView.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+/**
+ * MobileChannelView — Phase 5 mobile redesign.
+ *
+ * Full-bleed channel message stream for the active channel, with a top
+ * header (back chevron + channel name + topic) and the autocorrect-ON
+ * {@link MobileChannelComposer} pinned at the bottom.
+ *
+ * Reuses the existing GFM-rendering {@link ChannelMessageRow} so we don't
+ * duplicate markdown logic. Tapping a message's reply chip opens the thread
+ * via `onOpenThread(messageId)` — the parent owns the takeover layer.
+ *
+ * Behaviour notes:
+ *  - Auto-scrolls to bottom on new messages unless the user scrolled up.
+ *  - Marks the channel read when the latest message is visible.
+ *  - When there are no messages, the header + composer are still shown
+ *    (per the brief: "empty channel = composer-only, no greeter"), with a
+ *    very small inline whisper of context. We deliberately do not paint a
+ *    big illustrated empty state.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronLeft, Hash, Lock } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useChannelContext } from "@/contexts/ChannelContext";
+import { usePeerChatContext } from "@/contexts/PeerChatContext";
+import { ChannelMessageRow } from "@/components/channels/ChannelMessageRow";
+
+import { MobileChannelComposer } from "./MobileChannelComposer";
+
+const SCROLL_THRESHOLD_PX = 50;
+
+export interface MobileChannelViewProps {
+  /** Called when the user taps the back chevron in the header. */
+  onBack: () => void;
+  /** Called when the user taps a reply chip (or "n replies" in a thread). */
+  onOpenThread: (messageId: string) => void;
+}
+
+export function MobileChannelView({ onBack, onOpenThread }: MobileChannelViewProps) {
+  const {
+    groups,
+    activeChannelId,
+    activeChannelMessages,
+    sendMessage,
+    markChannelRead,
+    openThread,
+  } = useChannelContext();
+  const { peerNameMap } = usePeerChatContext();
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isUserScrolled, setIsUserScrolled] = useState(false);
+
+  const activeChannel = useMemo(
+    () =>
+      groups
+        .flatMap((g) => g.channels)
+        .find((c) => c.id === activeChannelId) ?? null,
+    [groups, activeChannelId]
+  );
+
+  // Auto-scroll on new messages unless the user scrolled up.
+  useEffect(() => {
+    if (!isUserScrolled) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
+    }
+  }, [activeChannelMessages, isUserScrolled]);
+
+  // Mark the channel read when we see new messages and we're not viewing
+  // an optimistic placeholder. Mirrors ChannelView's behaviour.
+  useEffect(() => {
+    if (!activeChannelId || activeChannelMessages.length === 0) return;
+    const last = activeChannelMessages[activeChannelMessages.length - 1];
+    if (last && !last.id.startsWith("opt-")) {
+      void markChannelRead(activeChannelId, last.id);
+    }
+  }, [activeChannelId, activeChannelMessages, markChannelRead]);
+
+  const handleScroll = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    setIsUserScrolled(scrollHeight - scrollTop - clientHeight > SCROLL_THRESHOLD_PX);
+  }, []);
+
+  const handleSend = useCallback(
+    async (text: string) => {
+      setIsUserScrolled(false);
+      await sendMessage(text);
+    },
+    [sendMessage]
+  );
+
+  const handleReplyClick = useCallback(
+    (messageId: string) => {
+      // Open in the context too so the takeover sees the thread loaded.
+      void openThread(messageId);
+      onOpenThread(messageId);
+    },
+    [openThread, onOpenThread]
+  );
+
+  if (!activeChannel) {
+    // Defensive: parent shouldn't render us without an active channel, but if
+    // it happens we render a minimal back-only screen rather than crash.
+    return (
+      <div className="flex h-full flex-col">
+        <header className="flex items-center gap-1 border-b border-border bg-card px-1 py-2">
+          <BackButton onBack={onBack} />
+          <span className="px-1 text-sm font-medium text-foreground">Channel</span>
+        </header>
+        <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
+          Channel unavailable.
+        </div>
+      </div>
+    );
+  }
+
+  const Icon = activeChannel.type === "dm" ? Lock : Hash;
+  const display = activeChannel.displayName || activeChannel.name;
+
+  return (
+    <div className="flex h-full flex-col" data-testid="mobile-channel-view">
+      <header className="flex items-center gap-1 border-b border-border bg-card px-1 py-2">
+        <BackButton onBack={onBack} />
+        <div className="flex min-w-0 flex-1 items-center gap-2 px-1">
+          <Icon aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span
+            className="truncate text-sm font-medium text-foreground"
+            data-testid="mobile-channel-view-title"
+          >
+            {display}
+          </span>
+          {activeChannel.topic ? (
+            <>
+              <span aria-hidden="true" className="text-muted-foreground/40">
+                ·
+              </span>
+              <span className="truncate text-xs text-muted-foreground">
+                {activeChannel.topic}
+              </span>
+            </>
+          ) : null}
+        </div>
+      </header>
+
+      <div
+        ref={containerRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto overscroll-contain py-2"
+        data-testid="mobile-channel-view-stream"
+      >
+        {activeChannelMessages.map((msg) => (
+          <ChannelMessageRow
+            key={msg.id}
+            message={msg}
+            peerNameMap={peerNameMap}
+            onReplyClick={handleReplyClick}
+            isThreadReply={false}
+          />
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {isUserScrolled ? (
+        <button
+          type="button"
+          onClick={() => {
+            setIsUserScrolled(false);
+            messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+          }}
+          className={cn(
+            "mx-auto mb-1 inline-flex items-center justify-center rounded-full",
+            "border border-border bg-card px-3 py-1 text-xs text-muted-foreground",
+            "shadow-sm hover:text-foreground"
+          )}
+        >
+          Jump to latest
+        </button>
+      ) : null}
+
+      <div className="pb-safe-bottom">
+        <MobileChannelComposer
+          onSubmit={handleSend}
+          placeholder={`Message ${display}`}
+        />
+      </div>
+    </div>
+  );
+}
+
+function BackButton({ onBack }: { onBack: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onBack}
+      aria-label="Back to channels"
+      data-testid="mobile-channel-back"
+      className={cn(
+        "inline-flex items-center gap-1 rounded-md px-2",
+        "min-h-[44px] min-w-[44px] text-sm font-medium text-foreground",
+        "hover:bg-accent/40 active:bg-accent/60",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      )}
+    >
+      <ChevronLeft aria-hidden="true" className="h-5 w-5" />
+    </button>
+  );
+}

--- a/src/components/mobile/channels/MobileThreadTakeover.tsx
+++ b/src/components/mobile/channels/MobileThreadTakeover.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+/**
+ * MobileThreadTakeover — full-screen slide-in-from-right thread panel.
+ *
+ * Phase 5 mobile redesign. Replaces the desktop {@link ThreadPanel}'s
+ * 320-wide side panel with a full-screen takeover that animates in over
+ * the channel view (`translateX(100%) → 0`) and dismisses with either the
+ * back chevron or a swipe-from-the-left-edge.
+ *
+ * The component reuses {@link ChannelMessageRow} for the parent + replies
+ * (no GFM duplication) and {@link MobileChannelComposer} for the reply
+ * composer (autocorrect ON).
+ *
+ * `position: fixed`, z-50; sits above the channel view but below the bottom
+ * tab bar so global navigation stays reachable. Reduced motion = instant.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronLeft, MessageSquare } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { usePrefersReducedMotion } from "@/hooks/useMobile";
+import { useChannelContext } from "@/contexts/ChannelContext";
+import { usePeerChatContext } from "@/contexts/PeerChatContext";
+import { ChannelMessageRow } from "@/components/channels/ChannelMessageRow";
+
+import { MobileChannelComposer } from "./MobileChannelComposer";
+import { useThreadTakeoverSwipe } from "./useThreadTakeoverSwipe";
+
+const TAKEOVER_DURATION_MS = 240;
+const TAKEOVER_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
+
+export interface MobileThreadTakeoverProps {
+  /** Externally controlled. The takeover renders only while this is true. */
+  open: boolean;
+  /** Fires when the user requests dismissal (back chevron or swipe). */
+  onClose: () => void;
+}
+
+export function MobileThreadTakeover({ open, onClose }: MobileThreadTakeoverProps) {
+  const reducedMotion = usePrefersReducedMotion();
+  const {
+    activeChannelMessages,
+    openThreadId,
+    threadMessages,
+    sendMessage,
+  } = useChannelContext();
+  const { peerNameMap } = usePeerChatContext();
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // Two-phase mount so the slide-in/out transitions both play.
+  const [mounted, setMounted] = useState(false);
+  const [entered, setEntered] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- two-phase mount/transition state machine
+      setMounted(true);
+      const id = requestAnimationFrame(() => setEntered(true));
+      return () => cancelAnimationFrame(id);
+    }
+    if (!mounted) return;
+    setEntered(false);
+    if (reducedMotion) {
+      setMounted(false);
+      return;
+    }
+    const t = window.setTimeout(() => setMounted(false), TAKEOVER_DURATION_MS);
+    return () => window.clearTimeout(t);
+  }, [open, mounted, reducedMotion]);
+
+  // ESC closes — handy for desktop testing and for users with hardware keyboards.
+  useEffect(() => {
+    if (!entered) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [entered, onClose]);
+
+  // Resolve the parent message from the active channel.
+  const parentMessage = useMemo(
+    () =>
+      openThreadId
+        ? activeChannelMessages.find((m) => m.id === openThreadId) ?? null
+        : null,
+    [openThreadId, activeChannelMessages]
+  );
+
+  // Auto-scroll to bottom on incoming replies (chat default).
+  useEffect(() => {
+    if (!entered) return;
+    messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
+  }, [entered, threadMessages]);
+
+  const handleSend = useCallback(
+    async (text: string) => {
+      if (!openThreadId) return;
+      await sendMessage(text, openThreadId);
+    },
+    [openThreadId, sendMessage]
+  );
+
+  // Swipe-from-left-edge back gesture.
+  const swipe = useThreadTakeoverSwipe({
+    enabled: entered,
+    onDismiss: onClose,
+  });
+
+  if (!mounted) return null;
+
+  // The live transform: while dragging, follow the finger 1:1; otherwise the
+  // transition handles enter/exit.
+  const dragging = swipe.dragging;
+  const transform = dragging
+    ? `translate3d(${swipe.dragOffsetPx}px, 0, 0)`
+    : entered
+      ? "translate3d(0, 0, 0)"
+      : "translate3d(100%, 0, 0)";
+
+  return (
+    <div
+      ref={containerRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={parentMessage ? "Thread replies" : "Thread"}
+      data-testid="mobile-thread-takeover"
+      data-state={entered ? "open" : "closed"}
+      className={cn(
+        // Full-screen above the channel view but below the bottom tab bar.
+        "fixed inset-0 z-40 flex flex-col bg-background text-foreground",
+        "pt-safe-top",
+        "will-change-transform"
+      )}
+      style={{
+        transform,
+        transitionProperty: dragging ? "none" : "transform",
+        transitionDuration: reducedMotion || dragging ? "0ms" : `${TAKEOVER_DURATION_MS}ms`,
+        transitionTimingFunction: reducedMotion ? "linear" : TAKEOVER_EASING,
+      }}
+      // Bind the back gesture on the outer container so any horizontal swipe
+      // starting in the left 24px is intercepted.
+      onTouchStart={swipe.bind.onTouchStart}
+      onTouchMove={swipe.bind.onTouchMove}
+      onTouchEnd={swipe.bind.onTouchEnd}
+      onTouchCancel={swipe.bind.onTouchCancel}
+    >
+      {/* Header */}
+      <header className="flex items-center gap-1 border-b border-border bg-card px-1 py-2">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Back to channel"
+          data-testid="mobile-thread-back"
+          className={cn(
+            "inline-flex items-center gap-1 rounded-md px-2",
+            "min-h-[44px] min-w-[44px] text-sm font-medium text-foreground",
+            "hover:bg-accent/40 active:bg-accent/60",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          )}
+        >
+          <ChevronLeft aria-hidden="true" className="h-5 w-5" />
+          <span className="sr-only sm:not-sr-only">Back</span>
+        </button>
+        <div className="flex flex-1 items-center gap-2 px-1">
+          <MessageSquare aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm font-medium text-foreground">Thread</span>
+          {threadMessages.length > 0 ? (
+            <span className="ml-auto text-xs text-muted-foreground">
+              {threadMessages.length}{" "}
+              {threadMessages.length === 1 ? "reply" : "replies"}
+            </span>
+          ) : null}
+        </div>
+      </header>
+
+      {/* Scroll region: parent + divider + replies */}
+      <div className="flex-1 overflow-y-auto overscroll-contain">
+        {parentMessage ? (
+          <>
+            <ChannelMessageRow
+              message={parentMessage}
+              peerNameMap={peerNameMap}
+              isThreadReply={false}
+            />
+            <div className="my-2 flex items-center gap-2 px-4">
+              <div className="flex-1 border-t border-border" />
+              <span className="shrink-0 text-[10px] text-muted-foreground">
+                {threadMessages.length === 0
+                  ? "No replies yet"
+                  : `${threadMessages.length} ${threadMessages.length === 1 ? "reply" : "replies"}`}
+              </span>
+              <div className="flex-1 border-t border-border" />
+            </div>
+          </>
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center px-6 py-12 text-center text-muted-foreground">
+            <MessageSquare aria-hidden="true" className="mb-2 h-6 w-6" />
+            <p className="text-sm">Thread is no longer available.</p>
+          </div>
+        )}
+
+        {parentMessage && threadMessages.length === 0 ? (
+          <p
+            data-testid="mobile-thread-empty"
+            className="px-6 pb-4 text-center text-xs text-muted-foreground"
+          >
+            Be the first to reply.
+          </p>
+        ) : null}
+
+        {threadMessages.map((msg) => (
+          <ChannelMessageRow
+            key={msg.id}
+            message={msg}
+            peerNameMap={peerNameMap}
+            isThreadReply
+          />
+        ))}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Reply composer */}
+      <div className="pb-safe-bottom">
+        <MobileChannelComposer
+          onSubmit={handleSend}
+          placeholder="Reply in thread"
+          disabled={!parentMessage}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/mobile/channels/MobileThreadTakeover.tsx
+++ b/src/components/mobile/channels/MobileThreadTakeover.tsx
@@ -25,6 +25,7 @@ import { useChannelContext } from "@/contexts/ChannelContext";
 import { usePeerChatContext } from "@/contexts/PeerChatContext";
 import { ChannelMessageRow } from "@/components/channels/ChannelMessageRow";
 
+import { useDialogPolish } from "../common/useDialogPolish";
 import { MobileChannelComposer } from "./MobileChannelComposer";
 import { useThreadTakeoverSwipe } from "./useThreadTakeoverSwipe";
 
@@ -82,6 +83,11 @@ export function MobileThreadTakeover({ open, onClose }: MobileThreadTakeoverProp
     return () => window.removeEventListener("keydown", onKey);
   }, [entered, onClose]);
 
+  // Focus trap + body scroll lock — WCAG / aria-modal compliance. Refcounts
+  // on `document.body.dataset.scrollLockCount` so concurrent BottomSheets
+  // and this takeover don't clobber each other's lock.
+  useDialogPolish({ active: entered, panelRef: containerRef });
+
   // Resolve the parent message from the active channel.
   const parentMessage = useMemo(
     () =>
@@ -91,11 +97,28 @@ export function MobileThreadTakeover({ open, onClose }: MobileThreadTakeoverProp
     [openThreadId, activeChannelMessages]
   );
 
-  // Auto-scroll to bottom on incoming replies (chat default).
+  // Auto-scroll to bottom only when a NEW reply arrives. Without the length
+  // gate, every unrelated context update (e.g. peer summary refresh) would
+  // produce a new `threadMessages` array reference and snap the user back
+  // to the bottom while they're reading earlier replies.
+  const prevLengthRef = useRef(0);
   useEffect(() => {
-    if (!entered) return;
-    messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
+    if (!entered) {
+      prevLengthRef.current = 0;
+      return;
+    }
+    if (threadMessages.length > prevLengthRef.current) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
+    }
+    prevLengthRef.current = threadMessages.length;
   }, [entered, threadMessages]);
+
+  // When the takeover targets a different parent message, treat it as a
+  // fresh thread and reset the length tracker so the first paint scrolls
+  // to bottom again.
+  useEffect(() => {
+    prevLengthRef.current = 0;
+  }, [openThreadId]);
 
   const handleSend = useCallback(
     async (text: string) => {

--- a/src/components/mobile/channels/MobileThreadTakeover.tsx
+++ b/src/components/mobile/channels/MobileThreadTakeover.tsx
@@ -17,6 +17,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { UIEvent } from "react";
 import { ChevronLeft, MessageSquare } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -31,6 +32,10 @@ import { useThreadTakeoverSwipe } from "./useThreadTakeoverSwipe";
 
 const TAKEOVER_DURATION_MS = 240;
 const TAKEOVER_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
+// Match the channel-view threshold so the two surfaces feel identical: any
+// scroll more than ~100px from bottom counts as "the user is reading older
+// replies" and disables auto-scroll.
+const SCROLL_THRESHOLD_PX = 100;
 
 export interface MobileThreadTakeoverProps {
   /** Externally controlled. The takeover renders only while this is true. */
@@ -51,6 +56,8 @@ export function MobileThreadTakeover({ open, onClose }: MobileThreadTakeoverProp
 
   const containerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [isUserScrolled, setIsUserScrolled] = useState(false);
 
   // Two-phase mount so the slide-in/out transitions both play.
   const [mounted, setMounted] = useState(false);
@@ -73,20 +80,13 @@ export function MobileThreadTakeover({ open, onClose }: MobileThreadTakeoverProp
     return () => window.clearTimeout(t);
   }, [open, mounted, reducedMotion]);
 
-  // ESC closes — handy for desktop testing and for users with hardware keyboards.
-  useEffect(() => {
-    if (!entered) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [entered, onClose]);
-
-  // Focus trap + body scroll lock — WCAG / aria-modal compliance. Refcounts
-  // on `document.body.dataset.scrollLockCount` so concurrent BottomSheets
-  // and this takeover don't clobber each other's lock.
-  useDialogPolish({ active: entered, panelRef: containerRef });
+  // Focus trap + body scroll lock + ESC — WCAG / aria-modal compliance.
+  // Refcounts on `document.body.dataset.scrollLockCount` so concurrent
+  // BottomSheets and this takeover don't clobber each other's lock; ESC
+  // routes through the shared modal stack so a sheet rendered above the
+  // takeover (e.g. an action sheet) closes itself instead of dismissing
+  // both layers at once.
+  useDialogPolish({ active: entered, panelRef: containerRef, onEscape: onClose });
 
   // Resolve the parent message from the active channel.
   const parentMessage = useMemo(
@@ -97,10 +97,14 @@ export function MobileThreadTakeover({ open, onClose }: MobileThreadTakeoverProp
     [openThreadId, activeChannelMessages]
   );
 
-  // Auto-scroll to bottom only when a NEW reply arrives. Without the length
-  // gate, every unrelated context update (e.g. peer summary refresh) would
-  // produce a new `threadMessages` array reference and snap the user back
-  // to the bottom while they're reading earlier replies.
+  // Auto-scroll to bottom only when a NEW reply arrives AND the user hasn't
+  // scrolled up to read older replies. Without the length gate every
+  // unrelated context update (e.g. peer summary refresh) would produce a
+  // new `threadMessages` array reference and snap us to the bottom; without
+  // the user-scroll gate a peer reply mid-read would yank the viewport away
+  // from what the user was actually reading. We still auto-scroll for the
+  // local user's own replies (optimistic id starts with `opt-`) since that
+  // matches their explicit intent.
   const prevLengthRef = useRef(0);
   useEffect(() => {
     if (!entered) {
@@ -108,22 +112,44 @@ export function MobileThreadTakeover({ open, onClose }: MobileThreadTakeoverProp
       return;
     }
     if (threadMessages.length > prevLengthRef.current) {
-      messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
+      const newest = threadMessages[threadMessages.length - 1];
+      const isOwnOptimistic = newest?.id?.startsWith("opt-") ?? false;
+      if (!isUserScrolled || isOwnOptimistic) {
+        messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
+      }
     }
     prevLengthRef.current = threadMessages.length;
-  }, [entered, threadMessages]);
+  }, [entered, threadMessages, isUserScrolled]);
 
   // When the takeover targets a different parent message, treat it as a
-  // fresh thread and reset the length tracker so the first paint scrolls
-  // to bottom again.
+  // fresh thread and reset the length + scroll trackers so the first paint
+  // scrolls to bottom again.
   useEffect(() => {
     prevLengthRef.current = 0;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- thread switch resets the scroll guard so the new thread auto-scrolls to bottom
+    setIsUserScrolled(false);
   }, [openThreadId]);
+
+  const handleScroll = useCallback((e: UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    setIsUserScrolled(distanceFromBottom > SCROLL_THRESHOLD_PX);
+  }, []);
+
+  const handleJumpToLatest = useCallback(() => {
+    setIsUserScrolled(false);
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
 
   const handleSend = useCallback(
     async (text: string) => {
       if (!openThreadId) return;
-      await sendMessage(text, openThreadId);
+      const result = await sendMessage(text, openThreadId);
+      if (!result.ok) {
+        throw result.error instanceof Error
+          ? result.error
+          : new Error("Failed to send");
+      }
     },
     [openThreadId, sendMessage]
   );
@@ -154,8 +180,11 @@ export function MobileThreadTakeover({ open, onClose }: MobileThreadTakeoverProp
       data-testid="mobile-thread-takeover"
       data-state={entered ? "open" : "closed"}
       className={cn(
-        // Full-screen above the channel view but below the bottom tab bar.
-        "fixed inset-0 z-40 flex flex-col bg-background text-foreground",
+        // Full-screen, layered above both the channel view and the bottom tab
+        // bar (z-40). The host hides the tab bar via `forceHidden` while the
+        // takeover is open so global navigation can't paint over the reply
+        // composer; z-50 here is a defensive belt-and-suspenders.
+        "fixed inset-0 z-50 flex flex-col bg-background text-foreground",
         "pt-safe-top",
         "will-change-transform"
       )}
@@ -202,7 +231,11 @@ export function MobileThreadTakeover({ open, onClose }: MobileThreadTakeoverProp
       </header>
 
       {/* Scroll region: parent + divider + replies */}
-      <div className="flex-1 overflow-y-auto overscroll-contain">
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto overscroll-contain"
+      >
         {parentMessage ? (
           <>
             <ChannelMessageRow
@@ -247,6 +280,21 @@ export function MobileThreadTakeover({ open, onClose }: MobileThreadTakeoverProp
 
         <div ref={messagesEndRef} />
       </div>
+
+      {isUserScrolled ? (
+        <button
+          type="button"
+          onClick={handleJumpToLatest}
+          data-testid="mobile-thread-jump-to-latest"
+          className={cn(
+            "mx-auto mb-1 inline-flex items-center justify-center rounded-full",
+            "border border-border bg-card px-3 py-1 text-xs text-muted-foreground",
+            "shadow-sm hover:text-foreground"
+          )}
+        >
+          Jump to latest
+        </button>
+      ) : null}
 
       {/* Reply composer */}
       <div className="pb-safe-bottom">

--- a/src/components/mobile/channels/__tests__/ChannelsTab.test.tsx
+++ b/src/components/mobile/channels/__tests__/ChannelsTab.test.tsx
@@ -49,7 +49,7 @@ const channelState = {
   activeChannelMessages: [] as ChannelMessage[],
   totalUnreadCount: 0,
   loading: false,
-  sendMessage: vi.fn().mockResolvedValue(undefined),
+  sendMessage: vi.fn().mockResolvedValue({ ok: true }),
   markChannelRead: vi.fn().mockResolvedValue(undefined),
   openThread: vi.fn(),
   closeThread: vi.fn(() => {

--- a/src/components/mobile/channels/__tests__/ChannelsTab.test.tsx
+++ b/src/components/mobile/channels/__tests__/ChannelsTab.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * ChannelsTab integration tests (Phase 5 mobile redesign).
+ *
+ * Drives the actual component with stubbed channel + peer + preferences +
+ * project tree contexts. Verifies:
+ *   - the list pane renders by default
+ *   - tapping a channel routes into the view pane
+ *   - the back chevron returns to the list
+ *   - the DM FAB opens the picker sheet
+ *   - the thread takeover renders when openThreadId is non-null
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import type { ChannelGroup, ChannelMessage } from "@/types/channels";
+
+// Mutable channel-context state so individual tests can flip openThreadId.
+const channelState = {
+  groups: [
+    {
+      id: "g1",
+      folderId: "p1",
+      name: "Channels",
+      position: 0,
+      channels: [
+        {
+          id: "c1",
+          folderId: "p1",
+          groupId: "g1",
+          name: "general",
+          displayName: "general",
+          type: "public" as const,
+          topic: "team chat",
+          isDefault: true,
+          lastMessageAt: null,
+          messageCount: 1,
+          unreadCount: 0,
+          createdAt: "2025-01-01T00:00:00Z",
+        },
+      ],
+    },
+  ] as ChannelGroup[],
+  activeChannelId: null as string | null,
+  setActiveChannelId: vi.fn((id: string | null) => {
+    channelState.activeChannelId = id;
+  }),
+  activeChannelMessages: [] as ChannelMessage[],
+  totalUnreadCount: 0,
+  loading: false,
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  markChannelRead: vi.fn().mockResolvedValue(undefined),
+  openThread: vi.fn(),
+  closeThread: vi.fn(() => {
+    channelState.openThreadId = null;
+  }),
+  openThreadId: null as string | null,
+  threadMessages: [] as ChannelMessage[],
+  refreshChannels: vi.fn().mockResolvedValue(undefined),
+  createChannel: vi.fn(),
+  addMessage: vi.fn(),
+  addThreadReply: vi.fn(),
+  addChannel: vi.fn(),
+};
+
+vi.mock("@/contexts/ChannelContext", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/contexts/ChannelContext")
+  >("@/contexts/ChannelContext");
+  return {
+    ...actual,
+    useChannelContext: () => channelState,
+    useChannelContextOptional: () => channelState,
+    ChannelProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  };
+});
+
+vi.mock("@/contexts/PeerChatContext", () => ({
+  usePeerChatContext: () => ({
+    peers: [],
+    peerNameMap: new Map(),
+  }),
+}));
+
+vi.mock("@/contexts/PreferencesContext", () => ({
+  usePreferencesContext: () => ({
+    activeProject: { folderId: "p1" },
+  }),
+}));
+
+vi.mock("@/contexts/ProjectTreeContext", () => ({
+  useProjectTree: () => ({
+    getProject: (id: string) =>
+      id === "p1"
+        ? { id: "p1", name: "Alpha", groupId: null, isAutoCreated: false, sortOrder: 0, collapsed: false }
+        : undefined,
+  }),
+}));
+
+vi.mock("@/contexts/SessionContext", () => ({
+  useSessionContext: () => ({
+    sessions: [],
+    activeSessionId: null,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), { error: vi.fn() }),
+}));
+
+import { ChannelsTab } from "../ChannelsTab";
+
+beforeEach(() => {
+  channelState.activeChannelId = null;
+  channelState.openThreadId = null;
+  channelState.activeChannelMessages = [];
+  channelState.threadMessages = [];
+  channelState.setActiveChannelId.mockClear();
+  channelState.closeThread.mockClear();
+  channelState.openThread.mockClear();
+});
+
+afterEach(() => cleanup());
+
+describe("ChannelsTab", () => {
+  it("renders the channel list by default with the project name in the header", () => {
+    render(<ChannelsTab />);
+    expect(screen.getByTestId("mobile-channels-tab")).toBeTruthy();
+    expect(screen.getByText(/Channels.*Alpha/)).toBeTruthy();
+    expect(screen.getByText("general")).toBeTruthy();
+    // FAB is visible on the list pane.
+    expect(screen.getByTestId("mobile-channels-dm-fab")).toBeTruthy();
+  });
+
+  it("routes to the channel view when a row is tapped", () => {
+    render(<ChannelsTab />);
+    const row = screen.getByTestId("mobile-channel-row");
+    fireEvent.click(row);
+    expect(channelState.setActiveChannelId).toHaveBeenCalledWith("c1");
+    expect(screen.getByTestId("mobile-channel-view")).toBeTruthy();
+    expect(screen.getByTestId("mobile-channel-view-title").textContent).toBe("general");
+    // FAB is hidden on the view pane.
+    expect(screen.queryByTestId("mobile-channels-dm-fab")).toBeNull();
+  });
+
+  it("returns to the list when the back chevron is tapped", () => {
+    channelState.activeChannelId = "c1";
+    render(<ChannelsTab />);
+    fireEvent.click(screen.getByTestId("mobile-channel-row"));
+    fireEvent.click(screen.getByTestId("mobile-channel-back"));
+    expect(screen.getByTestId("mobile-channel-list")).toBeTruthy();
+  });
+
+  it("opens the DM picker sheet when the FAB is tapped", () => {
+    render(<ChannelsTab />);
+    fireEvent.click(screen.getByTestId("mobile-channels-dm-fab"));
+    // BottomSheet portals into document.body — query the document.
+    const sheet = within(document.body).getByTestId("mobile-bottom-sheet");
+    expect(sheet).toBeTruthy();
+    expect(within(sheet).getByText("Direct message")).toBeTruthy();
+  });
+
+  it("renders the thread takeover when openThreadId is set", () => {
+    channelState.activeChannelId = "c1";
+    channelState.openThreadId = "m1";
+    channelState.activeChannelMessages = [
+      {
+        id: "m1",
+        channelId: "c1",
+        fromSessionId: "s1",
+        fromSessionName: "claude",
+        toSessionId: null,
+        body: "hello",
+        isUserMessage: false,
+        parentMessageId: null,
+        replyCount: 0,
+        createdAt: "2025-01-01T00:00:00Z",
+      },
+    ];
+    render(<ChannelsTab />);
+    fireEvent.click(screen.getByTestId("mobile-channel-row"));
+    expect(screen.getByTestId("mobile-thread-takeover")).toBeTruthy();
+    expect(screen.getByTestId("mobile-thread-back")).toBeTruthy();
+    expect(screen.getByTestId("mobile-thread-empty")).toBeTruthy();
+  });
+
+  it("closes the thread takeover when its back chevron is tapped", () => {
+    channelState.activeChannelId = "c1";
+    channelState.openThreadId = "m1";
+    channelState.activeChannelMessages = [
+      {
+        id: "m1",
+        channelId: "c1",
+        fromSessionId: null,
+        fromSessionName: "You",
+        toSessionId: null,
+        body: "ping",
+        isUserMessage: true,
+        parentMessageId: null,
+        replyCount: 0,
+        createdAt: "2025-01-01T00:00:00Z",
+      },
+    ];
+    render(<ChannelsTab />);
+    fireEvent.click(screen.getByTestId("mobile-channel-row"));
+    fireEvent.click(screen.getByTestId("mobile-thread-back"));
+    expect(channelState.closeThread).toHaveBeenCalled();
+  });
+});

--- a/src/components/mobile/channels/__tests__/DmPickerSheet.test.tsx
+++ b/src/components/mobile/channels/__tests__/DmPickerSheet.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * DmPickerSheet tests (Phase 5 mobile redesign).
+ *
+ * Covers the empty-state flavors, the happy path (POST /api/channels/dm
+ * triggers addChannel + setActiveChannelId + onOpenDm), and the failure
+ * path (sheet stays alive and surfaces a toast.error rather than crashing).
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, fireEvent, cleanup, waitFor, within } from "@testing-library/react";
+
+// Mutable channel/peer state so individual tests can vary.
+const channelState = {
+  setActiveChannelId: vi.fn(),
+  addChannel: vi.fn(),
+};
+
+const peerState = {
+  peers: [] as Array<{
+    sessionId: string;
+    name: string;
+    peerSummary: string | null;
+    agentProvider: string | null;
+  }>,
+};
+
+const sessionState = {
+  sessions: [] as Array<{ id: string; projectId: string; status: string }>,
+  activeSessionId: null as string | null,
+};
+
+const prefsState = {
+  activeProject: { folderId: null as string | null },
+};
+
+const toastError = vi.fn();
+
+vi.mock("@/contexts/ChannelContext", () => ({
+  useChannelContext: () => channelState,
+}));
+vi.mock("@/contexts/PeerChatContext", () => ({
+  usePeerChatContext: () => peerState,
+}));
+vi.mock("@/contexts/SessionContext", () => ({
+  useSessionContext: () => sessionState,
+}));
+vi.mock("@/contexts/PreferencesContext", () => ({
+  usePreferencesContext: () => prefsState,
+}));
+vi.mock("@/hooks/useMobile", () => ({
+  usePrefersReducedMotion: () => true,
+}));
+vi.mock("sonner", () => ({
+  toast: { error: (msg: string) => toastError(msg) },
+}));
+
+import { DmPickerSheet } from "../DmPickerSheet";
+
+beforeEach(() => {
+  channelState.setActiveChannelId.mockReset();
+  channelState.addChannel.mockReset();
+  toastError.mockReset();
+  peerState.peers = [];
+  sessionState.sessions = [];
+  sessionState.activeSessionId = null;
+  prefsState.activeProject.folderId = null;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("DmPickerSheet", () => {
+  it("shows the no-project empty state when no project is active", async () => {
+    render(<DmPickerSheet open={true} onOpenChange={() => {}} onOpenDm={() => {}} />);
+    const sheet = within(document.body).getByTestId("mobile-bottom-sheet");
+    expect(within(sheet).getByText("Pick a project first.")).toBeTruthy();
+  });
+
+  it("shows the no-from-session empty state when no session is in the project", async () => {
+    prefsState.activeProject.folderId = "p1";
+    sessionState.sessions = [];
+    render(<DmPickerSheet open={true} onOpenChange={() => {}} onOpenDm={() => {}} />);
+    const sheet = within(document.body).getByTestId("mobile-bottom-sheet");
+    expect(
+      within(sheet).getByText("Open a session in this project first.")
+    ).toBeTruthy();
+  });
+
+  it("shows the no-peers empty state when no eligible peers exist", () => {
+    prefsState.activeProject.folderId = "p1";
+    sessionState.sessions = [{ id: "s1", projectId: "p1", status: "active" }];
+    sessionState.activeSessionId = "s1";
+    peerState.peers = []; // no peers
+    render(<DmPickerSheet open={true} onOpenChange={() => {}} onOpenDm={() => {}} />);
+    const sheet = within(document.body).getByTestId("mobile-bottom-sheet");
+    expect(within(sheet).getByText("No peers online.")).toBeTruthy();
+  });
+
+  it("opens a DM on tap: POSTs, calls addChannel + setActiveChannelId + onOpenDm", async () => {
+    prefsState.activeProject.folderId = "p1";
+    sessionState.sessions = [{ id: "s1", projectId: "p1", status: "active" }];
+    sessionState.activeSessionId = "s1";
+    peerState.peers = [
+      { sessionId: "s2", name: "claude", peerSummary: null, agentProvider: "claude" },
+    ];
+
+    const fakeChannel = {
+      id: "ch-dm-1",
+      folderId: "p1",
+      groupId: "dms",
+      name: "claude",
+      displayName: "claude",
+      type: "dm",
+      topic: null,
+      isDefault: false,
+      lastMessageAt: null,
+      messageCount: 0,
+      unreadCount: 0,
+      createdAt: "2025-01-01T00:00:00Z",
+    };
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ channel: fakeChannel }),
+    } as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const onOpenChange = vi.fn();
+    const onOpenDm = vi.fn();
+    render(
+      <DmPickerSheet open={true} onOpenChange={onOpenChange} onOpenDm={onOpenDm} />
+    );
+    const row = within(document.body).getByTestId("dm-picker-sheet-row");
+    fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(channelState.addChannel).toHaveBeenCalledWith(fakeChannel);
+    });
+    expect(channelState.setActiveChannelId).toHaveBeenCalledWith("ch-dm-1");
+    expect(onOpenDm).toHaveBeenCalledWith("ch-dm-1");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/channels/dm",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("surfaces a toast.error when the POST fails (no crash)", async () => {
+    prefsState.activeProject.folderId = "p1";
+    sessionState.sessions = [{ id: "s1", projectId: "p1", status: "active" }];
+    sessionState.activeSessionId = "s1";
+    peerState.peers = [
+      { sessionId: "s2", name: "claude", peerSummary: null, agentProvider: null },
+    ];
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Boom" }),
+    } as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    render(<DmPickerSheet open={true} onOpenChange={() => {}} onOpenDm={() => {}} />);
+    const row = within(document.body).getByTestId("dm-picker-sheet-row");
+    fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Boom");
+    });
+    expect(channelState.addChannel).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/mobile/channels/__tests__/DmPickerSheet.test.tsx
+++ b/src/components/mobile/channels/__tests__/DmPickerSheet.test.tsx
@@ -13,6 +13,7 @@ import { render, fireEvent, cleanup, waitFor, within } from "@testing-library/re
 const channelState = {
   setActiveChannelId: vi.fn(),
   addChannel: vi.fn(),
+  refreshChannels: vi.fn().mockResolvedValue(undefined),
 };
 
 const peerState = {
@@ -59,6 +60,8 @@ import { DmPickerSheet } from "../DmPickerSheet";
 beforeEach(() => {
   channelState.setActiveChannelId.mockReset();
   channelState.addChannel.mockReset();
+  channelState.refreshChannels.mockReset();
+  channelState.refreshChannels.mockResolvedValue(undefined);
   toastError.mockReset();
   peerState.peers = [];
   sessionState.sessions = [];
@@ -98,7 +101,7 @@ describe("DmPickerSheet", () => {
     expect(within(sheet).getByText("No peers online.")).toBeTruthy();
   });
 
-  it("opens a DM on tap: POSTs, calls addChannel + setActiveChannelId + onOpenDm", async () => {
+  it("opens a DM on tap: POSTs, refreshChannels + setActiveChannelId + onOpenDm", async () => {
     prefsState.activeProject.folderId = "p1";
     sessionState.sessions = [{ id: "s1", projectId: "p1", status: "active" }];
     sessionState.activeSessionId = "s1";
@@ -106,23 +109,21 @@ describe("DmPickerSheet", () => {
       { sessionId: "s2", name: "claude", peerSummary: null, agentProvider: "claude" },
     ];
 
-    const fakeChannel = {
+    // The /api/channels/dm endpoint returns the raw DB row — missing
+    // unreadCount + folderId. The picker must NOT pipe that into addChannel
+    // (which would render NaN unread totals); instead it refetches the
+    // normalized channel list via refreshChannels.
+    const dbRow = {
       id: "ch-dm-1",
-      folderId: "p1",
+      projectId: "p1",
       groupId: "dms",
       name: "claude",
       displayName: "claude",
       type: "dm",
-      topic: null,
-      isDefault: false,
-      lastMessageAt: null,
-      messageCount: 0,
-      unreadCount: 0,
-      createdAt: "2025-01-01T00:00:00Z",
     };
     const fetchSpy = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ channel: fakeChannel }),
+      json: async () => ({ channel: dbRow }),
     } as Response);
     vi.stubGlobal("fetch", fetchSpy);
 
@@ -135,8 +136,10 @@ describe("DmPickerSheet", () => {
     fireEvent.click(row);
 
     await waitFor(() => {
-      expect(channelState.addChannel).toHaveBeenCalledWith(fakeChannel);
+      expect(channelState.refreshChannels).toHaveBeenCalledTimes(1);
     });
+    // addChannel must NOT be called with the unnormalized row.
+    expect(channelState.addChannel).not.toHaveBeenCalled();
     expect(channelState.setActiveChannelId).toHaveBeenCalledWith("ch-dm-1");
     expect(onOpenDm).toHaveBeenCalledWith("ch-dm-1");
     expect(onOpenChange).toHaveBeenCalledWith(false);
@@ -144,6 +147,55 @@ describe("DmPickerSheet", () => {
       "/api/channels/dm",
       expect.objectContaining({ method: "POST" })
     );
+  });
+
+  it("aborts the in-flight POST when the sheet closes mid-request", async () => {
+    prefsState.activeProject.folderId = "p1";
+    sessionState.sessions = [{ id: "s1", projectId: "p1", status: "active" }];
+    sessionState.activeSessionId = "s1";
+    peerState.peers = [
+      { sessionId: "s2", name: "claude", peerSummary: null, agentProvider: "claude" },
+    ];
+
+    let abortedSignal: AbortSignal | null = null;
+    // Resolve only after we observe an abort, so we exercise the cancel
+    // path without racing a fast resolution.
+    const fetchSpy = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      abortedSignal = init.signal ?? null;
+      return new Promise<Response>((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () =>
+          reject(
+            typeof DOMException !== "undefined"
+              ? new DOMException("Aborted", "AbortError")
+              : new Error("Aborted")
+          )
+        );
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const onOpenChange = vi.fn();
+    const onOpenDm = vi.fn();
+    const { rerender } = render(
+      <DmPickerSheet open={true} onOpenChange={onOpenChange} onOpenDm={onOpenDm} />
+    );
+    const row = within(document.body).getByTestId("dm-picker-sheet-row");
+    fireEvent.click(row);
+    // Close the sheet before the fetch resolves.
+    rerender(
+      <DmPickerSheet open={false} onOpenChange={onOpenChange} onOpenDm={onOpenDm} />
+    );
+
+    await waitFor(() => {
+      expect(abortedSignal?.aborted).toBe(true);
+    });
+    // Even after the rejection settles, no channel state should have
+    // been mutated and onOpenDm should NOT fire.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(channelState.refreshChannels).not.toHaveBeenCalled();
+    expect(channelState.setActiveChannelId).not.toHaveBeenCalled();
+    expect(onOpenDm).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
   });
 
   it("surfaces a toast.error when the POST fails (no crash)", async () => {

--- a/src/components/mobile/channels/__tests__/MobileChannelComposer.test.tsx
+++ b/src/components/mobile/channels/__tests__/MobileChannelComposer.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * MobileChannelComposer tests (Phase 5 mobile redesign).
+ *
+ * Verifies the actual DOM contract: autocorrect attributes are on, Enter
+ * submits, Shift+Enter inserts a newline, and the long-press send path
+ * keeps the draft in the textarea instead of submitting.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+
+import { MobileChannelComposer } from "../MobileChannelComposer";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("MobileChannelComposer", () => {
+  it("enables autocorrect and prose-friendly keyboard hints", () => {
+    render(<MobileChannelComposer onSubmit={() => {}} />);
+    const textarea = screen.getByTestId("mobile-channel-composer-textarea");
+    expect(textarea.getAttribute("autocorrect")).toBe("on");
+    expect(textarea.getAttribute("autocapitalize")).toBe("sentences");
+    expect(textarea.getAttribute("spellcheck")).toBe("true");
+    expect(textarea.getAttribute("enterkeyhint")).toBe("send");
+  });
+
+  it("submits on Enter and clears the textarea", () => {
+    const onSubmit = vi.fn();
+    render(<MobileChannelComposer onSubmit={onSubmit} />);
+    const textarea = screen.getByTestId(
+      "mobile-channel-composer-textarea"
+    ) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "hello world" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledWith("hello world");
+    expect(textarea.value).toBe("");
+  });
+
+  it("does not submit on Shift+Enter", () => {
+    const onSubmit = vi.fn();
+    render(<MobileChannelComposer onSubmit={onSubmit} />);
+    const textarea = screen.getByTestId("mobile-channel-composer-textarea");
+    fireEvent.change(textarea, { target: { value: "line one" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit when textarea is empty", () => {
+    const onSubmit = vi.fn();
+    render(<MobileChannelComposer onSubmit={onSubmit} />);
+    const textarea = screen.getByTestId("mobile-channel-composer-textarea");
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("trims whitespace before submitting", () => {
+    const onSubmit = vi.fn();
+    render(<MobileChannelComposer onSubmit={onSubmit} />);
+    const textarea = screen.getByTestId("mobile-channel-composer-textarea");
+    fireEvent.change(textarea, { target: { value: "   hi   " } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledWith("hi");
+  });
+
+  it("long-press on send keeps the text instead of submitting", () => {
+    vi.useFakeTimers();
+    const onSubmit = vi.fn();
+    render(<MobileChannelComposer onSubmit={onSubmit} />);
+    const textarea = screen.getByTestId(
+      "mobile-channel-composer-textarea"
+    ) as HTMLTextAreaElement;
+    const send = screen.getByTestId("mobile-channel-composer-send");
+    fireEvent.change(textarea, { target: { value: "draft prompt" } });
+    fireEvent.pointerDown(send);
+    act(() => {
+      vi.advanceTimersByTime(450);
+    });
+    fireEvent.pointerUp(send);
+    fireEvent.click(send);
+    // Long-press swallowed the click — onSubmit NOT called, draft preserved.
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(textarea.value).toBe("draft prompt");
+  });
+
+  it("send button is disabled while textarea is empty", () => {
+    render(<MobileChannelComposer onSubmit={() => {}} />);
+    const send = screen.getByTestId(
+      "mobile-channel-composer-send"
+    ) as HTMLButtonElement;
+    expect(send.disabled).toBe(true);
+  });
+});

--- a/src/components/mobile/channels/__tests__/MobileChannelComposer.test.tsx
+++ b/src/components/mobile/channels/__tests__/MobileChannelComposer.test.tsx
@@ -6,10 +6,19 @@
  * keeps the draft in the textarea instead of submitting.
  */
 
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, act, waitFor } from "@testing-library/react";
+
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { error: (msg: string) => toastError(msg) },
+}));
 
 import { MobileChannelComposer } from "../MobileChannelComposer";
+
+beforeEach(() => {
+  toastError.mockReset();
+});
 
 afterEach(() => {
   cleanup();
@@ -82,6 +91,24 @@ describe("MobileChannelComposer", () => {
     // Long-press swallowed the click — onSubmit NOT called, draft preserved.
     expect(onSubmit).not.toHaveBeenCalled();
     expect(textarea.value).toBe("draft prompt");
+  });
+
+  it("restores the draft and toasts when onSubmit rejects", async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error("network down"));
+    render(<MobileChannelComposer onSubmit={onSubmit} />);
+    const textarea = screen.getByTestId(
+      "mobile-channel-composer-textarea"
+    ) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "important draft" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    // Draft cleared optimistically.
+    expect(textarea.value).toBe("");
+    // After the rejection settles, the draft is restored and an error
+    // toast is shown so the user can retry.
+    await waitFor(() => {
+      expect(textarea.value).toBe("important draft");
+      expect(toastError).toHaveBeenCalledWith("Failed to send. Try again.");
+    });
   });
 
   it("send button is disabled while textarea is empty", () => {

--- a/src/components/mobile/channels/__tests__/MobileChannelList.test.tsx
+++ b/src/components/mobile/channels/__tests__/MobileChannelList.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * MobileChannelList tests (Phase 5 mobile redesign).
+ *
+ * Verifies channel groups render, unread badges show counts, and tapping a
+ * row both selects the channel in context and fires onOpen.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+import type { ChannelGroup } from "@/types/channels";
+
+import { MobileChannelList } from "../MobileChannelList";
+
+const setActiveChannelId = vi.fn();
+
+const baseChannel = (
+  over: Partial<ChannelGroup["channels"][number]> = {}
+): ChannelGroup["channels"][number] => ({
+  id: over.id ?? "c1",
+  folderId: "p1",
+  groupId: "g1",
+  name: over.name ?? "general",
+  displayName: over.displayName ?? "general",
+  type: over.type ?? "public",
+  topic: over.topic ?? null,
+  isDefault: over.isDefault ?? false,
+  lastMessageAt: null,
+  messageCount: 0,
+  unreadCount: over.unreadCount ?? 0,
+  createdAt: "2025-01-01T00:00:00Z",
+});
+
+vi.mock("@/contexts/ChannelContext", () => ({
+  useChannelContext: () => ({
+    groups: [
+      {
+        id: "g1",
+        folderId: "p1",
+        name: "Channels",
+        position: 0,
+        channels: [
+          baseChannel({ id: "c1", displayName: "general", topic: "team chat" }),
+          baseChannel({ id: "c2", displayName: "alerts", unreadCount: 3 }),
+        ],
+      },
+      {
+        id: "g2",
+        folderId: "p1",
+        name: "Direct Messages",
+        position: 1,
+        channels: [
+          baseChannel({ id: "dm1", displayName: "claude", type: "dm", unreadCount: 105 }),
+        ],
+      },
+    ],
+    activeChannelId: "c1",
+    setActiveChannelId,
+    loading: false,
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  setActiveChannelId.mockReset();
+});
+
+describe("MobileChannelList", () => {
+  it("renders all groups with their channel rows", () => {
+    render(<MobileChannelList onOpen={() => {}} />);
+    expect(screen.getByText("Channels")).toBeTruthy();
+    expect(screen.getByText("Direct Messages")).toBeTruthy();
+    expect(screen.getByText("general")).toBeTruthy();
+    expect(screen.getByText("alerts")).toBeTruthy();
+    expect(screen.getByText("claude")).toBeTruthy();
+  });
+
+  it("renders unread badges with correct counts", () => {
+    render(<MobileChannelList onOpen={() => {}} />);
+    const badges = screen.getAllByTestId("mobile-channel-row-unread");
+    // Two channels have unread > 0.
+    expect(badges).toHaveLength(2);
+    // Counts: 3 and 99+ (capped).
+    expect(badges.map((b) => b.textContent)).toEqual(["3", "99+"]);
+  });
+
+  it("does not render a badge for channels with 0 unread", () => {
+    render(<MobileChannelList onOpen={() => {}} />);
+    const generalRow = screen
+      .getAllByTestId("mobile-channel-row")
+      .find((el) => el.getAttribute("data-channel-id") === "c1");
+    expect(generalRow).toBeTruthy();
+    expect(
+      generalRow!.querySelector('[data-testid="mobile-channel-row-unread"]')
+    ).toBeNull();
+  });
+
+  it("calls setActiveChannelId and onOpen when a row is tapped", () => {
+    const onOpen = vi.fn();
+    render(<MobileChannelList onOpen={onOpen} />);
+    const row = screen
+      .getAllByTestId("mobile-channel-row")
+      .find((el) => el.getAttribute("data-channel-id") === "c2");
+    fireEvent.click(row!);
+    expect(setActiveChannelId).toHaveBeenCalledWith("c2");
+    expect(onOpen).toHaveBeenCalledWith("c2");
+  });
+
+  it("marks the active channel with aria-current=page", () => {
+    render(<MobileChannelList onOpen={() => {}} />);
+    const active = screen
+      .getAllByTestId("mobile-channel-row")
+      .find((el) => el.getAttribute("data-channel-id") === "c1");
+    expect(active!.getAttribute("aria-current")).toBe("page");
+  });
+});

--- a/src/components/mobile/channels/__tests__/MobileChannelView.test.tsx
+++ b/src/components/mobile/channels/__tests__/MobileChannelView.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
 
 import type { ChannelMessage, ChannelGroup } from "@/types/channels";
 
@@ -17,7 +17,7 @@ const channelState = {
   groups: [] as ChannelGroup[],
   activeChannelId: null as string | null,
   activeChannelMessages: [] as ChannelMessage[],
-  sendMessage: vi.fn().mockResolvedValue(undefined),
+  sendMessage: vi.fn().mockResolvedValue({ ok: true }),
   markChannelRead: vi.fn().mockResolvedValue(undefined),
   openThread: vi.fn(),
 };
@@ -107,6 +107,32 @@ describe("MobileChannelView", () => {
     channelState.activeChannelMessages = [message({ id: "opt-pending" })];
     render(<MobileChannelView onBack={() => {}} onOpenThread={() => {}} />);
     expect(channelState.markChannelRead).not.toHaveBeenCalled();
+  });
+
+  it("opens an action sheet on long-press and routes 'Reply in thread' through openThread", () => {
+    vi.useFakeTimers();
+    channelState.activeChannelMessages = [message({ id: "m1", body: "hello" })];
+    const onOpenThread = vi.fn();
+    render(<MobileChannelView onBack={() => {}} onOpenThread={onOpenThread} />);
+    const wrap = screen.getByTestId("mobile-channel-message-wrap");
+    // Begin a press; useLongPress fires after ~450ms.
+    fireEvent.pointerDown(wrap, { clientX: 0, clientY: 0, button: 0 });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    fireEvent.pointerUp(wrap);
+    // Action sheet is rendered; its menu items live inside the portal.
+    const sheet = screen.getByTestId("mobile-bottom-sheet");
+    expect(sheet).toBeTruthy();
+    // Tap "Reply in thread" — should call openThread + onOpenThread.
+    const replyItem = sheet.querySelector(
+      '[data-action-id="reply"]'
+    ) as HTMLButtonElement;
+    expect(replyItem).toBeTruthy();
+    fireEvent.click(replyItem);
+    expect(channelState.openThread).toHaveBeenCalledWith("m1");
+    expect(onOpenThread).toHaveBeenCalledWith("m1");
+    vi.useRealTimers();
   });
 
   it("renders an empty channel as composer + header only (no greeter)", () => {

--- a/src/components/mobile/channels/__tests__/MobileChannelView.test.tsx
+++ b/src/components/mobile/channels/__tests__/MobileChannelView.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * MobileChannelView tests (Phase 5 mobile redesign).
+ *
+ * Covers two adversarial-review concerns:
+ *   - markChannelRead is called once per UNIQUE last-message-id, not on
+ *     every re-render with the same id.
+ *   - Empty channels render without a greeter — the composer + header are
+ *     the only persistent UI.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import type { ChannelMessage, ChannelGroup } from "@/types/channels";
+
+const channelState = {
+  groups: [] as ChannelGroup[],
+  activeChannelId: null as string | null,
+  activeChannelMessages: [] as ChannelMessage[],
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  markChannelRead: vi.fn().mockResolvedValue(undefined),
+  openThread: vi.fn(),
+};
+
+vi.mock("@/contexts/ChannelContext", () => ({
+  useChannelContext: () => channelState,
+}));
+vi.mock("@/contexts/PeerChatContext", () => ({
+  usePeerChatContext: () => ({ peerNameMap: new Map() }),
+}));
+
+import { MobileChannelView } from "../MobileChannelView";
+
+const channel = (over: Partial<ChannelGroup["channels"][number]> = {}) => ({
+  id: over.id ?? "c1",
+  folderId: "p1",
+  groupId: "g1",
+  name: over.name ?? "general",
+  displayName: over.displayName ?? "general",
+  type: over.type ?? "public",
+  topic: over.topic ?? null,
+  isDefault: over.isDefault ?? false,
+  lastMessageAt: null,
+  messageCount: 0,
+  unreadCount: over.unreadCount ?? 0,
+  createdAt: "2025-01-01T00:00:00Z",
+});
+
+const message = (over: Partial<ChannelMessage> = {}): ChannelMessage => ({
+  id: over.id ?? "m1",
+  channelId: over.channelId ?? "c1",
+  fromSessionId: over.fromSessionId ?? "s1",
+  fromSessionName: over.fromSessionName ?? "claude",
+  toSessionId: over.toSessionId ?? null,
+  body: over.body ?? "hello",
+  isUserMessage: over.isUserMessage ?? false,
+  parentMessageId: over.parentMessageId ?? null,
+  replyCount: over.replyCount ?? 0,
+  createdAt: over.createdAt ?? "2025-01-01T00:00:00Z",
+});
+
+beforeEach(() => {
+  channelState.groups = [
+    {
+      id: "g1",
+      folderId: "p1",
+      name: "Channels",
+      position: 0,
+      channels: [channel({ id: "c1" })],
+    },
+  ] as ChannelGroup[];
+  channelState.activeChannelId = "c1";
+  channelState.activeChannelMessages = [];
+  channelState.markChannelRead.mockClear();
+  channelState.sendMessage.mockClear();
+  channelState.openThread.mockClear();
+  Element.prototype.scrollIntoView = vi.fn() as unknown as typeof Element.prototype.scrollIntoView;
+});
+
+afterEach(() => cleanup());
+
+describe("MobileChannelView", () => {
+  it("calls markChannelRead once per unique last-message-id, not on every re-render with the same id", () => {
+    channelState.activeChannelMessages = [message({ id: "m1" })];
+    const { rerender } = render(
+      <MobileChannelView onBack={() => {}} onOpenThread={() => {}} />
+    );
+    expect(channelState.markChannelRead).toHaveBeenCalledTimes(1);
+    expect(channelState.markChannelRead).toHaveBeenLastCalledWith("c1", "m1");
+
+    // New array reference, same trailing id — must NOT refire the request.
+    channelState.activeChannelMessages = [message({ id: "m1" })];
+    rerender(<MobileChannelView onBack={() => {}} onOpenThread={() => {}} />);
+    expect(channelState.markChannelRead).toHaveBeenCalledTimes(1);
+
+    // New trailing id — DOES refire.
+    channelState.activeChannelMessages = [
+      message({ id: "m1" }),
+      message({ id: "m2" }),
+    ];
+    rerender(<MobileChannelView onBack={() => {}} onOpenThread={() => {}} />);
+    expect(channelState.markChannelRead).toHaveBeenCalledTimes(2);
+    expect(channelState.markChannelRead).toHaveBeenLastCalledWith("c1", "m2");
+  });
+
+  it("ignores optimistic placeholder messages (id starts with 'opt-')", () => {
+    channelState.activeChannelMessages = [message({ id: "opt-pending" })];
+    render(<MobileChannelView onBack={() => {}} onOpenThread={() => {}} />);
+    expect(channelState.markChannelRead).not.toHaveBeenCalled();
+  });
+
+  it("renders an empty channel as composer + header only (no greeter)", () => {
+    channelState.activeChannelMessages = [];
+    render(<MobileChannelView onBack={() => {}} onOpenThread={() => {}} />);
+    // Composer and header are present.
+    expect(screen.getByTestId("mobile-channel-view")).toBeTruthy();
+    expect(screen.getByTestId("mobile-channel-view-title").textContent).toBe(
+      "general"
+    );
+    expect(screen.getByTestId("mobile-channel-composer-textarea")).toBeTruthy();
+    // No greeter / illustrated empty state.
+    expect(screen.queryByText(/be the first/i)).toBeNull();
+    expect(screen.queryByText(/welcome/i)).toBeNull();
+    expect(screen.queryByText(/no messages/i)).toBeNull();
+    // markChannelRead must not have been called for an empty stream.
+    expect(channelState.markChannelRead).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/mobile/channels/__tests__/MobileThreadTakeover.test.tsx
+++ b/src/components/mobile/channels/__tests__/MobileThreadTakeover.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * MobileThreadTakeover tests (Phase 5 mobile redesign).
+ *
+ * Covers the adversarial-review fixes:
+ *  - ESC closes the takeover.
+ *  - Auto-scroll fires only when threadMessages.length increases (a new
+ *    array reference with the same length must NOT scroll).
+ *  - The composer is disabled when the parent message can't be resolved.
+ *  - Focus moves into the takeover on open and is restored on close.
+ *  - Tab cycles between focusables inside the takeover.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+
+import type { ChannelMessage } from "@/types/channels";
+
+const channelState = {
+  activeChannelMessages: [] as ChannelMessage[],
+  openThreadId: null as string | null,
+  threadMessages: [] as ChannelMessage[],
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock("@/contexts/ChannelContext", () => ({
+  useChannelContext: () => channelState,
+}));
+
+vi.mock("@/contexts/PeerChatContext", () => ({
+  usePeerChatContext: () => ({ peerNameMap: new Map() }),
+}));
+
+vi.mock("@/hooks/useMobile", () => ({
+  usePrefersReducedMotion: () => true, // makes the two-phase mount synchronous
+}));
+
+import { MobileThreadTakeover } from "../MobileThreadTakeover";
+
+const baseMessage = (over: Partial<ChannelMessage> = {}): ChannelMessage => ({
+  id: over.id ?? "m1",
+  channelId: over.channelId ?? "c1",
+  fromSessionId: over.fromSessionId ?? "s1",
+  fromSessionName: over.fromSessionName ?? "claude",
+  toSessionId: over.toSessionId ?? null,
+  body: over.body ?? "hi",
+  isUserMessage: over.isUserMessage ?? false,
+  parentMessageId: over.parentMessageId ?? null,
+  replyCount: over.replyCount ?? 0,
+  createdAt: over.createdAt ?? "2025-01-01T00:00:00Z",
+});
+
+beforeEach(() => {
+  channelState.activeChannelMessages = [];
+  channelState.openThreadId = null;
+  channelState.threadMessages = [];
+  channelState.sendMessage.mockClear();
+  // jsdom's scrollIntoView is undefined; install a spy so the takeover
+  // doesn't blow up when it auto-scrolls.
+  Element.prototype.scrollIntoView = vi.fn() as unknown as typeof Element.prototype.scrollIntoView;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("MobileThreadTakeover", () => {
+  it("closes on ESC", async () => {
+    channelState.openThreadId = "m1";
+    channelState.activeChannelMessages = [baseMessage({ id: "m1" })];
+    const onClose = vi.fn();
+    render(<MobileThreadTakeover open={true} onClose={onClose} />);
+    // Wait one frame for the rAF inside the two-phase mount to fire.
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+    });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the composer when parentMessage cannot be resolved", async () => {
+    // openThreadId points at a message id that isn't in the channel — the
+    // takeover renders but the composer must lock so we don't post replies
+    // into the void.
+    channelState.openThreadId = "missing";
+    channelState.activeChannelMessages = [];
+    render(<MobileThreadTakeover open={true} onClose={() => {}} />);
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+    });
+    // The composer's textarea reflects the disabled prop.
+    const textarea = screen.getByTestId(
+      "mobile-channel-composer-textarea"
+    ) as HTMLTextAreaElement;
+    expect(textarea.disabled).toBe(true);
+  });
+
+  it("auto-scrolls only when threadMessages.length increases", async () => {
+    channelState.openThreadId = "m1";
+    channelState.activeChannelMessages = [baseMessage({ id: "m1" })];
+    channelState.threadMessages = [baseMessage({ id: "r1" })];
+    const scrollSpy = vi.spyOn(Element.prototype, "scrollIntoView");
+
+    const { rerender } = render(
+      <MobileThreadTakeover open={true} onClose={() => {}} />
+    );
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+    });
+    const initialCalls = scrollSpy.mock.calls.length;
+    expect(initialCalls).toBeGreaterThan(0);
+
+    // New array reference, SAME length — simulates an unrelated context
+    // update (e.g. a peer summary refresh). Must NOT scroll.
+    channelState.threadMessages = [baseMessage({ id: "r1" })];
+    rerender(<MobileThreadTakeover open={true} onClose={() => {}} />);
+    expect(scrollSpy.mock.calls.length).toBe(initialCalls);
+
+    // Length increases — DOES scroll.
+    channelState.threadMessages = [
+      baseMessage({ id: "r1" }),
+      baseMessage({ id: "r2" }),
+    ];
+    rerender(<MobileThreadTakeover open={true} onClose={() => {}} />);
+    expect(scrollSpy.mock.calls.length).toBeGreaterThan(initialCalls);
+  });
+
+  it("moves focus inside the takeover on open and restores it on close", async () => {
+    channelState.openThreadId = "m1";
+    channelState.activeChannelMessages = [baseMessage({ id: "m1" })];
+    // A button outside the takeover that holds focus before opening.
+    const previous = document.createElement("button");
+    previous.textContent = "before";
+    document.body.appendChild(previous);
+    previous.focus();
+    expect(document.activeElement).toBe(previous);
+
+    const { unmount } = render(
+      <MobileThreadTakeover open={true} onClose={() => {}} />
+    );
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+    });
+    const takeover = screen.getByTestId("mobile-thread-takeover");
+    // Focus should now be inside the takeover.
+    expect(takeover.contains(document.activeElement)).toBe(true);
+
+    unmount();
+    // Restored to the previously-focused element.
+    expect(document.activeElement).toBe(previous);
+    document.body.removeChild(previous);
+  });
+
+  it("traps Tab inside the takeover (cycles last → first)", async () => {
+    channelState.openThreadId = "m1";
+    channelState.activeChannelMessages = [baseMessage({ id: "m1" })];
+    render(<MobileThreadTakeover open={true} onClose={() => {}} />);
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+    });
+    const takeover = screen.getByTestId("mobile-thread-takeover");
+    const focusables = Array.from(
+      takeover.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+    );
+    expect(focusables.length).toBeGreaterThanOrEqual(2);
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    // Park focus on the last focusable, press Tab — should wrap to first.
+    last.focus();
+    expect(document.activeElement).toBe(last);
+    fireEvent.keyDown(takeover, { key: "Tab" });
+    expect(document.activeElement).toBe(first);
+
+    // Shift+Tab on the first wraps to the last.
+    fireEvent.keyDown(takeover, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
+});

--- a/src/components/mobile/channels/__tests__/MobileThreadTakeover.test.tsx
+++ b/src/components/mobile/channels/__tests__/MobileThreadTakeover.test.tsx
@@ -19,7 +19,7 @@ const channelState = {
   activeChannelMessages: [] as ChannelMessage[],
   openThreadId: null as string | null,
   threadMessages: [] as ChannelMessage[],
-  sendMessage: vi.fn().mockResolvedValue(undefined),
+  sendMessage: vi.fn().mockResolvedValue({ ok: true }),
 };
 
 vi.mock("@/contexts/ChannelContext", () => ({
@@ -93,6 +93,80 @@ describe("MobileThreadTakeover", () => {
       "mobile-channel-composer-textarea"
     ) as HTMLTextAreaElement;
     expect(textarea.disabled).toBe(true);
+  });
+
+  it("does NOT auto-scroll when the user has scrolled up to read older replies", async () => {
+    channelState.openThreadId = "m1";
+    channelState.activeChannelMessages = [baseMessage({ id: "m1" })];
+    channelState.threadMessages = [baseMessage({ id: "r1" })];
+    const scrollSpy = vi.spyOn(Element.prototype, "scrollIntoView");
+
+    const { rerender } = render(
+      <MobileThreadTakeover open={true} onClose={() => {}} />
+    );
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+    });
+    const initialCalls = scrollSpy.mock.calls.length;
+
+    // Simulate the user scrolling up. We dispatch onScroll with metrics
+    // putting us > 100px from the bottom, which flips isUserScrolledRef.
+    const takeover = screen.getByTestId("mobile-thread-takeover");
+    const scrollRegion = takeover.querySelector(
+      "div.flex-1.overflow-y-auto"
+    ) as HTMLDivElement;
+    expect(scrollRegion).toBeTruthy();
+    // happy-dom doesn't compute layout; stub the metrics so the handler
+    // sees us as 200px above the bottom.
+    Object.defineProperty(scrollRegion, "scrollHeight", { value: 1000, configurable: true });
+    Object.defineProperty(scrollRegion, "scrollTop", { value: 200, configurable: true });
+    Object.defineProperty(scrollRegion, "clientHeight", { value: 600, configurable: true });
+    fireEvent.scroll(scrollRegion);
+
+    // A new peer reply arrives — DESPITE the length increase, auto-scroll
+    // must stay off because the user is reading older replies.
+    channelState.threadMessages = [
+      baseMessage({ id: "r1" }),
+      baseMessage({ id: "r2", isUserMessage: false }),
+    ];
+    rerender(<MobileThreadTakeover open={true} onClose={() => {}} />);
+    expect(scrollSpy.mock.calls.length).toBe(initialCalls);
+
+    // The "Jump to latest" pill should appear now.
+    expect(screen.getByTestId("mobile-thread-jump-to-latest")).toBeTruthy();
+  });
+
+  it("auto-scrolls anyway when the new reply is the local user's optimistic message", async () => {
+    channelState.openThreadId = "m1";
+    channelState.activeChannelMessages = [baseMessage({ id: "m1" })];
+    channelState.threadMessages = [baseMessage({ id: "r1" })];
+    const scrollSpy = vi.spyOn(Element.prototype, "scrollIntoView");
+    const { rerender } = render(
+      <MobileThreadTakeover open={true} onClose={() => {}} />
+    );
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+    });
+    const baseline = scrollSpy.mock.calls.length;
+
+    // Mark the user as scrolled up.
+    const takeover = screen.getByTestId("mobile-thread-takeover");
+    const scrollRegion = takeover.querySelector(
+      "div.flex-1.overflow-y-auto"
+    ) as HTMLDivElement;
+    Object.defineProperty(scrollRegion, "scrollHeight", { value: 1000, configurable: true });
+    Object.defineProperty(scrollRegion, "scrollTop", { value: 200, configurable: true });
+    Object.defineProperty(scrollRegion, "clientHeight", { value: 600, configurable: true });
+    fireEvent.scroll(scrollRegion);
+
+    // The user posts a reply (optimistic id starts with "opt-") — we DO
+    // scroll, because that's their explicit intent.
+    channelState.threadMessages = [
+      baseMessage({ id: "r1" }),
+      baseMessage({ id: "opt-pending", isUserMessage: true }),
+    ];
+    rerender(<MobileThreadTakeover open={true} onClose={() => {}} />);
+    expect(scrollSpy.mock.calls.length).toBeGreaterThan(baseline);
   });
 
   it("auto-scrolls only when threadMessages.length increases", async () => {

--- a/src/components/mobile/channels/__tests__/useThreadTakeoverSwipe.test.tsx
+++ b/src/components/mobile/channels/__tests__/useThreadTakeoverSwipe.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * useThreadTakeoverSwipe tests (Phase 5 mobile redesign).
+ *
+ * Verifies the back-gesture state machine: start near the left edge, drag
+ * rightward past threshold, fire onDismiss.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, fireEvent, cleanup, act } from "@testing-library/react";
+import { useRef, type CSSProperties } from "react";
+
+import {
+  useThreadTakeoverSwipe,
+  type UseThreadTakeoverSwipeOptions,
+} from "../useThreadTakeoverSwipe";
+
+afterEach(() => cleanup());
+
+function Harness({
+  onDismiss,
+  edgeThresholdPx,
+  horizontalThresholdPx,
+}: Pick<UseThreadTakeoverSwipeOptions, "onDismiss" | "edgeThresholdPx" | "horizontalThresholdPx">) {
+  const ref = useRef<HTMLDivElement>(null);
+  const swipe = useThreadTakeoverSwipe({
+    onDismiss,
+    edgeThresholdPx,
+    horizontalThresholdPx,
+  });
+  const style: CSSProperties = swipe.dragging
+    ? { transform: `translate3d(${swipe.dragOffsetPx}px,0,0)` }
+    : {};
+  return (
+    <div
+      ref={ref}
+      data-testid="harness"
+      data-dragging={swipe.dragging ? "true" : "false"}
+      style={style}
+      onTouchStart={swipe.bind.onTouchStart}
+      onTouchMove={swipe.bind.onTouchMove}
+      onTouchEnd={swipe.bind.onTouchEnd}
+      onTouchCancel={swipe.bind.onTouchCancel}
+    >
+      panel
+    </div>
+  );
+}
+
+function makeTouch(x: number, y: number): Touch {
+  return { clientX: x, clientY: y } as unknown as Touch;
+}
+
+describe("useThreadTakeoverSwipe", () => {
+  it("does not trigger when the touch starts away from the left edge", () => {
+    const onDismiss = vi.fn();
+    const { getByTestId } = render(<Harness onDismiss={onDismiss} />);
+    const el = getByTestId("harness");
+    // happy-dom returns 0,0,0,0 for getBoundingClientRect; we use a touch
+    // intentionally past the edge threshold (default 24).
+    fireEvent.touchStart(el, { touches: [makeTouch(50, 100)] });
+    fireEvent.touchMove(el, { touches: [makeTouch(200, 100)] });
+    fireEvent.touchEnd(el);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("triggers onDismiss when an edge swipe travels past the horizontal threshold", () => {
+    const onDismiss = vi.fn();
+    const { getByTestId } = render(
+      <Harness onDismiss={onDismiss} horizontalThresholdPx={50} />
+    );
+    const el = getByTestId("harness");
+    fireEvent.touchStart(el, { touches: [makeTouch(5, 100)] });
+    fireEvent.touchMove(el, { touches: [makeTouch(60, 105)] });
+    expect(el.getAttribute("data-dragging")).toBe("true");
+    fireEvent.touchEnd(el);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not trigger when the swipe is shorter than the horizontal threshold", () => {
+    const onDismiss = vi.fn();
+    const { getByTestId } = render(
+      <Harness onDismiss={onDismiss} horizontalThresholdPx={80} />
+    );
+    const el = getByTestId("harness");
+    fireEvent.touchStart(el, { touches: [makeTouch(5, 100)] });
+    fireEvent.touchMove(el, { touches: [makeTouch(40, 100)] });
+    fireEvent.touchEnd(el);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("ignores swipes that are mostly vertical", () => {
+    const onDismiss = vi.fn();
+    const { getByTestId } = render(<Harness onDismiss={onDismiss} />);
+    const el = getByTestId("harness");
+    fireEvent.touchStart(el, { touches: [makeTouch(5, 100)] });
+    // Big vertical, small horizontal — looks like a scroll.
+    fireEvent.touchMove(el, { touches: [makeTouch(15, 220)] });
+    fireEvent.touchEnd(el);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger on leftward (wrong-direction) drags", () => {
+    const onDismiss = vi.fn();
+    const { getByTestId } = render(<Harness onDismiss={onDismiss} />);
+    const el = getByTestId("harness");
+    fireEvent.touchStart(el, { touches: [makeTouch(5, 100)] });
+    fireEvent.touchMove(el, { touches: [makeTouch(-100, 100)] });
+    fireEvent.touchEnd(el);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("resets drag offset after release without trigger", () => {
+    const onDismiss = vi.fn();
+    const { getByTestId } = render(
+      <Harness onDismiss={onDismiss} horizontalThresholdPx={120} />
+    );
+    const el = getByTestId("harness");
+    fireEvent.touchStart(el, { touches: [makeTouch(5, 100)] });
+    fireEvent.touchMove(el, { touches: [makeTouch(40, 100)] });
+    expect(el.getAttribute("data-dragging")).toBe("true");
+    act(() => {
+      fireEvent.touchEnd(el);
+    });
+    expect(el.getAttribute("data-dragging")).toBe("false");
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/mobile/channels/useThreadTakeoverSwipe.ts
+++ b/src/components/mobile/channels/useThreadTakeoverSwipe.ts
@@ -1,0 +1,151 @@
+"use client";
+
+/**
+ * useThreadTakeoverSwipe — left-edge back gesture for the mobile thread
+ * takeover.
+ *
+ * Detects a swipe that BEGINS within the leftmost `edgeThresholdPx` (default
+ * 24px) of the takeover panel and travels rightward past `horizontalThresholdPx`
+ * (default 64px) without enough vertical drift to look like a list scroll. On
+ * trigger it fires `onDismiss`. Returns a `dragging` flag and `dragOffsetPx`
+ * so the host panel can follow the finger one-to-one until release; the host
+ * decides whether to commit (≥ threshold) or rubber-band back to 0.
+ *
+ * Mirrors the iOS interactive-pop-gesture model: the user gets continuous
+ * visual feedback and a clear point of no return. Reduced motion is the
+ * caller's concern — this hook reports raw deltas, the panel's transition
+ * already short-circuits to 0ms when reduced-motion is set.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface UseThreadTakeoverSwipeOptions {
+  edgeThresholdPx?: number;
+  horizontalThresholdPx?: number;
+  enabled?: boolean;
+  onDismiss: () => void;
+}
+
+export interface UseThreadTakeoverSwipeState {
+  /** True once a valid edge-drag has begun. */
+  dragging: boolean;
+  /** Live horizontal offset (≥ 0). 0 when not dragging or after release. */
+  dragOffsetPx: number;
+  bind: {
+    onTouchStart: (e: React.TouchEvent<HTMLElement>) => void;
+    onTouchMove: (e: React.TouchEvent<HTMLElement>) => void;
+    onTouchEnd: () => void;
+    onTouchCancel: () => void;
+  };
+}
+
+const DEFAULT_EDGE = 24;
+const DEFAULT_HORIZONTAL = 64;
+
+export function useThreadTakeoverSwipe(
+  options: UseThreadTakeoverSwipeOptions
+): UseThreadTakeoverSwipeState {
+  const {
+    edgeThresholdPx = DEFAULT_EDGE,
+    horizontalThresholdPx = DEFAULT_HORIZONTAL,
+    enabled = true,
+    onDismiss,
+  } = options;
+
+  const onDismissRef = useRef(onDismiss);
+  useEffect(() => {
+    onDismissRef.current = onDismiss;
+  }, [onDismiss]);
+
+  const startX = useRef<number | null>(null);
+  const startY = useRef<number | null>(null);
+  const trackingRef = useRef(false);
+  const [dragging, setDragging] = useState(false);
+  const [dragOffsetPx, setDragOffsetPx] = useState(0);
+
+  const reset = useCallback(() => {
+    startX.current = null;
+    startY.current = null;
+    trackingRef.current = false;
+    setDragging(false);
+    setDragOffsetPx(0);
+  }, []);
+
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent<HTMLElement>) => {
+      if (!enabled) return;
+      const t = e.touches[0];
+      if (!t) return;
+      // Read the panel's left edge (in viewport coords) from the target
+      // element so the gesture works whether the panel sits at x=0 (full
+      // takeover) or is otherwise positioned.
+      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+      if (t.clientX - rect.left > edgeThresholdPx) {
+        // Start was not near the left edge — let the inner content handle
+        // the touch (scroll, link tap, etc.).
+        return;
+      }
+      startX.current = t.clientX;
+      startY.current = t.clientY;
+      trackingRef.current = true;
+      setDragging(false);
+      setDragOffsetPx(0);
+    },
+    [enabled, edgeThresholdPx]
+  );
+
+  const onTouchMove = useCallback(
+    (e: React.TouchEvent<HTMLElement>) => {
+      if (!trackingRef.current || startX.current === null || startY.current === null) {
+        return;
+      }
+      const t = e.touches[0];
+      if (!t) return;
+      const dx = t.clientX - startX.current;
+      const dy = t.clientY - startY.current;
+
+      // Vertical-bias: if the user is mostly scrolling, bail out.
+      if (Math.abs(dy) > Math.abs(dx) * 0.6 && !dragging) {
+        reset();
+        return;
+      }
+      // We only react to rightward drags from the left edge.
+      if (dx <= 0) {
+        if (dragging) {
+          setDragging(false);
+          setDragOffsetPx(0);
+        }
+        return;
+      }
+
+      setDragging(true);
+      setDragOffsetPx(dx);
+    },
+    [dragging, reset]
+  );
+
+  const onTouchEnd = useCallback(() => {
+    if (!trackingRef.current) {
+      reset();
+      return;
+    }
+    const triggered = dragOffsetPx >= horizontalThresholdPx;
+    setDragging(false);
+    setDragOffsetPx(0);
+    trackingRef.current = false;
+    startX.current = null;
+    startY.current = null;
+    if (triggered) onDismissRef.current();
+  }, [dragOffsetPx, horizontalThresholdPx, reset]);
+
+  return {
+    dragging,
+    dragOffsetPx,
+    bind: {
+      onTouchStart,
+      onTouchMove,
+      onTouchEnd,
+      onTouchCancel: reset,
+    },
+  };
+}

--- a/src/components/mobile/channels/useThreadTakeoverSwipe.ts
+++ b/src/components/mobile/channels/useThreadTakeoverSwipe.ts
@@ -60,6 +60,10 @@ export function useThreadTakeoverSwipe(
   const startX = useRef<number | null>(null);
   const startY = useRef<number | null>(null);
   const trackingRef = useRef(false);
+  // `dragOffsetRef` shadows `dragOffsetPx` so onTouchEnd reads the latest
+  // value even when React 18 batching delays the state update past the end
+  // of the gesture. The state flavor still drives rendering.
+  const dragOffsetRef = useRef(0);
   const [dragging, setDragging] = useState(false);
   const [dragOffsetPx, setDragOffsetPx] = useState(0);
 
@@ -67,6 +71,7 @@ export function useThreadTakeoverSwipe(
     startX.current = null;
     startY.current = null;
     trackingRef.current = false;
+    dragOffsetRef.current = 0;
     setDragging(false);
     setDragOffsetPx(0);
   }, []);
@@ -88,6 +93,7 @@ export function useThreadTakeoverSwipe(
       startX.current = t.clientX;
       startY.current = t.clientY;
       trackingRef.current = true;
+      dragOffsetRef.current = 0;
       setDragging(false);
       setDragOffsetPx(0);
     },
@@ -112,12 +118,15 @@ export function useThreadTakeoverSwipe(
       // We only react to rightward drags from the left edge.
       if (dx <= 0) {
         if (dragging) {
-          setDragging(false);
-          setDragOffsetPx(0);
+          // Leftward reversal cancels the gesture entirely; otherwise
+          // `trackingRef` would stay true and a subsequent rightward
+          // motion would resume the drag mid-flight from a stale anchor.
+          reset();
         }
         return;
       }
 
+      dragOffsetRef.current = dx;
       setDragging(true);
       setDragOffsetPx(dx);
     },
@@ -129,14 +138,17 @@ export function useThreadTakeoverSwipe(
       reset();
       return;
     }
-    const triggered = dragOffsetPx >= horizontalThresholdPx;
+    // Read from the ref so React 18's batched state updates can't hand us
+    // a stale `dragOffsetPx` here.
+    const triggered = dragOffsetRef.current >= horizontalThresholdPx;
+    dragOffsetRef.current = 0;
     setDragging(false);
     setDragOffsetPx(0);
     trackingRef.current = false;
     startX.current = null;
     startY.current = null;
     if (triggered) onDismissRef.current();
-  }, [dragOffsetPx, horizontalThresholdPx, reset]);
+  }, [horizontalThresholdPx, reset]);
 
   return {
     dragging,

--- a/src/components/mobile/common/BottomSheet.tsx
+++ b/src/components/mobile/common/BottomSheet.tsx
@@ -72,17 +72,8 @@ export function BottomSheet({
   // Only render the portal on the client to avoid SSR/CSR mismatches.
   const isClient = typeof document !== "undefined";
 
-  // ESC key support.
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onOpenChange(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onOpenChange]);
-
   const onOverlayClick = useCallback(() => onOpenChange(false), [onOpenChange]);
+  const handleEscape = useCallback(() => onOpenChange(false), [onOpenChange]);
 
   // Two-phase mount so the slide-up enter and slide-down exit animations
   // both play. `mounted` tracks DOM presence; `entered` tracks whether
@@ -109,9 +100,11 @@ export function BottomSheet({
     return () => window.clearTimeout(t);
   }, [open, mounted, reducedMotion]);
 
-  // Focus trap + body scroll lock — shared with MobileThreadTakeover so the
-  // refcount on `document.body.dataset.scrollLockCount` works across both.
-  useDialogPolish({ active: entered, panelRef });
+  // Focus trap + body scroll lock + ESC — shared with MobileThreadTakeover so
+  // the refcount on `document.body.dataset.scrollLockCount` works across
+  // both, and ESC only closes the topmost dialog (the sheet does not yank
+  // a thread takeover underneath it).
+  useDialogPolish({ active: entered, panelRef, onEscape: handleEscape });
 
   if (!isClient) return null;
   if (!mounted) return null;

--- a/src/components/mobile/common/BottomSheet.tsx
+++ b/src/components/mobile/common/BottomSheet.tsx
@@ -30,6 +30,8 @@ import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
 import { usePrefersReducedMotion } from "@/hooks/useMobile";
 
+import { useDialogPolish } from "./useDialogPolish";
+
 export interface BottomSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -80,28 +82,6 @@ export function BottomSheet({
     return () => window.removeEventListener("keydown", onKey);
   }, [open, onOpenChange]);
 
-  // Body scroll lock while open. Refcounted on a body data-attribute so
-  // multiple concurrent sheets don't leak a permanent locked state. Naive
-  // save/restore breaks under nested sheets: the second sheet would save
-  // `prev = "hidden"` (set by the first), and on its close would restore
-  // "hidden" — locking scroll forever. Only the first sheet actually
-  // applies the lock; only the last one to close releases it.
-  useEffect(() => {
-    if (!open || typeof document === "undefined") return;
-    const body = document.body;
-    const count = Number(body.dataset.scrollLockCount ?? "0") + 1;
-    body.dataset.scrollLockCount = String(count);
-    if (count === 1) body.style.overflow = "hidden";
-    return () => {
-      const next = Math.max(
-        0,
-        Number(body.dataset.scrollLockCount ?? "1") - 1
-      );
-      body.dataset.scrollLockCount = String(next);
-      if (next === 0) body.style.overflow = "";
-    };
-  }, [open]);
-
   const onOverlayClick = useCallback(() => onOpenChange(false), [onOpenChange]);
 
   // Two-phase mount so the slide-up enter and slide-down exit animations
@@ -120,7 +100,6 @@ export function BottomSheet({
       return () => cancelAnimationFrame(id);
     }
     if (!mounted) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- two-phase mount/transition state machine
     setEntered(false);
     if (reducedMotion) {
       setMounted(false);
@@ -130,48 +109,9 @@ export function BottomSheet({
     return () => window.clearTimeout(t);
   }, [open, mounted, reducedMotion]);
 
-  // Focus trap: WCAG / aria-modal compliance. When the sheet enters, move
-  // focus to the first focusable child (or the panel itself when no
-  // focusable children exist), trap Tab/Shift+Tab inside, and restore
-  // focus to the previously-focused element when the sheet closes.
-  useEffect(() => {
-    if (!entered) return;
-    const panel = panelRef.current;
-    if (!panel) return;
-    const previouslyFocused =
-      typeof document !== "undefined"
-        ? (document.activeElement as HTMLElement | null)
-        : null;
-    const focusableSelector =
-      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
-    const getFocusables = () =>
-      Array.from(panel.querySelectorAll<HTMLElement>(focusableSelector));
-    const initial = getFocusables()[0] ?? panel;
-    initial.focus();
-
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key !== "Tab") return;
-      const list = getFocusables();
-      if (list.length === 0) {
-        e.preventDefault();
-        return;
-      }
-      const first = list[0];
-      const last = list[list.length - 1];
-      if (e.shiftKey && document.activeElement === first) {
-        last.focus();
-        e.preventDefault();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        first.focus();
-        e.preventDefault();
-      }
-    };
-    panel.addEventListener("keydown", onKey);
-    return () => {
-      panel.removeEventListener("keydown", onKey);
-      previouslyFocused?.focus?.();
-    };
-  }, [entered]);
+  // Focus trap + body scroll lock — shared with MobileThreadTakeover so the
+  // refcount on `document.body.dataset.scrollLockCount` works across both.
+  useDialogPolish({ active: entered, panelRef });
 
   if (!isClient) return null;
   if (!mounted) return null;

--- a/src/components/mobile/common/useDialogPolish.ts
+++ b/src/components/mobile/common/useDialogPolish.ts
@@ -1,0 +1,97 @@
+"use client";
+
+/**
+ * useDialogPolish — shared accessibility primitives for modal-style mobile
+ * panels (BottomSheet, MobileThreadTakeover, etc.).
+ *
+ * Two concerns rolled into one hook so call sites stay short:
+ *
+ *  1. **Body scroll lock** — refcounted on `document.body.dataset.scrollLockCount`
+ *     so concurrent sheets/takeovers can't clobber each other's locked state.
+ *     Naive save/restore breaks under nesting: a second dialog would save
+ *     `prev = "hidden"` (set by the first), and on its close would restore
+ *     "hidden" — locking scroll forever. Only the first dialog actually
+ *     applies the lock; only the last one to close releases it.
+ *
+ *  2. **Focus trap** — WCAG / `aria-modal="true"` compliance. When the
+ *     dialog enters, move focus to the first focusable child (or the panel
+ *     itself when no focusable children exist), trap Tab/Shift+Tab inside,
+ *     and restore focus to the previously-focused element on close.
+ *
+ * Both effects key on the `active` flag so callers using a two-phase
+ * mount/transition lifecycle (`mounted` + `entered`) can pass `entered`
+ * here and have the polish track the visible state of the dialog.
+ */
+
+import { useEffect, type RefObject } from "react";
+
+export interface UseDialogPolishOptions {
+  /**
+   * When true the dialog is considered visible and interactive: the body
+   * scroll lock is applied and the focus trap is engaged. When false, both
+   * effects are released.
+   */
+  active: boolean;
+  /** The dialog's outer panel — used as the focus trap root. */
+  panelRef: RefObject<HTMLElement | null>;
+}
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function useDialogPolish({ active, panelRef }: UseDialogPolishOptions) {
+  // Body scroll lock with refcount.
+  useEffect(() => {
+    if (!active || typeof document === "undefined") return;
+    const body = document.body;
+    const count = Number(body.dataset.scrollLockCount ?? "0") + 1;
+    body.dataset.scrollLockCount = String(count);
+    if (count === 1) body.style.overflow = "hidden";
+    return () => {
+      const next = Math.max(
+        0,
+        Number(body.dataset.scrollLockCount ?? "1") - 1
+      );
+      body.dataset.scrollLockCount = String(next);
+      if (next === 0) body.style.overflow = "";
+    };
+  }, [active]);
+
+  // Focus trap.
+  useEffect(() => {
+    if (!active) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+    const previouslyFocused =
+      typeof document !== "undefined"
+        ? (document.activeElement as HTMLElement | null)
+        : null;
+    const getFocusables = () =>
+      Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+    const initial = getFocusables()[0] ?? panel;
+    initial.focus();
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const list = getFocusables();
+      if (list.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = list[0];
+      const last = list[list.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        last.focus();
+        e.preventDefault();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        first.focus();
+        e.preventDefault();
+      }
+    };
+    panel.addEventListener("keydown", onKey);
+    return () => {
+      panel.removeEventListener("keydown", onKey);
+      previouslyFocused?.focus?.();
+    };
+  }, [active, panelRef]);
+}

--- a/src/components/mobile/common/useDialogPolish.ts
+++ b/src/components/mobile/common/useDialogPolish.ts
@@ -4,7 +4,7 @@
  * useDialogPolish — shared accessibility primitives for modal-style mobile
  * panels (BottomSheet, MobileThreadTakeover, etc.).
  *
- * Two concerns rolled into one hook so call sites stay short:
+ * Three concerns rolled into one hook so call sites stay short:
  *
  *  1. **Body scroll lock** — refcounted on `document.body.dataset.scrollLockCount`
  *     so concurrent sheets/takeovers can't clobber each other's locked state.
@@ -18,28 +18,53 @@
  *     itself when no focusable children exist), trap Tab/Shift+Tab inside,
  *     and restore focus to the previously-focused element on close.
  *
- * Both effects key on the `active` flag so callers using a two-phase
+ *  3. **ESC handling with topmost-modal stack** — when stacked dialogs are
+ *     open (e.g. a BottomSheet over a MobileThreadTakeover), pressing
+ *     Escape must close ONLY the topmost panel. We push each active dialog
+ *     onto a module-level stack and only fire `onEscape` for the dialog
+ *     whose id is on top. This replaces the per-component window-level ESC
+ *     listeners that previously closed every layer at once.
+ *
+ * Both visual effects key on the `active` flag so callers using a two-phase
  * mount/transition lifecycle (`mounted` + `entered`) can pass `entered`
  * here and have the polish track the visible state of the dialog.
  */
 
-import { useEffect, type RefObject } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 
 export interface UseDialogPolishOptions {
   /**
    * When true the dialog is considered visible and interactive: the body
-   * scroll lock is applied and the focus trap is engaged. When false, both
-   * effects are released.
+   * scroll lock is applied, the focus trap is engaged, and ESC handling is
+   * registered. When false, all three effects are released.
    */
   active: boolean;
   /** The dialog's outer panel — used as the focus trap root. */
   panelRef: RefObject<HTMLElement | null>;
+  /**
+   * Optional ESC handler. When provided, ESC will only fire it while this
+   * dialog is on top of the modal stack — so a BottomSheet rendered over a
+   * MobileThreadTakeover can close itself without dismissing the takeover
+   * underneath.
+   */
+  onEscape?: () => void;
 }
 
 const FOCUSABLE_SELECTOR =
   'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-export function useDialogPolish({ active, panelRef }: UseDialogPolishOptions) {
+// Module-level monotonic id and stack of currently-active dialog ids. The
+// last entry is the topmost dialog; only it should respond to ESC.
+let nextDialogId = 0;
+const dialogStack: number[] = [];
+
+export function useDialogPolish({ active, panelRef, onEscape }: UseDialogPolishOptions) {
+  // A stable id per call site so the ESC handler can ask "am I on top?".
+  const idRef = useRef<number | null>(null);
+  if (idRef.current === null) {
+    idRef.current = ++nextDialogId;
+  }
+
   // Body scroll lock with refcount.
   useEffect(() => {
     if (!active || typeof document === "undefined") return;
@@ -56,6 +81,42 @@ export function useDialogPolish({ active, panelRef }: UseDialogPolishOptions) {
       if (next === 0) body.style.overflow = "";
     };
   }, [active]);
+
+  // Modal stack registration. Push on activate, pop on deactivate so
+  // `dialogStack[length-1]` always points at the topmost open dialog.
+  useEffect(() => {
+    if (!active) return;
+    const id = idRef.current;
+    if (id === null) return;
+    dialogStack.push(id);
+    return () => {
+      const idx = dialogStack.lastIndexOf(id);
+      if (idx >= 0) dialogStack.splice(idx, 1);
+    };
+  }, [active]);
+
+  // ESC handling — only fires when this dialog is on top of the stack. We
+  // keep a ref to the latest handler so callers don't have to memoize it.
+  const onEscapeRef = useRef(onEscape);
+  useEffect(() => {
+    onEscapeRef.current = onEscape;
+  }, [onEscape]);
+  useEffect(() => {
+    if (!active || !onEscape) return;
+    const id = idRef.current;
+    if (id === null) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (dialogStack[dialogStack.length - 1] !== id) return;
+      onEscapeRef.current?.();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // We intentionally only depend on `active` + presence of a handler; the
+    // identity of the handler is read through a ref so callers don't need
+    // to memoize.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, !!onEscape]);
 
   // Focus trap.
   useEffect(() => {

--- a/src/contexts/ChannelContext.tsx
+++ b/src/contexts/ChannelContext.tsx
@@ -78,6 +78,17 @@ function incrementParentReplyCount(
   });
 }
 
+/** Discriminated result returned by `sendMessage` so call sites can react
+ * to delivery failures without losing the user's draft. The previous
+ * silent-swallow shape (`Promise<void>` that resolved on both paths)
+ * couldn't distinguish a removed-optimistic from a successful post, which
+ * meant the mobile composer cleared its textarea even when the network
+ * request failed. Existing desktop callers don't await the promise, so
+ * returning a result instead of throwing remains source-compatible. */
+export type SendMessageResult =
+  | { ok: true }
+  | { ok: false; error?: unknown };
+
 interface ChannelContextValue {
   groups: ChannelGroup[];
   activeChannelId: string | null;
@@ -85,7 +96,7 @@ interface ChannelContextValue {
   activeChannelMessages: ChannelMessage[];
   totalUnreadCount: number;
   loading: boolean;
-  sendMessage: (body: string, parentMessageId?: string) => Promise<void>;
+  sendMessage: (body: string, parentMessageId?: string) => Promise<SendMessageResult>;
   markChannelRead: (channelId: string, messageId: string) => Promise<void>;
   openThread: (messageId: string) => void;
   closeThread: () => void;
@@ -249,8 +260,10 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
   // ---------------------------------------------------------------------------
 
   const sendMessage = useCallback(
-    async (body: string, parentMessageId?: string) => {
-      if (!activeChannelId || !body.trim()) return;
+    async (body: string, parentMessageId?: string): Promise<SendMessageResult> => {
+      if (!activeChannelId || !body.trim()) {
+        return { ok: false, error: new Error("No active channel or empty body") };
+      }
 
       const trimmedBody = body.trim();
       const targetChannelId = activeChannelId;
@@ -294,11 +307,19 @@ export function ChannelProvider({ children }: ChannelProviderProps) {
           if (data.message) {
             reconcileOptimistic(setter, key, optimistic.id, data.message);
           }
-        } else {
-          removeOptimistic(setter, key, optimistic.id);
+          return { ok: true };
         }
-      } catch {
+        // Non-2xx — roll back the optimistic row and surface the failure
+        // so the caller can restore the user's draft.
         removeOptimistic(setter, key, optimistic.id);
+        const errBody = (await resp.json().catch(() => ({}))) as { error?: string };
+        return {
+          ok: false,
+          error: new Error(errBody.error ?? `Request failed (${resp.status})`),
+        };
+      } catch (err) {
+        removeOptimistic(setter, key, optimistic.id);
+        return { ok: false, error: err };
       }
     },
     [activeChannelId]


### PR DESCRIPTION
## Summary

- Adds a gesture-first Channels tab to the mobile shell: list pane (groups + unread badges), channel view (full-bleed GFM stream + composer), full-screen slide-in thread takeover, DM picker FAB, all wired through the existing `ChannelContext`.
- New components live under `src/components/mobile/channels/` and reuse `ChannelMessageRow` so GFM rendering is not duplicated.
- `MobileApp.tsx` mounts the tab and forwards the channels unread total into `BottomTabBar.badges`.

## Decisions

- **Composer split, not shared.** `MobileChannelComposer` is a separate component from the terminal `MobileInputBar`. Both follow the same shape (textarea + trailing send + long-press semantics) but the channel composer enables autocorrect / autocapitalize / spellcheck / `enterkeyhint=send`, drops the terminal-modifier machinery, and reinterprets long-press as "keep the draft for editing" rather than "insert verbatim into the terminal" since prose is not shell-completion.
- **Thread takeover, not side panel.** Desktop's 320px `ThreadPanel` doesn't fit a phone, so on mobile threads slide in as a full-screen layer (`position: fixed`, `translateX(100% → 0)`, 240ms ease-out-quart) and dismiss with a back chevron OR `useThreadTakeoverSwipe` (left-edge swipe → rightward drift past 64px). Reduced motion short-circuits the transition to 0ms.
- **DM FAB resolves a from-session.** The DM endpoint requires both `targetSessionId` and `fromSessionId`; on mobile we resolve "from" by preferring the active session, falling back to the first session in the active project. When no eligible from-session exists, the picker shows calm guidance ("Open a session in this project first") instead of letting the user hit a 403.
- **No glass, no side-stripes, no neon.** Solid `bg-card` with hairline borders throughout. Active-row treatment is `bg-accent/40` (tint), unread weight is 500 vs 400 (Weight-Over-Size). The unread badge and DM FAB use `bg-foreground` / `text-background` so chrome stays achromatic.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` introduces 0 errors and 0 warnings on Phase 5 files (baseline 14 errors / 101 warnings stays at 9 errors / 100 warnings; the deltas come from non-Phase-5 files unrelated to this PR)
- [x] `bun run test:run src/components/mobile/channels/__tests__/` — 24 new vitest specs across 4 files, all passing
- [x] Full `bun run test:run` — 896 source tests pass + 24 new = 920 total. The single failure is `packages/mobile/.../RemoteDevApiClient.ts` tsconfig resolution, which is pre-existing and unrelated to web mobile
- [ ] Manual smoke on a real phone viewport: list → view → thread takeover → swipe-back; DM FAB → picker → open conversation; reduced-motion preference

Closes remote-dev-lyp3.

This pull request and its description were written by Isaac.