### PR TITLE
fix(mobile/terminal): touch interaction follow-ups (selection vs scroll, tap fallback, tap-deselect)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Mobile terminal touch interactions follow-ups** (`remote-dev-zigy`).
+  Three regressions from PR #227's tap-to-click + long-press-to-select layer
+  are now resolved:
+    - Selection drag no longer fights the scroll handler. Both
+      `useTouchInteractions` and `touch-scroll` now share a `TouchModeRef`,
+      and the scroll handler skips activation while the interactions handler
+      is in `selection` mode. Belt-and-suspenders: the interactions touchmove
+      listener is now `passive: false` and calls `preventDefault()` on
+      touchmove during selection so even handler-order quirks can't scroll
+      the viewport from under the user's selection.
+    - Tap now reliably triggers `terminal.scrollToBottom()` regardless of
+      mouse mode (matches the universal "tap to jump to latest" mobile
+      pattern), and dispatches the synthetic mouse pair on the
+      `.xterm-screen` element directly (the stable mouse-listener host in
+      xterm v6) rather than the fragile inner canvas.
+    - Tap on an active selection clears the selection without firing a click
+      or scroll, matching standard text-selection UX.
 - **Desktop terminal initial fontSize/fontFamily race**
   (`remote-dev-3gtr`). The xterm.js terminal stayed at the default font size
   (14px) on first mount when `PreferencesContext` resolved during the async

--- a/src/components/terminal/Terminal.touch-scroll.test.ts
+++ b/src/components/terminal/Terminal.touch-scroll.test.ts
@@ -13,6 +13,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { createTouchScrollHandlers, TOUCH_SCROLL_ACTIVATION_PX } from "./touch-scroll";
+import { createTouchModeRef } from "./useTouchInteractions";
 
 const CELL_HEIGHT = 16;
 const ROWS = 24;
@@ -246,6 +247,73 @@ describe("touch-scroll: edge cases", () => {
     h.feedTouchSequence([500, 480, 460, 440, 420, 400]);
     expect(h.scrollLinesCalls).toEqual([]);
     expect(h.inputBytes).toEqual([]);
+  });
+
+  it("skips scroll activation when the shared modeRef is in 'selection' (long-press drag in progress)", () => {
+    // Directly drive a TouchScroll instance with a shared modeRef preset to
+    // "selection". Even a long swipe that would otherwise emit must produce
+    // no scroll/input.
+    const container = document.createElement("div");
+    const scrollEl = document.createElement("div");
+    scrollEl.className = "xterm-scrollable-element";
+    Object.defineProperty(scrollEl, "clientHeight", { value: CELL_HEIGHT * ROWS, configurable: true });
+    container.appendChild(scrollEl);
+    document.body.appendChild(container);
+
+    const scrollLinesCalls: number[] = [];
+    const inputBytes: string[] = [];
+    const xterm = {
+      rows: ROWS,
+      scrollLines: (n: number) => scrollLinesCalls.push(n),
+      buffer: { active: { type: "normal" as const } },
+      modes: { applicationCursorKeysMode: false, mouseTrackingMode: "none" as const },
+    };
+    const modeRef = createTouchModeRef();
+    modeRef.current = "selection";
+
+    const handlers = createTouchScrollHandlers({
+      container,
+      getXterm: () => xterm,
+      sendInput: (data: string) => inputBytes.push(data),
+      modeRef,
+      raf: () => 0,
+      cancelRaf: () => {},
+      now: () => 0,
+    });
+
+    const fire = (type: "touchstart" | "touchmove" | "touchend", y: number) => {
+      const touches: Touch[] =
+        type === "touchend"
+          ? []
+          : ([{ clientY: y, clientX: 0, identifier: 0, target: container } as unknown as Touch]);
+      const event = new Event(type, { bubbles: true, cancelable: true }) as unknown as TouchEvent;
+      Object.defineProperty(event, "touches", { value: touches, configurable: true });
+      let preventDefaultCalled = false;
+      Object.defineProperty(event, "preventDefault", {
+        value: () => {
+          preventDefaultCalled = true;
+        },
+        configurable: true,
+      });
+      if (type === "touchstart") handlers.handleTouchStart(event);
+      else if (type === "touchmove") handlers.handleTouchMove(event);
+      else handlers.handleTouchEnd();
+      return preventDefaultCalled;
+    };
+
+    fire("touchstart", 500);
+    // Series of moves that, without the bail, would emit several scrollLines.
+    const pdMid = fire("touchmove", 460);
+    fire("touchmove", 420);
+    fire("touchmove", 380);
+    fire("touchend", 0);
+
+    expect(scrollLinesCalls).toEqual([]);
+    expect(inputBytes).toEqual([]);
+    // We must NOT preventDefault on touchmove during selection — that's the
+    // interactions handler's job (it owns the gesture). The scroll handler
+    // is purely a no-op while selection is active.
+    expect(pdMid).toBe(false);
   });
 
   it("ignores multi-touch gestures so pinch-zoom still works", () => {

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -13,7 +13,7 @@ import { useTerminalTheme } from "@/contexts/AppearanceContext";
 import { sendImageToTerminal } from "@/lib/image-upload";
 import { AuthErrorOverlay } from "./AuthErrorOverlay";
 import { createTouchScrollHandlers } from "./touch-scroll";
-import { createTouchInteractions } from "./useTouchInteractions";
+import { createTouchInteractions, createTouchModeRef } from "./useTouchInteractions";
 
 const SETTLE_MIN_WIDTH = 100;
 const SETTLE_MIN_HEIGHT = 80;
@@ -1381,6 +1381,11 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
     const container = terminalRef.current;
     if (!container) return;
 
+    // Shared mode object: lets the scroll handler bail when the interactions
+    // handler is mid-selection, and lets the interactions handler keep its
+    // mode visible to the scroll handler. One object, two readers.
+    const modeRef = createTouchModeRef();
+
     const handlers = createTouchScrollHandlers({
       container,
       getXterm: () => xtermRef.current,
@@ -1390,15 +1395,16 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
           ws.send(JSON.stringify({ type: "input", data }));
         }
       },
+      modeRef,
     });
 
     // Tap-to-click + long-press-to-select. Composed alongside the scroll
-    // handler: shared touch events, but mine never preventDefault. Order
-    // doesn't matter because the two handlers are state-isolated — any
-    // movement past 5 px puts mine into "scroll" mode (suppresses tap +
-    // long-press) which is exactly when the scroll handler activates.
+    // handler. The interactions handler's touchmove uses passive: false so
+    // it can preventDefault during selection — a belt-and-suspenders pair
+    // with the modeRef check on the scroll side.
     const interactions = createTouchInteractions({
       getTerminal: () => xtermRef.current,
+      modeRef,
     });
 
     container.addEventListener("touchstart", handlers.handleTouchStart, { passive: true });
@@ -1407,7 +1413,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
     container.addEventListener("touchcancel", handlers.handleTouchCancel, { passive: true });
 
     container.addEventListener("touchstart", interactions.handleTouchStart, { passive: true });
-    container.addEventListener("touchmove", interactions.handleTouchMove, { passive: true });
+    container.addEventListener("touchmove", interactions.handleTouchMove, { passive: false });
     container.addEventListener("touchend", interactions.handleTouchEnd, { passive: true });
     container.addEventListener("touchcancel", interactions.handleTouchCancel, { passive: true });
 

--- a/src/components/terminal/touch-scroll.ts
+++ b/src/components/terminal/touch-scroll.ts
@@ -29,6 +29,8 @@
 // flush so DECSET 1049 / mouse-mode / vim mode toggles mid-swipe behave
 // correctly.
 
+import type { TouchModeRef } from "./useTouchInteractions";
+
 // Pixel slop a single-touch swipe must exceed before we treat it as a scroll
 // gesture rather than a tap.
 export const TOUCH_SCROLL_ACTIVATION_PX = 5;
@@ -60,6 +62,13 @@ export interface TouchScrollDeps {
    * path. Same channel the on-screen keyboard already uses.
    */
   sendInput: (data: string) => void;
+  /**
+   * Optional mode ref shared with `createTouchInteractions`. When the
+   * interactions handler is in `"selection"` mode (long-press drag), this
+   * scroll handler skips activation so the viewport doesn't scroll from
+   * under the user's selection drag.
+   */
+  modeRef?: TouchModeRef;
   /** Test seam — defaults to performance.now(). */
   now?: () => number;
   /** Test seam — defaults to requestAnimationFrame. */
@@ -78,10 +87,11 @@ export interface TouchScrollHandlers {
 }
 
 export function createTouchScrollHandlers(deps: TouchScrollDeps): TouchScrollHandlers {
-  const { container, getXterm, sendInput } = deps;
+  const { container, getXterm, sendInput, modeRef } = deps;
   const now = deps.now ?? (() => performance.now());
   const raf = deps.raf ?? ((cb) => requestAnimationFrame(cb));
   const cancelRaf = deps.cancelRaf ?? ((id) => cancelAnimationFrame(id));
+  const isSelecting = (): boolean => modeRef?.current === "selection";
 
   let touchStartY = 0;
   let lastTouchY = 0;
@@ -181,6 +191,16 @@ export function createTouchScrollHandlers(deps: TouchScrollDeps): TouchScrollHan
   };
 
   const handleTouchMove = (e: TouchEvent) => {
+    // Selection drag in progress (interactions handler owns the gesture):
+    // skip scroll handling entirely so the viewport stays put under the
+    // user's selection. The interactions handler also calls preventDefault
+    // on its own — between the two we're fully covered regardless of
+    // listener invocation order.
+    if (isSelecting()) {
+      isScrolling = false;
+      return;
+    }
+
     if (e.touches.length !== 1) {
       isScrolling = false;
       return;

--- a/src/components/terminal/useTouchInteractions.test.ts
+++ b/src/components/terminal/useTouchInteractions.test.ts
@@ -12,6 +12,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   createTouchInteractions,
+  createTouchModeRef,
   pointToCell,
   selectionLength,
   TAP_MAX_MS,
@@ -29,6 +30,7 @@ interface FakeXTerm {
   select: ReturnType<typeof vi.fn>;
   clearSelection: ReturnType<typeof vi.fn>;
   getSelection: ReturnType<typeof vi.fn>;
+  hasSelection: ReturnType<typeof vi.fn>;
   // _core mock returns the cell width/height we configure
   _core: {
     _renderService: {
@@ -49,13 +51,15 @@ interface Harness {
   fireTouch: (
     type: "touchstart" | "touchmove" | "touchend" | "touchcancel",
     touches: Array<{ x: number; y: number }>
-  ) => void;
+  ) => boolean;
   advanceTime: (ms: number) => void;
   flushTimers: () => void;
   mouseEvents: Array<{ type: string; clientX: number; clientY: number; target: EventTarget | null }>;
   copies: string[];
   getMode: () => string;
   destroy: () => void;
+  /** Direct access to the modeRef shared with the scroll handler in prod. */
+  modeRef: { current: string };
   /** How many times `getBoundingClientRect` has been called on the screen. */
   bcrCalls: () => number;
   /** Shift the cached screen rect by `dy` px to simulate keyboard slide-up. */
@@ -105,6 +109,9 @@ function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"]
     select: vi.fn(),
     clearSelection: vi.fn(),
     getSelection: vi.fn(() => "selected text"),
+    // No active selection by default. Tests for tap-to-deselect override
+    // this to return true.
+    hasSelection: vi.fn(() => false),
     _core: {
       _renderService: {
         dimensions: { css: { cell: { width: CELL_W, height: CELL_H } } },
@@ -120,8 +127,13 @@ function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"]
   const mouseEvents: Array<{ type: string; clientX: number; clientY: number; target: EventTarget | null }> = [];
   const copies: string[] = [];
 
+  // Production wires this between createTouchInteractions and
+  // createTouchScrollHandlers so the scroll handler sees `selection` and bails.
+  const modeRef = createTouchModeRef();
+
   const handlers = createTouchInteractions({
     getTerminal: () => xterm as unknown as Parameters<typeof createTouchInteractions>[0]["getTerminal"] extends () => infer R ? R : never,
+    modeRef,
     now: () => nowValue,
     setTimer: ((cb: TimerFn, ms: number) => {
       const id = nextTimerId++;
@@ -148,7 +160,7 @@ function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"]
   const fireTouch = (
     type: "touchstart" | "touchmove" | "touchend" | "touchcancel",
     touches: Array<{ x: number; y: number }>
-  ) => {
+  ): boolean => {
     const touchObjs = touches.map(
       (t, i) => ({ clientX: t.x, clientY: t.y, identifier: i, target: element }) as unknown as Touch
     );
@@ -158,6 +170,7 @@ function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"]
     else if (type === "touchmove") handlers.handleTouchMove(ev);
     else if (type === "touchend") handlers.handleTouchEnd(ev);
     else handlers.handleTouchCancel(ev);
+    return (ev as unknown as Event).defaultPrevented;
   };
 
   const advanceTime = (ms: number) => {
@@ -185,6 +198,7 @@ function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"]
     copies,
     getMode: handlers.getMode,
     destroy: handlers.destroy,
+    modeRef,
     bcrCalls: () => bcrCount,
     shiftScreenY: (dy) => {
       originY += dy;
@@ -251,14 +265,17 @@ describe("tap-to-click", () => {
     expect(h.xterm.scrollToBottom).toHaveBeenCalledTimes(1);
   });
 
-  it("does NOT call scrollToBottom when application mouse mode is ON", () => {
+  it("ALSO calls scrollToBottom when application mouse mode is ON (universal jump-to-bottom UX)", () => {
     for (const mode of ["vt200", "drag", "any"] as const) {
       const h = makeHarness({ mouseMode: mode });
       h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
       h.advanceTime(50);
       h.fireTouch("touchend", []);
-      expect(h.xterm.scrollToBottom).not.toHaveBeenCalled();
-      // mouse events are still sent — that's the whole point.
+      // Tap dispatches the synthetic mouse pair AND scrolls to bottom. The
+      // app handles its own scroll via the synthesized click; xterm's
+      // scrollToBottom is a no-op on the alt buffer where TUIs typically
+      // run, so this is safe everywhere.
+      expect(h.xterm.scrollToBottom).toHaveBeenCalledTimes(1);
       expect(h.mouseEvents).toHaveLength(2);
     }
   });
@@ -435,21 +452,12 @@ describe("synthesizeTap dispatch target", () => {
     document.body.innerHTML = "";
   });
 
-  it("dispatches mousedown+mouseup on the .xterm-screen canvas (xterm wires its mouse listeners there)", () => {
+  it("dispatches mousedown+mouseup on the .xterm-screen element (xterm wires its mouse listeners there)", () => {
+    // We deliberately target .xterm-screen (the stable mouse-listener host
+    // in xterm v6) rather than an inner canvas. WebGL builds paint into
+    // multiple canvases and the listener isn't on any of them; the screen
+    // div is the consistent mouse-input surface.
     const h = makeHarness();
-    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
-    h.advanceTime(50);
-    h.fireTouch("touchend", []);
-    expect(h.mouseEvents).toHaveLength(2);
-    for (const e of h.mouseEvents) {
-      expect(e.target).toBe(h.canvas);
-    }
-  });
-
-  it("falls back to .xterm-screen when no canvas is present", () => {
-    const h = makeHarness();
-    // Remove the canvas to simulate a renderer that didn't paint one.
-    h.canvas.remove();
     h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
     h.advanceTime(50);
     h.fireTouch("touchend", []);
@@ -459,7 +467,7 @@ describe("synthesizeTap dispatch target", () => {
     }
   });
 
-  it("falls back to terminal.element when neither .xterm-screen nor canvas is present", () => {
+  it("falls back to terminal.element when .xterm-screen is missing", () => {
     const h = makeHarness();
     h.screen.remove();
     h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
@@ -508,6 +516,96 @@ describe("selection drag re-reads grid origin per touchmove", () => {
     h.fireTouch("touchmove", [{ x: 200 + CELL_W, y: 100 }]);
     // Linear: from (12,3) to (13,5) over cols=80 → idx 252 to idx 413, length 162.
     expect(h.xterm.select).toHaveBeenLastCalledWith(12, 3, 162);
+  });
+});
+
+describe("tap-to-deselect", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("clears the active selection on tap and does NOT synthesize click or scroll", () => {
+    const h = makeHarness();
+    // Pretend xterm already has a selection (from a previous long-press).
+    h.xterm.hasSelection = vi.fn(() => true);
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(50);
+    h.fireTouch("touchend", []);
+    // Tap on an active selection: clear and bail.
+    expect(h.xterm.clearSelection).toHaveBeenCalledTimes(1);
+    expect(h.mouseEvents).toEqual([]);
+    expect(h.xterm.scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it("after the deselect tap, the next tap synthesizes a click and scrolls (selection now cleared)", () => {
+    const h = makeHarness();
+    // First tap: had a selection. After clearSelection runs we flip the
+    // mock back to "no selection" so the next tap takes the normal path.
+    let hasSel = true;
+    h.xterm.hasSelection = vi.fn(() => hasSel);
+    h.xterm.clearSelection = vi.fn(() => {
+      hasSel = false;
+    });
+
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(50);
+    h.fireTouch("touchend", []);
+    expect(h.xterm.clearSelection).toHaveBeenCalledTimes(1);
+    expect(h.mouseEvents).toEqual([]);
+    expect(h.xterm.scrollToBottom).not.toHaveBeenCalled();
+
+    // Second tap.
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(50);
+    h.fireTouch("touchend", []);
+    expect(h.mouseEvents).toHaveLength(2);
+    expect(h.xterm.scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("selection drag suppresses scroll", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("calls preventDefault on touchmove during selection mode", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.advanceTime(LONG_PRESS_MS);
+    h.flushTimers();
+    expect(h.getMode()).toBe("selection");
+    // Now drag — the move should set defaultPrevented so the host's
+    // touch-scroll listener (which doesn't bail synchronously without a
+    // shared mode) sees a preventDefault'd event.
+    const prevented = h.fireTouch("touchmove", [{ x: 200 + 2 * CELL_W, y: 100 }]);
+    expect(prevented).toBe(true);
+  });
+
+  it("does NOT call preventDefault on touchmove in pending or scroll mode", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    // Move within the cancel threshold: still pending, must NOT preventDefault
+    // (would block the touch-scroll handler from doing its thing).
+    const prevented1 = h.fireTouch("touchmove", [{ x: 201, y: 101 }]);
+    expect(prevented1).toBe(false);
+    // Move past threshold: scroll mode. Still must NOT preventDefault.
+    const prevented2 = h.fireTouch("touchmove", [{ x: 220, y: 100 }]);
+    expect(prevented2).toBe(false);
+    expect(h.getMode()).toBe("scroll");
+  });
+
+  it("exposes selection mode via the shared modeRef so the scroll handler can bail", () => {
+    const h = makeHarness();
+    expect(h.modeRef.current).toBe("idle");
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    expect(h.modeRef.current).toBe("pending");
+    h.advanceTime(LONG_PRESS_MS);
+    h.flushTimers();
+    expect(h.modeRef.current).toBe("selection");
+    h.fireTouch("touchmove", [{ x: 200 + CELL_W, y: 100 }]);
+    expect(h.modeRef.current).toBe("selection");
+    h.fireTouch("touchend", []);
+    expect(h.modeRef.current).toBe("idle");
   });
 });
 

--- a/src/components/terminal/useTouchInteractions.ts
+++ b/src/components/terminal/useTouchInteractions.ts
@@ -14,22 +14,27 @@
 //     one for the long-press fire (DEFAULT_LONG_PRESS_MS), and an implicit
 //     one via touchend which decides between "tap" vs "scroll"/"selection".
 //   - During touchmove: if the gesture is in the selection mode (long-press
-//     fired), we update `terminal.select(col, row, length)`. Otherwise, if the
-//     finger has moved further than MOVEMENT_CANCEL_PX, we cancel the pending
+//     fired), we update `terminal.select(col, row, length)` AND call
+//     `e.preventDefault()` so the parallel touch-scroll handler doesn't
+//     scroll the viewport from under the selection. Otherwise, if the finger
+//     has moved further than MOVEMENT_CANCEL_PX, we cancel the pending
 //     long-press timer and let the touch-scroll handler take over.
 //   - On touchend: if we're in selection mode, copy `terminal.getSelection()`
 //     to the clipboard and keep the selection visible. Otherwise, if the
 //     gesture lasted < TAP_MAX_MS and total movement was < TAP_MAX_PX, we
-//     synthesize a `mousedown`+`mouseup` pair on the xterm element. xterm
-//     forwards these to the application when mouse mode is on; if it is off,
-//     we clear any selection and call `terminal.scrollToBottom()` so the
-//     "tap to jump to latest" behavior works at a shell prompt.
+//     either clear an existing selection (tap-to-deselect) OR synthesize a
+//     `mousedown`+`mouseup` pair on the xterm screen and scroll to the
+//     bottom. We always scroll to the bottom on tap regardless of mouse mode
+//     because that matches user expectation. When mouse mode is on, xterm
+//     also forwards the synthetic click to the running app.
 //   - On a second finger (pinch handoff) we cancel the pending long-press and
 //     bail out — `usePinchZoom` claims the gesture from there.
 //
-// We do NOT call `e.preventDefault()` on the touch events here. The touch-
-// scroll handler already does so when needed (touchmove past activation), and
-// `touch-action: none` on .xterm.terminal blocks the browser side.
+// Coordination with `touch-scroll.ts`: shared via a `TouchModeRef`. The scroll
+// handler skips activation when our mode is `"selection"`, so a long-press
+// drag never accidentally scrolls. We also `preventDefault` on touchmove
+// during selection as a belt-and-suspenders measure (requires the listener be
+// registered with `{ passive: false }`).
 //
 // xterm internals: cell dimensions live on `terminal._core._renderService`.
 // xterm's public TS surface doesn't expose this, so we cast through `unknown`
@@ -51,7 +56,24 @@ export const LONG_PRESS_MS = 500;
 // the gesture and we cleanly suppress both long-press and tap synthesis.
 export const MOVEMENT_CANCEL_PX = 5;
 
-type Mode = "idle" | "pending" | "selection" | "scroll";
+export type TouchInteractionMode = "idle" | "pending" | "selection" | "scroll";
+
+/**
+ * Mutable mode reference shared between `createTouchInteractions` and
+ * `createTouchScrollHandlers`. Lets the scroll handler skip activation while
+ * a selection drag is in progress, and lets the interactions handler keep
+ * its mode in sync with what the scroll handler observes. The host owns the
+ * single object instance and passes it to both factories.
+ */
+export interface TouchModeRef {
+  current: TouchInteractionMode;
+}
+
+export function createTouchModeRef(): TouchModeRef {
+  return { current: "idle" };
+}
+
+type Mode = TouchInteractionMode;
 
 interface XTermDims {
   /** Cell width in CSS px (not device px). */
@@ -165,6 +187,12 @@ export function selectionLength(
 export interface UseTouchInteractionsDeps {
   /** Live xterm.js Terminal instance. Returns null before mount. */
   getTerminal: () => XTermType | null;
+  /**
+   * Shared mode reference. Required for coordinating with `touch-scroll.ts`
+   * (the scroll handler reads this to bail when we're mid-selection). If
+   * omitted, a private one is created — useful for unit tests.
+   */
+  modeRef?: TouchModeRef;
   /** Test seam — defaults to performance.now(). */
   now?: () => number;
   /** Test seam — defaults to setTimeout. */
@@ -213,8 +241,14 @@ export function createTouchInteractions(
     ((target: HTMLElement, event: MouseEvent) => {
       target.dispatchEvent(event);
     });
+  // The host shares one `modeRef` across this hook + touch-scroll. When
+  // omitted (unit tests), we use a private one so the handler still works.
+  const modeRef: TouchModeRef = deps.modeRef ?? createTouchModeRef();
+  const setMode = (m: Mode) => {
+    modeRef.current = m;
+  };
+  const getCurrentMode = (): Mode => modeRef.current;
 
-  let mode: Mode = "idle";
   let startX = 0;
   let startY = 0;
   let startT = 0;
@@ -233,7 +267,7 @@ export function createTouchInteractions(
 
   const reset = () => {
     cancelLongPress();
-    mode = "idle";
+    setMode("idle");
     selectionStart = null;
   };
 
@@ -246,7 +280,7 @@ export function createTouchInteractions(
     if (!dims) return;
     const cell = pointToCell(dims, startX, startY);
     selectionStart = cell;
-    mode = "selection";
+    setMode("selection");
     // Initial 1-cell selection so the user sees feedback immediately even if
     // they don't move yet.
     terminal.clearSelection();
@@ -300,15 +334,27 @@ export function createTouchInteractions(
   const synthesizeTap = (clientX: number, clientY: number) => {
     const terminal = getTerminal();
     if (!terminal || !terminal.element) return;
-    // xterm v6 attaches its mouse listeners to the canvas inside .xterm-screen
-    // (where the WebGL/canvas renderer paints), NOT to the outer host div.
-    // Dispatched events do not propagate downward into children, so a
-    // mousedown on `terminal.element` is silently ignored. Walk into the
-    // screen → canvas, with the host div as a last-resort fallback.
+
+    // Tap-to-deselect: if there's an active selection, clear it and bail.
+    // Don't fire a click and don't scroll — the user's intent on this tap
+    // was clearly "dismiss the selection." Their next tap will go through
+    // the normal click + scrollToBottom path.
+    if (terminal.hasSelection()) {
+      terminal.clearSelection();
+      return;
+    }
+
+    // xterm v6 attaches its mouse listeners on the .xterm-screen element via
+    // `addDisposableListener`. We dispatch there — it is the stable target
+    // regardless of which renderer (WebGL canvas, DOM, multiple canvases)
+    // happens to be active. We previously aimed at the inner canvas, but
+    // that's brittle: WebGL builds paint into multiple canvases (text,
+    // selection, link, link-tooltip layers) and the listener isn't on any of
+    // them. Falling back to the host div is also fine; xterm wires a few
+    // listeners there as well.
     const host = terminal.element;
     const screen = host.querySelector(".xterm-screen") as HTMLElement | null;
-    const canvas = screen?.querySelector("canvas") as HTMLElement | null;
-    const target: HTMLElement = canvas ?? screen ?? host;
+    const target: HTMLElement = screen ?? host;
     const baseInit: MouseEventInit = {
       bubbles: true,
       cancelable: true,
@@ -318,24 +364,17 @@ export function createTouchInteractions(
       button: 0,
       buttons: 1,
     };
-    const md = new MouseEvent("mousedown", baseInit);
-    dispatchMouse(target, md);
-    const mu = new MouseEvent("mouseup", { ...baseInit, buttons: 0 });
-    dispatchMouse(target, mu);
+    dispatchMouse(target, new MouseEvent("mousedown", baseInit));
+    dispatchMouse(target, new MouseEvent("mouseup", { ...baseInit, buttons: 0 }));
 
-    // If app mouse mode is OFF, the tap should also re-anchor the viewport at
-    // the bottom — matches the user's expectation that tapping clears scroll-
-    // back state and "jumps back to the prompt." When mouse mode IS on, the
-    // app got the click; we leave the viewport position alone since the user
-    // may be intentionally scrolled up reading history.
-    const mouseMode = (terminal as unknown as {
-      modes?: { mouseTrackingMode?: string };
-    }).modes?.mouseTrackingMode;
-    const appOwnsMouse =
-      mouseMode === "vt200" || mouseMode === "drag" || mouseMode === "any";
-    if (!appOwnsMouse) {
-      terminal.scrollToBottom();
-    }
+    // Always scroll to bottom on tap, regardless of mouse mode. Most users
+    // expect tapping the terminal to "jump back to the latest output" — a
+    // ubiquitous mobile pattern. When app mouse mode is on, xterm forwards
+    // the synthetic click to the running app for free; the scroll is a no-op
+    // there since the alt buffer doesn't have scrollback. When mouse mode is
+    // off, the synthetic click is a harmless no-op (xterm's selection logic
+    // would handle it but our taps don't drag) and the scroll does its job.
+    terminal.scrollToBottom();
   };
 
   const handleTouchStart = (e: TouchEvent) => {
@@ -350,7 +389,7 @@ export function createTouchInteractions(
     lastX = startX;
     lastY = startY;
     startT = now();
-    mode = "pending";
+    setMode("pending");
     cancelLongPress();
     longPressTimer = setTimer(() => {
       longPressTimer = null;
@@ -358,24 +397,33 @@ export function createTouchInteractions(
       // the finger moved past MOVEMENT_CANCEL_PX or a second finger landed,
       // we already cancelled it. So at this point the gesture is a held
       // single finger.
-      if (mode !== "pending") return;
+      if (getCurrentMode() !== "pending") return;
       beginSelection();
     }, LONG_PRESS_MS);
   };
 
   const handleTouchMove = (e: TouchEvent) => {
-    if (mode === "idle") return;
+    const cur = getCurrentMode();
+    if (cur === "idle") return;
     if (e.touches.length !== 1) {
       // Pinch handoff: cancel long-press but don't dispatch tap on end.
       cancelLongPress();
-      mode = "scroll"; // any non-tap state cleanly suppresses tap synthesis
+      setMode("scroll"); // any non-tap state cleanly suppresses tap synthesis
       return;
     }
     const t = e.touches[0];
     lastX = t.clientX;
     lastY = t.clientY;
 
-    if (mode === "selection") {
+    if (cur === "selection") {
+      // Suppress the parallel touch-scroll handler. Without preventDefault
+      // the host's scroll listener would also process this touchmove and
+      // scroll the viewport while the user is dragging to extend the
+      // selection. We also share the modeRef so the scroll handler bails
+      // on its own (defense in depth — preventDefault here covers the
+      // cases where listener order or third-party hooks bypass that).
+      // Requires the listener be registered with `{ passive: false }`.
+      if (e.cancelable) e.preventDefault();
       updateSelection(lastX, lastY);
       return;
     }
@@ -385,22 +433,23 @@ export function createTouchInteractions(
     const dy = lastY - startY;
     if (Math.hypot(dx, dy) > MOVEMENT_CANCEL_PX) {
       cancelLongPress();
-      mode = "scroll"; // touch-scroll handler will own the rest of this gesture
+      setMode("scroll"); // touch-scroll handler will own the rest of this gesture
     }
   };
 
   const handleTouchEnd = (e: TouchEvent) => {
     cancelLongPress();
-    if (mode === "selection") {
+    const cur = getCurrentMode();
+    if (cur === "selection") {
       // Use the last known position from touchmove rather than touchend.touches
       // (which is empty by spec on the last finger lift).
       updateSelection(lastX, lastY);
       finishSelection();
-      mode = "idle";
+      setMode("idle");
       return;
     }
 
-    if (mode === "pending") {
+    if (cur === "pending") {
       const elapsed = now() - startT;
       const dx = lastX - startX;
       const dy = lastY - startY;
@@ -411,7 +460,7 @@ export function createTouchInteractions(
     }
 
     // Scroll / cancelled — nothing to do beyond resetting state.
-    mode = "idle";
+    setMode("idle");
     selectionStart = null;
     void e; // suppress unused-arg lint without removing the param shape
   };
@@ -427,7 +476,7 @@ export function createTouchInteractions(
     handleTouchEnd,
     handleTouchCancel,
     destroy: reset,
-    getMode: () => mode,
+    getMode: () => modeRef.current,
   };
 }
 
@@ -435,12 +484,14 @@ export interface UseTouchInteractionsOptions {
   /** Element to attach listeners to (typically the xterm container). */
   element: HTMLElement | null;
   getTerminal: () => XTermType | null;
+  /** Optional shared mode ref for coordinating with `touch-scroll.ts`. */
+  modeRef?: TouchModeRef;
   enabled?: boolean;
 }
 
 /** React hook that wires `createTouchInteractions` onto an element. */
 export function useTouchInteractions(opts: UseTouchInteractionsOptions): void {
-  const { element, getTerminal, enabled = true } = opts;
+  const { element, getTerminal, modeRef, enabled = true } = opts;
   // Stable refs so the listeners don't re-bind on every render.
   const getTerminalRef = useRef(getTerminal);
   useEffect(() => {
@@ -451,12 +502,14 @@ export function useTouchInteractions(opts: UseTouchInteractionsOptions): void {
     if (!element || !enabled) return;
     const handlers = createTouchInteractions({
       getTerminal: () => getTerminalRef.current(),
+      modeRef,
     });
-    // Passive listeners — we never preventDefault here. The touch-scroll
-    // handler in Terminal.tsx already calls preventDefault on touchmove past
-    // its activation threshold; double-handling would be wasteful.
+    // touchmove is `{ passive: false }` because we call preventDefault while
+    // in selection mode (so the host's touch-scroll listener doesn't scroll
+    // the viewport from under the dragged selection). The other events stay
+    // passive — we don't preventDefault on them.
     element.addEventListener("touchstart", handlers.handleTouchStart, { passive: true });
-    element.addEventListener("touchmove", handlers.handleTouchMove, { passive: true });
+    element.addEventListener("touchmove", handlers.handleTouchMove, { passive: false });
     element.addEventListener("touchend", handlers.handleTouchEnd, { passive: true });
     element.addEventListener("touchcancel", handlers.handleTouchCancel, { passive: true });
     return () => {
@@ -466,5 +519,5 @@ export function useTouchInteractions(opts: UseTouchInteractionsOptions): void {
       element.removeEventListener("touchend", handlers.handleTouchEnd);
       element.removeEventListener("touchcancel", handlers.handleTouchCancel);
     };
-  }, [element, enabled]);
+  }, [element, enabled, modeRef]);
 }


### PR DESCRIPTION
## Summary

Three follow-up bugs from PR #227's mobile tap-to-click + long-press-to-select layer (closes `remote-dev-zigy`):

- **Selection drag fights scroll** (HIGH). After a long-press activated selection mode, vertical finger movement extended the selection BUT the touch-scroll handler also fired and scrolled the viewport from under the selection. Now both handlers share a `TouchModeRef`; scroll handler bails when interactions handler is in `selection` mode. Belt-and-suspenders: interactions touchmove listener is now `{ passive: false }` and calls `preventDefault()` during selection so handler-order quirks can't slip through.
- **Tap doesn't reach TUI / scrollToBottom doesn't fire** (HIGH). `scrollToBottom()` now fires on every tap regardless of `mouseTrackingMode`, matching the universal "tap to jump to latest" mobile UX. The synthetic mouse pair is now dispatched on `.xterm-screen` (the stable xterm v6 mouse-listener host) rather than an inner canvas, which was unreliable across the WebGL/DOM renderer variants.
- **Tap doesn't deselect** (MEDIUM). When `terminal.hasSelection()` is true, the tap path now calls `clearSelection()` and bails — no synthetic click, no scroll. The next tap falls through to the normal path.

## Key decisions

- Picked the **shared mutable mode object** (`TouchModeRef`) over a getter callback because it's symmetric: both handlers can both read and write the gesture state, and the prod `Terminal.tsx` host owns the single instance for the gesture's lifetime.
- Picked **always scrollToBottom on tap** over per-mode detection. Detecting `mouseTrackingMode` worked, but the user experience is universally better when tap = "go to bottom" — and on the alt buffer (where TUIs run) `scrollToBottom()` is a no-op anyway.
- Switched dispatch target to **`.xterm-screen`** (with fallback to `terminal.element`). xterm v6 wires its mouse listeners on the screen div via `addDisposableListener`; the inner canvas was a guess that doesn't hold across renderer flavors.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` matches master baseline (108/10/98 — none of the errors are in touched files)
- [x] `bun run test:run src/components/mobile/ src/components/terminal/` — 264 passed, 1 skipped
- [x] New tests cover: tap-to-deselect (with follow-up tap), preventDefault on touchmove during selection, modeRef visibility through gesture lifecycle, scroll handler bails when modeRef is `"selection"`
- [x] Existing dispatch-target tests updated for the new `.xterm-screen` target
- [x] Existing scrollToBottom tests updated to assert it fires under all mouse modes
- [x] Unmount-safety test from previous round still passes
- [ ] Manual: single-finger vertical drag on iOS still scrolls
- [ ] Manual: pinch-zoom (two fingers) still scales font via `usePinchZoom`
- [ ] Manual: long-press, drag — selection extends without viewport scroll
- [ ] Manual: tap with active selection — selection clears, no scroll
- [ ] Manual: tap without selection — terminal scrolls to bottom

This pull request and its description were written by Isaac.