### PR TITLE
feat(terminal): auto-resize on tab/window focus with multi-client priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   confirmation; on confirm it calls `deleteAllNotifications` and shows a
   toast with the count. The button is hidden when the list is empty and is
   disabled while the request is in flight.
+- **Mobile redesign Phase 6: Auth flow + Profile tab** (remote-dev-lud6).
+  Polishes the post-Cloudflare-Access landing into a calm, two-step flow:
+  a `MobileLockScreen` interstitial ("Authenticating via Cloudflare Access")
+  while the session resolves, then a one-time `MobileWelcomeScreen` with a
+  signed-in-as line, an optional Connect-GitHub CTA, and a Skip-for-now
+  button. First-run state is persisted via a localStorage flag
+  (`remote-dev:mobile:welcome-seen:v1`) so subsequent visits jump straight
+  to Sessions. The GitHub OAuth callback's `?github=connected` query param
+  now surfaces a one-shot success toast on the Sessions tab and is stripped
+  from the URL on read. The Profile tab ships as a pushed-row stack
+  (Account, GitHub accounts, Projects, Agent profiles, Secrets, Ports,
+  Trash, Settings, About, Sign out) with a tab-local navigation stack —
+  no modals for routine settings, every row pushes a sub-screen, and Sign
+  out confirms via an `ActionSheet` (not a dialog). Sub-screens beyond
+  About are intentionally stubbed in this build with a TODO note pointing
+  at the desktop component to port; the navigation chrome and primary
+  flows are real.
+- **Mobile redesign Phase 4: Notifications tab** (remote-dev-qvpf). The
+  mobile Notifications tab preserves the existing notification model and
+  the canonical attention-blue halo end-to-end. Filter chips (All / Unread
+  / Mentions) sticky to top, count pills on Unread / Mentions. Each row
+  uses a leading 12px (6px-radius) dot in `--color-signal-attention-solid`
+  for unread state instead of a colored side-stripe (DESIGN.md "No
+  Side-Stripe Rule"); the `notification-ring-pulse` halo renders on
+  `agent_waiting` rows and is suppressed under `prefers-reduced-motion`.
+  Swipe-left = delete with 5s undo toast (sonner); swipe-right = toggle
+  read; long-press opens an ActionSheet with Jump to session, Mark
+  read/unread, Mute project, and Dismiss. Tapping a row inline-expands the
+  body (no push navigation) and marks unread items read. Pull-to-refresh
+  uses the canonical absolutely-positioned indicator pattern. Empty state
+  copy is "Inbox zero" for the All filter; filter-specific empties for
+  Unread and Mentions. New files under
+  `src/components/mobile/notifications/` (`NotificationsTab`,
+  `MobileNotificationRow`, `NotificationFilterChips`,
+  `useNotificationSwipe`). Wired into `MobileApp.tsx`.
+- **Mobile redesign Phase 2: Sessions tab** (remote-dev-l9qg). The mobile
+  home is now the Sessions tab. A header strip with a project switcher chip,
+  a `+ New` pill, and a recent-projects rail sits above a session list with
+  a 6px state pip per row, weight-driven hierarchy on the title, and a
+  foreground line-segment indicator for the active row (no colored side
+  stripes). Long-press opens an action sheet (Suspend / Resume / Rename /
+  Move / View recordings / Close session). Swipe-left dispatches suspend
+  with a 5s undo toast. Pull-to-refresh, attention-blue halo for waiting
+  sessions, and reduced-motion respect everywhere. New `BottomSheet` and
+  `ActionSheet` primitives, `usePullToRefresh` hook, and a project-tree
+  bottom sheet with search complete the surface. Built on top of the Phase 1
+  shell from remote-dev-3ozu.
 
 ### Security
 
@@ -88,56 +135,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prevent a hydration mismatch under React 19 / Next.js 16. Extracted the
   shared `AnsiStripper` to `src/lib/terminal/ansi-stripper.ts` so
   `MobileTerminalView` and the new `MobileSessionView` can't drift apart.
-
-### Added
-
-- **Mobile redesign Phase 6: Auth flow + Profile tab** (remote-dev-lud6).
-  Polishes the post-Cloudflare-Access landing into a calm, two-step flow:
-  a `MobileLockScreen` interstitial ("Authenticating via Cloudflare Access")
-  while the session resolves, then a one-time `MobileWelcomeScreen` with a
-  signed-in-as line, an optional Connect-GitHub CTA, and a Skip-for-now
-  button. First-run state is persisted via a localStorage flag
-  (`remote-dev:mobile:welcome-seen:v1`) so subsequent visits jump straight
-  to Sessions. The GitHub OAuth callback's `?github=connected` query param
-  now surfaces a one-shot success toast on the Sessions tab and is stripped
-  from the URL on read. The Profile tab ships as a pushed-row stack
-  (Account, GitHub accounts, Projects, Agent profiles, Secrets, Ports,
-  Trash, Settings, About, Sign out) with a tab-local navigation stack —
-  no modals for routine settings, every row pushes a sub-screen, and Sign
-  out confirms via an `ActionSheet` (not a dialog). Sub-screens beyond
-  About are intentionally stubbed in this build with a TODO note pointing
-  at the desktop component to port; the navigation chrome and primary
-  flows are real.
-- **Mobile redesign Phase 4: Notifications tab** (remote-dev-qvpf). The
-  mobile Notifications tab preserves the existing notification model and
-  the canonical attention-blue halo end-to-end. Filter chips (All / Unread
-  / Mentions) sticky to top, count pills on Unread / Mentions. Each row
-  uses a leading 12px (6px-radius) dot in `--color-signal-attention-solid`
-  for unread state instead of a colored side-stripe (DESIGN.md "No
-  Side-Stripe Rule"); the `notification-ring-pulse` halo renders on
-  `agent_waiting` rows and is suppressed under `prefers-reduced-motion`.
-  Swipe-left = delete with 5s undo toast (sonner); swipe-right = toggle
-  read; long-press opens an ActionSheet with Jump to session, Mark
-  read/unread, Mute project, and Dismiss. Tapping a row inline-expands the
-  body (no push navigation) and marks unread items read. Pull-to-refresh
-  uses the canonical absolutely-positioned indicator pattern. Empty state
-  copy is "Inbox zero" for the All filter; filter-specific empties for
-  Unread and Mentions. New files under
-  `src/components/mobile/notifications/` (`NotificationsTab`,
-  `MobileNotificationRow`, `NotificationFilterChips`,
-  `useNotificationSwipe`). Wired into `MobileApp.tsx`.
-- **Mobile redesign Phase 2: Sessions tab** (remote-dev-l9qg). The mobile
-  home is now the Sessions tab. A header strip with a project switcher chip,
-  a `+ New` pill, and a recent-projects rail sits above a session list with
-  a 6px state pip per row, weight-driven hierarchy on the title, and a
-  foreground line-segment indicator for the active row (no colored side
-  stripes). Long-press opens an action sheet (Suspend / Resume / Rename /
-  Move / View recordings / Close session). Swipe-left dispatches suspend
-  with a 5s undo toast. Pull-to-refresh, attention-blue halo for waiting
-  sessions, and reduced-motion respect everywhere. New `BottomSheet` and
-  `ActionSheet` primitives, `usePullToRefresh` hook, and a project-tree
-  bottom sheet with search complete the surface. Built on top of the Phase 1
-  shell from remote-dev-3ozu.
 
 ## [0.3.7] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       xterm v6) rather than the fragile inner canvas.
     - Tap on an active selection clears the selection without firing a click
       or scroll, matching standard text-selection UX.
+- **Multi-client tmux resize stuck after switching windows**
+  (`remote-dev-nlfm`). The terminal server now elects the primary connection
+  (the one allowed to call `tmux resize-window`) by most-recently-focused
+  client instead of newest connection. The browser sends `client_focus` /
+  `client_blur` on `visibilitychange`, `window.focus`, and `window.blur`; a
+  1-second per-session cooldown prevents ping-pong between two side-by-side
+  windows. When the primary disconnects the server picks the most recently
+  focused remaining (visible) client and re-applies its size to tmux. A small
+  "Another window is in control · click to claim" pill appears on
+  non-primary clients and force-promotes when clicked. Clients that don't
+  send focus signals continue to work via the existing newest-on-connect
+  rule.
 - **Desktop terminal initial fontSize/fontFamily race**
   (`remote-dev-3gtr`). The xterm.js terminal stayed at the default font size
   (14px) on first mount when `PreferencesContext` resolved during the async

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -143,6 +143,8 @@ interface TerminalProps {
   onDimensionsChange?: (cols: number, rows: number) => void;
   /** Called when terminal scroll position changes between scrolled-up and at-bottom */
   onScrollStateChange?: (isScrolledUp: boolean) => void;
+  /** Called when the server changes which connection controls tmux resize */
+  onPrimaryChange?: (isPrimary: boolean) => void;
 }
 
 export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal({
@@ -179,6 +181,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   onOutput,
   onDimensionsChange,
   onScrollStateChange,
+  onPrimaryChange,
 }, ref) {
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermContainerRef = useRef<HTMLDivElement>(null);
@@ -193,6 +196,9 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [authError, setAuthError] = useState<string | null>(null);
+  // Primary = this connection controls tmux sizing. Defaults to true so the
+  // single-client flow shows nothing until/unless the server demotes us.
+  const [isPrimary, setIsPrimary] = useState(true);
   const isScrolledUpRef = useRef(false);
   const isUnmountingRef = useRef(false);
   // IDisposables registered against the terminal that need explicit cleanup
@@ -246,6 +252,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   const onOutputRef = useRef(onOutput);
   const onDimensionsChangeRef = useRef(onDimensionsChange);
   const onScrollStateChangeRef = useRef(onScrollStateChange);
+  const onPrimaryChangeRef = useRef(onPrimaryChange);
   const recordActivityRef = useRef(recordActivity);
 
   // FIX: Use refs for font and scrollback to avoid recreating terminal on changes.
@@ -289,6 +296,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
     onOutputRef.current = onOutput;
     onDimensionsChangeRef.current = onDimensionsChange;
     onScrollStateChangeRef.current = onScrollStateChange;
+    onPrimaryChangeRef.current = onPrimaryChange;
     recordActivityRef.current = recordActivity;
     // Keep font refs in sync for pending terminal initialization
     fontSizeRef.current = fontSize;
@@ -301,7 +309,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
     environmentVarsRef.current = environmentVars;
     // Keep theme ref in sync for pending terminal initialization
     terminalThemeRef.current = terminalTheme;
-  }, [onStatusChange, onWebSocketReady, onSessionExit, onAgentExited, onAgentRestarted, onAgentActivityStatus, onBeadsIssuesUpdated, onSessionRenamed, onNotification, onSessionStatus, onSessionProgress, onPeerMessageCreated, onChannelMessageCreated, onThreadReplyCreated, onChannelCreated, onOutput, onDimensionsChange, onScrollStateChange, recordActivity, fontSize, fontFamily, scrollback, tmuxHistoryLimit, mobileMode, environmentVars, terminalTheme]);
+  }, [onStatusChange, onWebSocketReady, onSessionExit, onAgentExited, onAgentRestarted, onAgentActivityStatus, onBeadsIssuesUpdated, onSessionRenamed, onNotification, onSessionStatus, onSessionProgress, onPeerMessageCreated, onChannelMessageCreated, onThreadReplyCreated, onChannelCreated, onOutput, onDimensionsChange, onScrollStateChange, onPrimaryChange, recordActivity, fontSize, fontFamily, scrollback, tmuxHistoryLimit, mobileMode, environmentVars, terminalTheme]);
 
   // Expose focus method to parent components
   useImperativeHandle(ref, () => ({
@@ -794,6 +802,12 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
                   );
                 }
                 break;
+              case "primary_changed": {
+                const next = Boolean(msg.isPrimary);
+                setIsPrimary(next);
+                onPrimaryChangeRef.current?.(next);
+                break;
+              }
               case "voice_ready":
                 console.log(`[Voice] Ready for session ${msg.sessionId}`);
                 break;
@@ -940,10 +954,29 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
         });
       };
 
+      // Track last focus signal sent to the server to avoid redundant WS chatter
+      // (focus/blur fire frequently — alt-tab, devtools, etc.). The server-side
+      // 1s cooldown handles thrash, but skipping no-op sends is still cheap.
+      let lastSentFocusState: "focus" | "blur" | null = null;
+      const sendFocusSignal = (next: "focus" | "blur") => {
+        if (lastSentFocusState === next) return;
+        const ws = wsRef.current;
+        if (!ws || ws.readyState !== WebSocket.OPEN) return;
+        try {
+          ws.send(JSON.stringify({ type: next === "focus" ? "client_focus" : "client_blur" }));
+          lastSentFocusState = next;
+        } catch {
+          // Ignore send errors — connection might be tearing down
+        }
+      };
+
       // Re-fit when page becomes visible again (returning from background)
       let visibilityTimeout: ReturnType<typeof setTimeout> | null = null;
       const handleVisibilityChange = () => {
         if (!document.hidden) {
+          // Send focus signal immediately so the server can promote in time for
+          // the resize message that follows from settleAndFit.
+          sendFocusSignal("focus");
           // Clear any pending timeout to avoid duplicate calls
           if (visibilityTimeout) {
             clearTimeout(visibilityTimeout);
@@ -955,11 +988,26 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
             // Focus terminal when page becomes visible
             terminal.focus();
           }, 100);
+        } else {
+          sendFocusSignal("blur");
         }
+      };
+
+      const handleWindowFocus = () => {
+        sendFocusSignal("focus");
+        // Container size may have shifted while unfocused (desktop window
+        // resize, etc.) — settleAndFit on the next frame.
+        requestAnimationFrame(handleResize);
+      };
+
+      const handleWindowBlur = () => {
+        sendFocusSignal("blur");
       };
 
       window.addEventListener("resize", handleResize);
       document.addEventListener("visibilitychange", handleVisibilityChange);
+      window.addEventListener("focus", handleWindowFocus);
+      window.addEventListener("blur", handleWindowBlur);
 
       // Use ResizeObserver to detect when terminal container becomes visible
       // This handles the case when switching tabs (hidden -> visible)
@@ -998,6 +1046,8 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
         }
         window.removeEventListener("resize", handleResize);
         document.removeEventListener("visibilitychange", handleVisibilityChange);
+        window.removeEventListener("focus", handleWindowFocus);
+        window.removeEventListener("blur", handleWindowBlur);
         terminalRef.current?.removeEventListener("contextmenu", preventContextMenu);
         resizeObserver.disconnect();
         if (resizeTimeout) clearTimeout(resizeTimeout);
@@ -1534,6 +1584,24 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
             Drop image to paste
           </div>
         </div>
+      )}
+
+      {/* Non-primary indicator: another window/tab currently controls tmux sizing */}
+      {!isPrimary && (
+        <button
+          type="button"
+          onClick={() => {
+            const ws = wsRef.current;
+            if (ws && ws.readyState === WebSocket.OPEN) {
+              ws.send(JSON.stringify({ type: "client_focus", force: true }));
+            }
+          }}
+          title="Click to take over tmux sizing for this session"
+          className="absolute top-2 left-1/2 z-20 -translate-x-1/2 flex items-center gap-1.5 rounded-full border border-white/15 bg-black/60 px-2.5 py-1 text-[10px] font-medium text-white/85 shadow-lg backdrop-blur-sm hover:bg-black/75"
+        >
+          <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-400" />
+          Another window is in control · click to claim
+        </button>
       )}
 
       {/* Auth error overlay */}

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -674,6 +674,23 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
           lastSentFocusStateRef.current = null;
           onWebSocketReadyRef.current?.(ws);
 
+          // Re-assert focus state on (re)connect: if this window currently has
+          // focus, the focus listeners won't fire (the window already had it),
+          // so the server would never learn this connection is the active one.
+          // Send the current state proactively before the resize below, so any
+          // server-side primary promotion happens before the resize lands.
+          try {
+            const hasFocus =
+              typeof document !== "undefined" &&
+              document.hasFocus() &&
+              !document.hidden;
+            const focusType = hasFocus ? "client_focus" : "client_blur";
+            ws.send(JSON.stringify({ type: focusType }));
+            lastSentFocusStateRef.current = hasFocus ? "focus" : "blur";
+          } catch {
+            // Best-effort; if document is unavailable (SSR safety) just skip.
+          }
+
           // Send resize immediately after connection to sync dimensions
           // The URL params may be stale if container resized during connection
           requestAnimationFrame(() => {
@@ -1604,20 +1621,27 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
 
       {/* Non-primary indicator: another window/tab currently controls tmux sizing */}
       {!isPrimary && (
-        <button
-          type="button"
-          onClick={() => {
-            const ws = wsRef.current;
-            if (ws && ws.readyState === WebSocket.OPEN) {
-              ws.send(JSON.stringify({ type: "client_focus", force: true }));
-            }
-          }}
-          title="Click to take over tmux sizing for this session"
-          className="absolute top-2 left-1/2 z-20 -translate-x-1/2 flex items-center gap-1.5 rounded-full border border-white/15 bg-black/60 px-2.5 py-1 text-[10px] font-medium text-white/85 shadow-lg backdrop-blur-sm hover:bg-black/75"
+        <div
+          role="status"
+          aria-live="polite"
+          className="absolute top-2 left-1/2 z-20 -translate-x-1/2"
         >
-          <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-400" />
-          Another window is in control · click to claim
-        </button>
+          <button
+            type="button"
+            onClick={() => {
+              const ws = wsRef.current;
+              if (ws && ws.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify({ type: "client_focus", force: true }));
+              }
+            }}
+            aria-label="Claim primary control of this terminal session"
+            title="Click to take over tmux sizing for this session"
+            className="flex items-center gap-1.5 rounded-full border border-white/15 bg-black/60 px-2.5 py-1 text-[10px] font-medium text-white/85 shadow-lg backdrop-blur-sm hover:bg-black/75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black/60"
+          >
+            <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-400" />
+            Another window is in control · click to claim
+          </button>
+        </div>
       )}
 
       {/* Auth error overlay */}

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -191,6 +191,10 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   const searchAddonRef = useRef<SearchAddonType | null>(null);
   const webglAddonRef = useRef<WebglAddonType | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
+  // Last focus signal sent to the server, tracked across reconnects so that a
+  // fresh socket starts with a clean baseline (the server's debounce state
+  // resets per-connection on its side too).
+  const lastSentFocusStateRef = useRef<"focus" | "blur" | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -665,6 +669,9 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
 
           updateStatus("connected");
           reconnectAttemptsRef.current = 0;
+          // Reset focus-send debounce baseline so the first signal on this fresh
+          // socket is always sent (the previous socket's state is irrelevant).
+          lastSentFocusStateRef.current = null;
           onWebSocketReadyRef.current?.(ws);
 
           // Send resize immediately after connection to sync dimensions
@@ -840,6 +847,11 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
 
           updateStatus("disconnected");
           onWebSocketReadyRef.current?.(null);
+          // Reset to optimistic primary so the "click to claim" pill doesn't
+          // hang around during reconnect (a click would no-op while the WS is
+          // closed). The server will broadcast `primary_changed` after the
+          // reconnect completes with the authoritative value.
+          setIsPrimary(true);
 
           // Don't reconnect if this was an intentional exit (user typed "exit" or Ctrl+D)
           if (intentionalExitRef.current) {
@@ -957,14 +969,18 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       // Track last focus signal sent to the server to avoid redundant WS chatter
       // (focus/blur fire frequently — alt-tab, devtools, etc.). The server-side
       // 1s cooldown handles thrash, but skipping no-op sends is still cheap.
-      let lastSentFocusState: "focus" | "blur" | null = null;
+      // Stored in a ref (declared at component scope) so the baseline survives
+      // initTerminal() but resets when a new socket opens — a closure-local
+      // `let` would persist across reconnects and cause the first focus/blur on
+      // the new socket to be silently dropped if it matched the prior socket's
+      // last-sent value.
       const sendFocusSignal = (next: "focus" | "blur") => {
-        if (lastSentFocusState === next) return;
+        if (lastSentFocusStateRef.current === next) return;
         const ws = wsRef.current;
         if (!ws || ws.readyState !== WebSocket.OPEN) return;
         try {
           ws.send(JSON.stringify({ type: next === "focus" ? "client_focus" : "client_blur" }));
-          lastSentFocusState = next;
+          lastSentFocusStateRef.current = next;
         } catch {
           // Ignore send errors — connection might be tearing down
         }

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -2004,10 +2004,14 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       sessionConnections.set(sessionId, new Set());
     }
     sessionConnections.get(sessionId)!.add(connectionId);
-    // New connection becomes primary for resize (back-compat with clients that
-    // never send client_focus). Subsequent focus signals can re-promote.
-    sessionPrimaryConnection.set(sessionId, connectionId);
-    sessionLastPromotionAt.set(sessionId, Date.now());
+    // Seed initial primary only if no connection currently holds it for this
+    // session. This prevents a reconnect within the cooldown window from
+    // stealing primary away from an active connection. Subsequent focus signals
+    // (subject to the promotion cooldown) can re-promote later.
+    if (!sessionPrimaryConnection.has(sessionId)) {
+      sessionPrimaryConnection.set(sessionId, connectionId);
+      sessionLastPromotionAt.set(sessionId, Date.now());
+    }
 
     log.debug("Terminal connection started", { connectionId, sessionId, cols, rows, tmuxSessionName });
 

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -111,6 +111,9 @@ interface TerminalConnection {
   terminalType: "shell" | "agent" | "file" | string;
   // User ID for session service calls
   userId: string;
+  // Last-focus bookkeeping for primary-connection election (focus-based promotion).
+  lastFocusAt: number;
+  isVisible: boolean;
   // Voice mode state
   voiceFifoPath: string | null;
   voiceFifoFd: number | null;
@@ -125,8 +128,13 @@ const connections = new Map<string, TerminalConnection>();
 // Session -> connection IDs for multi-client support
 const sessionConnections = new Map<string, Set<string>>();
 
-// Which connection controls tmux resize per session (newest wins)
+// Which connection controls tmux resize per session (most-recently-focused wins)
 const sessionPrimaryConnection = new Map<string, string>();
+
+// Last time the primary changed for a session — used as a 1s cooldown to prevent
+// ping-pong between two side-by-side windows.
+const sessionLastPromotionAt = new Map<string, number>();
+const PROMOTION_COOLDOWN_MS = 1000;
 
 /** Get all active connections for a session */
 function getConnectionsForSession(sessionId: string): TerminalConnection[] {
@@ -274,6 +282,79 @@ function broadcastToSession(sessionId: string, data: Record<string, unknown>): v
   }
 }
 
+/** Run `tmux resize-window` for the given session asynchronously. */
+function runTmuxResize(tmuxSessionName: string, cols: number, rows: number): void {
+  execFile(
+    "tmux",
+    ["resize-window", "-t", tmuxSessionName, "-x", String(cols), "-y", String(rows)],
+    (err) => {
+      if (err) {
+        log.warn("tmux resize-window failed", { error: String(err), tmuxSessionName, cols, rows });
+      }
+    },
+  );
+}
+
+/** Notify each connection in the session whether it is the current primary. */
+function broadcastPrimaryChanged(sessionId: string): void {
+  const primaryId = sessionPrimaryConnection.get(sessionId);
+  for (const conn of getConnectionsForSession(sessionId)) {
+    if (conn.ws.readyState !== WebSocket.OPEN) continue;
+    try {
+      conn.ws.send(JSON.stringify({
+        type: "primary_changed",
+        isPrimary: conn.connectionId === primaryId,
+      }));
+    } catch (err) {
+      log.warn("Failed to send primary_changed", { error: String(err), connectionId: conn.connectionId });
+    }
+  }
+}
+
+/**
+ * Promote `connectionId` to be the session's primary (tmux-resize controller).
+ * Honors a per-session cooldown unless `force` is true.
+ */
+function tryPromoteToPrimary(sessionId: string, connectionId: string, force: boolean): void {
+  const currentPrimary = sessionPrimaryConnection.get(sessionId);
+  if (currentPrimary === connectionId) return;
+
+  const now = Date.now();
+  const lastPromo = sessionLastPromotionAt.get(sessionId) ?? 0;
+  const msSincePrev = now - lastPromo;
+  if (!force && msSincePrev < PROMOTION_COOLDOWN_MS) {
+    log.debug("promotion denied (cooldown)", { connectionId, sessionId, msSincePrev });
+    return;
+  }
+
+  sessionPrimaryConnection.set(sessionId, connectionId);
+  sessionLastPromotionAt.set(sessionId, now);
+
+  const conn = connections.get(connectionId);
+  if (conn?.lastCols && conn?.lastRows) {
+    runTmuxResize(conn.tmuxSessionName, conn.lastCols, conn.lastRows);
+  }
+
+  log.debug("promoted connection to primary", { connectionId, sessionId, force });
+  broadcastPrimaryChanged(sessionId);
+}
+
+/**
+ * Select the best replacement primary from a session's remaining connections:
+ * prefer visible connections, break ties by most recent `lastFocusAt`.
+ */
+function pickNextPrimary(sessionId: string): string | null {
+  const conns = getConnectionsForSession(sessionId);
+  if (conns.length === 0) return null;
+  const visible = conns.filter((c) => c.isVisible);
+  const pool = visible.length > 0 ? visible : conns;
+  let best = pool[0];
+  for (const c of pool) {
+    if (c.lastFocusAt > best.lastFocusAt) best = c;
+  }
+  return best.connectionId;
+}
+
 /**
  * Destroy a PTY and release its file descriptors.
  * Uses the runtime's destroy() method which closes the socket/FDs,
@@ -317,6 +398,7 @@ function cleanupConnection(connectionId: string): void {
     // Last connection closed — clean up all session-level state
     sessionConnections.delete(conn.sessionId);
     sessionPrimaryConnection.delete(conn.sessionId);
+    sessionLastPromotionAt.delete(conn.sessionId);
     sessionStatusIndicators.delete(conn.sessionId);
     sessionProgressBars.delete(conn.sessionId);
     for (const [claudeId, rdvId] of claudeSessionMap) {
@@ -333,10 +415,18 @@ function cleanupConnection(connectionId: string): void {
       }
     }).catch(() => {});
   } else if (sessionPrimaryConnection.get(conn.sessionId) === connectionId) {
-    // Promote another connection to primary for resize control
-    const nextPrimary = connSet.values().next().value;
+    // Primary disconnected — pick the most-recently-focused (preferring visible)
+    // remaining connection and apply its size to tmux.
+    const nextPrimary = pickNextPrimary(conn.sessionId);
     if (nextPrimary) {
       sessionPrimaryConnection.set(conn.sessionId, nextPrimary);
+      sessionLastPromotionAt.set(conn.sessionId, Date.now());
+      const nextConn = connections.get(nextPrimary);
+      if (nextConn?.lastCols && nextConn?.lastRows) {
+        runTmuxResize(nextConn.tmuxSessionName, nextConn.lastCols, nextConn.lastRows);
+      }
+      log.debug("primary handoff on disconnect", { from: connectionId, to: nextPrimary, sessionId: conn.sessionId });
+      broadcastPrimaryChanged(conn.sessionId);
     }
   }
 
@@ -1899,6 +1989,8 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       resizeTimeout: null,
       terminalType,
       userId,
+      lastFocusAt: Date.now(),
+      isVisible: true,
       voiceFifoPath: null,
       voiceFifoFd: null,
       voiceAudioBuffer: [],
@@ -1912,8 +2004,10 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       sessionConnections.set(sessionId, new Set());
     }
     sessionConnections.get(sessionId)!.add(connectionId);
-    // Newest connection is primary for resize
+    // New connection becomes primary for resize (back-compat with clients that
+    // never send client_focus). Subsequent focus signals can re-promote.
     sessionPrimaryConnection.set(sessionId, connectionId);
+    sessionLastPromotionAt.set(sessionId, Date.now());
 
     log.debug("Terminal connection started", { connectionId, sessionId, cols, rows, tmuxSessionName });
 
@@ -2018,21 +2112,22 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
 
               // Only resize the tmux window if this is the primary connection
               if (sessionPrimaryConnection.get(sessionId) === connectionId) {
-                execFile(
-                  "tmux",
-                  [
-                    "resize-window",
-                    "-t",
-                    tmuxSessionName,
-                    "-x",
-                    String(pending.cols),
-                    "-y",
-                    String(pending.rows),
-                  ],
-                  () => {}
-                );
+                runTmuxResize(tmuxSessionName, pending.cols, pending.rows);
               }
             }, 50);
+            break;
+          }
+          case "client_focus": {
+            connection.lastFocusAt = Date.now();
+            connection.isVisible = true;
+            const force = msg.force === true;
+            log.debug("client_focus received", { connectionId, sessionId, force });
+            tryPromoteToPrimary(sessionId, connectionId, force);
+            break;
+          }
+          case "client_blur": {
+            connection.isVisible = false;
+            // Bookkeeping only — do not change primary on blur.
             break;
           }
           case "detach":
@@ -2229,6 +2324,9 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
 
     // Send ready signal
     ws.send(JSON.stringify({ type: "ready", sessionId, tmuxSessionName }));
+    // Inform every session client of the new primary set (this connection became
+    // primary on connect; previously-primary clients will flip to secondary).
+    broadcastPrimaryChanged(sessionId);
   });
 
   return wss;
@@ -2246,6 +2344,7 @@ function cleanup() {
   connections.clear();
   sessionConnections.clear();
   sessionPrimaryConnection.clear();
+  sessionLastPromotionAt.clear();
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

Closes `remote-dev-nlfm`. Replaces the server's "newest connection wins" tmux-resize policy with **most-recently-focused wins, with a 1s per-session cooldown**. Fixes the symptom where opening a session on phone (becomes primary, tmux shrinks) and then returning to desktop leaves the desktop terminal mis-sized until a manual sidebar toggle.

- **Server** (`src/server/terminal.ts`):
  - Tracks `lastFocusAt` + `isVisible` per `TerminalConnection`.
  - New WS messages `client_focus` / `client_blur` update bookkeeping; `client_focus` calls `tryPromoteToPrimary` gated by a 1s cooldown. `force=true` bypasses cooldown for explicit "claim" clicks.
  - On promotion, immediately re-applies the new primary's last reported size to tmux via the extracted `runTmuxResize` helper.
  - Broadcasts a `primary_changed { isPrimary }` message to every session client whenever the primary set flips (including on connect and disconnect handoff).
  - Disconnect handoff now picks the most-recently-focused **visible** remaining connection (was: arbitrary first in the set).
  - Initial-connect only seeds the primary if none exists for the session — reconnects within the cooldown no longer steal primary.
  - Back-compat: clients that never send focus signals still work via the existing newest-on-connect rule.

- **Client** (`src/components/terminal/Terminal.tsx`):
  - Adds `window.focus` / `window.blur` listeners; sends `client_focus` / `client_blur` on focus events and `visibilitychange`. Debounced via `lastSentFocusStateRef` (reset in `ws.onopen`) to avoid WS chatter on alt-tab.
  - Tracks `isPrimary` from `primary_changed`; reset to `true` on `ws.onclose` so the claim banner clears during reconnect.
  - Renders a small "Another window is in control · click to claim" pill when not primary; click sends `client_focus` with `force=true`.

## Test plan

- [ ] Open the same session on two browser windows. Switch focus between them — pill appears on the inactive window, disappears on the active one. Both windows render at their own size after a brief settle.
- [ ] Open the same session on phone (PWA) and desktop. Use phone for a few seconds, then bring desktop to focus — desktop terminal auto-resizes to desktop size without manual sidebar toggle.
- [ ] Click the "claim" pill on a non-primary window — it immediately becomes primary and tmux resizes to its dimensions.
- [ ] Alt-tab rapidly between two windows — no thrash; cooldown holds primary stable.
- [ ] Single client: pill never appears; resize behavior unchanged from before.
- [ ] Disconnect the primary client (close tab) — remaining client takes over and tmux resizes to its size.
- [ ] Reconnect after a network blip — pill briefly disappears, server re-establishes correct primary, no stale debounce state.

This pull request and its description were written by Isaac.