### PR TITLE
fix(terminal/ssh): emit OpenSSH-format private keys (was PKCS#8 PEM)

### DIFF
--- a/src/services/__tests__/ssh-connection-service.test.ts
+++ b/src/services/__tests__/ssh-connection-service.test.ts
@@ -10,7 +10,20 @@
 import { mkdtemp, rm, stat, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+async function hasSshKeygen(): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync("which", ["ssh-keygen"]);
+    return stdout.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
 
 // Pin the SSH dir into a tmp location so the suite never touches the
 // user's real ~/.remote-dev. Must be set before importing the service.
@@ -88,6 +101,45 @@ describe("SshConnectionService — filesystem helpers", () => {
     expect(algoLen).toBe(11);
     const algoStr = decoded.subarray(4, 4 + algoLen).toString("utf8");
     expect(algoStr).toBe("ssh-ed25519");
+  });
+
+  it("generateKeypair writes a private key in OpenSSH PEM format", async () => {
+    const mod = await import("../ssh-connection-service");
+    const id = "gen-openssh-format-test";
+    await mod.generateKeypair(id);
+
+    const privContents = await readFile(mod.getPrivateKeyPath(id), "utf8");
+    expect(privContents.startsWith("-----BEGIN OPENSSH PRIVATE KEY-----\n")).toBe(true);
+    expect(privContents.endsWith("-----END OPENSSH PRIVATE KEY-----\n")).toBe(true);
+    // Body should NOT be PKCS#8 — that's the bug we're fixing.
+    expect(privContents).not.toContain("BEGIN PRIVATE KEY");
+
+    // Decoded body must start with the OpenSSH magic bytes.
+    const body = privContents
+      .replace("-----BEGIN OPENSSH PRIVATE KEY-----\n", "")
+      .replace("-----END OPENSSH PRIVATE KEY-----\n", "")
+      .replace(/\n/g, "");
+    const decoded = Buffer.from(body, "base64");
+    expect(decoded.subarray(0, 15).toString("utf8")).toBe("openssh-key-v1\0");
+  });
+
+  it("generateKeypair private key is loadable by ssh-keygen", async () => {
+    if (!(await hasSshKeygen())) {
+      // Skip on systems without OpenSSH installed (some minimal CI images).
+      return;
+    }
+    const mod = await import("../ssh-connection-service");
+    const id = "gen-ssh-keygen-test";
+    await mod.generateKeypair(id);
+    const privPath = mod.getPrivateKeyPath(id);
+
+    const { stdout, stderr } = await execFileAsync("ssh-keygen", [
+      "-y",
+      "-f",
+      privPath,
+    ]);
+    expect(stderr).not.toMatch(/invalid format/i);
+    expect(stdout.trim().startsWith("ssh-ed25519 ")).toBe(true);
   });
 
   it("hasPrivateKey reflects on-disk state", async () => {
@@ -276,5 +328,134 @@ describe("SshConnectionService — password encryption round-trip", () => {
       lastUsedAt: null,
     };
     expect(mod.getDecryptedPassword(conn)).toBeNull();
+  });
+});
+
+describe("SshConnectionService — OpenSSH wire-format encoders", () => {
+  it("encodeOpensshEd25519PublicKey emits the expected wire format for a known input", async () => {
+    const mod = await import("../ssh-connection-service");
+    // 32-byte all-zero public key: deterministic output we can hand-check.
+    const rawPub = Buffer.alloc(32, 0);
+    const line = mod.encodeOpensshEd25519PublicKey(rawPub);
+    expect(line.startsWith("ssh-ed25519 ")).toBe(true);
+
+    const b64 = line.split(" ")[1];
+    const decoded = Buffer.from(b64, "base64");
+    // uint32(11) || "ssh-ed25519" || uint32(32) || 32 zero bytes
+    expect(decoded.length).toBe(4 + 11 + 4 + 32);
+    expect(decoded.readUInt32BE(0)).toBe(11);
+    expect(decoded.subarray(4, 15).toString("utf8")).toBe("ssh-ed25519");
+    expect(decoded.readUInt32BE(15)).toBe(32);
+    expect(decoded.subarray(19, 51).equals(Buffer.alloc(32, 0))).toBe(true);
+  });
+
+  it("encodeOpensshEd25519PublicKey rejects keys that are not 32 bytes", async () => {
+    const mod = await import("../ssh-connection-service");
+    expect(() => mod.encodeOpensshEd25519PublicKey(Buffer.alloc(31, 0))).toThrow();
+    expect(() => mod.encodeOpensshEd25519PublicKey(Buffer.alloc(64, 0))).toThrow();
+  });
+
+  it("encodeOpensshEd25519PrivateKey produces a wrapped PEM with the OpenSSH magic", async () => {
+    const mod = await import("../ssh-connection-service");
+    const rawPriv = Buffer.alloc(32, 1);
+    const rawPub = Buffer.alloc(32, 2);
+    const pem = mod.encodeOpensshEd25519PrivateKey(rawPriv, rawPub, "test");
+
+    expect(pem.startsWith("-----BEGIN OPENSSH PRIVATE KEY-----\n")).toBe(true);
+    expect(pem.endsWith("-----END OPENSSH PRIVATE KEY-----\n")).toBe(true);
+
+    const lines = pem.split("\n");
+    // First line is the BEGIN marker, last two are END marker + empty trailing.
+    const bodyLines = lines.slice(1, -2);
+    expect(bodyLines.length).toBeGreaterThan(0);
+    for (const line of bodyLines) {
+      // ssh-keygen wraps at 70 columns; final line may be shorter.
+      expect(line.length).toBeLessThanOrEqual(70);
+    }
+
+    const body = bodyLines.join("");
+    const decoded = Buffer.from(body, "base64");
+    expect(decoded.subarray(0, 15).toString("utf8")).toBe("openssh-key-v1\0");
+
+    // Walk the wire format and verify checkints match + the private blob
+    // round-trips.
+    let off = 15;
+    const readString = (): Buffer => {
+      const len = decoded.readUInt32BE(off);
+      off += 4;
+      const b = decoded.subarray(off, off + len);
+      off += len;
+      return b;
+    };
+    expect(readString().toString("utf8")).toBe("none"); // ciphername
+    expect(readString().toString("utf8")).toBe("none"); // kdfname
+    expect(readString().length).toBe(0); // kdfoptions
+    const numKeys = decoded.readUInt32BE(off);
+    off += 4;
+    expect(numKeys).toBe(1);
+
+    const pubBlob = readString();
+    let inner = 0;
+    expect(pubBlob.readUInt32BE(inner)).toBe(11);
+    inner += 4;
+    expect(pubBlob.subarray(inner, inner + 11).toString("utf8")).toBe(
+      "ssh-ed25519"
+    );
+    inner += 11;
+    expect(pubBlob.readUInt32BE(inner)).toBe(32);
+    inner += 4;
+    expect(pubBlob.subarray(inner, inner + 32).equals(rawPub)).toBe(true);
+
+    const privBlob = readString();
+    // checkint repeated.
+    expect(privBlob.subarray(0, 4).equals(privBlob.subarray(4, 8))).toBe(true);
+    let pi = 8;
+    // type
+    expect(privBlob.readUInt32BE(pi)).toBe(11);
+    pi += 4;
+    expect(privBlob.subarray(pi, pi + 11).toString("utf8")).toBe("ssh-ed25519");
+    pi += 11;
+    // public
+    expect(privBlob.readUInt32BE(pi)).toBe(32);
+    pi += 4;
+    expect(privBlob.subarray(pi, pi + 32).equals(rawPub)).toBe(true);
+    pi += 32;
+    // priv+pub seed (64)
+    expect(privBlob.readUInt32BE(pi)).toBe(64);
+    pi += 4;
+    expect(privBlob.subarray(pi, pi + 32).equals(rawPriv)).toBe(true);
+    expect(privBlob.subarray(pi + 32, pi + 64).equals(rawPub)).toBe(true);
+    pi += 64;
+    // comment
+    const commentLen = privBlob.readUInt32BE(pi);
+    pi += 4;
+    expect(privBlob.subarray(pi, pi + commentLen).toString("utf8")).toBe("test");
+    pi += commentLen;
+    // padding to multiple of 8 with incrementing bytes
+    let pad = 1;
+    while (pi < privBlob.length) {
+      expect(privBlob[pi]).toBe(pad);
+      pi += 1;
+      pad += 1;
+    }
+    expect(privBlob.length % 8).toBe(0);
+  });
+
+  it("encodeOpensshEd25519PrivateKey rejects malformed inputs", async () => {
+    const mod = await import("../ssh-connection-service");
+    expect(() =>
+      mod.encodeOpensshEd25519PrivateKey(
+        Buffer.alloc(31, 0),
+        Buffer.alloc(32, 0),
+        "x"
+      )
+    ).toThrow();
+    expect(() =>
+      mod.encodeOpensshEd25519PrivateKey(
+        Buffer.alloc(32, 0),
+        Buffer.alloc(33, 0),
+        "x"
+      )
+    ).toThrow();
   });
 });

--- a/src/services/ssh-connection-service.ts
+++ b/src/services/ssh-connection-service.ts
@@ -15,7 +15,7 @@
  */
 
 import { mkdir, writeFile, readFile, rm, access, chmod } from "node:fs/promises";
-import { generateKeyPairSync } from "node:crypto";
+import { generateKeyPairSync, randomBytes } from "node:crypto";
 import { join, resolve, sep } from "node:path";
 import { db } from "@/db";
 import { sshConnections } from "@/db/schema";
@@ -457,56 +457,140 @@ export async function writeKey(
 /**
  * Generate a new ed25519 keypair, write both halves to disk, and return
  * the public key for display in the UI.
+ *
+ * The private key is emitted in the native OpenSSH private-key format
+ * (`-----BEGIN OPENSSH PRIVATE KEY-----`). PKCS#8 PEM is *not* loadable by
+ * `ssh-keygen`/`ssh` for ed25519 keys despite the OpenSSL key APIs
+ * supporting it — OpenSSH refuses anything that isn't its own wire format.
  */
 export async function generateKeypair(connectionId: string): Promise<{
   publicKey: string;
 }> {
   await ensureConnectionDir(connectionId);
 
-  // node:crypto cannot emit OpenSSH-format private keys directly until
-  // Node 19+. We render the private key as PKCS#8 PEM (which OpenSSH reads
-  // fine for ed25519) and the public key in OpenSSH single-line format.
-  const { publicKey, privateKey } = generateKeyPairSync("ed25519", {
-    privateKeyEncoding: { type: "pkcs8", format: "pem" },
-    publicKeyEncoding: { type: "spki", format: "pem" },
-  });
+  // Use the KeyObject form so we can JWK-export to grab the raw 32-byte
+  // private seed and 32-byte public key. node:crypto has no built-in
+  // OpenSSH-format private-key encoder, so we hand-pack the bytes below.
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
 
-  // Convert SPKI public key to OpenSSH "ssh-ed25519 BASE64 comment" format.
-  const opensshPub = spkiPemToOpensshEd25519(publicKey as string);
+  const privJwk = privateKey.export({ format: "jwk" }) as {
+    d?: string;
+    x?: string;
+  };
+  const pubJwk = publicKey.export({ format: "jwk" }) as { x?: string };
+  if (!privJwk.d || !privJwk.x || !pubJwk.x) {
+    throw new Error("Unexpected ed25519 JWK shape (missing d/x)");
+  }
+  const rawPriv = Buffer.from(privJwk.d, "base64url");
+  const rawPub = Buffer.from(pubJwk.x, "base64url");
+  if (rawPriv.length !== 32 || rawPub.length !== 32) {
+    throw new Error(
+      `Invalid ed25519 raw key lengths: priv=${rawPriv.length} pub=${rawPub.length}`
+    );
+  }
+
   const comment = `rdv-${connectionId.slice(0, 8)}`;
-  const opensshPubLine = `${opensshPub} ${comment}`;
+  const opensshPubLine = `${encodeOpensshEd25519PublicKey(rawPub)} ${comment}`;
+  const opensshPriv = encodeOpensshEd25519PrivateKey(rawPriv, rawPub, comment);
 
-  await writeKey(connectionId, privateKey as string, opensshPubLine);
+  await writeKey(connectionId, opensshPriv, opensshPubLine);
   return { publicKey: opensshPubLine };
 }
 
-/**
- * Convert an SPKI-PEM ed25519 public key to OpenSSH single-line format
- * (`ssh-ed25519 BASE64`).
- *
- * The SPKI ed25519 wrapping is a fixed-length 44-byte structure where the
- * last 32 bytes are the raw public key. We extract those bytes and wrap
- * them in the OpenSSH wire format: 4-byte length-prefixed strings.
- */
-function spkiPemToOpensshEd25519(pem: string): string {
-  const b64 = pem
-    .replace(/-----BEGIN PUBLIC KEY-----/g, "")
-    .replace(/-----END PUBLIC KEY-----/g, "")
-    .replace(/\s+/g, "");
-  const der = Buffer.from(b64, "base64");
-  // SPKI for ed25519 is exactly 44 bytes; the raw key is the last 32.
-  if (der.length < 32) {
-    throw new Error("Invalid SPKI ed25519 public key");
-  }
-  const raw = der.subarray(der.length - 32);
+// ---------------------------------------------------------------------------
+// OpenSSH wire-format encoders for ed25519 keys.
+//
+// Reference: PROTOCOL.key in the OpenSSH source tree.
+// All integers are big-endian; `string` is `uint32 length || bytes`.
+// ---------------------------------------------------------------------------
 
-  const algo = Buffer.from("ssh-ed25519", "utf8");
-  const algoLen = Buffer.alloc(4);
-  algoLen.writeUInt32BE(algo.length, 0);
-  const keyLen = Buffer.alloc(4);
-  keyLen.writeUInt32BE(raw.length, 0);
-  const wire = Buffer.concat([algoLen, algo, keyLen, raw]);
+function packUint32(n: number): Buffer {
+  const buf = Buffer.alloc(4);
+  buf.writeUInt32BE(n >>> 0, 0);
+  return buf;
+}
+
+function packString(buf: Buffer): Buffer {
+  return Buffer.concat([packUint32(buf.length), buf]);
+}
+
+/**
+ * Encode a raw 32-byte ed25519 public key as the OpenSSH single-line
+ * `ssh-ed25519 BASE64` representation (no trailing comment).
+ */
+export function encodeOpensshEd25519PublicKey(rawPub: Buffer): string {
+  if (rawPub.length !== 32) {
+    throw new Error(`ed25519 public key must be 32 bytes, got ${rawPub.length}`);
+  }
+  const wire = Buffer.concat([
+    packString(Buffer.from("ssh-ed25519", "utf8")),
+    packString(rawPub),
+  ]);
   return `ssh-ed25519 ${wire.toString("base64")}`;
+}
+
+/**
+ * Encode a raw ed25519 private + public seed pair as the OpenSSH
+ * native private-key PEM (`-----BEGIN OPENSSH PRIVATE KEY-----`).
+ *
+ * Cipher and KDF are `none` (no passphrase). The base64 body is wrapped
+ * at 70 columns to match `ssh-keygen` output. Result ends with a newline.
+ */
+export function encodeOpensshEd25519PrivateKey(
+  rawPriv: Buffer,
+  rawPub: Buffer,
+  comment: string
+): string {
+  if (rawPriv.length !== 32) {
+    throw new Error(`ed25519 private seed must be 32 bytes, got ${rawPriv.length}`);
+  }
+  if (rawPub.length !== 32) {
+    throw new Error(`ed25519 public key must be 32 bytes, got ${rawPub.length}`);
+  }
+
+  // Public key blob (length-prefixed, then packed as a string at the outer
+  // layer when assembled into the file).
+  const pubBlob = Buffer.concat([
+    packString(Buffer.from("ssh-ed25519", "utf8")),
+    packString(rawPub),
+  ]);
+
+  // Private key blob (cleartext because cipher=none): two equal checkints,
+  // then key type, public key, concatenated private+public seed, comment,
+  // and incrementing padding to a multiple of 8.
+  const checkint = randomBytes(4);
+  const privSeed = Buffer.concat([rawPriv, rawPub]); // 64 bytes
+  const commentBuf = Buffer.from(comment, "utf8");
+  const inner = Buffer.concat([
+    checkint,
+    checkint,
+    packString(Buffer.from("ssh-ed25519", "utf8")),
+    packString(rawPub),
+    packString(privSeed),
+    packString(commentBuf),
+  ]);
+  const padLen = (8 - (inner.length % 8)) % 8;
+  const padding = Buffer.alloc(padLen);
+  for (let i = 0; i < padLen; i++) padding[i] = i + 1; // 1, 2, 3, ...
+  const paddedPriv = Buffer.concat([inner, padding]);
+
+  // Outer file: magic, ciphername, kdfname, kdfoptions, numkeys, pubkey,
+  // padded privatekey.
+  const magic = Buffer.from("openssh-key-v1\0", "utf8"); // 15 bytes incl. NUL
+  const file = Buffer.concat([
+    magic,
+    packString(Buffer.from("none", "utf8")), // ciphername
+    packString(Buffer.from("none", "utf8")), // kdfname
+    packString(Buffer.alloc(0)), // kdfoptions (empty string)
+    packUint32(1), // numkeys
+    packString(pubBlob),
+    packString(paddedPriv),
+  ]);
+
+  const b64 = file.toString("base64");
+  // ssh-keygen wraps the body at 70 columns.
+  const wrapped = b64.match(/.{1,70}/g)?.join("\n") ?? b64;
+  return `-----BEGIN OPENSSH PRIVATE KEY-----\n${wrapped}\n-----END OPENSSH PRIVATE KEY-----\n`;
 }
 
 /** Read a connection's public key, if present. */


### PR DESCRIPTION
## Summary

P0 fix for `remote-dev-te9t`. `generateKeypair()` was emitting PKCS#8 PEM (`-----BEGIN PRIVATE KEY-----`), which OpenSSH refuses to load: `ssh-keygen -y -f <path>` reports `Load key: invalid format`. The earlier comment claiming "OpenSSH reads PKCS#8 PEM fine for ed25519" was wrong.

Hand-encodes the native OpenSSH wire format per [PROTOCOL.key](https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.key) since Node has no built-in encoder. Extracts the raw 32-byte ed25519 seed and public key via JWK export, packs the openssh-key-v1 structure with matching checkints + incrementing padding, base64-wraps at 70 cols.

## Verification

Live-tested against `/usr/bin/ssh-keygen` on macOS:
```
ssh-keygen output: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII2if8...
Generated pub line: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII2if8...
SUCCESS: ssh-keygen accepted the key and derived pubkey matches.
```

24/24 service tests pass (5 new). Typecheck and lint clean.

## Test plan
- [ ] Settings → SSH → New connection → Generate ed25519 → confirm the displayed public key matches what `ssh-keygen -y -f ~/.remote-dev/ssh/<id>/id` produces
- [ ] Use that connection to actually connect to a remote host (after copying the public key into the remote's `authorized_keys`)
- [ ] Existing connections with already-generated PKCS#8 keys will still fail; users will need to regenerate. Worth a release note if any have been created in production.

This pull request and its description were written by Isaac.