### PR TITLE
fix(mobile/session): wire wsUrl to MobileSessionView (closes remote-dev-8h39)

### DIFF
--- a/src/components/mobile/MobileApp.tsx
+++ b/src/components/mobile/MobileApp.tsx
@@ -214,11 +214,9 @@ export function MobileApp({ isGitHubConnected, initialUser }: MobileAppProps) {
 
   const sessionCtx = useSessionContext();
   const projectTree = useProjectTree();
-  // Resolve the terminal WebSocket URL once so MobileSessionView's
-  // useTerminalWebSocket hook receives the correct URL (the hook's default
-  // `ws://localhost:3001` is wrong on prod and on the standard dev port
-  // 6002). Shared with SessionManager via the same hook — see
-  // remote-dev-8h39.
+  // Shared resolver with SessionManager — without an explicit URL,
+  // MobileSessionView falls back to `ws://localhost:3001`, which is wrong
+  // on prod and on the standard 6002 dev port.
   const wsUrl = useTerminalWsUrl();
 
   const activeSession = useMemo(() => {

--- a/src/components/mobile/MobileApp.tsx
+++ b/src/components/mobile/MobileApp.tsx
@@ -63,6 +63,7 @@ import { toast } from "sonner";
 import { useProjectTree } from "@/contexts/ProjectTreeContext";
 import { useSessionContext } from "@/contexts/SessionContext";
 import { useChannelContextOptional } from "@/contexts/ChannelContext";
+import { useTerminalWsUrl } from "@/hooks/useTerminalWsUrl";
 
 import { MobileShell } from "./MobileShell";
 import type { MobileTab } from "./BottomTabBar";
@@ -213,6 +214,12 @@ export function MobileApp({ isGitHubConnected, initialUser }: MobileAppProps) {
 
   const sessionCtx = useSessionContext();
   const projectTree = useProjectTree();
+  // Resolve the terminal WebSocket URL once so MobileSessionView's
+  // useTerminalWebSocket hook receives the correct URL (the hook's default
+  // `ws://localhost:3001` is wrong on prod and on the standard dev port
+  // 6002). Shared with SessionManager via the same hook — see
+  // remote-dev-8h39.
+  const wsUrl = useTerminalWsUrl();
 
   const activeSession = useMemo(() => {
     const id = sessionCtx.activeSessionId;
@@ -366,6 +373,7 @@ export function MobileApp({ isGitHubConnected, initialUser }: MobileAppProps) {
           session={activeSession}
           projectName={projectName}
           activityStatus={sessionCtx.getAgentActivityStatus(activeSession.id)}
+          wsUrl={wsUrl}
           isRecording={false /* Phase 3 ships read-only; recording UI is Phase 6 */}
           hasRecordings={false}
           initialFontSize={initialFontSize}

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -52,6 +52,7 @@ import { cn } from "@/lib/utils";
 import type { TerminalWithKeyboardRef } from "@/components/terminal/TerminalWithKeyboard";
 import type { AgentActivityStatus } from "@/types/terminal-type";
 import { useAgentNotifications } from "@/hooks/useAgentNotifications";
+import { useTerminalWsUrl } from "@/hooks/useTerminalWsUrl";
 import { NotificationPanel } from "@/components/notifications/NotificationPanel";
 import { useNotificationContext, hydrateNotification } from "@/contexts/NotificationContext";
 import { dismissToastsForSession } from "@/lib/notification-toast";
@@ -218,19 +219,10 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
   const sessionsRef = useRef(sessions);
   useEffect(() => { sessionsRef.current = sessions; }, [sessions]);
 
-  // Compute WebSocket URL based on current location (supports cloudflared tunnels)
-  const wsUrl = useMemo(() => {
-    if (typeof window === "undefined") return "ws://localhost:3001";
-    const { protocol, hostname, port } = window.location;
-    const isLocalhost = hostname === "localhost" || hostname === "127.0.0.1";
-    if (isLocalhost) {
-      // Local development: use terminal server port directly
-      return `ws://localhost:${process.env.NEXT_PUBLIC_TERMINAL_PORT || "3001"}`;
-    }
-    // Remote access via tunnel: use /ws path (cloudflared routes to terminal server)
-    const wsProtocol = protocol === "https:" ? "wss:" : "ws:";
-    return `${wsProtocol}//${hostname}${port ? `:${port}` : ""}/ws`;
-  }, []);
+  // Compute WebSocket URL based on current location (supports cloudflared tunnels).
+  // Logic lives in `useTerminalWsUrl` so the mobile single-session view can
+  // share the exact same resolver — see remote-dev-8h39.
+  const wsUrl = useTerminalWsUrl();
 
   // Note: No longer need refs for keyboard handler - useEffectEvent handles this
 

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -219,9 +219,8 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
   const sessionsRef = useRef(sessions);
   useEffect(() => { sessionsRef.current = sessions; }, [sessions]);
 
-  // Compute WebSocket URL based on current location (supports cloudflared tunnels).
-  // Logic lives in `useTerminalWsUrl` so the mobile single-session view can
-  // share the exact same resolver — see remote-dev-8h39.
+  // Terminal WebSocket URL (handles localhost dev + cloudflared tunnels).
+  // Shared with MobileApp via `useTerminalWsUrl`.
   const wsUrl = useTerminalWsUrl();
 
   // Note: No longer need refs for keyboard handler - useEffectEvent handles this

--- a/src/hooks/__tests__/useTerminalWsUrl.test.ts
+++ b/src/hooks/__tests__/useTerminalWsUrl.test.ts
@@ -1,14 +1,7 @@
 /**
- * Tests for `useTerminalWsUrl` — verifies the resolver covers the four
- * deployment shapes the terminal WebSocket runs in:
- *   1. Localhost dev (uses NEXT_PUBLIC_TERMINAL_PORT, fallback 3001)
- *   2. Remote https tunnel (wss://hostname/ws)
- *   3. Remote http tunnel (ws://hostname/ws)
- *   4. SSR / `typeof window === "undefined"` (legacy ws://localhost:3001)
- *
- * Background: this hook was extracted from SessionManager because MobileApp
- * was not passing `wsUrl` into MobileSessionView, leaving the mobile
- * single-session view stuck on "Reconnecting" — see remote-dev-8h39.
+ * Tests for `useTerminalWsUrl` and the underlying `resolveTerminalWsUrl`.
+ * Covers the four deployment shapes the terminal WebSocket runs in:
+ * localhost dev, https tunnel, http tunnel, and SSR.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
@@ -19,7 +12,6 @@ import {
   resolveTerminalWsUrl,
 } from "@/hooks/useTerminalWsUrl";
 
-// Save the real `window.location` so we can restore it between tests.
 const REAL_LOCATION = window.location;
 
 function setLocation(opts: {
@@ -27,8 +19,7 @@ function setLocation(opts: {
   hostname: string;
   port?: string;
 }): void {
-  // happy-dom: window.location is read-only via assignment but we can
-  // replace it via Object.defineProperty.
+  // happy-dom: window.location is read-only via assignment; replace via defineProperty.
   Object.defineProperty(window, "location", {
     configurable: true,
     writable: true,
@@ -63,52 +54,55 @@ describe("useTerminalWsUrl", () => {
     }
   });
 
-  it("returns ws://localhost:<NEXT_PUBLIC_TERMINAL_PORT> on localhost", () => {
-    setLocation({ protocol: "http:", hostname: "localhost", port: "6001" });
-    const { result } = renderHook(() => useTerminalWsUrl());
-    expect(result.current).toBe("ws://localhost:6002");
-  });
+  const cases: Array<{
+    name: string;
+    location: { protocol: string; hostname: string; port?: string };
+    expected: string;
+  }> = [
+    {
+      name: "localhost uses NEXT_PUBLIC_TERMINAL_PORT",
+      location: { protocol: "http:", hostname: "localhost", port: "6001" },
+      expected: "ws://localhost:6002",
+    },
+    {
+      name: "127.0.0.1 is treated as localhost",
+      location: { protocol: "http:", hostname: "127.0.0.1", port: "6001" },
+      expected: "ws://localhost:6002",
+    },
+    {
+      name: "https tunnel without explicit port → wss://host/ws",
+      location: { protocol: "https:", hostname: "rdv.example.com" },
+      expected: "wss://rdv.example.com/ws",
+    },
+    {
+      name: "https tunnel with explicit port → wss://host:port/ws",
+      location: { protocol: "https:", hostname: "rdv.example.com", port: "8443" },
+      expected: "wss://rdv.example.com:8443/ws",
+    },
+    {
+      name: "http on non-localhost hostname → ws://host/ws",
+      location: { protocol: "http:", hostname: "rdv.lan" },
+      expected: "ws://rdv.lan/ws",
+    },
+  ];
 
-  it("treats 127.0.0.1 as localhost", () => {
-    setLocation({ protocol: "http:", hostname: "127.0.0.1", port: "6001" });
-    const { result } = renderHook(() => useTerminalWsUrl());
-    expect(result.current).toBe("ws://localhost:6002");
-  });
+  for (const { name, location, expected } of cases) {
+    it(name, () => {
+      setLocation(location);
+      const { result } = renderHook(() => useTerminalWsUrl());
+      expect(result.current).toBe(expected);
+    });
+  }
 
   it("falls back to port 3001 on localhost when NEXT_PUBLIC_TERMINAL_PORT is unset", () => {
     delete process.env.NEXT_PUBLIC_TERMINAL_PORT;
     setLocation({ protocol: "http:", hostname: "localhost", port: "6001" });
-    const { result } = renderHook(() => useTerminalWsUrl());
-    expect(result.current).toBe("ws://localhost:3001");
-  });
-
-  it("returns wss://<host>/ws over https (cloudflared tunnel, default port)", () => {
-    setLocation({ protocol: "https:", hostname: "rdv.example.com" });
-    const { result } = renderHook(() => useTerminalWsUrl());
-    expect(result.current).toBe("wss://rdv.example.com/ws");
-  });
-
-  it("returns wss://<host>:<port>/ws over https with an explicit port", () => {
-    setLocation({
-      protocol: "https:",
-      hostname: "rdv.example.com",
-      port: "8443",
-    });
-    const { result } = renderHook(() => useTerminalWsUrl());
-    expect(result.current).toBe("wss://rdv.example.com:8443/ws");
-  });
-
-  it("returns ws://<host>/ws over http on a non-localhost hostname", () => {
-    setLocation({ protocol: "http:", hostname: "rdv.lan" });
-    const { result } = renderHook(() => useTerminalWsUrl());
-    expect(result.current).toBe("ws://rdv.lan/ws");
+    expect(resolveTerminalWsUrl()).toBe("ws://localhost:3001");
   });
 
   it("returns the legacy ws://localhost:3001 placeholder during SSR", () => {
-    // We can't drive useMemo via renderHook with `window` undefined
-    // because React itself reads `window` during render. Instead we
-    // exercise the pure resolver — the hook is just `useMemo(resolve, [])`
-    // and the SSR branch lives entirely in `resolveTerminalWsUrl`.
+    // `renderHook` always provides a real `window`, so the SSR branch can
+    // only be exercised by calling the resolver with `window` stubbed out.
     vi.stubGlobal("window", undefined);
     try {
       expect(resolveTerminalWsUrl()).toBe("ws://localhost:3001");

--- a/src/hooks/__tests__/useTerminalWsUrl.test.ts
+++ b/src/hooks/__tests__/useTerminalWsUrl.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for `useTerminalWsUrl` — verifies the resolver covers the four
+ * deployment shapes the terminal WebSocket runs in:
+ *   1. Localhost dev (uses NEXT_PUBLIC_TERMINAL_PORT, fallback 3001)
+ *   2. Remote https tunnel (wss://hostname/ws)
+ *   3. Remote http tunnel (ws://hostname/ws)
+ *   4. SSR / `typeof window === "undefined"` (legacy ws://localhost:3001)
+ *
+ * Background: this hook was extracted from SessionManager because MobileApp
+ * was not passing `wsUrl` into MobileSessionView, leaving the mobile
+ * single-session view stuck on "Reconnecting" — see remote-dev-8h39.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import {
+  useTerminalWsUrl,
+  resolveTerminalWsUrl,
+} from "@/hooks/useTerminalWsUrl";
+
+// Save the real `window.location` so we can restore it between tests.
+const REAL_LOCATION = window.location;
+
+function setLocation(opts: {
+  protocol: string;
+  hostname: string;
+  port?: string;
+}): void {
+  // happy-dom: window.location is read-only via assignment but we can
+  // replace it via Object.defineProperty.
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    writable: true,
+    value: {
+      ...REAL_LOCATION,
+      protocol: opts.protocol,
+      hostname: opts.hostname,
+      port: opts.port ?? "",
+      host: opts.port ? `${opts.hostname}:${opts.port}` : opts.hostname,
+      href: `${opts.protocol}//${opts.hostname}${opts.port ? `:${opts.port}` : ""}/`,
+    },
+  });
+}
+
+describe("useTerminalWsUrl", () => {
+  const originalEnv = process.env.NEXT_PUBLIC_TERMINAL_PORT;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_TERMINAL_PORT = "6002";
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: REAL_LOCATION,
+    });
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_TERMINAL_PORT;
+    } else {
+      process.env.NEXT_PUBLIC_TERMINAL_PORT = originalEnv;
+    }
+  });
+
+  it("returns ws://localhost:<NEXT_PUBLIC_TERMINAL_PORT> on localhost", () => {
+    setLocation({ protocol: "http:", hostname: "localhost", port: "6001" });
+    const { result } = renderHook(() => useTerminalWsUrl());
+    expect(result.current).toBe("ws://localhost:6002");
+  });
+
+  it("treats 127.0.0.1 as localhost", () => {
+    setLocation({ protocol: "http:", hostname: "127.0.0.1", port: "6001" });
+    const { result } = renderHook(() => useTerminalWsUrl());
+    expect(result.current).toBe("ws://localhost:6002");
+  });
+
+  it("falls back to port 3001 on localhost when NEXT_PUBLIC_TERMINAL_PORT is unset", () => {
+    delete process.env.NEXT_PUBLIC_TERMINAL_PORT;
+    setLocation({ protocol: "http:", hostname: "localhost", port: "6001" });
+    const { result } = renderHook(() => useTerminalWsUrl());
+    expect(result.current).toBe("ws://localhost:3001");
+  });
+
+  it("returns wss://<host>/ws over https (cloudflared tunnel, default port)", () => {
+    setLocation({ protocol: "https:", hostname: "rdv.example.com" });
+    const { result } = renderHook(() => useTerminalWsUrl());
+    expect(result.current).toBe("wss://rdv.example.com/ws");
+  });
+
+  it("returns wss://<host>:<port>/ws over https with an explicit port", () => {
+    setLocation({
+      protocol: "https:",
+      hostname: "rdv.example.com",
+      port: "8443",
+    });
+    const { result } = renderHook(() => useTerminalWsUrl());
+    expect(result.current).toBe("wss://rdv.example.com:8443/ws");
+  });
+
+  it("returns ws://<host>/ws over http on a non-localhost hostname", () => {
+    setLocation({ protocol: "http:", hostname: "rdv.lan" });
+    const { result } = renderHook(() => useTerminalWsUrl());
+    expect(result.current).toBe("ws://rdv.lan/ws");
+  });
+
+  it("returns the legacy ws://localhost:3001 placeholder during SSR", () => {
+    // We can't drive useMemo via renderHook with `window` undefined
+    // because React itself reads `window` during render. Instead we
+    // exercise the pure resolver — the hook is just `useMemo(resolve, [])`
+    // and the SSR branch lives entirely in `resolveTerminalWsUrl`.
+    vi.stubGlobal("window", undefined);
+    try {
+      expect(resolveTerminalWsUrl()).toBe("ws://localhost:3001");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/src/hooks/useTerminalWsUrl.ts
+++ b/src/hooks/useTerminalWsUrl.ts
@@ -1,0 +1,43 @@
+"use client";
+
+/**
+ * useTerminalWsUrl — shared resolver for the terminal WebSocket URL.
+ *
+ * Computes the URL based on `window.location` so the same logic works for:
+ *   - Localhost development (uses `NEXT_PUBLIC_TERMINAL_PORT`, fallback 3001)
+ *   - Remote access via cloudflared (https → wss, http → ws, `/ws` path)
+ *   - SSR (returns the legacy `ws://localhost:3001` placeholder which is
+ *     immediately replaced on hydration via `useMemo`)
+ *
+ * Extracted from {@link SessionManager} so the mobile single-session view
+ * can reuse the exact same logic — previously {@link MobileApp} did not
+ * pass `wsUrl` to {@link MobileSessionView}, so the hook default
+ * (`ws://localhost:3001`) was used and the connection failed on every
+ * deployment that wasn't dev (no localhost from a phone, wrong port on
+ * localhost dev where the project default is 6002).
+ */
+
+import { useMemo } from "react";
+
+/**
+ * Pure resolver — exported separately so the SSR branch can be unit-tested
+ * without rendering a hook (renderHook needs a real `window`, so we'd
+ * never be able to exercise the `typeof window === "undefined"` branch
+ * via renderHook alone).
+ */
+export function resolveTerminalWsUrl(): string {
+  if (typeof window === "undefined") return "ws://localhost:3001";
+  const { protocol, hostname, port } = window.location;
+  const isLocalhost = hostname === "localhost" || hostname === "127.0.0.1";
+  if (isLocalhost) {
+    // Local development: use terminal server port directly
+    return `ws://localhost:${process.env.NEXT_PUBLIC_TERMINAL_PORT || "3001"}`;
+  }
+  // Remote access via tunnel: use /ws path (cloudflared routes to terminal server)
+  const wsProtocol = protocol === "https:" ? "wss:" : "ws:";
+  return `${wsProtocol}//${hostname}${port ? `:${port}` : ""}/ws`;
+}
+
+export function useTerminalWsUrl(): string {
+  return useMemo(() => resolveTerminalWsUrl(), []);
+}

--- a/src/hooks/useTerminalWsUrl.ts
+++ b/src/hooks/useTerminalWsUrl.ts
@@ -1,43 +1,33 @@
 "use client";
 
 /**
- * useTerminalWsUrl — shared resolver for the terminal WebSocket URL.
+ * Resolves the terminal WebSocket URL from `window.location`:
+ *   - Localhost dev → `ws://localhost:${NEXT_PUBLIC_TERMINAL_PORT ?? 3001}`
+ *   - Remote (cloudflared tunnel) → `wss?://<host>[:port]/ws`
+ *   - SSR → `ws://localhost:3001` placeholder (replaced on hydration)
  *
- * Computes the URL based on `window.location` so the same logic works for:
- *   - Localhost development (uses `NEXT_PUBLIC_TERMINAL_PORT`, fallback 3001)
- *   - Remote access via cloudflared (https → wss, http → ws, `/ws` path)
- *   - SSR (returns the legacy `ws://localhost:3001` placeholder which is
- *     immediately replaced on hydration via `useMemo`)
- *
- * Extracted from {@link SessionManager} so the mobile single-session view
- * can reuse the exact same logic — previously {@link MobileApp} did not
- * pass `wsUrl` to {@link MobileSessionView}, so the hook default
- * (`ws://localhost:3001`) was used and the connection failed on every
- * deployment that wasn't dev (no localhost from a phone, wrong port on
- * localhost dev where the project default is 6002).
+ * Shared between `SessionManager` and `MobileApp` so both views resolve
+ * the URL identically.
  */
 
 import { useMemo } from "react";
 
 /**
- * Pure resolver — exported separately so the SSR branch can be unit-tested
- * without rendering a hook (renderHook needs a real `window`, so we'd
- * never be able to exercise the `typeof window === "undefined"` branch
- * via renderHook alone).
+ * Pure resolver, exported for unit tests — `renderHook` requires a real
+ * `window`, so the SSR branch can only be exercised by calling this
+ * directly with `window` stubbed out.
  */
 export function resolveTerminalWsUrl(): string {
   if (typeof window === "undefined") return "ws://localhost:3001";
   const { protocol, hostname, port } = window.location;
   const isLocalhost = hostname === "localhost" || hostname === "127.0.0.1";
   if (isLocalhost) {
-    // Local development: use terminal server port directly
     return `ws://localhost:${process.env.NEXT_PUBLIC_TERMINAL_PORT || "3001"}`;
   }
-  // Remote access via tunnel: use /ws path (cloudflared routes to terminal server)
   const wsProtocol = protocol === "https:" ? "wss:" : "ws:";
   return `${wsProtocol}//${hostname}${port ? `:${port}` : ""}/ws`;
 }
 
 export function useTerminalWsUrl(): string {
-  return useMemo(() => resolveTerminalWsUrl(), []);
+  return useMemo(resolveTerminalWsUrl, []);
 }


### PR DESCRIPTION
## Summary

- `MobileApp` wasn't passing `wsUrl` into `MobileSessionView`, so the underlying `useTerminalWebSocket` hook fell back to its default `ws://localhost:3001`. That URL is wrong on every deployment that isn't dev (no localhost from a phone over the tunnel) and on localhost dev where the project's terminal server runs on port 6002, not 3001 — leaving the mobile single-session view stuck on "Reconnecting…".
- Extracted the existing inline resolver from `SessionManager.tsx` into a shared `useTerminalWsUrl` hook (plus a pure `resolveTerminalWsUrl` for testability). `SessionManager` now consumes the hook; `MobileApp` consumes it too and threads `wsUrl` into `MobileSessionView`.
- Added unit tests for all four code paths.

## Decisions

- **Why a shared hook instead of inlining the logic in `MobileApp`?** Two callers, one branchy resolver — keep it DRY so the next deployment shape (e.g. an SSR path that ends up in a mobile context) only has to change in one place.
- **Why a separate pure `resolveTerminalWsUrl` export?** `useMemo` requires `window` to render, so the SSR branch (`typeof window === "undefined"`) can't be exercised via `renderHook` in happy-dom. Extracting the resolver lets the SSR test stub `window` and call the function directly.
- **Did NOT change the `3001` default literal in `useTerminalWebSocket`** — per the issue, that's the legacy fallback; the fix is to make mobile use the hook, not change the port.
- **`MobileSessionView`'s `wsUrl` prop stays optional** so existing tests that don't pass it still compile.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` — no new errors (9 pre-existing errors in `SessionsTab.tsx` / `useSwipeAction.ts` already on master)
- [x] `bun run test:run src/hooks/__tests__/useTerminalWsUrl.test.ts` — all 7 tests pass
- [x] `bun run test:run` — 1045 tests passing, only pre-existing `tests/mobile/restart-agent-api-client.test.ts` tsconfig failure remains (also failing on master, unrelated)
- [ ] Manual: open mobile session view on a remote (cloudflared) deployment and confirm it connects instead of hanging on "Reconnecting…"
- [ ] Manual: open mobile session view on localhost dev (port 6002) and confirm same

Fixes mobile "Reconnecting" loop.

Closes remote-dev-8h39