### PR TITLE
fix(terminal/ssh): combine ssh args into single shellCommand string

### DIFF
--- a/src/lib/terminal-plugins/plugins/__tests__/ssh-plugin-server.test.ts
+++ b/src/lib/terminal-plugins/plugins/__tests__/ssh-plugin-server.test.ts
@@ -418,4 +418,13 @@ describe("buildSshCommandLine", () => {
     const { shellCommand } = buildSshCommandLine(conn);
     expect(shellCommand).toContain("'weird;name@h o s t'");
   });
+
+  it("safely quotes a username containing an embedded single quote", () => {
+    const conn = makeConnection({
+      username: "o'brien",
+      host: "example.com",
+    });
+    const { shellCommand } = buildSshCommandLine(conn);
+    expect(shellCommand).toContain("'o'\\''brien@example.com'");
+  });
 });

--- a/src/lib/terminal-plugins/plugins/__tests__/ssh-plugin-server.test.ts
+++ b/src/lib/terminal-plugins/plugins/__tests__/ssh-plugin-server.test.ts
@@ -26,6 +26,8 @@ const mockGetDecryptedPassword = SshService.getDecryptedPassword as unknown as R
 import {
   SshServerPlugin,
   buildSshArgs,
+  buildSshCommandLine,
+  shellQuote,
 } from "../ssh-plugin-server";
 import type {
   SshAuthType,
@@ -136,11 +138,17 @@ describe("SshServerPlugin.createSession", () => {
   };
   const stub: Partial<TerminalSession> = { userId: "user-1" };
 
-  it("uses ssh as the shell command for key auth", async () => {
+  it("returns a single ssh command line + empty shellArgs for key auth", async () => {
     mockGet.mockResolvedValue(makeConnection({ authType: "key" }));
     const config = await SshServerPlugin.createSession(baseInput, stub);
-    expect(config.shellCommand).toBe("ssh");
-    expect(config.shellArgs[0]).toBe("-p");
+    // The fix: shellCommand carries the full quoted command line and
+    // shellArgs is unused (SessionService consumes only shellCommand).
+    expect(config.shellCommand).not.toBeNull();
+    expect(config.shellCommand?.startsWith("ssh ")).toBe(true);
+    expect(config.shellCommand).toContain("'-p'");
+    expect(config.shellCommand).toContain("'2222'");
+    expect(config.shellCommand?.endsWith("'alice@example.com'")).toBe(true);
+    expect(config.shellArgs).toEqual([]);
     expect(config.environment.TERM).toBe("xterm-256color");
     expect(config.useTmux).toBe(true);
     expect(config.metadata).toMatchObject({
@@ -153,14 +161,14 @@ describe("SshServerPlugin.createSession", () => {
     });
   });
 
-  it("wraps with sshpass and injects SSHPASS for password auth", async () => {
+  it("wraps with sshpass -e ssh and injects SSHPASS for password auth", async () => {
     mockGet.mockResolvedValue(makeConnection({ authType: "password", passwordEnc: "ENCRYPTED" }));
     mockGetDecryptedPassword.mockReturnValue("hunter2");
     const config = await SshServerPlugin.createSession(baseInput, stub);
-    expect(config.shellCommand).toBe("sshpass");
-    expect(config.shellArgs[0]).toBe("-e");
-    expect(config.shellArgs[1]).toBe("ssh");
+    expect(config.shellCommand?.startsWith("sshpass -e ssh ")).toBe(true);
+    expect(config.shellArgs).toEqual([]);
     expect(config.environment.SSHPASS).toBe("hunter2");
+    expect(config.environment.TERM).toBe("xterm-256color");
   });
 
   it("throws when password auth has no stored password", async () => {
@@ -279,7 +287,9 @@ describe("SshServerPlugin lifecycle hooks", () => {
     };
     const config = await SshServerPlugin.onSessionRestart?.(session);
     expect(config).not.toBeNull();
-    expect(config?.shellCommand).toBe("ssh");
+    expect(config?.shellCommand).not.toBeNull();
+    expect(config?.shellCommand?.startsWith("ssh ")).toBe(true);
+    expect(config?.shellArgs).toEqual([]);
   });
 
   it("onSessionRestart returns null when typeMetadata is missing connectionId", async () => {
@@ -314,5 +324,98 @@ describe("SshServerPlugin capability flags", () => {
 
   it("declares useTmux: true (SSH always runs in a tmux pane)", () => {
     expect(SshServerPlugin.useTmux).toBe(true);
+  });
+});
+
+describe("shellQuote", () => {
+  it("wraps simple alphanumeric input in single quotes", () => {
+    expect(shellQuote("foo")).toBe("'foo'");
+    expect(shellQuote("alice123")).toBe("'alice123'");
+  });
+
+  it("wraps strings with spaces so they survive split-by-whitespace", () => {
+    expect(shellQuote("hello world")).toBe("'hello world'");
+  });
+
+  it("escapes embedded single quotes via close/escape/reopen", () => {
+    // The classic POSIX trick: ' → '\''
+    expect(shellQuote("it's")).toBe(`'it'\\''s'`);
+    expect(shellQuote("'leading")).toBe(`''\\''leading'`);
+    expect(shellQuote("trailing'")).toBe(`'trailing'\\'''`);
+  });
+
+  it("returns '' (empty single-quoted token) for the empty string", () => {
+    // Empty string still needs to be a real argv slot, not nothing.
+    expect(shellQuote("")).toBe("''");
+  });
+
+  it("leaves shell metacharacters inert inside single quotes", () => {
+    // Inside single quotes, $, `, \, *, etc. are literal — that's the
+    // whole point of using single quotes here.
+    expect(shellQuote("$HOME")).toBe("'$HOME'");
+    expect(shellQuote("a;b|c&d")).toBe("'a;b|c&d'");
+    expect(shellQuote("`pwd`")).toBe("'`pwd`'");
+  });
+});
+
+describe("buildSshCommandLine", () => {
+  it("starts with 'ssh ' and ends with the quoted user@host for non-password auth", () => {
+    const conn = makeConnection({ authType: "key" });
+    const { shellCommand, environment } = buildSshCommandLine(conn);
+    expect(shellCommand.startsWith("ssh ")).toBe(true);
+    expect(shellCommand.endsWith("'alice@example.com'")).toBe(true);
+    expect(environment).toEqual({ TERM: "xterm-256color" });
+  });
+
+  it("preserves the known-hosts and key flags in argv order", () => {
+    const conn = makeConnection({ authType: "key" });
+    const { shellCommand } = buildSshCommandLine(conn);
+    // Each canonical flag/value lands in the line, single-quoted.
+    expect(shellCommand).toContain("'-p' '2222'");
+    expect(shellCommand).toContain("'-o' 'ConnectTimeout=10'");
+    expect(shellCommand).toContain("'StrictHostKeyChecking=accept-new'");
+    expect(shellCommand).toContain(
+      `'UserKnownHostsFile=/tmp/rdv-test-ssh/${conn.id}/known_hosts'`
+    );
+    expect(shellCommand).toContain("'-i'");
+    expect(shellCommand).toContain(`'/tmp/rdv-test-ssh/${conn.id}/id'`);
+    expect(shellCommand).toContain("'IdentitiesOnly=yes'");
+    // Order: -p ... -o ConnectTimeout=10 ... StrictHostKeyChecking ... -i ...
+    const pIdx = shellCommand.indexOf("'-p'");
+    const ctIdx = shellCommand.indexOf("'ConnectTimeout=10'");
+    const skIdx = shellCommand.indexOf("'StrictHostKeyChecking=accept-new'");
+    const iIdx = shellCommand.indexOf("'-i'");
+    const userHostIdx = shellCommand.indexOf("'alice@example.com'");
+    expect(pIdx).toBeLessThan(ctIdx);
+    expect(ctIdx).toBeLessThan(skIdx);
+    expect(skIdx).toBeLessThan(iIdx);
+    expect(iIdx).toBeLessThan(userHostIdx);
+  });
+
+  it("prefixes 'sshpass -e ssh ' and exports SSHPASS for password auth", () => {
+    const conn = makeConnection({ authType: "password", passwordEnc: "ENC" });
+    mockGetDecryptedPassword.mockReturnValue("hunter2");
+    const { shellCommand, environment } = buildSshCommandLine(conn);
+    expect(shellCommand.startsWith("sshpass -e ssh ")).toBe(true);
+    expect(shellCommand.endsWith("'alice@example.com'")).toBe(true);
+    expect(environment.SSHPASS).toBe("hunter2");
+    expect(environment.TERM).toBe("xterm-256color");
+  });
+
+  it("throws when password auth has no decryptable password", () => {
+    const conn = makeConnection({ authType: "password", passwordEnc: null });
+    mockGetDecryptedPassword.mockReturnValue(null);
+    expect(() => buildSshCommandLine(conn)).toThrow(/password auth/);
+  });
+
+  it("safely quotes hosts and usernames containing shell metacharacters", () => {
+    // Defensive: even though usernames/hosts are normally vanilla, the
+    // command line must not let them break out of their token.
+    const conn = makeConnection({
+      username: "weird;name",
+      host: "h o s t",
+    });
+    const { shellCommand } = buildSshCommandLine(conn);
+    expect(shellCommand).toContain("'weird;name@h o s t'");
   });
 });

--- a/src/lib/terminal-plugins/plugins/ssh-plugin-server.ts
+++ b/src/lib/terminal-plugins/plugins/ssh-plugin-server.ts
@@ -112,13 +112,9 @@ function buildExitMessage(exitCode: number | null): string {
 }
 
 /**
- * POSIX-shell-safe single quoting. Wraps the arg in single quotes and
- * escapes any embedded single quote by closing, escaping, and reopening
- * (`'` → `'\''`). Always returns a quoted form so concatenation with a
- * space is unambiguous (including the empty-string case → `''`).
- *
- * Exported only so the unit test suite can exercise the quoting rules
- * directly; treat as a private helper from any other module.
+ * POSIX-shell-safe single quoting: wraps arg in single quotes, escaping
+ * any embedded `'` as `'\''`. Empty string → `''` so it occupies a token.
+ * Exported for unit tests; treat as private elsewhere.
  */
 export function shellQuote(arg: string): string {
   return `'${arg.replace(/'/g, `'\\''`)}'`;
@@ -126,10 +122,8 @@ export function shellQuote(arg: string): string {
 
 /**
  * Build the full shell command line + environment for an SSH connection.
- *
- * The returned `shellCommand` is a single, shell-quoted command line
- * that tmux can execute as its shell process. SessionService passes it
- * through verbatim (see `effectiveStartupCommand` in session-service).
+ * `shellCommand` is a single shell-quoted line that SessionService passes
+ * through verbatim to tmux (see `effectiveStartupCommand`).
  */
 export function buildSshCommandLine(connection: SshConnection): {
   shellCommand: string;
@@ -217,10 +211,10 @@ export function createSshServerPlugin(): TerminalTypeServerPlugin {
         });
       });
 
+      // shellArgs is empty: full ssh command line is baked into shellCommand
+      // (see file header).
       return {
         shellCommand,
-        // SessionService only consumes shellCommand for the tmux shell; the
-        // full ssh command line (binary + flags) is baked into shellCommand.
         shellArgs: [],
         environment,
         cwd: input.projectPath,

--- a/src/lib/terminal-plugins/plugins/ssh-plugin-server.ts
+++ b/src/lib/terminal-plugins/plugins/ssh-plugin-server.ts
@@ -1,16 +1,23 @@
 /**
  * SshPlugin (server half) — lifecycle for SSH terminal sessions.
  *
- * The `ssh` command (or `sshpass ssh ...` for password auth) runs as the
- * tmux shell process. When the SSH process exits — either because the
- * remote shell closed or the connection dropped — the tmux session exits
- * too and the client surfaces the exit screen with a Reconnect button,
- * mirroring the agent plugin's UX.
+ * The `ssh` command (or `sshpass -e ssh ...` for password auth) runs as
+ * the tmux shell process. When the SSH process exits — either because
+ * the remote shell closed or the connection dropped — the tmux session
+ * exits too and the client surfaces the exit screen with a Reconnect
+ * button, mirroring the agent plugin's UX.
  *
  * Connection details (host, user, port, auth method, options) come from
  * the `ssh_connection` DB table. The plugin loads the row by
  * `input.sshConnectionId` at create time and bakes the resolved settings
  * into `SessionConfig`.
+ *
+ * IMPORTANT: SessionService treats `SessionConfig.shellCommand` as the
+ * full command line that tmux sends to its shell (see
+ * `effectiveStartupCommand` in session-service.ts) — `shellArgs` is
+ * NOT appended. We therefore build a shell-quoted single-string command
+ * line here and leave `shellArgs: []`, mirroring the agent plugin
+ * convention.
  *
  * @see ./ssh-plugin-client.tsx for rendering.
  * @see src/services/ssh-connection-service.ts
@@ -104,14 +111,32 @@ function buildExitMessage(exitCode: number | null): string {
   return `SSH session exited with code ${exitCode}`;
 }
 
-interface ShellInvocation {
-  shellCommand: string;
-  shellArgs: string[];
-  environment: Record<string, string>;
+/**
+ * POSIX-shell-safe single quoting. Wraps the arg in single quotes and
+ * escapes any embedded single quote by closing, escaping, and reopening
+ * (`'` → `'\''`). Always returns a quoted form so concatenation with a
+ * space is unambiguous (including the empty-string case → `''`).
+ *
+ * Exported only so the unit test suite can exercise the quoting rules
+ * directly; treat as a private helper from any other module.
+ */
+export function shellQuote(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
 }
 
-function buildShellInvocation(connection: SshConnection): ShellInvocation {
+/**
+ * Build the full shell command line + environment for an SSH connection.
+ *
+ * The returned `shellCommand` is a single, shell-quoted command line
+ * that tmux can execute as its shell process. SessionService passes it
+ * through verbatim (see `effectiveStartupCommand` in session-service).
+ */
+export function buildSshCommandLine(connection: SshConnection): {
+  shellCommand: string;
+  environment: Record<string, string>;
+} {
   const sshArgs = buildSshArgs(connection);
+  const quotedArgs = sshArgs.map(shellQuote).join(" ");
 
   if (connection.authType === "password") {
     const password = SshConnectionService.getDecryptedPassword(connection);
@@ -121,8 +146,7 @@ function buildShellInvocation(connection: SshConnection): ShellInvocation {
       );
     }
     return {
-      shellCommand: "sshpass",
-      shellArgs: ["-e", "ssh", ...sshArgs],
+      shellCommand: `sshpass -e ssh ${quotedArgs}`,
       environment: {
         SSHPASS: password,
         TERM: "xterm-256color",
@@ -131,8 +155,7 @@ function buildShellInvocation(connection: SshConnection): ShellInvocation {
   }
 
   return {
-    shellCommand: "ssh",
-    shellArgs: sshArgs,
+    shellCommand: `ssh ${quotedArgs}`,
     environment: {
       TERM: "xterm-256color",
     },
@@ -171,7 +194,7 @@ export function createSshServerPlugin(): TerminalTypeServerPlugin {
       }
 
       const connection = await loadConnection(input.sshConnectionId, session.userId);
-      const { shellCommand, shellArgs, environment } = buildShellInvocation(connection);
+      const { shellCommand, environment } = buildSshCommandLine(connection);
 
       const metadata: SshSessionMetadata = {
         connectionId: connection.id,
@@ -196,7 +219,9 @@ export function createSshServerPlugin(): TerminalTypeServerPlugin {
 
       return {
         shellCommand,
-        shellArgs,
+        // SessionService only consumes shellCommand for the tmux shell; the
+        // full ssh command line (binary + flags) is baked into shellCommand.
+        shellArgs: [],
         environment,
         cwd: input.projectPath,
         useTmux: true,
@@ -223,10 +248,10 @@ export function createSshServerPlugin(): TerminalTypeServerPlugin {
         return null;
       }
       const connection = await loadConnection(connectionId, session.userId);
-      const { shellCommand, shellArgs, environment } = buildShellInvocation(connection);
+      const { shellCommand, environment } = buildSshCommandLine(connection);
       return {
         shellCommand,
-        shellArgs,
+        shellArgs: [],
         environment,
         cwd: session.projectPath ?? undefined,
         useTmux: true,


### PR DESCRIPTION
## Summary
- P0 fix for `remote-dev-jwbi`: SSH sessions opened from PR #233 ran bare `ssh` and immediately exited.
- `session-service.ts:639` only consumes `sessionConfig.shellCommand`; the SSH plugin's `shellArgs` array was silently dropped on the way to tmux.
- Match the agent plugin convention: bake the full command into `shellCommand` as a single shell-quoted string (with POSIX single-quote escaping), leave `shellArgs: []`. Updated the plugin file's header doc so this contract is explicit.
- Adds tests for `shellQuote` + `buildSshCommandLine` covering all auth modes and edge cases (embedded quotes, shell metacharacters, weird user/host).

## Test plan
- [ ] In a fresh session, hover the `+` menu → New SSH → pick a saved connection → confirm a working remote shell appears (not the `ssh` usage screen)
- [ ] Same flow via right-click on a project
- [ ] Disconnect on the remote (`exit`) → confirm the agent-style exit screen with Reconnect appears (validates that the exit-event wiring from PR #233 still works with the new command shape)
- [ ] Try a connection with a single quote or space in the host/user (e.g. an extraOption value containing a space) — should still build and run

This pull request and its description were written by Isaac.