### PR TITLE
feat(mobile/terminal): tap-to-click + long-press-to-select

### DIFF
--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -1413,6 +1413,10 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
 
     return () => {
       handlers.cancelMomentum();
+      // Cancel any pending long-press timer so it can't fire on a disposed
+      // xterm. Without this, a user who long-presses then closes the tab
+      // within 500 ms hits `terminal.select()` on a torn-down instance.
+      interactions.destroy();
       container.removeEventListener("touchstart", handlers.handleTouchStart);
       container.removeEventListener("touchmove", handlers.handleTouchMove);
       container.removeEventListener("touchend", handlers.handleTouchEnd);

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -13,6 +13,7 @@ import { useTerminalTheme } from "@/contexts/AppearanceContext";
 import { sendImageToTerminal } from "@/lib/image-upload";
 import { AuthErrorOverlay } from "./AuthErrorOverlay";
 import { createTouchScrollHandlers } from "./touch-scroll";
+import { createTouchInteractions } from "./useTouchInteractions";
 
 const SETTLE_MIN_WIDTH = 100;
 const SETTLE_MIN_HEIGHT = 80;
@@ -1391,10 +1392,24 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       },
     });
 
+    // Tap-to-click + long-press-to-select. Composed alongside the scroll
+    // handler: shared touch events, but mine never preventDefault. Order
+    // doesn't matter because the two handlers are state-isolated — any
+    // movement past 5 px puts mine into "scroll" mode (suppresses tap +
+    // long-press) which is exactly when the scroll handler activates.
+    const interactions = createTouchInteractions({
+      getTerminal: () => xtermRef.current,
+    });
+
     container.addEventListener("touchstart", handlers.handleTouchStart, { passive: true });
     container.addEventListener("touchmove", handlers.handleTouchMove, { passive: false });
     container.addEventListener("touchend", handlers.handleTouchEnd, { passive: true });
     container.addEventListener("touchcancel", handlers.handleTouchCancel, { passive: true });
+
+    container.addEventListener("touchstart", interactions.handleTouchStart, { passive: true });
+    container.addEventListener("touchmove", interactions.handleTouchMove, { passive: true });
+    container.addEventListener("touchend", interactions.handleTouchEnd, { passive: true });
+    container.addEventListener("touchcancel", interactions.handleTouchCancel, { passive: true });
 
     return () => {
       handlers.cancelMomentum();
@@ -1402,6 +1417,11 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       container.removeEventListener("touchmove", handlers.handleTouchMove);
       container.removeEventListener("touchend", handlers.handleTouchEnd);
       container.removeEventListener("touchcancel", handlers.handleTouchCancel);
+
+      container.removeEventListener("touchstart", interactions.handleTouchStart);
+      container.removeEventListener("touchmove", interactions.handleTouchMove);
+      container.removeEventListener("touchend", interactions.handleTouchEnd);
+      container.removeEventListener("touchcancel", interactions.handleTouchCancel);
     };
   }, []);
 

--- a/src/components/terminal/useTouchInteractions.test.ts
+++ b/src/components/terminal/useTouchInteractions.test.ts
@@ -45,34 +45,51 @@ const ROWS = 24;
 interface Harness {
   xterm: FakeXTerm;
   screen: HTMLElement;
+  canvas: HTMLElement;
   fireTouch: (
     type: "touchstart" | "touchmove" | "touchend" | "touchcancel",
     touches: Array<{ x: number; y: number }>
   ) => void;
   advanceTime: (ms: number) => void;
   flushTimers: () => void;
-  mouseEvents: Array<{ type: string; clientX: number; clientY: number }>;
+  mouseEvents: Array<{ type: string; clientX: number; clientY: number; target: EventTarget | null }>;
   copies: string[];
   getMode: () => string;
+  destroy: () => void;
+  /** How many times `getBoundingClientRect` has been called on the screen. */
+  bcrCalls: () => number;
+  /** Shift the cached screen rect by `dy` px to simulate keyboard slide-up. */
+  shiftScreenY: (dy: number) => void;
 }
 
 function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"] } = {}): Harness {
   const screen = document.createElement("div");
   screen.className = "xterm-screen";
+  // xterm v6 paints into a canvas inside .xterm-screen. The tap handler
+  // dispatches there; we add one so we can assert the dispatch target.
+  const canvas = document.createElement("canvas");
+  screen.appendChild(canvas);
   // Position the screen at viewport (100, 50) — non-zero origin shakes out
-  // any bugs that assume (0,0).
+  // any bugs that assume (0,0). Origin is mutable via shiftScreenY so we can
+  // simulate the iOS soft keyboard sliding up mid-gesture.
+  const originX = 100;
+  let originY = 50;
+  let bcrCount = 0;
   Object.defineProperty(screen, "getBoundingClientRect", {
-    value: () => ({
-      left: 100,
-      top: 50,
-      right: 100 + COLS * CELL_W,
-      bottom: 50 + ROWS * CELL_H,
-      width: COLS * CELL_W,
-      height: ROWS * CELL_H,
-      x: 100,
-      y: 50,
-      toJSON: () => "",
-    }),
+    value: () => {
+      bcrCount++;
+      return {
+        left: originX,
+        top: originY,
+        right: originX + COLS * CELL_W,
+        bottom: originY + ROWS * CELL_H,
+        width: COLS * CELL_W,
+        height: ROWS * CELL_H,
+        x: originX,
+        y: originY,
+        toJSON: () => "",
+      };
+    },
     configurable: true,
   });
   const element = document.createElement("div");
@@ -100,7 +117,7 @@ function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"]
   const pendingTimers: Array<{ id: number; cb: TimerFn; fireAt: number }> = [];
   let nextTimerId = 1;
 
-  const mouseEvents: Array<{ type: string; clientX: number; clientY: number }> = [];
+  const mouseEvents: Array<{ type: string; clientX: number; clientY: number; target: EventTarget | null }> = [];
   const copies: string[] = [];
 
   const handlers = createTouchInteractions({
@@ -115,8 +132,13 @@ function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"]
       const idx = pendingTimers.findIndex((t) => t.id === id);
       if (idx >= 0) pendingTimers.splice(idx, 1);
     }) as unknown as (id: ReturnType<typeof setTimeout>) => void,
-    dispatchMouse: (_target, ev) => {
-      mouseEvents.push({ type: ev.type, clientX: ev.clientX, clientY: ev.clientY });
+    dispatchMouse: (target, ev) => {
+      mouseEvents.push({
+        type: ev.type,
+        clientX: ev.clientX,
+        clientY: ev.clientY,
+        target,
+      });
     },
     copyToClipboard: async (text) => {
       copies.push(text);
@@ -135,7 +157,7 @@ function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"]
     if (type === "touchstart") handlers.handleTouchStart(ev);
     else if (type === "touchmove") handlers.handleTouchMove(ev);
     else if (type === "touchend") handlers.handleTouchEnd(ev);
-    else handlers.handleTouchCancel();
+    else handlers.handleTouchCancel(ev);
   };
 
   const advanceTime = (ms: number) => {
@@ -155,12 +177,18 @@ function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"]
   return {
     xterm,
     screen,
+    canvas,
     fireTouch,
     advanceTime,
     flushTimers,
     mouseEvents,
     copies,
     getMode: handlers.getMode,
+    destroy: handlers.destroy,
+    bcrCalls: () => bcrCount,
+    shiftScreenY: (dy) => {
+      originY += dy;
+    },
   };
 }
 
@@ -209,7 +237,7 @@ describe("tap-to-click", () => {
     h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
     h.advanceTime(TAP_MAX_MS - 50);
     h.fireTouch("touchend", []);
-    expect(h.mouseEvents).toEqual([
+    expect(h.mouseEvents.map(({ type, clientX, clientY }) => ({ type, clientX, clientY }))).toEqual([
       { type: "mousedown", clientX: 200, clientY: 100 },
       { type: "mouseup", clientX: 200, clientY: 100 },
     ]);
@@ -370,5 +398,128 @@ describe("threshold guards", () => {
   it("TAP_MAX_PX matches the touch-scroll activation threshold (5 px) so scroll vs tap is unambiguous", () => {
     expect(TAP_MAX_PX).toBe(5);
     expect(MOVEMENT_CANCEL_PX).toBe(5);
+  });
+});
+
+// ── Pre-merge review fixes ────────────────────────────────────────────
+
+describe("destroy() — unmount safety", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("cancels a pending long-press timer so it cannot fire after unmount", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    // Simulate effect cleanup before the 500 ms timer fires.
+    h.destroy();
+    // Even after time passes and timers flush, no selection should occur.
+    h.advanceTime(LONG_PRESS_MS + 100);
+    h.flushTimers();
+    expect(h.xterm.select).not.toHaveBeenCalled();
+    expect(h.xterm.clearSelection).not.toHaveBeenCalled();
+    expect(h.getMode()).toBe("idle");
+  });
+
+  it("destroy() is idempotent", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.destroy();
+    expect(() => h.destroy()).not.toThrow();
+    expect(h.getMode()).toBe("idle");
+  });
+});
+
+describe("synthesizeTap dispatch target", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("dispatches mousedown+mouseup on the .xterm-screen canvas (xterm wires its mouse listeners there)", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(50);
+    h.fireTouch("touchend", []);
+    expect(h.mouseEvents).toHaveLength(2);
+    for (const e of h.mouseEvents) {
+      expect(e.target).toBe(h.canvas);
+    }
+  });
+
+  it("falls back to .xterm-screen when no canvas is present", () => {
+    const h = makeHarness();
+    // Remove the canvas to simulate a renderer that didn't paint one.
+    h.canvas.remove();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(50);
+    h.fireTouch("touchend", []);
+    expect(h.mouseEvents).toHaveLength(2);
+    for (const e of h.mouseEvents) {
+      expect(e.target).toBe(h.screen);
+    }
+  });
+
+  it("falls back to terminal.element when neither .xterm-screen nor canvas is present", () => {
+    const h = makeHarness();
+    h.screen.remove();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(50);
+    h.fireTouch("touchend", []);
+    expect(h.mouseEvents).toHaveLength(2);
+    for (const e of h.mouseEvents) {
+      expect(e.target).toBe(h.xterm.element);
+    }
+  });
+});
+
+describe("selection drag re-reads grid origin per touchmove", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("calls getBoundingClientRect more than once during a selection drag", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(LONG_PRESS_MS);
+    h.flushTimers();
+    const baseline = h.bcrCalls();
+    expect(baseline).toBeGreaterThanOrEqual(1); // initial readDims at long-press fire
+    h.fireTouch("touchmove", [{ x: 200 + 2 * CELL_W, y: 100 }]);
+    h.fireTouch("touchmove", [{ x: 200 + 4 * CELL_W, y: 100 }]);
+    // Each move should have re-read the rect.
+    expect(h.bcrCalls()).toBeGreaterThan(baseline + 1);
+  });
+
+  it("tracks the soft-keyboard slide-up: rows shift correctly when origin moves mid-drag", () => {
+    const h = makeHarness();
+    // Start at viewport (200, 100). Screen origin starts at (100, 50).
+    // (200-100)/8 = col 12, (100-50)/16 = row 3. Long-press at cell (12, 3).
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(LONG_PRESS_MS);
+    h.flushTimers();
+    expect(h.xterm.select).toHaveBeenLastCalledWith(12, 3, 1);
+
+    // Soft keyboard slides up by 32 px (i.e. screen origin top moves from 50
+    // to 18). Without re-reading, a touch at viewport (200, 100) would still
+    // resolve to row 3 — but now (200, 100) lives at (100-18)/16 = row 5.
+    h.shiftScreenY(-32);
+    // Drag 1 cell to the right (no vertical move) — endpoint should be
+    // (col 13, row 5), not (col 13, row 3).
+    h.fireTouch("touchmove", [{ x: 200 + CELL_W, y: 100 }]);
+    // Linear: from (12,3) to (13,5) over cols=80 → idx 252 to idx 413, length 162.
+    expect(h.xterm.select).toHaveBeenLastCalledWith(12, 3, 162);
+  });
+});
+
+describe("handleTouchCancel signature", () => {
+  it("accepts a TouchEvent argument (DOM EventListener compatibility)", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(LONG_PRESS_MS);
+    h.flushTimers();
+    // fireTouch dispatches handleTouchCancel with a real Event — just assert
+    // it doesn't throw and resets state.
+    expect(() => h.fireTouch("touchcancel", [])).not.toThrow();
+    expect(h.getMode()).toBe("idle");
   });
 });

--- a/src/components/terminal/useTouchInteractions.test.ts
+++ b/src/components/terminal/useTouchInteractions.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Tests for tap-to-click + long-press-to-select interaction layer.
+ *
+ * Drives `createTouchInteractions` directly with a fake xterm instance so
+ * the test runs the production code path. Stubs:
+ *   - `now()` for deterministic timestamps
+ *   - `setTimer / clearTimer` so long-press fires only when we tell it to
+ *   - `dispatchMouse` to capture synthesized MouseEvents instead of relying
+ *     on JSDOM/happy-dom event bubbling on a non-rendered element
+ *   - `copyToClipboard` to verify the right text was written
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  createTouchInteractions,
+  pointToCell,
+  selectionLength,
+  TAP_MAX_MS,
+  TAP_MAX_PX,
+  LONG_PRESS_MS,
+  MOVEMENT_CANCEL_PX,
+} from "./useTouchInteractions";
+
+interface FakeXTerm {
+  cols: number;
+  rows: number;
+  element: HTMLElement;
+  modes: { mouseTrackingMode: "none" | "x10" | "vt200" | "drag" | "any" };
+  scrollToBottom: ReturnType<typeof vi.fn>;
+  select: ReturnType<typeof vi.fn>;
+  clearSelection: ReturnType<typeof vi.fn>;
+  getSelection: ReturnType<typeof vi.fn>;
+  // _core mock returns the cell width/height we configure
+  _core: {
+    _renderService: {
+      dimensions: { css: { cell: { width: number; height: number } } };
+    };
+  };
+}
+
+const CELL_W = 8;
+const CELL_H = 16;
+const COLS = 80;
+const ROWS = 24;
+
+interface Harness {
+  xterm: FakeXTerm;
+  screen: HTMLElement;
+  fireTouch: (
+    type: "touchstart" | "touchmove" | "touchend" | "touchcancel",
+    touches: Array<{ x: number; y: number }>
+  ) => void;
+  advanceTime: (ms: number) => void;
+  flushTimers: () => void;
+  mouseEvents: Array<{ type: string; clientX: number; clientY: number }>;
+  copies: string[];
+  getMode: () => string;
+}
+
+function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"] } = {}): Harness {
+  const screen = document.createElement("div");
+  screen.className = "xterm-screen";
+  // Position the screen at viewport (100, 50) — non-zero origin shakes out
+  // any bugs that assume (0,0).
+  Object.defineProperty(screen, "getBoundingClientRect", {
+    value: () => ({
+      left: 100,
+      top: 50,
+      right: 100 + COLS * CELL_W,
+      bottom: 50 + ROWS * CELL_H,
+      width: COLS * CELL_W,
+      height: ROWS * CELL_H,
+      x: 100,
+      y: 50,
+      toJSON: () => "",
+    }),
+    configurable: true,
+  });
+  const element = document.createElement("div");
+  element.appendChild(screen);
+  document.body.appendChild(element);
+
+  const xterm: FakeXTerm = {
+    cols: COLS,
+    rows: ROWS,
+    element,
+    modes: { mouseTrackingMode: opts.mouseMode ?? "none" },
+    scrollToBottom: vi.fn(),
+    select: vi.fn(),
+    clearSelection: vi.fn(),
+    getSelection: vi.fn(() => "selected text"),
+    _core: {
+      _renderService: {
+        dimensions: { css: { cell: { width: CELL_W, height: CELL_H } } },
+      },
+    },
+  };
+
+  let nowValue = 0;
+  type TimerFn = () => void;
+  const pendingTimers: Array<{ id: number; cb: TimerFn; fireAt: number }> = [];
+  let nextTimerId = 1;
+
+  const mouseEvents: Array<{ type: string; clientX: number; clientY: number }> = [];
+  const copies: string[] = [];
+
+  const handlers = createTouchInteractions({
+    getTerminal: () => xterm as unknown as Parameters<typeof createTouchInteractions>[0]["getTerminal"] extends () => infer R ? R : never,
+    now: () => nowValue,
+    setTimer: ((cb: TimerFn, ms: number) => {
+      const id = nextTimerId++;
+      pendingTimers.push({ id, cb, fireAt: nowValue + ms });
+      return id as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as (cb: () => void, ms: number) => ReturnType<typeof setTimeout>,
+    clearTimer: ((id: number) => {
+      const idx = pendingTimers.findIndex((t) => t.id === id);
+      if (idx >= 0) pendingTimers.splice(idx, 1);
+    }) as unknown as (id: ReturnType<typeof setTimeout>) => void,
+    dispatchMouse: (_target, ev) => {
+      mouseEvents.push({ type: ev.type, clientX: ev.clientX, clientY: ev.clientY });
+    },
+    copyToClipboard: async (text) => {
+      copies.push(text);
+    },
+  });
+
+  const fireTouch = (
+    type: "touchstart" | "touchmove" | "touchend" | "touchcancel",
+    touches: Array<{ x: number; y: number }>
+  ) => {
+    const touchObjs = touches.map(
+      (t, i) => ({ clientX: t.x, clientY: t.y, identifier: i, target: element }) as unknown as Touch
+    );
+    const ev = new Event(type, { bubbles: true, cancelable: true }) as unknown as TouchEvent;
+    Object.defineProperty(ev, "touches", { value: touchObjs, configurable: true });
+    if (type === "touchstart") handlers.handleTouchStart(ev);
+    else if (type === "touchmove") handlers.handleTouchMove(ev);
+    else if (type === "touchend") handlers.handleTouchEnd(ev);
+    else handlers.handleTouchCancel();
+  };
+
+  const advanceTime = (ms: number) => {
+    nowValue += ms;
+  };
+
+  const flushTimers = () => {
+    // Fire any timers whose fireAt is <= nowValue.
+    while (true) {
+      const idx = pendingTimers.findIndex((t) => t.fireAt <= nowValue);
+      if (idx < 0) break;
+      const [t] = pendingTimers.splice(idx, 1);
+      t.cb();
+    }
+  };
+
+  return {
+    xterm,
+    screen,
+    fireTouch,
+    advanceTime,
+    flushTimers,
+    mouseEvents,
+    copies,
+    getMode: handlers.getMode,
+  };
+}
+
+describe("pointToCell", () => {
+  it("clamps to grid bounds and floors fractional cells", () => {
+    const dims = {
+      cellWidth: 10,
+      cellHeight: 20,
+      originX: 0,
+      originY: 0,
+      cols: 80,
+      rows: 24,
+    };
+    expect(pointToCell(dims, 5, 9)).toEqual({ col: 0, row: 0 });
+    expect(pointToCell(dims, 25, 41)).toEqual({ col: 2, row: 2 });
+    // Past right/bottom edge: clamped to cols-1/rows-1.
+    expect(pointToCell(dims, 9999, 9999)).toEqual({ col: 79, row: 23 });
+    // Negative (off the left/top): clamped to 0.
+    expect(pointToCell(dims, -50, -50)).toEqual({ col: 0, row: 0 });
+  });
+});
+
+describe("selectionLength", () => {
+  it("computes left-to-right linear length within a row", () => {
+    const r = selectionLength(2, 1, 7, 1, 80);
+    expect(r).toEqual({ col: 2, row: 1, length: 6 });
+  });
+  it("wraps across multiple rows using cols stride", () => {
+    // (col=78,row=0) → (col=2,row=2) over cols=80 → idx 78 to idx 162 → length 85
+    const r = selectionLength(78, 0, 2, 2, 80);
+    expect(r).toEqual({ col: 78, row: 0, length: 85 });
+  });
+  it("flips start/end when end is before start in reading order", () => {
+    const r = selectionLength(10, 5, 3, 5, 80);
+    expect(r).toEqual({ col: 3, row: 5, length: 8 });
+  });
+});
+
+describe("tap-to-click", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("synthesizes mousedown+mouseup at the touch coordinates within tap window", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(TAP_MAX_MS - 50);
+    h.fireTouch("touchend", []);
+    expect(h.mouseEvents).toEqual([
+      { type: "mousedown", clientX: 200, clientY: 100 },
+      { type: "mouseup", clientX: 200, clientY: 100 },
+    ]);
+  });
+
+  it("calls scrollToBottom when mouse mode is OFF", () => {
+    const h = makeHarness({ mouseMode: "none" });
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(50);
+    h.fireTouch("touchend", []);
+    expect(h.xterm.scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call scrollToBottom when application mouse mode is ON", () => {
+    for (const mode of ["vt200", "drag", "any"] as const) {
+      const h = makeHarness({ mouseMode: mode });
+      h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+      h.advanceTime(50);
+      h.fireTouch("touchend", []);
+      expect(h.xterm.scrollToBottom).not.toHaveBeenCalled();
+      // mouse events are still sent — that's the whole point.
+      expect(h.mouseEvents).toHaveLength(2);
+    }
+  });
+
+  it("does NOT tap when the gesture exceeds TAP_MAX_MS", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(TAP_MAX_MS + 1);
+    h.fireTouch("touchend", []);
+    expect(h.mouseEvents).toEqual([]);
+    expect(h.xterm.scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it("does NOT tap when the finger moved past MOVEMENT_CANCEL_PX", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.fireTouch("touchmove", [{ x: 200 + MOVEMENT_CANCEL_PX + 1, y: 100 }]);
+    h.advanceTime(50);
+    h.fireTouch("touchend", []);
+    expect(h.mouseEvents).toEqual([]);
+  });
+
+  it("does NOT tap when a second finger lands during the gesture (pinch handoff)", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.fireTouch("touchmove", [
+      { x: 200, y: 100 },
+      { x: 250, y: 150 },
+    ]);
+    h.advanceTime(50);
+    h.fireTouch("touchend", []);
+    expect(h.mouseEvents).toEqual([]);
+    expect(h.xterm.scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire the long-press when a tap happens before the timer", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(50);
+    h.fireTouch("touchend", []);
+    // No selection should have been started.
+    expect(h.xterm.select).not.toHaveBeenCalled();
+  });
+});
+
+describe("long-press-to-select", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("enters selection mode after LONG_PRESS_MS with no movement", () => {
+    const h = makeHarness();
+    // Touch at viewport (200, 100). Screen origin is (100, 50), cell 8×16.
+    // Cell = ((200-100)/8, (100-50)/16) = (12, 3).
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(LONG_PRESS_MS);
+    h.flushTimers();
+    expect(h.getMode()).toBe("selection");
+    expect(h.xterm.clearSelection).toHaveBeenCalled();
+    expect(h.xterm.select).toHaveBeenCalledWith(12, 3, 1);
+  });
+
+  it("updates the selection as the finger drags", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]); // cell (12, 3)
+    h.advanceTime(LONG_PRESS_MS);
+    h.flushTimers();
+
+    // Drag right by 4 cells (32 px).
+    h.fireTouch("touchmove", [{ x: 200 + 4 * CELL_W, y: 100 }]);
+    // Last call should select from (12,3) for length 5 (12,13,14,15,16).
+    expect(h.xterm.select).toHaveBeenLastCalledWith(12, 3, 5);
+
+    // Drag down to next row, col 0 from screen origin.
+    h.fireTouch("touchmove", [{ x: 100, y: 100 + CELL_H }]); // (0, 4)
+    // Selection from (12,3) to (0,4): start idx = 3*80+12 = 252, end idx = 4*80+0 = 320 → length 69
+    expect(h.xterm.select).toHaveBeenLastCalledWith(12, 3, 69);
+  });
+
+  it("cancels the long-press if the finger moves > MOVEMENT_CANCEL_PX before the timer fires", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    // Move just past the cancel threshold before the timer fires.
+    h.advanceTime(LONG_PRESS_MS - 100);
+    h.fireTouch("touchmove", [{ x: 200 + MOVEMENT_CANCEL_PX + 1, y: 100 }]);
+    h.advanceTime(200);
+    h.flushTimers();
+    expect(h.xterm.select).not.toHaveBeenCalled();
+    expect(h.getMode()).toBe("scroll");
+  });
+
+  it("cancels the long-press on multi-touch (pinch)", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(LONG_PRESS_MS - 100);
+    h.fireTouch("touchmove", [
+      { x: 200, y: 100 },
+      { x: 260, y: 100 },
+    ]);
+    h.advanceTime(200);
+    h.flushTimers();
+    expect(h.xterm.select).not.toHaveBeenCalled();
+  });
+
+  it("copies selection text to clipboard on touchend", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(LONG_PRESS_MS);
+    h.flushTimers();
+    h.fireTouch("touchmove", [{ x: 200 + 3 * CELL_W, y: 100 }]);
+    h.fireTouch("touchend", []);
+    expect(h.copies).toEqual(["selected text"]);
+  });
+
+  it("does not copy when getSelection returns empty", () => {
+    const h = makeHarness();
+    h.xterm.getSelection = vi.fn(() => "");
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(LONG_PRESS_MS);
+    h.flushTimers();
+    h.fireTouch("touchend", []);
+    expect(h.copies).toEqual([]);
+  });
+
+  it("touchcancel resets state without copying", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(LONG_PRESS_MS);
+    h.flushTimers();
+    h.fireTouch("touchcancel", []);
+    expect(h.copies).toEqual([]);
+    expect(h.getMode()).toBe("idle");
+  });
+});
+
+describe("threshold guards", () => {
+  it("TAP_MAX_PX matches the touch-scroll activation threshold (5 px) so scroll vs tap is unambiguous", () => {
+    expect(TAP_MAX_PX).toBe(5);
+    expect(MOVEMENT_CANCEL_PX).toBe(5);
+  });
+});

--- a/src/components/terminal/useTouchInteractions.ts
+++ b/src/components/terminal/useTouchInteractions.ts
@@ -184,7 +184,13 @@ export interface TouchInteractionsHandlers {
   handleTouchStart: (e: TouchEvent) => void;
   handleTouchMove: (e: TouchEvent) => void;
   handleTouchEnd: (e: TouchEvent) => void;
-  handleTouchCancel: () => void;
+  handleTouchCancel: (e: TouchEvent) => void;
+  /**
+   * Cancel any pending long-press timer and reset all state to idle. Must be
+   * called from the host effect's cleanup so a long-press timer started just
+   * before unmount doesn't fire on a disposed xterm. Idempotent.
+   */
+  destroy: () => void;
   /** Current internal mode — exposed for tests. */
   getMode: () => Mode;
 }
@@ -217,9 +223,6 @@ export function createTouchInteractions(
   let longPressTimer: ReturnType<typeof setTimeout> | null = null;
   // Cell coords captured when the long-press fires.
   let selectionStart: { col: number; row: number } | null = null;
-  // Stored dims from the moment the long-press fires; we trust the layout
-  // didn't shift mid-gesture.
-  let selectionDims: XTermDims | null = null;
 
   const cancelLongPress = () => {
     if (longPressTimer !== null) {
@@ -232,17 +235,17 @@ export function createTouchInteractions(
     cancelLongPress();
     mode = "idle";
     selectionStart = null;
-    selectionDims = null;
   };
 
   const beginSelection = () => {
     const terminal = getTerminal();
     if (!terminal) return;
+    // Re-read dims at fire time. We do NOT cache origin — see updateSelection
+    // for why (soft keyboard animations shift the viewport mid-gesture).
     const dims = readDims(terminal);
     if (!dims) return;
     const cell = pointToCell(dims, startX, startY);
     selectionStart = cell;
-    selectionDims = dims;
     mode = "selection";
     // Initial 1-cell selection so the user sees feedback immediately even if
     // they don't move yet.
@@ -261,14 +264,23 @@ export function createTouchInteractions(
 
   const updateSelection = (clientX: number, clientY: number) => {
     const terminal = getTerminal();
-    if (!terminal || !selectionStart || !selectionDims) return;
-    const end = pointToCell(selectionDims, clientX, clientY);
+    if (!terminal || !selectionStart) return;
+    // Re-read dims every move. The iOS soft keyboard animates up after the
+    // user starts a gesture (focus shifts to the input bar, etc.), shifting
+    // the terminal upward by the keyboard height. A cached `originY` from
+    // long-press-fire would put every subsequent row off by that delta. The
+    // call is cheap (a getBoundingClientRect plus an internal property read).
+    // Cell width/height also re-read for parity, since pinch-zoom can change
+    // them, although pinch cancels selection mode anyway.
+    const dims = readDims(terminal);
+    if (!dims) return;
+    const end = pointToCell(dims, clientX, clientY);
     const span = selectionLength(
       selectionStart.col,
       selectionStart.row,
       end.col,
       end.row,
-      selectionDims.cols
+      dims.cols
     );
     terminal.select(span.col, span.row, span.length);
   };
@@ -288,11 +300,15 @@ export function createTouchInteractions(
   const synthesizeTap = (clientX: number, clientY: number) => {
     const terminal = getTerminal();
     if (!terminal || !terminal.element) return;
-    const target = terminal.element;
-    // Mouse events fired on the xterm host element are picked up by xterm's
-    // own listeners. When DECSET 1000/1002/1006 is active xterm forwards them
-    // to the PTY; when not, xterm's selection logic clears any prior
-    // selection (which is what we want before we explicitly scroll).
+    // xterm v6 attaches its mouse listeners to the canvas inside .xterm-screen
+    // (where the WebGL/canvas renderer paints), NOT to the outer host div.
+    // Dispatched events do not propagate downward into children, so a
+    // mousedown on `terminal.element` is silently ignored. Walk into the
+    // screen → canvas, with the host div as a last-resort fallback.
+    const host = terminal.element;
+    const screen = host.querySelector(".xterm-screen") as HTMLElement | null;
+    const canvas = screen?.querySelector("canvas") as HTMLElement | null;
+    const target: HTMLElement = canvas ?? screen ?? host;
     const baseInit: MouseEventInit = {
       bubbles: true,
       cancelable: true,
@@ -397,11 +413,11 @@ export function createTouchInteractions(
     // Scroll / cancelled — nothing to do beyond resetting state.
     mode = "idle";
     selectionStart = null;
-    selectionDims = null;
     void e; // suppress unused-arg lint without removing the param shape
   };
 
-  const handleTouchCancel = () => {
+  const handleTouchCancel = (e: TouchEvent) => {
+    void e; // ignored; matches DOM EventListener signature
     reset();
   };
 
@@ -410,6 +426,7 @@ export function createTouchInteractions(
     handleTouchMove,
     handleTouchEnd,
     handleTouchCancel,
+    destroy: reset,
     getMode: () => mode,
   };
 }
@@ -443,6 +460,7 @@ export function useTouchInteractions(opts: UseTouchInteractionsOptions): void {
     element.addEventListener("touchend", handlers.handleTouchEnd, { passive: true });
     element.addEventListener("touchcancel", handlers.handleTouchCancel, { passive: true });
     return () => {
+      handlers.destroy();
       element.removeEventListener("touchstart", handlers.handleTouchStart);
       element.removeEventListener("touchmove", handlers.handleTouchMove);
       element.removeEventListener("touchend", handlers.handleTouchEnd);

--- a/src/components/terminal/useTouchInteractions.ts
+++ b/src/components/terminal/useTouchInteractions.ts
@@ -1,0 +1,452 @@
+"use client";
+
+// Mobile tap-to-click and long-press-to-select for the xterm.js terminal.
+//
+// Why this exists: `.terminal.xterm` has `touch-action: none` so the browser
+// never synthesizes click events from taps — and our touch-scroll handler
+// preventDefaults touchmove unconditionally for single-finger gestures. As a
+// result, an ordinary tap on the xterm viewport produces nothing visible. TUIs
+// that enable application mouse mode (DECSET 1000/1002/1006), e.g. Claude
+// Code's clickable buttons, never see the click.
+//
+// This hook composes alongside `touch-scroll.ts` and `usePinchZoom`:
+//   - On touchstart with one finger we record (x, y, t) and arm two timers:
+//     one for the long-press fire (DEFAULT_LONG_PRESS_MS), and an implicit
+//     one via touchend which decides between "tap" vs "scroll"/"selection".
+//   - During touchmove: if the gesture is in the selection mode (long-press
+//     fired), we update `terminal.select(col, row, length)`. Otherwise, if the
+//     finger has moved further than MOVEMENT_CANCEL_PX, we cancel the pending
+//     long-press timer and let the touch-scroll handler take over.
+//   - On touchend: if we're in selection mode, copy `terminal.getSelection()`
+//     to the clipboard and keep the selection visible. Otherwise, if the
+//     gesture lasted < TAP_MAX_MS and total movement was < TAP_MAX_PX, we
+//     synthesize a `mousedown`+`mouseup` pair on the xterm element. xterm
+//     forwards these to the application when mouse mode is on; if it is off,
+//     we clear any selection and call `terminal.scrollToBottom()` so the
+//     "tap to jump to latest" behavior works at a shell prompt.
+//   - On a second finger (pinch handoff) we cancel the pending long-press and
+//     bail out — `usePinchZoom` claims the gesture from there.
+//
+// We do NOT call `e.preventDefault()` on the touch events here. The touch-
+// scroll handler already does so when needed (touchmove past activation), and
+// `touch-action: none` on .xterm.terminal blocks the browser side.
+//
+// xterm internals: cell dimensions live on `terminal._core._renderService`.
+// xterm's public TS surface doesn't expose this, so we cast through `unknown`
+// at the boundary and handle missing values gracefully (fall back to font-
+// size-based estimates). When dimensions are unavailable we cannot produce a
+// (col, row), so taps are still synthesized at the raw pixel position (xterm
+// then computes its own cell from the mouse coords) but selections cannot
+// proceed and we silently no-op.
+
+import { useEffect, useRef } from "react";
+import type { Terminal as XTermType } from "@xterm/xterm";
+
+export const TAP_MAX_MS = 250;
+// MUST be <= touch-scroll's TOUCH_SCROLL_ACTIVATION_PX (5) so we don't
+// register a "tap" on a finger that already engaged the scroll handler.
+export const TAP_MAX_PX = 5;
+export const LONG_PRESS_MS = 500;
+// Same threshold as touch-scroll: once we cross it the scroll handler owns
+// the gesture and we cleanly suppress both long-press and tap synthesis.
+export const MOVEMENT_CANCEL_PX = 5;
+
+type Mode = "idle" | "pending" | "selection" | "scroll";
+
+interface XTermDims {
+  /** Cell width in CSS px (not device px). */
+  cellWidth: number;
+  /** Cell height in CSS px. */
+  cellHeight: number;
+  /** Origin of the cell grid in viewport coords (top-left of (0,0)). */
+  originX: number;
+  originY: number;
+  /** Total grid columns (terminal.cols). */
+  cols: number;
+  /** Total grid rows (terminal.rows). */
+  rows: number;
+}
+
+/**
+ * Resolve cell dimensions and the grid origin for a live terminal. Returns
+ * `null` when xterm hasn't laid out yet or when the internal API shape we
+ * rely on is missing (older / patched xterm builds).
+ */
+function readDims(terminal: XTermType): XTermDims | null {
+  if (!terminal.element) return null;
+
+  // xterm exposes `_core._renderService.dimensions.css.cell` in v6. Cast
+  // through unknown to avoid leaking the internal type into our public API.
+  // Shape (xterm v6):
+  //   dimensions: { css: { cell: { width, height } }, device: {...} }
+  const core = (terminal as unknown as {
+    _core?: {
+      _renderService?: {
+        dimensions?: {
+          css?: { cell?: { width?: number; height?: number } };
+        };
+      };
+    };
+  })._core;
+  const cell = core?._renderService?.dimensions?.css?.cell;
+  const cellWidth = Number.isFinite(cell?.width) && (cell?.width ?? 0) > 0 ? (cell!.width as number) : 0;
+  const cellHeight = Number.isFinite(cell?.height) && (cell?.height ?? 0) > 0 ? (cell!.height as number) : 0;
+  if (cellWidth === 0 || cellHeight === 0) return null;
+
+  // The xterm screen element (.xterm-screen) is the grid origin. Its bounding
+  // rect's top-left maps to (col=0, row=0). The outer `.terminal.xterm` may
+  // include scrollbars / padding so we use the screen specifically.
+  const screen = terminal.element.querySelector(".xterm-screen") as HTMLElement | null;
+  const rect = (screen ?? terminal.element).getBoundingClientRect();
+
+  return {
+    cellWidth,
+    cellHeight,
+    originX: rect.left,
+    originY: rect.top,
+    cols: terminal.cols,
+    rows: terminal.rows,
+  };
+}
+
+/**
+ * Convert viewport-space (x, y) to (col, row) within the current grid. Result
+ * is clamped to the grid bounds so a finger that drifts off the edge still
+ * produces a valid selection endpoint. Returns null when dimensions are
+ * unavailable.
+ */
+export function pointToCell(
+  dims: XTermDims,
+  clientX: number,
+  clientY: number
+): { col: number; row: number } {
+  const col = Math.max(
+    0,
+    Math.min(dims.cols - 1, Math.floor((clientX - dims.originX) / dims.cellWidth))
+  );
+  const row = Math.max(
+    0,
+    Math.min(dims.rows - 1, Math.floor((clientY - dims.originY) / dims.cellHeight))
+  );
+  return { col, row };
+}
+
+/**
+ * Compute the linear `length` value `terminal.select(col, row, length)`
+ * expects to span from (startCol, startRow) to (endCol, endRow) in the
+ * VIEWPORT — wrapping across rows. xterm's `select` interprets length as a
+ * count of cells walking left-to-right, top-to-bottom from the start. We use
+ * `cols` (the active grid width) for the row stride.
+ */
+export function selectionLength(
+  startCol: number,
+  startRow: number,
+  endCol: number,
+  endRow: number,
+  cols: number
+): { col: number; row: number; length: number } {
+  // Order start <= end in reading direction.
+  const fromIdx = startRow * cols + startCol;
+  const toIdx = endRow * cols + endCol;
+  if (toIdx < fromIdx) {
+    return {
+      col: endCol,
+      row: endRow,
+      length: fromIdx - toIdx + 1,
+    };
+  }
+  return {
+    col: startCol,
+    row: startRow,
+    length: toIdx - fromIdx + 1,
+  };
+}
+
+export interface UseTouchInteractionsDeps {
+  /** Live xterm.js Terminal instance. Returns null before mount. */
+  getTerminal: () => XTermType | null;
+  /** Test seam — defaults to performance.now(). */
+  now?: () => number;
+  /** Test seam — defaults to setTimeout. */
+  setTimer?: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  /** Test seam — defaults to clearTimeout. */
+  clearTimer?: (id: ReturnType<typeof setTimeout>) => void;
+  /** Test seam — defaults to navigator.clipboard.writeText. */
+  copyToClipboard?: (text: string) => Promise<void>;
+  /**
+   * Test seam — receives the synthesized MouseEvents. In production we
+   * dispatch them directly on the xterm element.
+   */
+  dispatchMouse?: (target: HTMLElement, event: MouseEvent) => void;
+}
+
+export interface TouchInteractionsHandlers {
+  handleTouchStart: (e: TouchEvent) => void;
+  handleTouchMove: (e: TouchEvent) => void;
+  handleTouchEnd: (e: TouchEvent) => void;
+  handleTouchCancel: () => void;
+  /** Current internal mode — exposed for tests. */
+  getMode: () => Mode;
+}
+
+export function createTouchInteractions(
+  deps: UseTouchInteractionsDeps
+): TouchInteractionsHandlers {
+  const { getTerminal } = deps;
+  const now = deps.now ?? (() => performance.now());
+  const setTimer = deps.setTimer ?? ((cb, ms) => setTimeout(cb, ms));
+  const clearTimer = deps.clearTimer ?? ((id) => clearTimeout(id));
+  const copyToClipboard =
+    deps.copyToClipboard ??
+    ((text: string) =>
+      typeof navigator !== "undefined" && navigator.clipboard
+        ? navigator.clipboard.writeText(text)
+        : Promise.resolve());
+  const dispatchMouse =
+    deps.dispatchMouse ??
+    ((target: HTMLElement, event: MouseEvent) => {
+      target.dispatchEvent(event);
+    });
+
+  let mode: Mode = "idle";
+  let startX = 0;
+  let startY = 0;
+  let startT = 0;
+  let lastX = 0;
+  let lastY = 0;
+  let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+  // Cell coords captured when the long-press fires.
+  let selectionStart: { col: number; row: number } | null = null;
+  // Stored dims from the moment the long-press fires; we trust the layout
+  // didn't shift mid-gesture.
+  let selectionDims: XTermDims | null = null;
+
+  const cancelLongPress = () => {
+    if (longPressTimer !== null) {
+      clearTimer(longPressTimer);
+      longPressTimer = null;
+    }
+  };
+
+  const reset = () => {
+    cancelLongPress();
+    mode = "idle";
+    selectionStart = null;
+    selectionDims = null;
+  };
+
+  const beginSelection = () => {
+    const terminal = getTerminal();
+    if (!terminal) return;
+    const dims = readDims(terminal);
+    if (!dims) return;
+    const cell = pointToCell(dims, startX, startY);
+    selectionStart = cell;
+    selectionDims = dims;
+    mode = "selection";
+    // Initial 1-cell selection so the user sees feedback immediately even if
+    // they don't move yet.
+    terminal.clearSelection();
+    terminal.select(cell.col, cell.row, 1);
+    // Haptic cue on supporting browsers (iOS Safari ignores `vibrate`; that's
+    // fine — it's purely additive).
+    if (typeof navigator !== "undefined" && typeof navigator.vibrate === "function") {
+      try {
+        navigator.vibrate(10);
+      } catch {
+        // Some browsers throw on vibrate without a user gesture; ignore.
+      }
+    }
+  };
+
+  const updateSelection = (clientX: number, clientY: number) => {
+    const terminal = getTerminal();
+    if (!terminal || !selectionStart || !selectionDims) return;
+    const end = pointToCell(selectionDims, clientX, clientY);
+    const span = selectionLength(
+      selectionStart.col,
+      selectionStart.row,
+      end.col,
+      end.row,
+      selectionDims.cols
+    );
+    terminal.select(span.col, span.row, span.length);
+  };
+
+  const finishSelection = () => {
+    const terminal = getTerminal();
+    if (!terminal) return;
+    const text = terminal.getSelection();
+    if (text) {
+      // Best-effort clipboard write. We don't surface failures here — the
+      // selection itself remains visible so the user can try again or copy
+      // manually via the system selection menu if available.
+      void copyToClipboard(text).catch(() => {});
+    }
+  };
+
+  const synthesizeTap = (clientX: number, clientY: number) => {
+    const terminal = getTerminal();
+    if (!terminal || !terminal.element) return;
+    const target = terminal.element;
+    // Mouse events fired on the xterm host element are picked up by xterm's
+    // own listeners. When DECSET 1000/1002/1006 is active xterm forwards them
+    // to the PTY; when not, xterm's selection logic clears any prior
+    // selection (which is what we want before we explicitly scroll).
+    const baseInit: MouseEventInit = {
+      bubbles: true,
+      cancelable: true,
+      view: typeof window !== "undefined" ? window : undefined,
+      clientX,
+      clientY,
+      button: 0,
+      buttons: 1,
+    };
+    const md = new MouseEvent("mousedown", baseInit);
+    dispatchMouse(target, md);
+    const mu = new MouseEvent("mouseup", { ...baseInit, buttons: 0 });
+    dispatchMouse(target, mu);
+
+    // If app mouse mode is OFF, the tap should also re-anchor the viewport at
+    // the bottom — matches the user's expectation that tapping clears scroll-
+    // back state and "jumps back to the prompt." When mouse mode IS on, the
+    // app got the click; we leave the viewport position alone since the user
+    // may be intentionally scrolled up reading history.
+    const mouseMode = (terminal as unknown as {
+      modes?: { mouseTrackingMode?: string };
+    }).modes?.mouseTrackingMode;
+    const appOwnsMouse =
+      mouseMode === "vt200" || mouseMode === "drag" || mouseMode === "any";
+    if (!appOwnsMouse) {
+      terminal.scrollToBottom();
+    }
+  };
+
+  const handleTouchStart = (e: TouchEvent) => {
+    if (e.touches.length !== 1) {
+      // Pinch or other multi-touch: relinquish.
+      reset();
+      return;
+    }
+    const t = e.touches[0];
+    startX = t.clientX;
+    startY = t.clientY;
+    lastX = startX;
+    lastY = startY;
+    startT = now();
+    mode = "pending";
+    cancelLongPress();
+    longPressTimer = setTimer(() => {
+      longPressTimer = null;
+      // The long-press timer only fires while we're still in "pending" — if
+      // the finger moved past MOVEMENT_CANCEL_PX or a second finger landed,
+      // we already cancelled it. So at this point the gesture is a held
+      // single finger.
+      if (mode !== "pending") return;
+      beginSelection();
+    }, LONG_PRESS_MS);
+  };
+
+  const handleTouchMove = (e: TouchEvent) => {
+    if (mode === "idle") return;
+    if (e.touches.length !== 1) {
+      // Pinch handoff: cancel long-press but don't dispatch tap on end.
+      cancelLongPress();
+      mode = "scroll"; // any non-tap state cleanly suppresses tap synthesis
+      return;
+    }
+    const t = e.touches[0];
+    lastX = t.clientX;
+    lastY = t.clientY;
+
+    if (mode === "selection") {
+      updateSelection(lastX, lastY);
+      return;
+    }
+
+    // Pending: see if movement disqualifies a tap / long-press.
+    const dx = lastX - startX;
+    const dy = lastY - startY;
+    if (Math.hypot(dx, dy) > MOVEMENT_CANCEL_PX) {
+      cancelLongPress();
+      mode = "scroll"; // touch-scroll handler will own the rest of this gesture
+    }
+  };
+
+  const handleTouchEnd = (e: TouchEvent) => {
+    cancelLongPress();
+    if (mode === "selection") {
+      // Use the last known position from touchmove rather than touchend.touches
+      // (which is empty by spec on the last finger lift).
+      updateSelection(lastX, lastY);
+      finishSelection();
+      mode = "idle";
+      return;
+    }
+
+    if (mode === "pending") {
+      const elapsed = now() - startT;
+      const dx = lastX - startX;
+      const dy = lastY - startY;
+      const dist = Math.hypot(dx, dy);
+      if (elapsed <= TAP_MAX_MS && dist <= TAP_MAX_PX) {
+        synthesizeTap(startX, startY);
+      }
+    }
+
+    // Scroll / cancelled — nothing to do beyond resetting state.
+    mode = "idle";
+    selectionStart = null;
+    selectionDims = null;
+    void e; // suppress unused-arg lint without removing the param shape
+  };
+
+  const handleTouchCancel = () => {
+    reset();
+  };
+
+  return {
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+    handleTouchCancel,
+    getMode: () => mode,
+  };
+}
+
+export interface UseTouchInteractionsOptions {
+  /** Element to attach listeners to (typically the xterm container). */
+  element: HTMLElement | null;
+  getTerminal: () => XTermType | null;
+  enabled?: boolean;
+}
+
+/** React hook that wires `createTouchInteractions` onto an element. */
+export function useTouchInteractions(opts: UseTouchInteractionsOptions): void {
+  const { element, getTerminal, enabled = true } = opts;
+  // Stable refs so the listeners don't re-bind on every render.
+  const getTerminalRef = useRef(getTerminal);
+  useEffect(() => {
+    getTerminalRef.current = getTerminal;
+  }, [getTerminal]);
+
+  useEffect(() => {
+    if (!element || !enabled) return;
+    const handlers = createTouchInteractions({
+      getTerminal: () => getTerminalRef.current(),
+    });
+    // Passive listeners — we never preventDefault here. The touch-scroll
+    // handler in Terminal.tsx already calls preventDefault on touchmove past
+    // its activation threshold; double-handling would be wasteful.
+    element.addEventListener("touchstart", handlers.handleTouchStart, { passive: true });
+    element.addEventListener("touchmove", handlers.handleTouchMove, { passive: true });
+    element.addEventListener("touchend", handlers.handleTouchEnd, { passive: true });
+    element.addEventListener("touchcancel", handlers.handleTouchCancel, { passive: true });
+    return () => {
+      element.removeEventListener("touchstart", handlers.handleTouchStart);
+      element.removeEventListener("touchmove", handlers.handleTouchMove);
+      element.removeEventListener("touchend", handlers.handleTouchEnd);
+      element.removeEventListener("touchcancel", handlers.handleTouchCancel);
+    };
+  }, [element, enabled]);
+}


### PR DESCRIPTION
## Summary

Add a mobile touch-interaction layer for the xterm.js viewport so:
- A **tap** (≤250 ms, ≤5 px) synthesizes a `mousedown`+`mouseup` pair on the xterm element. xterm forwards these to the PTY when application mouse mode is on (DECSET 1000/1002/1006) — Claude Code's clickable TUI buttons now respond. When mouse mode is off, the tap also calls `terminal.scrollToBottom()` so a shell-prompt tap jumps back to latest.
- A **long-press** (≥500 ms, no movement, single finger) locks the gesture into selection mode. A subsequent drag updates `terminal.select(col, row, length)` (spans across rows). `touchend` copies the selection via `navigator.clipboard.writeText`. Optional `navigator.vibrate(10)` on browsers that support it.

## Key decisions

- **Path B (synthesize) over Path A (let browser synthesize).** `.terminal.xterm` has `touch-action: none`, so the browser will never synthesize click events from taps. Path A is impossible without removing the `touch-action: none` rule, which would re-enable native pinch zoom and rubber-band scroll on the terminal.
- **New hook `createTouchInteractions` lives next to `touch-scroll.ts`** in `src/components/terminal/useTouchInteractions.ts`. It composes alongside the existing scroll handler (and `usePinchZoom` on mobile) — they share touch events but my listeners are fully `passive: true`, so I never preventDefault. Only the scroll handler does, and only when it needs to.
- **Threshold alignment.** `MOVEMENT_CANCEL_PX = 5` matches `TOUCH_SCROLL_ACTIVATION_PX`, so the moment the scroll handler activates, my mode flips to `scroll` and cleanly suppresses both tap synthesis and long-press fire — no overlap.
- **Multi-touch handoff.** A second finger landing during the gesture cancels the long-press timer and switches my mode to a non-tap state, so `usePinchZoom` owns the gesture without a tap firing on lift.
- **xterm cell dims** read from `terminal._core._renderService.dimensions.css.cell` (xterm v6 internal, no public alternative). Cast through `unknown` at the boundary; gracefully no-op if unavailable.

## Files

- `src/components/terminal/useTouchInteractions.ts` — new hook + factory
- `src/components/terminal/useTouchInteractions.test.ts` — 19 tests
- `src/components/terminal/Terminal.tsx` — wire the hook alongside the existing scroll handler

## Test plan

- [x] `bun run test:run src/components/terminal/useTouchInteractions.test.ts` — 19/19 pass
- [x] `bun run test:run src/components/mobile/ src/components/terminal/` — 251/251 pass (1 pre-existing skipped)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 108/10/98 (matches master baseline; no new errors or warnings in the new files)
- [ ] Manual on a mobile device:
  - Tap on a Claude Code TUI button → button responds
  - Tap at the prompt while scrolled up → viewport jumps to bottom
  - Long-press + drag in vim/less/normal output → selection follows finger, copies on lift
  - Two-finger pinch → font-size still resizes; no spurious selection or tap
  - Single-finger drag → still scrolls; no spurious selection or tap

This pull request and its description were written by Isaac.