### PR TITLE
fix(terminal): apply latest fontSize/fontFamily on initial mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Desktop terminal initial fontSize/fontFamily race**
+  (`remote-dev-3gtr`). The xterm.js terminal stayed at the default font size
+  (14px) on first mount when `PreferencesContext` resolved during the async
+  init window (xterm/addon imports + WebGL load). The font-update effect
+  re-fired with the new values but bailed because `xtermRef.current` was
+  still null, and no later effect re-applied them. Switching to another
+  session and back masked the bug because the second mount saw the loaded
+  preferences synchronously. Fixed by reconciling
+  `terminal.options.fontSize`/`fontFamily` against the synchronized refs
+  immediately after `xtermRef.current = terminal`, closing the race window.
 - **Phase 3 mobile session view: adversarial-review fixes** (PR #220). Replaced
   the saturated `text-green-400 bg-green-400/20` long-press indicator on
   `MobileInputBar` with the token-based `--color-signal-running` to honor the

--- a/src/components/terminal/Terminal.fontRace.test.tsx
+++ b/src/components/terminal/Terminal.fontRace.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * Regression test for remote-dev-3gtr:
+ *
+ * The desktop terminal didn't apply the user's `fontSize`/`fontFamily`
+ * preference on initial mount. PreferencesContext loads asynchronously, so
+ * the Terminal component initially mounts with the default (14px). If the
+ * preferences resolved during the async xterm initialization window
+ * (xterm/addon imports + WebGL load), the font-update effect would re-run
+ * with the latest values but bail because `xtermRef.current` was still null.
+ * Once `xtermRef.current` was finally assigned, no effect re-fired to apply
+ * the now-stale prop, so the terminal stayed at 14px until the session was
+ * unmounted/remounted.
+ *
+ * The fix reconciles `terminal.options.fontSize`/`fontFamily` against the
+ * sync-ref values immediately after `xtermRef.current = terminal`. This
+ * test exercises that path by deferring the WebGL import until after the
+ * parent re-renders with the new fontSize.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, cleanup } from "@testing-library/react";
+import { useState, useEffect } from "react";
+
+// Capture every XTerm instance created so we can assert against options
+const xtermInstances: Array<{
+  options: { fontSize: number; fontFamily: string; [k: string]: unknown };
+}> = [];
+
+vi.mock("@xterm/xterm", () => {
+  class FakeTerminal {
+    options: {
+      fontSize: number;
+      fontFamily: string;
+      [k: string]: unknown;
+    };
+    cols = 80;
+    rows = 24;
+    textarea: HTMLTextAreaElement;
+    buffer = {
+      active: { type: "normal" as const, viewportY: 0, baseY: 0 },
+      onBufferChange: () => ({ dispose: () => {} }),
+    };
+    constructor(options: Record<string, unknown>) {
+      this.options = {
+        ...options,
+        fontSize: (options.fontSize as number) ?? 14,
+        fontFamily: (options.fontFamily as string) ?? "monospace",
+      };
+      this.textarea = document.createElement("textarea");
+      xtermInstances.push(this);
+    }
+    loadAddon() {}
+    open() {}
+    onData() {
+      return { dispose: () => {} };
+    }
+    onScroll() {
+      return { dispose: () => {} };
+    }
+    attachCustomKeyEventHandler() {}
+    focus() {}
+    write() {}
+    writeln() {}
+    dispose() {}
+    scrollToBottom() {}
+  }
+  return { Terminal: FakeTerminal };
+});
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    activate() {}
+    dispose() {}
+    fit() {}
+  },
+}));
+
+vi.mock("@xterm/addon-web-links", () => ({
+  WebLinksAddon: class {
+    activate() {}
+    dispose() {}
+  },
+}));
+
+vi.mock("@xterm/addon-image", () => ({
+  ImageAddon: class {
+    activate() {}
+    dispose() {}
+  },
+}));
+
+vi.mock("@xterm/addon-search", () => ({
+  SearchAddon: class {
+    activate() {}
+    dispose() {}
+    findNext() {
+      return false;
+    }
+    findPrevious() {
+      return false;
+    }
+    clearDecorations() {}
+  },
+}));
+
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+// Hold-and-release controller for the WebGL import so the test can pause init
+// at the exact moment xtermRef.current is still null but the addons exist.
+let webglRelease: (() => void) | null = null;
+const webglDeferred = new Promise<void>((resolve) => {
+  webglRelease = resolve;
+});
+
+vi.mock("@xterm/addon-webgl", async () => {
+  // Block until the test releases — this widens the race window.
+  await webglDeferred;
+  return {
+    WebglAddon: class {
+      activate() {}
+      dispose() {}
+      onContextLoss() {
+        return { dispose: () => {} };
+      }
+    },
+  };
+});
+
+// Mock theme + notifications hooks Terminal depends on
+vi.mock("@/contexts/AppearanceContext", () => ({
+  useTerminalTheme: () => ({
+    background: "#000000",
+    foreground: "#ffffff",
+    cursor: "#ffffff",
+    cursorAccent: "#000000",
+    selectionBackground: "#444444",
+    black: "#000000",
+    red: "#ff0000",
+    green: "#00ff00",
+    yellow: "#ffff00",
+    blue: "#0000ff",
+    magenta: "#ff00ff",
+    cyan: "#00ffff",
+    white: "#ffffff",
+    brightBlack: "#444444",
+    brightRed: "#ff4444",
+    brightGreen: "#44ff44",
+    brightYellow: "#ffff44",
+    brightBlue: "#4444ff",
+    brightMagenta: "#ff44ff",
+    brightCyan: "#44ffff",
+    brightWhite: "#ffffff",
+    cursorStyle: "block" as const,
+    opacity: 100,
+    blur: 0,
+  }),
+}));
+
+vi.mock("@/hooks/useNotifications", () => ({
+  useNotifications: () => ({
+    recordActivity: () => {},
+    notify: () => {},
+  }),
+}));
+
+// Also mock the network token fetch the connect() path makes — we don't
+// need WebSocket success for this test.
+const originalFetch = globalThis.fetch;
+beforeEach(() => {
+  globalThis.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve({}),
+    } as Response)
+  ) as unknown as typeof fetch;
+  // Stub document.fonts so the font-update effect doesn't await indefinitely
+  // happy-dom doesn't ship FontFaceSet by default.
+  if (!("fonts" in document)) {
+    Object.defineProperty(document, "fonts", {
+      configurable: true,
+      value: {
+        load: () => Promise.resolve([]),
+        ready: Promise.resolve(),
+      },
+    });
+  }
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  xtermInstances.length = 0;
+  cleanup();
+});
+
+// Lazily import Terminal AFTER mocks are registered
+async function getTerminal() {
+  const mod = await import("./Terminal");
+  return mod.Terminal;
+}
+
+/**
+ * Wrapper that simulates the PreferencesContext loading pattern: starts with
+ * a default fontSize and switches to the user's value after a microtask.
+ */
+function PrefsHarness({ initialFontSize, finalFontSize }: { initialFontSize: number; finalFontSize: number }) {
+  const [fontSize, setFontSize] = useState(initialFontSize);
+  // Bumps fontSize once on mount, mimicking PreferencesContext resolving its
+  // /api/preferences fetch a tick after the Terminal mounts.
+  useEffect(() => {
+    const id = setTimeout(() => setFontSize(finalFontSize), 0);
+    return () => clearTimeout(id);
+  }, [finalFontSize]);
+
+  // Render Terminal lazily — caller wires this up
+  return <TerminalUnderTest fontSize={fontSize} />;
+}
+
+let TerminalUnderTest: (props: { fontSize: number }) => React.ReactElement;
+
+describe("Terminal fontSize race (remote-dev-3gtr)", () => {
+  it("applies latest fontSize even when prefs resolve during async init", async () => {
+    const Terminal = await getTerminal();
+
+    function TerminalWrapper({ fontSize }: { fontSize: number }) {
+      return (
+        <Terminal
+          sessionId="s1"
+          tmuxSessionName="rdv-s1"
+          wsUrl="ws://localhost:0"
+          fontSize={fontSize}
+          fontFamily="'TestFont', monospace"
+          scrollback={1000}
+          tmuxHistoryLimit={1000}
+          terminalType="shell"
+          isActive
+        />
+      );
+    }
+    TerminalUnderTest = TerminalWrapper;
+
+    await act(async () => {
+      render(<PrefsHarness initialFontSize={14} finalFontSize={20} />);
+    });
+
+    // Let the harness's setTimeout fire so the parent re-renders with 20.
+    // The XTerm constructor has already run (with 14), but xtermRef.current
+    // is gated behind the WebGL await, which we have not released yet.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // At this point, the XTerm instance was created with the stale 14
+    expect(xtermInstances.length).toBeGreaterThanOrEqual(1);
+    const xterm = xtermInstances[0]!;
+
+    // Now release the WebGL import so init can finish and assign xtermRef.
+    // The fix runs the post-init reconciliation synchronously after
+    // xtermRef.current = terminal, before the async font-update effect can
+    // re-fire. The reconciliation reads `fontSizeRef.current` — which the
+    // sync-ref effect already updated to 20.
+    expect(webglRelease).not.toBeNull();
+    webglRelease!();
+
+    await act(async () => {
+      // Flush the WebGL import + the post-init reconciliation
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    expect(xterm.options.fontSize).toBe(20);
+  });
+});

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -585,6 +585,19 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       imageAddonRef.current = imageAddon;
       searchAddonRef.current = searchAddon;
 
+      // Post-init reconciliation: if PreferencesContext resolved during the
+      // async init window (xterm/addon imports + WebGL load), the font-update
+      // effect would have run with the latest fontSize/fontFamily but bailed
+      // because xtermRef.current was still null. The refs are kept in sync
+      // by the sync-ref effect, so re-apply them here to catch any drift.
+      // This is a no-op when the values match what was passed to `new XTerm`.
+      if (terminal.options.fontSize !== fontSizeRef.current) {
+        terminal.options.fontSize = fontSizeRef.current;
+      }
+      if (terminal.options.fontFamily !== fontFamilyRef.current) {
+        terminal.options.fontFamily = fontFamilyRef.current;
+      }
+
       async function connect() {
         if (wsRef.current?.readyState === WebSocket.OPEN) return;
 


### PR DESCRIPTION
## Summary

Closes `remote-dev-3gtr`.

The desktop terminal didn't honor the user's `fontSize`/`fontFamily` preference on initial mount. The terminal stayed at the 14px default until the user switched to another session and back. This was a race between `PreferencesContext` (async fetch) and xterm.js initialization.

## Root cause

`Terminal.tsx`'s init effect awaits dynamic xterm/addon imports plus the WebGL addon. During that async window, the parent re-renders with the loaded prefs and the font-update effect at line 1022 re-fires. It bails because `xtermRef.current` is still null (it's assigned at line 583, AFTER the WebGL import). Once the init flow finally assigns `xtermRef.current = terminal`, no effect re-runs to apply the now-stale prop, so the terminal keeps the default font until the session is unmounted/remounted.

The previous attempt (`fontSizeRef` + sync-ref effect) handled the case where prefs load BEFORE the terminal is constructed but missed the case where they load DURING construction.

## Fix

Option C from the issue's recommended approaches: **post-init reconciliation**.

After `xtermRef.current = terminal`, re-apply `terminal.options.fontSize`/`fontFamily` from the already-synced refs. The sync-ref effect (deps include `fontSize`/`fontFamily`) keeps the refs in lockstep with the latest props, so this is a no-op when they match what was passed to `new XTerm(...)` and a one-shot fix when prefs landed mid-init. Subsequent prefs changes still go through the existing font-update effect unchanged.

```ts
xtermRef.current = terminal;
// ...
if (terminal.options.fontSize !== fontSizeRef.current) {
  terminal.options.fontSize = fontSizeRef.current;
}
if (terminal.options.fontFamily !== fontFamilyRef.current) {
  terminal.options.fontFamily = fontFamilyRef.current;
}
```

## Test plan

- [x] New regression test `src/components/terminal/Terminal.fontRace.test.tsx` mocks `@xterm/addon-webgl` with a controllable deferred promise. The test mounts Terminal at 14px, lets the parent re-render to 20px while the WebGL import is held, then releases the import — without the fix the terminal stays at 14, with the fix it reconciles to 20. Verified the test fails on master and passes with the fix.
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — same baseline (109 problems, no new ones from these changes).
- [x] `bun run test:run` — 1046 passed; only pre-existing `tests/mobile/restart-agent-api-client.test.ts` failure unrelated to this PR.

## Constraints

- Did not touch mobile session code (`src/components/mobile/session/*`) per issue brief.
- Did not change `PreferencesContext` loading semantics.
- Subsequent fontSize prop changes still flow through the existing font-update effect with no behavior change.

This pull request and its description were written by Isaac.