### PR TITLE
chore(infra): worktree-warm.sh — fast node_modules bootstrap (<1 min cold start)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`scripts/worktree-warm.sh`** (`remote-dev-unpj`). Bootstraps a fresh agent
+  worktree by cloning the main checkout's `node_modules/` into the worktree
+  using APFS `cp -cR` (copy-on-write clonefile), with rsync and `bun install`
+  fallbacks. Resolves the Turbopack 16 build failure caused by symlinking
+  `node_modules` outside the worktree filesystem root, and replaces the 9+
+  minute cold `bun install`. End-to-end cold start to a successful `bun run
+  build`: ~45 seconds. Documented in CLAUDE.md under "Worktree Setup".
 - **SSH terminal type** (`remote-dev-i13k`). New `ssh` terminal type opens a
   tmux-backed pane that runs `ssh` (or `sshpass ssh` for password auth) as
   the shell process; when SSH disconnects, the agent-style exit screen

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -818,6 +818,23 @@ Update the changelog when making changes that are:
 5. Push tag: `git push origin vX.Y.Z`
 6. Add new `[Unreleased]` section at top for future changes
 
+## Worktree Setup
+
+Agent worktrees start with no `node_modules`. Three pitfalls to avoid:
+
+1. **Do not symlink** `node_modules` to the main checkout. Turbopack 16 rejects symlinks that point outside the worktree's filesystem root with `Symlink node_modules is invalid, it points out of the filesystem root`, breaking `bun run build` and `bun run dev`.
+2. **Do not run a cold `bun install` if you can avoid it.** It can take 5–10 minutes on this codebase.
+3. **Do not edit source files in the main checkout** to work around the above — that violates the worktree-isolation rule above.
+
+Instead, **clone `node_modules` into the worktree** with the helper script:
+
+```bash
+./scripts/worktree-warm.sh
+```
+
+It uses APFS `cp -cR` (copy-on-write clonefile) to materialize a real `node_modules/` directory inside the worktree in ~30 seconds. Internal symlinks in bun's isolated layout are relative, so they stay valid post-clone and Turbopack accepts the tree. Total cold-start to a successful `bun run build`: under a minute.
+
+The script falls back to `rsync --links` on non-APFS filesystems and to `bun install` if neither path is available.
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 ## Development Workflow

--- a/scripts/worktree-warm.sh
+++ b/scripts/worktree-warm.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# worktree-warm.sh — fast node_modules bootstrap for agent worktrees
+#
+# Problem: `bun run build` (Next.js + Turbopack 16) refuses to follow a
+# top-level `node_modules` symlink that points outside the worktree's
+# filesystem root, and `bun install` from cold can take 9+ minutes here.
+#
+# Fix: clone the main checkout's `node_modules/` into the worktree using APFS
+# `cp -cR` (clonefile, copy-on-write). Internal symlinks in bun's isolated
+# layout are relative — they stay valid inside the clone — so Turbopack is
+# happy and the cold-start time drops from minutes to ~30 seconds.
+#
+# Usage (from inside an agent worktree):
+#   ./scripts/worktree-warm.sh           # auto-detects the main checkout
+#   ./scripts/worktree-warm.sh /path/to/main/repo
+#
+# Falls back to `bun install` on non-APFS filesystems.
+
+set -euo pipefail
+
+WORKTREE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$WORKTREE_ROOT"
+
+# 1. Detect the main checkout: prefer the explicit arg, else parse `git worktree list`.
+if [[ ${1:-} ]]; then
+  MAIN_REPO="$1"
+else
+  # `git worktree list --porcelain` lists the main checkout first.
+  MAIN_REPO="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+fi
+
+if [[ -z "${MAIN_REPO:-}" || ! -d "$MAIN_REPO" ]]; then
+  echo "worktree-warm: could not locate main checkout (got: '${MAIN_REPO:-}')" >&2
+  exit 1
+fi
+
+if [[ "$MAIN_REPO" == "$WORKTREE_ROOT" ]]; then
+  echo "worktree-warm: refusing to clone into the main checkout itself" >&2
+  exit 1
+fi
+
+if [[ ! -d "$MAIN_REPO/node_modules" ]]; then
+  echo "worktree-warm: $MAIN_REPO/node_modules does not exist — run 'bun install' there first" >&2
+  exit 1
+fi
+
+if [[ -e "$WORKTREE_ROOT/node_modules" || -L "$WORKTREE_ROOT/node_modules" ]]; then
+  echo "worktree-warm: ./node_modules already exists; remove it first if you want to re-warm" >&2
+  exit 1
+fi
+
+# 2. Choose strategy. APFS clonefile (`cp -c`) is essentially free and
+# preserves relative symlinks; everything else is the slow fallback.
+FS_TYPE="$(df -P "$WORKTREE_ROOT" | awk 'NR==2 {print $1}' | xargs -I{} diskutil info {} 2>/dev/null | awk -F: '/Type \(Bundle\)/{gsub(/ /,"",$2); print $2; exit}')"
+
+echo "worktree-warm: cloning node_modules from $MAIN_REPO"
+echo "worktree-warm: filesystem type = ${FS_TYPE:-unknown}"
+
+start_ts=$(date +%s)
+
+if [[ "$FS_TYPE" == "apfs" ]]; then
+  # APFS copy-on-write clone. Near-instant for ~1.6G; under a minute even cold.
+  cp -cR "$MAIN_REPO/node_modules" "$WORKTREE_ROOT/node_modules"
+elif command -v rsync >/dev/null 2>&1; then
+  echo "worktree-warm: APFS unavailable, falling back to rsync (slower)"
+  rsync -a --links "$MAIN_REPO/node_modules/" "$WORKTREE_ROOT/node_modules/"
+else
+  echo "worktree-warm: no fast clone path available; falling back to 'bun install'"
+  bun install
+  exit $?
+fi
+
+elapsed=$(( $(date +%s) - start_ts ))
+echo "worktree-warm: done in ${elapsed}s"
+echo "worktree-warm: you can now run 'bun run build', 'bun run typecheck', etc."


### PR DESCRIPTION
## Summary

Fixes `remote-dev-unpj`. Unblocks `remote-dev-k583` (Lighthouse mobile perf vs prod build).

Agent worktrees start without `node_modules`, and the obvious workarounds both fail:
- **Symlinking** the main repo's `node_modules` into the worktree → Turbopack 16 panics with `Symlink node_modules is invalid, it points out of the filesystem root`.
- **`bun install` cold** in a fresh worktree → 9+ minutes on this codebase.

This PR ships `scripts/worktree-warm.sh`. From inside an agent worktree it auto-detects the main checkout (`git worktree list`) and clones `node_modules` via **APFS `cp -cR`** (copy-on-write clonefile). Bun's isolated layout uses relative symlinks inside `node_modules/`, so the clone stays valid and Turbopack accepts it.

End-to-end: **~32 s clone + ~11 s `bun run build` = 43 s** (well under the 5-minute target). Falls back to `rsync --links` on non-APFS filesystems, then to `bun install` if neither path is available.

## Files

- `scripts/worktree-warm.sh` (new, executable)
- `CLAUDE.md` — adds a "Worktree Setup" section that documents the symlink pitfall and points at the script.
- `CHANGELOG.md` — entry under `[Unreleased] → Added`.

## Why not the other options

- **`bun install --linker=hoisted`** would change install behavior across the team without solving the cold install time.
- **CLAUDE.md exception** to allow builds in the main checkout was unnecessary once the warm script proved fast enough.

## Test plan

- [x] Symlink failure reproduced (Turbopack panic captured).
- [x] `cp -RL` measured: 7m38s, 10 GB — too slow.
- [x] `cp -cR` measured: **32 s, 1.6 GB** — kept.
- [x] `./scripts/worktree-warm.sh && bun run build` succeeds end-to-end on a fresh worktree (verified twice).