### PR TITLE
fix(mobile): phase 7 static audit + polish (a11y, contrast, reduced-motion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Mobile redesign Phase 7 audit + polish** (`remote-dev-0hx8`). Surgical
+  pass against the DESIGN.md bar:
+  - **A11y** — Mobile session rows now announce status to screen readers
+    (`Open session foo, waiting for input` etc.) so the colour-only pip
+    isn't the only signal channel. The bottom tab bar's unread badge is
+    folded into the tab's `aria-label` (e.g. `Channels, 3 unread`); the
+    visual badge stays `aria-hidden` so SRs hear it once, not twice.
+  - **Contrast** — `MobileNotificationRow` metadata (sessionName +
+    timestamp) moved off `text-muted-foreground/60` and `/40` (failed AA at
+    10px) onto solid `text-muted-foreground` with a middle-dot separator.
+    `ProjectTreeSheet`'s `auto` chip moved off `/70` for the same reason.
+  - **Reduced motion** — `.agent-breathing` (used on desktop sidebar +
+    peer tab bar pips) now gates on `prefers-reduced-motion` consistently
+    with `.notification-ring`; the pulsing-opacity animation is suppressed
+    rather than running through the user's preference.
 - **Mobile terminal touch interactions: adversarial-review bugs**
   (`remote-dev-ub9k`). Four bugs in the touch-selection state machine fixed:
     - Selection rows now use buffer-absolute coordinates (`viewportRow +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     peer tab bar pips) now gates on `prefers-reduced-motion` consistently
     with `.notification-ring`; the pulsing-opacity animation is suppressed
     rather than running through the user's preference.
+  - Adversarial-review polish: pin `.agent-breathing` opacity in
+    reduced-motion; quiet idle-state SR announcement on mobile session
+    rows; match visual `99+` in tab-bar SR label; sr-only comma between
+    notification metadata fields.
 - **Mobile terminal touch interactions: adversarial-review bugs**
   (`remote-dev-ub9k`). Four bugs in the touch-selection state machine fixed:
     - Selection rows now use buffer-absolute coordinates (`viewportRow +

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -732,6 +732,7 @@
   }
   .agent-breathing {
     animation: none;
+    opacity: 1;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -723,11 +723,15 @@
 
 /* Honor reduced-motion globally so any caller (including legacy mobile
    surfaces that don't gate the className on a reduced-motion hook) gets
-   a static halo instead of a pulsing animation. */
+   a static halo instead of a pulsing animation. The agent-breathing pip
+   shares the same discipline: animation off, full opacity static state. */
 @media (prefers-reduced-motion: reduce) {
   .notification-ring {
     animation: none;
     box-shadow: 0 0 0 2px var(--signal-attention);
+  }
+  .agent-breathing {
+    animation: none;
   }
 }
 

--- a/src/components/mobile/BottomTabBar.tsx
+++ b/src/components/mobile/BottomTabBar.tsx
@@ -145,7 +145,7 @@ export function BottomTabBar({
                 aria-current={active ? "page" : undefined}
                 aria-label={
                   badge > 0
-                    ? `${label}, ${badge > 99 ? "99 or more" : badge} unread`
+                    ? `${label}, ${badge > 99 ? "99+" : badge} unread`
                     : label
                 }
                 data-tab={id}

--- a/src/components/mobile/BottomTabBar.tsx
+++ b/src/components/mobile/BottomTabBar.tsx
@@ -143,7 +143,11 @@ export function BottomTabBar({
                 role="tab"
                 aria-selected={active}
                 aria-current={active ? "page" : undefined}
-                aria-label={label}
+                aria-label={
+                  badge > 0
+                    ? `${label}, ${badge > 99 ? "99 or more" : badge} unread`
+                    : label
+                }
                 data-tab={id}
                 onClick={() => handleTabPress(id)}
                 // 44pt minimum target; the parent <li> stretches to 56pt so

--- a/src/components/mobile/notifications/MobileNotificationRow.tsx
+++ b/src/components/mobile/notifications/MobileNotificationRow.tsx
@@ -289,6 +289,7 @@ export function MobileNotificationRow({
             {notification.sessionName ? (
               <>
                 <span>{notification.sessionName}</span>
+                <span className="sr-only">,</span>
                 <span aria-hidden="true">·</span>
               </>
             ) : null}

--- a/src/components/mobile/notifications/MobileNotificationRow.tsx
+++ b/src/components/mobile/notifications/MobileNotificationRow.tsx
@@ -285,15 +285,14 @@ export function MobileNotificationRow({
               {notification.body}
             </p>
           ) : null}
-          <div className="mt-1 flex items-center gap-2">
+          <div className="mt-1 flex items-center gap-1.5 text-[10px] text-muted-foreground">
             {notification.sessionName ? (
-              <span className="text-[10px] text-muted-foreground/60">
-                {notification.sessionName}
-              </span>
+              <>
+                <span>{notification.sessionName}</span>
+                <span aria-hidden="true">·</span>
+              </>
             ) : null}
-            <span className="text-[10px] text-muted-foreground/40">
-              {relativeTime}
-            </span>
+            <span>{relativeTime}</span>
           </div>
         </div>
       </div>

--- a/src/components/mobile/sessions/MobileSessionRow.tsx
+++ b/src/components/mobile/sessions/MobileSessionRow.tsx
@@ -107,7 +107,9 @@ export function MobileSessionRow({
 
   // Status announcement for screen readers. The pip carries state visually;
   // SR users read this prefix so colour-only signal isn't the only channel.
-  const statusAnnouncement = (() => {
+  // Idle returns null so the default-state row announces just the session
+  // name — avoids verbose "idle" repetition on every row in long lists.
+  const statusAnnouncement = ((): string | null => {
     switch (presentation.pip) {
       case "attention":
         return "waiting for input";
@@ -119,7 +121,7 @@ export function MobileSessionRow({
         return "suspended";
       case "idle":
       default:
-        return "idle";
+        return null;
     }
   })();
 
@@ -199,7 +201,11 @@ export function MobileSessionRow({
         onMouseLeave={longPress.bind.onMouseLeave}
         role="button"
         tabIndex={0}
-        aria-label={`Open session ${session.name}, ${statusAnnouncement}`}
+        aria-label={
+          statusAnnouncement
+            ? `Open session ${session.name}, ${statusAnnouncement}`
+            : `Open session ${session.name}`
+        }
         aria-current={active ? "true" : undefined}
         onClick={() => onTap(session.id)}
         onKeyDown={(e) => {

--- a/src/components/mobile/sessions/MobileSessionRow.tsx
+++ b/src/components/mobile/sessions/MobileSessionRow.tsx
@@ -105,6 +105,24 @@ export function MobileSessionRow({
 
   const rowMinHeight = density === "dense" ? "min-h-[48px]" : "min-h-[56px]";
 
+  // Status announcement for screen readers. The pip carries state visually;
+  // SR users read this prefix so colour-only signal isn't the only channel.
+  const statusAnnouncement = (() => {
+    switch (presentation.pip) {
+      case "attention":
+        return "waiting for input";
+      case "running":
+        return "running";
+      case "error":
+        return "error";
+      case "suspended":
+        return "suspended";
+      case "idle":
+      default:
+        return "idle";
+    }
+  })();
+
   // Behind-layer label/tone for the swipe affordance. Active rows show
   // "Close" (destructive) once stage 1 is crossed, otherwise "Suspend".
   // Suspended rows always say "Close" and turn destructive at stage 0.
@@ -181,7 +199,7 @@ export function MobileSessionRow({
         onMouseLeave={longPress.bind.onMouseLeave}
         role="button"
         tabIndex={0}
-        aria-label={`Open session ${session.name}`}
+        aria-label={`Open session ${session.name}, ${statusAnnouncement}`}
         aria-current={active ? "true" : undefined}
         onClick={() => onTap(session.id)}
         onKeyDown={(e) => {

--- a/src/components/mobile/sessions/ProjectTreeSheet.tsx
+++ b/src/components/mobile/sessions/ProjectTreeSheet.tsx
@@ -320,7 +320,7 @@ export function ProjectTreeSheet({
               >
                 <span className="truncate">{row.name}</span>
                 {row.isAutoCreated ? (
-                  <span className="ml-2 text-[10px] uppercase tracking-wide text-muted-foreground/70">
+                  <span className="ml-2 text-[10px] uppercase tracking-wide text-muted-foreground">
                     auto
                   </span>
                 ) : null}


### PR DESCRIPTION
## Summary

Static-review pass against the DESIGN.md bar for the mobile redesign (Phase 7, `remote-dev-0hx8`). Four P0 + one P1 fix:

- **A11y** — Mobile session rows now announce status to screen readers; bottom-tab unread badge folded into `aria-label`. Color-only signal is no longer the only channel.
- **Contrast** — `MobileNotificationRow` metadata moved off `text-muted-foreground/60` and `/40` (failed AA at 10px); `ProjectTreeSheet` `auto` chip moved off `/70`.
- **Reduced motion** — `.agent-breathing` (sidebar + peer-tab pips) now gates on `prefers-reduced-motion` consistently with `.notification-ring`.

## Scope this PR does NOT cover

The bead also requires Lighthouse mobile ≥90 perf / 100 a11y and live browser verification at 375/414/768 in light + dark. Those weren't run — auth flow + six viewport×mode combos out-budgeted the agent. Filed as a follow-up bead so `remote-dev-0hx8` stays open until live verification lands.

## Test plan

- [x] `bun run typecheck` — pass
- [x] `bun run lint` — no new errors (10 pre-existing on master, unchanged)
- [x] `bun run test:run` — 1117 pass; mobile suite 211/211
- [ ] Live verification at 375 / 414 / 768, light + dark (deferred to follow-up bead)
- [ ] Lighthouse mobile ≥90 perf, 100 a11y (deferred to follow-up bead)