### PR TITLE
fix(mobile/session): dynamic cols/rows + respect font preferences

### DIFF
--- a/src/components/mobile/session/MobileSessionView.tsx
+++ b/src/components/mobile/session/MobileSessionView.tsx
@@ -30,6 +30,7 @@ import AnsiToHtml from "ansi-to-html";
 import { cn } from "@/lib/utils";
 import { AnsiStripper } from "@/lib/terminal/ansi-stripper";
 import { useTerminalTheme } from "@/contexts/AppearanceContext";
+import { usePreferencesContext } from "@/contexts/PreferencesContext";
 import { useSessionContext } from "@/contexts/SessionContext";
 import { useTerminalWebSocket } from "@/hooks/useTerminalWebSocket";
 import { usePrefersReducedMotion } from "@/hooks/useMobile";
@@ -48,14 +49,14 @@ import {
 import { SmartKeyStrip } from "./SmartKeyStrip";
 import { useModifierLatch } from "./useModifierLatch";
 import { usePinchZoom } from "./usePinchZoom";
+import { useViewportDimensions } from "./useViewportDimensions";
 import { SessionMetadataSheet } from "./SessionMetadataSheet";
 
 const MAX_OUTPUT_ENTRIES = 2000;
-const MOBILE_COLS = 120;
-const MOBILE_ROWS = 24;
 const FONT_SIZE_MIN = 9;
 const FONT_SIZE_MAX = 22;
 const DEFAULT_FONT_SIZE = 12;
+const DEFAULT_FONT_FAMILY = "'JetBrainsMono Nerd Font Mono', monospace";
 
 interface OutputEntry {
   id: number;
@@ -115,7 +116,11 @@ export interface MobileSessionViewProps {
   isRecording?: boolean;
   hasRecordings?: boolean;
   environmentVars?: Record<string, string> | null;
-  /** Initial mono font size in px; persists between mounts when supplied. */
+  /**
+   * Initial mono font size in px; persists between mounts when supplied.
+   * When `undefined` (e.g. localStorage unset on first load) the view
+   * seeds from `usePreferencesContext().currentPreferences.fontSize`.
+   */
   initialFontSize?: number;
   /** Called after a pinch gesture commits a new size. */
   onPersistFontSize?: (size: number) => void;
@@ -141,7 +146,7 @@ export function MobileSessionView({
   isRecording = false,
   hasRecordings = false,
   environmentVars,
-  initialFontSize = DEFAULT_FONT_SIZE,
+  initialFontSize,
   onPersistFontSize,
   onBack,
   onSuspend,
@@ -152,6 +157,8 @@ export function MobileSessionView({
   const reducedMotion = usePrefersReducedMotion();
   const theme = useTerminalTheme();
   const sessionCtx = useSessionContext();
+  const { currentPreferences } = usePreferencesContext();
+  const fontFamily = currentPreferences.fontFamily || DEFAULT_FONT_FAMILY;
 
   const liveRegionId = useId();
 
@@ -172,9 +179,19 @@ export function MobileSessionView({
   const [isRestarting, setIsRestarting] = useState(false);
   const [metadataOpen, setMetadataOpen] = useState(false);
 
-  // Font-size (pinch zoom). Clamp incoming initial value.
+  // Font-size (pinch zoom). Source priority on first mount:
+  //   1. `initialFontSize` prop (localStorage-backed via MobileApp)
+  //   2. user-level preference `fontSize`
+  //   3. DEFAULT_FONT_SIZE
+  // Subsequent updates come exclusively from pinch-to-zoom; we do NOT
+  // re-seed from prefs (preventing a desktop preference change from
+  // surprising a mobile user mid-session).
   const [fontSize, setFontSize] = useState<number>(() => {
-    return Math.max(FONT_SIZE_MIN, Math.min(FONT_SIZE_MAX, initialFontSize));
+    const seed =
+      initialFontSize ??
+      currentPreferences.fontSize ??
+      DEFAULT_FONT_SIZE;
+    return Math.max(FONT_SIZE_MIN, Math.min(FONT_SIZE_MAX, seed));
   });
   const fontSizeBaselineRef = useRef<number>(fontSize);
 
@@ -185,6 +202,16 @@ export function MobileSessionView({
   useEffect(() => {
     converterRef.current = createAnsiConverter(theme);
   }, [theme]);
+
+  // ── Viewport-driven cols/rows ───────────────────────────────────────────
+  // PTY/tmux dimensions are recomputed from the rendered viewport's pixel
+  // size and the current mono font. Updates on viewport resize (soft
+  // keyboard, rotation), font-family change (preferences), and font-size
+  // change (pinch zoom). Sent to the server via `sendResize` below.
+  const { ref: viewportRef, dimensions } = useViewportDimensions({
+    fontFamily,
+    fontSize,
+  });
 
   // ── Modifier latch ──────────────────────────────────────────────────────
   const latch = useModifierLatch();
@@ -238,11 +265,20 @@ export function MobileSessionView({
   }, [theme]);
 
   // ── WebSocket connection ────────────────────────────────────────────────
+  // Snapshot the *initial* dimensions for the WebSocket URL params. The
+  // hook re-establishes the connection when these change, which we don't
+  // want — runtime resizes are sent via `sendResize` instead. We freeze
+  // the values at first mount via lazy `useState` initializers (read-
+  // during-render ref values trip the react-hooks/refs rule).
+  const [initialCols] = useState(() => dimensions.cols);
+  const [initialRows] = useState(() => dimensions.rows);
+
   const {
     wsRef,
     status,
     authError,
     sendInput,
+    sendResize,
     sendRestartAgent,
   } = useTerminalWebSocket({
     sessionId: session.id,
@@ -252,8 +288,8 @@ export function MobileSessionView({
     terminalType: session.terminalType ?? "shell",
     tmuxHistoryLimit,
     environmentVars,
-    initialCols: MOBILE_COLS,
-    initialRows: MOBILE_ROWS,
+    initialCols,
+    initialRows,
     notificationsEnabled,
     sessionName: session.name,
     onOutput: handleOutput,
@@ -261,6 +297,24 @@ export function MobileSessionView({
     onAgentRestarted: handleAgentRestarted,
     onStatusMessage: handleStatusMessage,
   });
+
+  // Send a `resize` message to the server whenever the computed cols/rows
+  // change. The first emission (matching initialCols/initialRows) is
+  // skipped — the server already has those from the URL — but we send on
+  // any subsequent change once the socket is connected.
+  const lastSentDimsRef = useRef<{ cols: number; rows: number } | null>(null);
+  useEffect(() => {
+    if (status !== "connected") return;
+    if (lastSentDimsRef.current === null) {
+      // First connection — server already has the URL-param dims. Mark
+      // the baseline so subsequent diffs only fire on real changes.
+      lastSentDimsRef.current = { cols: initialCols, rows: initialRows };
+    }
+    const last = lastSentDimsRef.current;
+    if (last.cols === dimensions.cols && last.rows === dimensions.rows) return;
+    sendResize(dimensions.cols, dimensions.rows);
+    lastSentDimsRef.current = { cols: dimensions.cols, rows: dimensions.rows };
+  }, [status, dimensions.cols, dimensions.rows, sendResize, initialCols, initialRows]);
 
   // ── Auto-scroll ─────────────────────────────────────────────────────────
   const scrollToBottom = useCallback(() => {
@@ -415,10 +469,13 @@ export function MobileSessionView({
         ref={(node) => {
           scrollRef.current = node;
           pinch.ref(node);
+          viewportRef(node);
         }}
         onScroll={handleScroll}
         data-testid="mobile-session-output"
         data-font-size={fontSize}
+        data-cols={dimensions.cols}
+        data-rows={dimensions.rows}
         className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden"
         style={{
           backgroundColor: outputBg,
@@ -430,7 +487,7 @@ export function MobileSessionView({
         <pre
           className="p-2 leading-relaxed font-mono whitespace-pre-wrap break-words min-h-full"
           style={{
-            fontFamily: "'JetBrainsMono Nerd Font Mono', monospace",
+            fontFamily,
             fontSize: `${fontSize}px`,
           }}
         >

--- a/src/components/mobile/session/__tests__/MobileSessionView.resize.test.tsx
+++ b/src/components/mobile/session/__tests__/MobileSessionView.resize.test.tsx
@@ -1,0 +1,436 @@
+/**
+ * MobileSessionView resize + font preferences tests.
+ *
+ * Covers the fixes for remote-dev-vexb:
+ *   1. ResizeObserver fires → `sendResize` is called with computed
+ *      cols/rows.
+ *   2. Pinch-to-zoom (fontSize change) → `sendResize` is called and
+ *      smaller font produces more cols.
+ *   3. Min cols/rows floor (cols ≥ 20, rows ≥ 5) for tiny viewports.
+ *   4. `fontFamily` from `PreferencesContext` is applied to the `<pre>`
+ *      block style.
+ *   5. Initial fontSize falls back to `prefs.fontSize` when no
+ *      `initialFontSize` prop is supplied.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+
+import { MobileSessionView } from "@/components/mobile/session/MobileSessionView";
+import { clearCharWidthCacheForTesting } from "@/components/mobile/session/useViewportDimensions";
+import type { TerminalSession } from "@/types/session";
+
+// ── ResizeObserver mock ───────────────────────────────────────────────
+// happy-dom doesn't ship ResizeObserver. Capture the latest registered
+// instance so tests can manually trigger it with synthetic dimensions.
+
+class MockResizeObserver {
+  callback: ResizeObserverCallback;
+  observed: Element | null = null;
+  observe = vi.fn((target: Element) => {
+    this.observed = target;
+  });
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  constructor(cb: ResizeObserverCallback) {
+    this.callback = cb;
+    MockResizeObserver.last = this;
+  }
+  trigger(width: number, height: number) {
+    const entry = {
+      contentRect: { width, height } as DOMRectReadOnly,
+      target: this.observed ?? document.body,
+    } as unknown as ResizeObserverEntry;
+    this.callback([entry], this as unknown as ResizeObserver);
+  }
+  static last: MockResizeObserver | null = null;
+}
+
+(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+  MockResizeObserver as unknown as typeof ResizeObserver;
+
+// ── Stub element-size measurement ─────────────────────────────────────
+// happy-dom returns 0×0 for getBoundingClientRect. We monkey-patch it
+// so that:
+//   - the off-screen `<span>` measurement returns a width proportional
+//     to the rendered text length × the styled font-size × 0.6 (a
+//     reasonable mono-font heuristic), and
+//   - the viewport `<div>` returns the dimensions stashed via
+//     `setMockViewportSize`.
+// This produces deterministic cols/rows the tests can reason about.
+
+const VIEWPORT_TESTID = "mobile-session-output";
+let mockViewportSize: { width: number; height: number } = {
+  width: 600,
+  height: 800,
+};
+
+function setMockViewportSize(width: number, height: number) {
+  mockViewportSize = { width, height };
+}
+
+const originalGetBCR = Element.prototype.getBoundingClientRect;
+
+function installRectStub() {
+  Element.prototype.getBoundingClientRect = function (this: Element) {
+    if (
+      this instanceof HTMLElement &&
+      this.dataset?.testid === VIEWPORT_TESTID
+    ) {
+      const { width, height } = mockViewportSize;
+      return {
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: width,
+        bottom: height,
+        width,
+        height,
+        toJSON: () => ({}),
+      } as DOMRect;
+    }
+    if (this instanceof HTMLElement && this.tagName === "SPAN") {
+      // Off-screen char-width probe span.
+      const text = this.textContent ?? "";
+      const fontSizeStr = this.style.fontSize || "12px";
+      const fs = parseFloat(fontSizeStr);
+      const charW = fs * 0.6;
+      const width = text.length * charW;
+      return {
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: width,
+        bottom: fs,
+        width,
+        height: fs,
+        toJSON: () => ({}),
+      } as DOMRect;
+    }
+    return originalGetBCR.call(this);
+  };
+}
+
+function uninstallRectStub() {
+  Element.prototype.getBoundingClientRect = originalGetBCR;
+}
+
+// ── Hook + context mocks ──────────────────────────────────────────────
+
+const sendResize = vi.fn();
+let mockStatus: "connected" | "connecting" = "connected";
+
+vi.mock("@/hooks/useTerminalWebSocket", () => ({
+  useTerminalWebSocket: ({
+    initialCols,
+    initialRows,
+  }: {
+    initialCols: number;
+    initialRows: number;
+  }) => {
+    // Expose initialCols/initialRows for assertions via a side channel.
+    (
+      globalThis as unknown as {
+        __lastInitialDims: { cols: number; rows: number };
+      }
+    ).__lastInitialDims = { cols: initialCols, rows: initialRows };
+    return {
+      wsRef: { current: null },
+      status: mockStatus,
+      authError: null,
+      sendInput: vi.fn(),
+      sendResize,
+      sendRestartAgent: vi.fn(),
+      markIntentionalExit: vi.fn(),
+    };
+  },
+}));
+
+vi.mock("@/contexts/AppearanceContext", () => ({
+  useTerminalTheme: () => ({
+    background: "#000000",
+    foreground: "#ffffff",
+    opacity: 100,
+    black: "#000000",
+    red: "#ff0000",
+    green: "#00ff00",
+    yellow: "#ffff00",
+    blue: "#0000ff",
+    magenta: "#ff00ff",
+    cyan: "#00ffff",
+    white: "#ffffff",
+    brightBlack: "#444444",
+    brightRed: "#ff4444",
+    brightGreen: "#44ff44",
+    brightYellow: "#ffff44",
+    brightBlue: "#4444ff",
+    brightMagenta: "#ff44ff",
+    brightCyan: "#44ffff",
+    brightWhite: "#ffffff",
+  }),
+}));
+
+vi.mock("@/hooks/useMobile", () => ({
+  usePrefersReducedMotion: () => false,
+}));
+
+vi.mock("@/contexts/SessionContext", () => ({
+  useSessionContext: () => ({
+    activeSessionId: "session-1",
+    getAgentActivityStatus: () => "idle",
+  }),
+}));
+
+let mockPreferences: { fontFamily: string | null; fontSize: number | null } = {
+  fontFamily: "MockMono, monospace",
+  fontSize: 14,
+};
+
+vi.mock("@/contexts/PreferencesContext", () => ({
+  usePreferencesContext: () => ({
+    currentPreferences: {
+      fontFamily: mockPreferences.fontFamily,
+      fontSize: mockPreferences.fontSize,
+    },
+  }),
+}));
+
+// Replace heavy children with thin stubs so we don't need to wire all
+// their dependencies. We only care about the output viewport + resize
+// behavior in this file.
+vi.mock("@/components/terminal/MobileInputBar", () => ({
+  MobileInputBar: () => <div data-testid="stub-input-bar" />,
+}));
+vi.mock("@/components/terminal/AgentExitScreen", () => ({
+  AgentExitScreen: () => null,
+}));
+vi.mock("@/components/terminal/AuthErrorOverlay", () => ({
+  AuthErrorOverlay: () => null,
+}));
+vi.mock("@/components/mobile/session/SmartKeyStrip", () => ({
+  SmartKeyStrip: () => <div data-testid="stub-smart-key-strip" />,
+}));
+vi.mock("@/components/mobile/session/SessionStatusBar", () => ({
+  SessionStatusBar: () => <div data-testid="stub-status-bar" />,
+}));
+vi.mock("@/components/mobile/session/SessionMetadataSheet", () => ({
+  SessionMetadataSheet: () => null,
+}));
+vi.mock("@/components/mobile/session/usePinchZoom", () => ({
+  // Expose the onScale hook to tests via window so we can simulate a
+  // pinch-driven font-size change without dispatching real touch events.
+  usePinchZoom: (opts: {
+    onScale?: (factor: number) => void;
+    onScaleCommit?: (factor: number) => void;
+  }) => {
+    (
+      globalThis as unknown as {
+        __pinch: typeof opts;
+      }
+    ).__pinch = opts;
+    return { ref: () => {} };
+  },
+}));
+vi.mock("@/components/mobile/session/useModifierLatch", () => ({
+  useModifierLatch: () => ({
+    state: { ctrl: false, alt: false, shift: false, meta: false },
+    anyActive: false,
+    toggle: vi.fn(),
+    consume: vi.fn(),
+    resolveKey: (k: string) => k,
+  }),
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────
+
+const baseSession: TerminalSession = {
+  id: "session-1",
+  name: "test-session",
+  tmuxSessionName: "rdv-test",
+  status: "active",
+  terminalType: "shell",
+  projectId: null,
+  projectPath: "/tmp",
+  agentRestartCount: 0,
+} as unknown as TerminalSession;
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function renderView(props: Partial<React.ComponentProps<typeof MobileSessionView>> = {}) {
+  return render(
+    <MobileSessionView
+      session={baseSession}
+      activityStatus="idle"
+      {...props}
+    />
+  );
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────
+
+beforeEach(() => {
+  installRectStub();
+  sendResize.mockReset();
+  clearCharWidthCacheForTesting();
+  mockStatus = "connected";
+  mockPreferences = { fontFamily: "MockMono, monospace", fontSize: 14 };
+  setMockViewportSize(600, 800);
+  MockResizeObserver.last = null;
+});
+
+afterEach(() => {
+  cleanup();
+  uninstallRectStub();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("MobileSessionView, resize", () => {
+  it("sends sendResize with new dims when ResizeObserver fires", async () => {
+    renderView({ initialFontSize: 14 });
+
+    // Wait one microtask for the connected-status effect to settle the
+    // baseline.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const observer = MockResizeObserver.last;
+    expect(observer).not.toBeNull();
+
+    // Trigger a viewport size change. With fontSize 14:
+    //   charW = 14 * 0.6 = 8.4
+    //   lineH = 14 * 1.625 = 22.75
+    //   usableWidth  = 1200 - 16 = 1184  → cols = floor(1184 / 8.4) = 140
+    //   usableHeight = 600 - 16 = 584    → rows = floor(584 / 22.75) = 25
+    setMockViewportSize(1200, 600);
+    act(() => {
+      observer!.trigger(1200, 600);
+    });
+
+    // The resize is debounced (~75ms). Advance time + flush.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    expect(sendResize).toHaveBeenCalled();
+    const call = sendResize.mock.calls[sendResize.mock.calls.length - 1];
+    expect(call[0]).toBe(140);
+    expect(call[1]).toBe(25);
+  });
+
+  it("recomputes cols when fontSize changes (smaller font → more cols)", async () => {
+    renderView({ initialFontSize: 14 });
+
+    // Seed an initial viewport so we have a non-trivial baseline.
+    setMockViewportSize(800, 600);
+    const observer = MockResizeObserver.last;
+    act(() => {
+      observer?.trigger(800, 600);
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    sendResize.mockClear();
+
+    // Simulate a pinch that halves the font (factor 0.5 of baseline 14
+    // → clamped to FONT_SIZE_MIN = 9 by the view).
+    const pinch = (
+      globalThis as unknown as {
+        __pinch?: { onScale?: (factor: number) => void };
+      }
+    ).__pinch;
+    expect(pinch?.onScale).toBeDefined();
+
+    act(() => {
+      pinch!.onScale!(0.5);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    // With smaller fontSize the same viewport produces more cols.
+    expect(sendResize).toHaveBeenCalled();
+    const last = sendResize.mock.calls[sendResize.mock.calls.length - 1];
+    // fontSize 9 → charW 5.4 → cols = floor((800-16)/5.4) = 145
+    expect(last[0]).toBe(145);
+    // rows = floor((600-16)/(9*1.625)) = floor(584/14.625) = 39
+    expect(last[1]).toBe(39);
+  });
+
+  it("floors cols ≥ 20 and rows ≥ 5 for tiny viewports", async () => {
+    renderView({ initialFontSize: 16 });
+
+    const observer = MockResizeObserver.last;
+    setMockViewportSize(50, 30);
+    act(() => {
+      observer?.trigger(50, 30);
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    // Even though the viewport math would produce single-digit cols/rows,
+    // the floor kicks in.
+    if (sendResize.mock.calls.length > 0) {
+      const last = sendResize.mock.calls[sendResize.mock.calls.length - 1];
+      expect(last[0]).toBeGreaterThanOrEqual(20);
+      expect(last[1]).toBeGreaterThanOrEqual(5);
+    }
+
+    // The data attributes on the viewport always reflect the floored
+    // values regardless of whether the resize message was sent.
+    const viewport = screen.getByTestId(VIEWPORT_TESTID);
+    expect(Number(viewport.getAttribute("data-cols"))).toBeGreaterThanOrEqual(
+      20
+    );
+    expect(Number(viewport.getAttribute("data-rows"))).toBeGreaterThanOrEqual(
+      5
+    );
+  });
+});
+
+describe("MobileSessionView, font preferences", () => {
+  it("applies fontFamily from PreferencesContext to the <pre> block", () => {
+    mockPreferences = { fontFamily: "Custom Font, monospace", fontSize: 14 };
+    renderView({ initialFontSize: 14 });
+
+    const viewport = screen.getByTestId(VIEWPORT_TESTID);
+    const pre = viewport.querySelector("pre");
+    expect(pre).not.toBeNull();
+    // jsdom/happy-dom serialize fontFamily into the inline style.
+    expect(pre!.style.fontFamily).toContain("Custom Font");
+  });
+
+  it("falls back to a default fontFamily when prefs.fontFamily is null", () => {
+    mockPreferences = { fontFamily: null, fontSize: 14 };
+    renderView({ initialFontSize: 14 });
+
+    const viewport = screen.getByTestId(VIEWPORT_TESTID);
+    const pre = viewport.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre!.style.fontFamily).toContain("JetBrainsMono");
+  });
+
+  it("seeds initial fontSize from prefs.fontSize when initialFontSize is undefined", () => {
+    mockPreferences = { fontFamily: "MockMono, monospace", fontSize: 18 };
+    // No initialFontSize prop → should fall back to prefs.fontSize (18).
+    renderView();
+
+    const viewport = screen.getByTestId(VIEWPORT_TESTID);
+    expect(viewport.getAttribute("data-font-size")).toBe("18");
+  });
+
+  it("prefers initialFontSize over prefs.fontSize when both are supplied", () => {
+    mockPreferences = { fontFamily: "MockMono, monospace", fontSize: 18 };
+    renderView({ initialFontSize: 11 });
+
+    const viewport = screen.getByTestId(VIEWPORT_TESTID);
+    expect(viewport.getAttribute("data-font-size")).toBe("11");
+  });
+});
+

--- a/src/components/mobile/session/useViewportDimensions.ts
+++ b/src/components/mobile/session/useViewportDimensions.ts
@@ -1,0 +1,228 @@
+"use client";
+
+/**
+ * useViewportDimensions, Phase 3 mobile session view.
+ *
+ * Computes terminal cols/rows from the rendered viewport's pixel size
+ * and the current mono font (family + size). Recomputes on:
+ *   - viewport resize (ResizeObserver — soft keyboard show/hide,
+ *     orientation rotation, etc.)
+ *   - fontFamily / fontSize change (pinch-to-zoom, preference update)
+ *
+ * Char-width is measured by rendering an off-screen `<span>` with a
+ * known character count in the same font/size and reading the actual
+ * `getBoundingClientRect().width / charCount`. Results are cached per
+ * (fontFamily, fontSize) tuple in module scope so that quick toggles
+ * don't re-measure.
+ *
+ * Notifications are debounced (75ms trailing) so a pinch gesture
+ * doesn't spam dependent effects (e.g. WebSocket resize messages).
+ *
+ * Floors:
+ *   - cols ≥ 20
+ *   - rows ≥ 5
+ *
+ * Tiny viewports (e.g. inline iframe previews on dev tools) won't
+ * produce a 0×0 PTY which would otherwise break tmux.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const MIN_COLS = 20;
+const MIN_ROWS = 5;
+const DEBOUNCE_MS = 75;
+/**
+ * Tailwind's `leading-relaxed` resolves to line-height 1.625; the `<pre>`
+ * block in MobileSessionView uses that class. Keep this in sync with the
+ * className on that element.
+ */
+const LINE_HEIGHT_RATIO = 1.625;
+/**
+ * Padding on the `<pre>` block (`p-2` = 0.5rem ≈ 8px) on each side.
+ * Subtracted from the available width / height before computing cols /
+ * rows so we don't try to render content into the padding.
+ */
+const PRE_PADDING_PX = 8;
+
+const charWidthCache = new Map<string, number>();
+
+/** Measure char width by rendering an off-screen span. Cached. */
+export function measureCharWidth(
+  fontFamily: string,
+  fontSize: number,
+  doc: Document = document
+): number {
+  const key = `${fontFamily}|${fontSize}`;
+  const cached = charWidthCache.get(key);
+  if (cached !== undefined) return cached;
+
+  const span = doc.createElement("span");
+  span.textContent = "M".repeat(20);
+  span.style.fontFamily = fontFamily;
+  span.style.fontSize = `${fontSize}px`;
+  // Match the `<pre>` block: same whitespace, no kerning/ligature
+  // weirdness.
+  span.style.fontVariantLigatures = "none";
+  span.style.whiteSpace = "pre";
+  span.style.position = "absolute";
+  span.style.left = "-9999px";
+  span.style.top = "-9999px";
+  span.style.visibility = "hidden";
+  span.style.pointerEvents = "none";
+  span.setAttribute("aria-hidden", "true");
+  doc.body.appendChild(span);
+
+  let charWidth: number;
+  try {
+    const width = span.getBoundingClientRect().width;
+    charWidth = width > 0 ? width / 20 : fontSize * 0.6;
+  } finally {
+    span.remove();
+  }
+
+  // Approximation fallback — happy-dom returns 0 widths for layout-less
+  // synthesized DOM. Use the conservative `fontSize * 0.6` heuristic so
+  // tests that don't stub the measurement still get sane numbers.
+  if (!Number.isFinite(charWidth) || charWidth <= 0) {
+    charWidth = fontSize * 0.6;
+  }
+
+  charWidthCache.set(key, charWidth);
+  return charWidth;
+}
+
+/** Reset the char-width cache (test hook). */
+export function clearCharWidthCacheForTesting(): void {
+  charWidthCache.clear();
+}
+
+export interface ViewportDimensions {
+  cols: number;
+  rows: number;
+}
+
+export interface UseViewportDimensionsOptions {
+  /** Mono font family used by the `<pre>` block. */
+  fontFamily: string;
+  /** Mono font size in px. */
+  fontSize: number;
+  /** Disabled when the terminal is hidden (e.g. exit screen overlaid). */
+  enabled?: boolean;
+}
+
+export interface UseViewportDimensionsResult {
+  /** Attach to the host viewport element via `ref={dims.ref}`. */
+  ref: (node: HTMLElement | null) => void;
+  /** Current cols/rows. Floored to (MIN_COLS, MIN_ROWS). */
+  dimensions: ViewportDimensions;
+}
+
+/**
+ * Track terminal cols/rows from a viewport element's pixel size.
+ *
+ * Pure observation — does not touch the WebSocket. Consumers wire the
+ * resulting dimensions into their PTY resize call.
+ */
+export function useViewportDimensions(
+  options: UseViewportDimensionsOptions
+): UseViewportDimensionsResult {
+  const { fontFamily, fontSize, enabled = true } = options;
+
+  const [dimensions, setDimensions] = useState<ViewportDimensions>(() => ({
+    cols: MIN_COLS,
+    rows: MIN_ROWS,
+  }));
+
+  const elementRef = useRef<HTMLElement | null>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSizeRef = useRef<{ width: number; height: number }>({
+    width: 0,
+    height: 0,
+  });
+
+  const compute = useCallback(
+    (width: number, height: number): ViewportDimensions => {
+      const usableWidth = Math.max(0, width - PRE_PADDING_PX * 2);
+      const usableHeight = Math.max(0, height - PRE_PADDING_PX * 2);
+      const charWidth = measureCharWidth(fontFamily, fontSize);
+      const lineHeight = fontSize * LINE_HEIGHT_RATIO;
+
+      const cols =
+        charWidth > 0 ? Math.floor(usableWidth / charWidth) : MIN_COLS;
+      const rows =
+        lineHeight > 0 ? Math.floor(usableHeight / lineHeight) : MIN_ROWS;
+
+      return {
+        cols: Math.max(MIN_COLS, cols),
+        rows: Math.max(MIN_ROWS, rows),
+      };
+    },
+    [fontFamily, fontSize]
+  );
+
+  const recompute = useCallback(() => {
+    const { width, height } = lastSizeRef.current;
+    if (width === 0 && height === 0) return;
+    const next = compute(width, height);
+    setDimensions((prev) =>
+      prev.cols === next.cols && prev.rows === next.rows ? prev : next
+    );
+  }, [compute]);
+
+  const scheduleRecompute = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      debounceRef.current = null;
+      recompute();
+    }, DEBOUNCE_MS);
+  }, [recompute]);
+
+  // Recompute synchronously when font changes — char width caches are
+  // keyed by (family, size) so this is cheap, and we want the new size
+  // reflected before the next paint rather than after a debounce delay.
+  useEffect(() => {
+    recompute();
+  }, [recompute]);
+
+  const setRef = useCallback(
+    (node: HTMLElement | null) => {
+      // Detach old observer.
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+      elementRef.current = node;
+      if (!node || !enabled) return;
+
+      // Seed an immediate size read so the first dimensions reflect
+      // the actual rendered viewport rather than the (MIN_COLS, MIN_ROWS)
+      // floor.
+      const rect = node.getBoundingClientRect();
+      lastSizeRef.current = { width: rect.width, height: rect.height };
+      recompute();
+
+      if (typeof ResizeObserver === "undefined") return;
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        const cr = entry.contentRect;
+        lastSizeRef.current = { width: cr.width, height: cr.height };
+        scheduleRecompute();
+      });
+      observer.observe(node);
+      observerRef.current = observer;
+    },
+    [enabled, recompute, scheduleRecompute]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+    };
+  }, []);
+
+  return { ref: setRef, dimensions };
+}


### PR DESCRIPTION
## Summary

Fixes two bugs in the Phase 3 mobile single-session view (closes remote-dev-vexb):

1. **PTY dimensions never updated.** `MOBILE_COLS = 120` / `MOBILE_ROWS = 24` were hardcoded into the WebSocket connect URL and `sendResize` was never called afterward. PTY/tmux thought the terminal was 120×24 regardless of phone screen, so TUI apps wrapped/clipped.
2. **fontFamily ignored user preferences.** The `<pre>` block hardcoded `'JetBrainsMono Nerd Font Mono'` instead of reading `prefs.fontFamily` from `PreferencesContext` (the way desktop already does in `SessionManager`).

## Root cause

- `MobileSessionView.tsx` only fed `initialCols`/`initialRows` to `useTerminalWebSocket` once and the hook had no resize observer wired in for mobile.
- `MobileSessionView.tsx` was constructed before mobile preference plumbing landed and never picked up the (already-context-exposed) `currentPreferences.fontFamily` / `.fontSize` values.

## Fix

- New `useViewportDimensions` hook computes `cols`/`rows` from the rendered viewport's pixel size and the current mono font (family + size). Recomputes on:
  - `ResizeObserver` events (soft keyboard show/hide, orientation rotation)
  - font-family change (preference update)
  - font-size change (pinch-to-zoom)
- Char width measured by an off-screen probe `<span>`, cached per `(fontFamily, fontSize)` tuple. Falls back to `fontSize * 0.6` when measurement is unavailable (e.g. happy-dom).
- Floors `cols ≥ 20`, `rows ≥ 5` so a tiny viewport doesn't break the PTY.
- Debounced ~75 ms so a pinch gesture doesn't spam the WebSocket.
- `sendResize(cols, rows)` is called whenever dimensions change while the socket is connected. Initial dims (already in the WS URL) are not re-sent.
- `<pre>` `fontFamily` now reads `currentPreferences.fontFamily` (with the JetBrains Mono string as a defensive fallback when the preference is null).
- Initial `fontSize` falls back to `prefs.fontSize` when no localStorage-backed `initialFontSize` is supplied (first load). Pinch zoom remains the runtime source of truth — we don't re-seed from prefs once the view is mounted.
- Desktop `SessionManager.tsx` and `Terminal.tsx` are untouched.

## Test plan

- [x] New unit tests in `src/components/mobile/session/__tests__/MobileSessionView.resize.test.tsx` cover:
  - `ResizeObserver` fires → `sendResize` is called with computed cols/rows
  - Pinch-to-zoom (smaller font) → `sendResize` called with bigger cols
  - 50×30 viewport → `cols ≥ 20`, `rows ≥ 5`
  - `prefs.fontFamily` applied to the `<pre>` block style
  - Initial `fontSize` seeds from `prefs.fontSize` when prop is undefined
- [x] `bun run typecheck` clean
- [x] `bun run lint` — no new errors (10 pre-existing baseline errors unchanged)
- [x] `bun run test:run` — 1052 passing tests, only pre-existing worktree-env tsconfig failure in `tests/mobile/restart-agent-api-client.test.ts` remains
- [ ] Manual smoke on a phone: rotate device + open soft keyboard, verify TUI app re-flows
- [ ] Manual smoke: change `prefs.fontFamily` in user settings, verify mobile session picks it up next mount

Closes remote-dev-vexb.

This pull request and its description were written by Isaac.