### PR TITLE
fix(mobile/terminal): address skipped adversarial-review items (remote-dev-kw6d)

### DIFF
--- a/src/components/terminal/useTouchInteractions.test.ts
+++ b/src/components/terminal/useTouchInteractions.test.ts
@@ -57,7 +57,14 @@ interface Harness {
   ) => boolean;
   advanceTime: (ms: number) => void;
   flushTimers: () => void;
-  mouseEvents: Array<{ type: string; clientX: number; clientY: number; target: EventTarget | null }>;
+  mouseEvents: Array<{
+    type: string;
+    clientX: number;
+    clientY: number;
+    screenX: number;
+    screenY: number;
+    target: EventTarget | null;
+  }>;
   copies: string[];
   getMode: () => string;
   destroy: () => void;
@@ -128,7 +135,14 @@ function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"]
   const pendingTimers: Array<{ id: number; cb: TimerFn; fireAt: number }> = [];
   let nextTimerId = 1;
 
-  const mouseEvents: Array<{ type: string; clientX: number; clientY: number; target: EventTarget | null }> = [];
+  const mouseEvents: Array<{
+    type: string;
+    clientX: number;
+    clientY: number;
+    screenX: number;
+    screenY: number;
+    target: EventTarget | null;
+  }> = [];
   const copies: string[] = [];
 
   // Production wires this between createTouchInteractions and
@@ -153,6 +167,8 @@ function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"]
         type: ev.type,
         clientX: ev.clientX,
         clientY: ev.clientY,
+        screenX: ev.screenX,
+        screenY: ev.screenY,
         target,
       });
     },
@@ -771,5 +787,72 @@ describe("touchend with remaining fingers down does not block the gesture", () =
     // Final touchend (touches.length === 0) — normal tap path.
     h.fireTouch("touchend", []);
     expect(h.getMode()).toBe("idle");
+  });
+});
+
+// ── Adversarial-review fixes (remote-dev-kw6d) ──────────────────────────
+
+describe("axis-aligned cancel threshold matches touch-scroll activation", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // Diagonal swipe with dx=4, dy=4. Under the old `Math.hypot(dx,dy)` cancel
+  // (~5.66 > 5) the long-press would be cancelled, but touch-scroll's
+  // `Math.abs(currentY - touchStartY) > 5` would NOT activate (4 not > 5),
+  // creating a dead-motion window where neither gesture is active.
+  // We now use `Math.abs(dx) > 5 || Math.abs(dy) > 5`, so dx=4, dy=4
+  // does NOT cancel: long-press is preserved at the same threshold the
+  // scroll handler uses to decide whether to take over.
+  it("does NOT cancel long-press at dx=4, dy=4 (just below the 5 px axis threshold)", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    // Move diagonally to dx=4, dy=4. Hypot ~= 5.66, but neither axis crosses 5.
+    h.fireTouch("touchmove", [{ x: 204, y: 104 }]);
+    h.advanceTime(LONG_PRESS_MS);
+    h.flushTimers();
+    // Long-press still fires.
+    expect(h.getMode()).toBe("selection");
+    expect(h.xterm.select).toHaveBeenCalled();
+  });
+
+  it("cancels long-press as soon as |dx| crosses 5", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.fireTouch("touchmove", [{ x: 200 + 6, y: 100 }]); // dx=6, dy=0
+    h.advanceTime(LONG_PRESS_MS);
+    h.flushTimers();
+    expect(h.getMode()).toBe("scroll");
+    expect(h.xterm.select).not.toHaveBeenCalled();
+  });
+
+  it("cancels long-press as soon as |dy| crosses 5 (matches touch-scroll's activation)", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    h.fireTouch("touchmove", [{ x: 200, y: 100 + 6 }]); // dx=0, dy=6
+    h.advanceTime(LONG_PRESS_MS);
+    h.flushTimers();
+    expect(h.getMode()).toBe("scroll");
+    expect(h.xterm.select).not.toHaveBeenCalled();
+  });
+});
+
+describe("synthesized MouseEvent carries screenX/screenY", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("mirrors clientX/Y onto screenX/Y so consumers asserting on screen coords see real values", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 213, y: 117 }]);
+    h.advanceTime(50);
+    h.fireTouch("touchend", []);
+    expect(h.mouseEvents).toHaveLength(2);
+    for (const ev of h.mouseEvents) {
+      expect(ev.screenX).toBe(ev.clientX);
+      expect(ev.screenY).toBe(ev.clientY);
+      expect(ev.screenX).toBe(213);
+      expect(ev.screenY).toBe(117);
+    }
   });
 });

--- a/src/components/terminal/useTouchInteractions.ts
+++ b/src/components/terminal/useTouchInteractions.ts
@@ -89,6 +89,13 @@ interface XTermDims {
   rows: number;
 }
 
+// Module-scope flag so we warn at most once per page load when the xterm
+// private cell-dimensions API is missing. The warning is for developers (so a
+// silent break of long-press selection on an xterm version bump is visible),
+// not users; every gesture would otherwise rediscover the same failure and
+// flood the console.
+let warnedAboutMissingDims = false;
+
 /**
  * Resolve cell dimensions and the grid origin for a live terminal. Returns
  * `null` when xterm hasn't laid out yet or when the internal API shape we
@@ -113,7 +120,20 @@ function readDims(terminal: XTermType): XTermDims | null {
   const cell = core?._renderService?.dimensions?.css?.cell;
   const cellWidth = Number.isFinite(cell?.width) && (cell?.width ?? 0) > 0 ? (cell!.width as number) : 0;
   const cellHeight = Number.isFinite(cell?.height) && (cell?.height ?? 0) > 0 ? (cell!.height as number) : 0;
-  if (cellWidth === 0 || cellHeight === 0) return null;
+  if (cellWidth === 0 || cellHeight === 0) {
+    // The private path (`_core._renderService.dimensions.css.cell`) is the
+    // only way xterm exposes cell metrics today. If it disappears on a minor
+    // version bump, long-press selection silently no-ops with no signal, so
+    // emit a one-time developer warning so the regression is visible. Per
+    // CLAUDE.md, client-side code may use console.* directly.
+    if (!warnedAboutMissingDims && typeof console !== "undefined") {
+      warnedAboutMissingDims = true;
+      console.warn(
+        "[touch-interactions] xterm private cell-dimensions API is unavailable; long-press selection disabled. Update xterm version or report a bug."
+      );
+    }
+    return null;
+  }
 
   // The xterm screen element (.xterm-screen) is the grid origin. Its bounding
   // rect's top-left maps to (col=0, row=0). The outer `.terminal.xterm` may
@@ -305,14 +325,27 @@ export function createTouchInteractions(
     // instead of where the user's finger is.
     const viewportY = terminal.buffer.active.viewportY;
     const cell = { col: viewportCell.col, row: viewportCell.row + viewportY };
+    // selectionStart is the buffer-absolute cell the user's finger landed on
+    // AT FIRE TIME. We deliberately do NOT recompute it later (e.g. when the
+    // soft keyboard slides up and shifts the terminal's screen position),
+    // because the user's anchor intent is "the cell I pressed"; the cell's
+    // position in the buffer doesn't move when the keyboard pops. Note: if
+    // new output is emitted between fire and a subsequent move, viewportY
+    // may shift but the buffer index of the anchored cell is stable, so the
+    // anchor remains semantically correct.
     selectionStart = cell;
     setMode("selection");
     // Initial 1-cell selection so the user sees feedback immediately even if
     // they don't move yet.
     terminal.clearSelection();
     terminal.select(cell.col, cell.row, 1);
-    // Haptic cue on supporting browsers (iOS Safari ignores `vibrate`; that's
-    // fine — it's purely additive).
+    // Haptic cue on supporting browsers. Caveats we accept silently:
+    //   - iOS Safari ignores `vibrate` entirely (no Vibration API support).
+    //   - Some Android Chrome versions suppress `vibrate` when called outside
+    //     a synchronous user-gesture frame; the long-press fires from a
+    //     setTimeout callback, which is NOT such a frame, so the call may be
+    //     a no-op. The try/catch absorbs any thrown errors as well.
+    // The haptic is purely additive; the selection still works without it.
     if (typeof navigator !== "undefined" && typeof navigator.vibrate === "function") {
       try {
         navigator.vibrate(10);
@@ -385,12 +418,20 @@ export function createTouchInteractions(
     const host = terminal.element;
     const screen = host.querySelector(".xterm-screen") as HTMLElement | null;
     const target: HTMLElement = screen ?? host;
+    // Real browser-synthesized mouse-from-touch events include screenX /
+    // screenY. xterm itself doesn't read those for cell math (it uses
+    // clientX/Y plus its own bounding-rect origin), but other consumers in
+    // the dispatch chain might assert on them. We mirror clientX/Y here;
+    // the values aren't load-bearing for terminal coords; we just want the
+    // event shape to match what a real mouse would carry.
     const baseInit: MouseEventInit = {
       bubbles: true,
       cancelable: true,
       view: typeof window !== "undefined" ? window : undefined,
       clientX,
       clientY,
+      screenX: clientX,
+      screenY: clientY,
       button: 0,
       buttons: 1,
     };
@@ -459,9 +500,16 @@ export function createTouchInteractions(
     }
 
     // Pending: see if movement disqualifies a tap / long-press.
+    // We use axis-aligned thresholds (max of |dx|, |dy|) rather than
+    // Euclidean distance to match `touch-scroll.ts`, which activates scroll
+    // at `Math.abs(currentY - touchStartY) > TOUCH_SCROLL_ACTIVATION_PX`.
+    // Using `Math.hypot(dx, dy)` here would create a small dead-motion
+    // window for diagonal swipes (e.g. dx=4, dy=4 → hypot ~5.66 cancels
+    // long-press, but |dy|=4 doesn't activate scroll), where neither
+    // gesture is active. Aligning the metric closes that gap.
     const dx = lastX - startX;
     const dy = lastY - startY;
-    if (Math.hypot(dx, dy) > MOVEMENT_CANCEL_PX) {
+    if (Math.abs(dx) > MOVEMENT_CANCEL_PX || Math.abs(dy) > MOVEMENT_CANCEL_PX) {
       cancelLongPress();
       setMode("scroll"); // touch-scroll handler will own the rest of this gesture
     }


### PR DESCRIPTION
## Summary

Address the five low/medium-confidence items deferred from PR #230's touch-interactions review (beads: `remote-dev-kw6d`).

### Decisions per item

1. **`navigator.vibrate` user-gesture context (low)** — comment-only. Expanded the existing iOS-ignores note to also call out that Android Chrome may suppress `vibrate` when called outside a synchronous user-gesture frame (the long-press fires from `setTimeout`). The try/catch already absorbs throws; we silently accept the no-op.

2. **Distance-metric mismatch (low)** — applied option 1 (cleanest): replaced `Math.hypot(dx, dy) > MOVEMENT_CANCEL_PX` with `Math.abs(dx) > 5 || Math.abs(dy) > 5`. This matches `touch-scroll.ts`'s `Math.abs(currentY - touchStartY) > 5` activation and closes the small dead-motion window on diagonal swipes (e.g. dx=4, dy=4 used to cancel long-press without activating scroll).

3. **xterm private-API fragility (medium)** — added a module-scope `warnedAboutMissingDims` flag and a one-time `console.warn` in `readDims` when the private `_core._renderService.dimensions.css.cell` path is missing. Per CLAUDE.md, client-side `console.*` is permitted. The flag is at module scope so it warns once per page load, not per gesture.

4. **Synthetic MouseEvent missing screenX/screenY (low)** — added `screenX: clientX, screenY: clientY` to the synthesized mouse events. xterm itself doesn't read screen coords for cell math, but other consumers might assert on them. The existing init shape (`bubbles, cancelable, view, button, buttons, clientX, clientY`) is otherwise complete for what xterm reads.

5. **Frozen anchor on keyboard slide-up (medium-debatable)** — confirmed the existing behavior is correct, no code change. Added a comment near `selectionStart = cell;` documenting the design intent: the anchor is buffer-absolute and intentionally not recomputed because (a) the cell's buffer index is stable across keyboard repositioning, and (b) it is also stable across new output emitted between fire and subsequent moves (viewportY may shift but the anchored buffer line stays fixed). The reviewer's analysis was right.

## Test plan

- [x] New test: dx=4, dy=4 does NOT cancel long-press (regression for #2).
- [x] New tests: |dx|>5 alone and |dy|>5 alone DO cancel long-press.
- [x] New test: synthesized MouseEvents carry `screenX === clientX` and `screenY === clientY` (for #4).
- [x] Harness updated to capture `screenX`/`screenY`.
- [x] No new test for #3 (private xterm internals not testable without faking xterm); the new `warnedAboutMissingDims` symbol is referenced by `readDims` and compiles clean.
- [x] No tests for #1 / #5 (comment-only).
- [x] `bun run test:run src/components/terminal/useTouchInteractions.test.ts` — 45 passed.
- [x] `bun run test:run src/components/mobile/ src/components/terminal/` — 278 passed, 1 skipped.
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — 108/10/98, matching the master baseline; no regression from this change.

This pull request and its description were written by Isaac.