### PR TITLE
feat(mobile/embed): Phase 0 — PWA routes & rdv-bridge for new Flutter app

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,9 @@ import { headers } from "next/headers";
 import dynamicImport from "next/dynamic";
 import "./globals.css";
 
-// Lazy-loaded so the /login bundle never includes NextAuth SessionProvider,
-// AppearanceProvider, sonner Toaster, or ServiceWorkerRegistration.
+// Lazy-loaded so the /login and /m/* bundles never include NextAuth
+// SessionProvider, AppearanceProvider, sonner Toaster, or
+// ServiceWorkerRegistration.
 const AppShell = dynamicImport(() => import("@/components/layout/AppShell"));
 
 const geistSans = Geist({
@@ -54,6 +55,11 @@ export default async function RootLayout({
   const hdrs = await headers();
   const pathname = hdrs.get("x-pathname") ?? "";
   const isLoginRoute = pathname === "/login";
+  // /m/* routes are loaded by the Flutter WebView host and must not
+  // mount the desktop AppShell (which would inject MobileShell with its
+  // bottom tab bar on mobile viewports).
+  const isMobileEmbedRoute = pathname.startsWith("/m/");
+  const skipAppShell = isLoginRoute || isMobileEmbedRoute;
 
   return (
     // suppressHydrationWarning: Theme class is applied client-side by AppearanceProvider
@@ -67,7 +73,7 @@ export default async function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {isLoginRoute ? children : <AppShell>{children}</AppShell>}
+        {skipAppShell ? children : <AppShell>{children}</AppShell>}
       </body>
     </html>
   );

--- a/src/app/m/channel/[id]/page.tsx
+++ b/src/app/m/channel/[id]/page.tsx
@@ -1,0 +1,64 @@
+export const dynamic = "force-dynamic";
+
+/**
+ * /m/channel/[id] — single-channel view for the native Flutter shell.
+ *
+ * Auth: resolved via getAuthSession() (NextAuth credentials OR CF
+ * Access JWT). Unauthenticated requests are redirected to /login by
+ * src/middleware.ts before they reach this page.
+ *
+ * Providers mounted here (scoped to this route, not the /m/* layout):
+ *   - PreferencesProvider — required transitively by ChannelProvider
+ *     (it reads activeProject.folderId via usePreferencesContext()).
+ *   - ProjectTreeProvider — required transitively by ChannelProvider
+ *     (it reads activeNode via useProjectTree()).
+ *   - ChannelProvider — required by EmbeddedChannelView, which calls
+ *     useChannelContextOptional() and renders a "Channels unavailable."
+ *     empty state when the provider is missing.
+ *
+ * AppearanceProvider is NOT mounted: MobileChannelView never calls
+ * useTerminalTheme()/useAppearance(), so the channel surface doesn't
+ * pay for it.
+ *
+ * Note on params.id: ChannelProvider's current API takes only
+ * { children } — there is no initialChannelId / selectedChannelId
+ * prop, and activeChannelId is internal state initialized to null.
+ * For v1 we accept the deep-link id but do not pre-select the
+ * channel; the user lands on the channel list. A follow-up should
+ * either extend ChannelProviderProps with initialChannelId or expose
+ * a setter via ref so EmbeddedChannelView can call
+ * setActiveChannelId(id) on mount.
+ */
+
+import { redirect } from "next/navigation";
+
+import { ChannelProvider } from "@/contexts/ChannelContext";
+import { PreferencesProvider } from "@/contexts/PreferencesContext";
+import { ProjectTreeProvider } from "@/contexts/ProjectTreeContext";
+import { EmbeddedChannelView } from "@/components/mobile/embed/EmbeddedChannelView";
+import { getAuthSession } from "@/lib/auth-utils";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function MobileChannelPage({ params }: PageProps) {
+  // Resolve params (Next.js requires awaiting dynamic-segment params)
+  // and auth. The id is currently unused at the server layer — see
+  // file-level docblock for the v1 limitation.
+  await params;
+  const auth = await getAuthSession();
+  if (!auth?.user?.id) {
+    redirect("/login");
+  }
+
+  return (
+    <PreferencesProvider>
+      <ProjectTreeProvider>
+        <ChannelProvider>
+          <EmbeddedChannelView />
+        </ChannelProvider>
+      </ProjectTreeProvider>
+    </PreferencesProvider>
+  );
+}

--- a/src/app/m/channel/[id]/page.tsx
+++ b/src/app/m/channel/[id]/page.tsx
@@ -15,6 +15,9 @@ export const dynamic = "force-dynamic";
  *   - ChannelProvider — required by EmbeddedChannelView, which calls
  *     useChannelContextOptional() and renders a "Channels unavailable."
  *     empty state when the provider is missing.
+ *   - PeerChatProvider — required by MobileChannelView, which calls
+ *     usePeerChatContext() unconditionally and throws if the provider
+ *     is absent. Without it, the channel route crashes in any browser.
  *
  * AppearanceProvider is NOT mounted: MobileChannelView never calls
  * useTerminalTheme()/useAppearance(), so the channel surface doesn't
@@ -33,6 +36,7 @@ export const dynamic = "force-dynamic";
 import { redirect } from "next/navigation";
 
 import { ChannelProvider } from "@/contexts/ChannelContext";
+import { PeerChatProvider } from "@/contexts/PeerChatContext";
 import { PreferencesProvider } from "@/contexts/PreferencesContext";
 import { ProjectTreeProvider } from "@/contexts/ProjectTreeContext";
 import { EmbeddedChannelView } from "@/components/mobile/embed/EmbeddedChannelView";
@@ -56,7 +60,9 @@ export default async function MobileChannelPage({ params }: PageProps) {
     <PreferencesProvider>
       <ProjectTreeProvider>
         <ChannelProvider>
-          <EmbeddedChannelView />
+          <PeerChatProvider>
+            <EmbeddedChannelView />
+          </PeerChatProvider>
         </ChannelProvider>
       </ProjectTreeProvider>
     </PreferencesProvider>

--- a/src/app/m/layout.tsx
+++ b/src/app/m/layout.tsx
@@ -1,0 +1,46 @@
+/**
+ * Layout for /m/* mobile-embed routes.
+ *
+ * These routes are loaded by the new Flutter app's WebView host and
+ * render only their target surface (terminal, channel, recording) —
+ * no MobileShell, no bottom tab bar, no AppShell.
+ *
+ * Auth gating is handled by `src/middleware.ts` (which protects every
+ * route except /login and /api). When CF Access challenges, the
+ * challenge happens *inside* the WebView and lands the user back here
+ * with a CF_Authorization cookie set on the WebView's cookie store —
+ * see spec §3.
+ *
+ * We deliberately do NOT mount the heavy desktop providers
+ * (Template, Recording, Trash, Schedule, Secrets, GitHubAccount, …) so
+ * the embed bundle stays lean. Surface-specific providers live inside
+ * each surface's page.
+ */
+
+import type { Metadata, Viewport } from "next";
+
+export const metadata: Metadata = {
+  title: "Remote Dev",
+  description: "Remote Dev mobile embed",
+};
+
+export const viewport: Viewport = {
+  themeColor: "#1a1b26",
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 5,
+  userScalable: true,
+  viewportFit: "cover",
+};
+
+export default function MobileEmbedLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="relative h-[100dvh] w-full overflow-hidden bg-[#1a1b26]">
+      {children}
+    </div>
+  );
+}

--- a/src/app/m/recording/[id]/page.tsx
+++ b/src/app/m/recording/[id]/page.tsx
@@ -1,0 +1,33 @@
+export const dynamic = "force-dynamic";
+
+/**
+ * /m/recording/[id] — recording playback for the native Flutter shell.
+ *
+ * Auth handled by middleware. AppearanceProvider is mounted here
+ * because RecordingPlayer (rendered inside EmbeddedRecordingView)
+ * calls useTerminalTheme()/useAppearance() — the /m/* layout
+ * deliberately excludes AppShell, so the provider lives at the page
+ * scope.
+ */
+
+import { redirect } from "next/navigation";
+
+import { AppearanceProvider } from "@/contexts/AppearanceContext";
+import { EmbeddedRecordingView } from "@/components/mobile/embed/EmbeddedRecordingView";
+import { getAuthSession } from "@/lib/auth-utils";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function MobileRecordingPage({ params }: PageProps) {
+  const { id } = await params;
+  const auth = await getAuthSession();
+  if (!auth?.user?.id) redirect("/login");
+
+  return (
+    <AppearanceProvider>
+      <EmbeddedRecordingView recordingId={id} />
+    </AppearanceProvider>
+  );
+}

--- a/src/app/m/session/[id]/page.tsx
+++ b/src/app/m/session/[id]/page.tsx
@@ -1,0 +1,74 @@
+export const dynamic = "force-dynamic";
+
+/**
+ * /m/session/[id] — terminal-only session view for the native Flutter
+ * shell's WebView host.
+ *
+ * Auth: resolved via getAuthSession() (NextAuth credentials OR CF
+ * Access JWT). Unauthenticated requests are redirected to /login by
+ * src/middleware.ts before they reach this page.
+ *
+ * Session: loaded from DB by id; 404 if not found or not owned by the
+ * current user.
+ *
+ * Providers: AppearanceProvider is mounted here because Terminal.tsx
+ * (rendered inside EmbeddedSessionView via TerminalWithKeyboard) calls
+ * useTerminalTheme()/useAppearance(). The desktop AppShell normally
+ * mounts AppearanceProvider, but the /m/* layout deliberately excludes
+ * AppShell to keep the embed bundle minimal — so the provider lives
+ * here, scoped to this route.
+ *
+ * No SessionContext / ProjectTree / Preferences are mounted — the
+ * embed surface only needs the session row + WS URL.
+ */
+
+import { headers } from "next/headers";
+import { notFound, redirect } from "next/navigation";
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import { terminalSessions } from "@/db/schema";
+import { getAuthSession } from "@/lib/auth-utils";
+import { AppearanceProvider } from "@/contexts/AppearanceContext";
+import { EmbeddedSessionView } from "@/components/mobile/embed/EmbeddedSessionView";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function MobileSessionPage({ params }: PageProps) {
+  const { id } = await params;
+  const auth = await getAuthSession();
+  if (!auth?.user?.id) {
+    redirect("/login");
+  }
+
+  const row = await db.query.terminalSessions.findFirst({
+    where: and(eq(terminalSessions.id, id), eq(terminalSessions.userId, auth.user.id)),
+  });
+  if (!row) notFound();
+
+  // Resolve WS URL from the request host so the WebView talks back to
+  // the same Remote Dev origin it loaded the page from.
+  const h = await headers();
+  const host = h.get("host") ?? "localhost";
+  const proto = h.get("x-forwarded-proto") ?? "http";
+  const wsProto = proto === "https" ? "wss" : "ws";
+  const terminalPort = process.env.NEXT_PUBLIC_TERMINAL_PORT ?? "6002";
+  const hostNoPort = host.split(":")[0];
+  const wsUrl = `${wsProto}://${hostNoPort}:${terminalPort}`;
+
+  return (
+    <AppearanceProvider>
+      <EmbeddedSessionView
+        session={{
+          id: row.id,
+          name: row.name,
+          tmuxSessionName: row.tmuxSessionName,
+          status: row.status as "active" | "suspended" | "closed",
+        }}
+        wsUrl={wsUrl}
+      />
+    </AppearanceProvider>
+  );
+}

--- a/src/components/mobile/embed/EmbeddedChannelView.tsx
+++ b/src/components/mobile/embed/EmbeddedChannelView.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+/**
+ * EmbeddedChannelView — channel list / view / thread, no app chrome.
+ *
+ * Reuses the existing MobileChannelView. On mount we install a minimal
+ * window.rdvBridge whose only meaningful method is `back`, which closes
+ * an open thread first — equivalent to the user tapping the native back
+ * button while a thread is on top. Otherwise the native shell pops the
+ * route based on its own back-stack state.
+ *
+ * Other rdvBridge methods (input, key, paste, setFontSize,
+ * scrollToBottom) are stubbed since the channel surface doesn't drive
+ * a terminal.
+ *
+ * Note on prop shape vs. plan: the plan's snippet kept thread state in
+ * local `useState`, but the actual MobileThreadTakeover takes `open` +
+ * `onClose` and reads the thread id from ChannelContext (`openThreadId`,
+ * `closeThread`). MobileChannelView.handleReplyClick already calls
+ * `openThread(messageId)` on context. We mirror ChannelsTab and consume
+ * the context directly so the takeover renders correctly.
+ */
+
+import { useEffect } from "react";
+
+import { MobileChannelView } from "@/components/mobile/channels/MobileChannelView";
+import { MobileThreadTakeover } from "@/components/mobile/channels/MobileThreadTakeover";
+import { useChannelContextOptional } from "@/contexts/ChannelContext";
+import { installRdvBridge, type RdvBridgeAdapter } from "@/lib/rdv-bridge";
+
+const noop = () => {};
+
+export function EmbeddedChannelView() {
+  const channels = useChannelContextOptional();
+  const openThreadId = channels?.openThreadId ?? null;
+  const closeThread = channels?.closeThread;
+
+  useEffect(() => {
+    const adapter: RdvBridgeAdapter = {
+      input: noop,
+      key: noop,
+      paste: noop,
+      setFontSize: noop,
+      scrollToBottom: noop,
+      back: () => {
+        // Closing an open thread takes priority over leaving the route.
+        if (openThreadId && closeThread) {
+          closeThread();
+          return;
+        }
+        // Otherwise this is a no-op; the native shell pops the route
+        // itself based on its own back-stack state.
+      },
+    };
+    return installRdvBridge(adapter);
+  }, [openThreadId, closeThread]);
+
+  // Defensive: if no ChannelProvider is mounted (e.g. desktop browser
+  // smoke test outside the proper route), render a calm empty state
+  // instead of crashing inside MobileChannelView.
+  if (!channels || !closeThread) {
+    return (
+      <div
+        data-testid="embedded-channel-no-provider"
+        className="flex h-full w-full items-center justify-center bg-[#1a1b26] px-6 text-center text-sm text-muted-foreground"
+      >
+        Channels unavailable.
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-full w-full bg-[#1a1b26]">
+      {/* MobileChannelView already drives `openThread` on the context when
+          the user taps a reply chip, so the local onOpenThread callback is
+          a no-op — the takeover renders off `openThreadId`. */}
+      <MobileChannelView onBack={noop} onOpenThread={noop} />
+      <MobileThreadTakeover open={!!openThreadId} onClose={closeThread} />
+    </div>
+  );
+}

--- a/src/components/mobile/embed/EmbeddedRecordingView.tsx
+++ b/src/components/mobile/embed/EmbeddedRecordingView.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+/**
+ * EmbeddedRecordingView — recording playback only, no app chrome.
+ *
+ * Wraps the existing RecordingPlayer. window.rdvBridge.back() is the
+ * only meaningful native-driven action; everything else is stubbed.
+ *
+ * Note on prop shape vs. plan: the plan's snippet assumed
+ * `RecordingPlayer` accepts a `recordingId: string`, but the actual
+ * component takes a parsed recording object. Task 8's page hands us a
+ * `recordingId: string` (from the URL), so this wrapper owns the fetch.
+ * We hit the same `/api/recordings/:id?parsed=true` endpoint
+ * RecordingContext.getRecording uses, so we don't depend on a
+ * RecordingProvider being mounted under the embed route.
+ */
+
+import { useEffect, useState } from "react";
+
+import { RecordingPlayer } from "@/components/terminal/RecordingPlayer";
+import { installRdvBridge, type RdvBridgeAdapter } from "@/lib/rdv-bridge";
+import type { ParsedRecording } from "@/types/recording";
+
+const noop = () => {};
+
+export interface EmbeddedRecordingViewProps {
+  recordingId: string;
+}
+
+export function EmbeddedRecordingView({
+  recordingId,
+}: EmbeddedRecordingViewProps) {
+  const [recording, setRecording] = useState<ParsedRecording | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const adapter: RdvBridgeAdapter = {
+      input: noop,
+      key: noop,
+      paste: noop,
+      setFontSize: noop,
+      scrollToBottom: noop,
+      back: noop, // native shell pops the route
+    };
+    return installRdvBridge(adapter);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setRecording(null);
+
+    void (async () => {
+      try {
+        const response = await fetch(
+          `/api/recordings/${encodeURIComponent(recordingId)}?parsed=true`
+        );
+        if (cancelled) return;
+        if (!response.ok) {
+          setError(
+            response.status === 404
+              ? "Recording not found"
+              : "Failed to load recording"
+          );
+          return;
+        }
+        const parsed = (await response.json()) as ParsedRecording;
+        if (cancelled) return;
+        setRecording(parsed);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load recording");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [recordingId]);
+
+  return (
+    <div className="relative h-full w-full bg-[#1a1b26]">
+      {loading ? (
+        <div
+          data-testid="embedded-recording-loading"
+          className="flex h-full w-full items-center justify-center text-sm text-muted-foreground"
+        >
+          Loading recording...
+        </div>
+      ) : error ? (
+        <div
+          data-testid="embedded-recording-error"
+          className="flex h-full w-full items-center justify-center px-6 text-center text-sm text-destructive"
+        >
+          {error}
+        </div>
+      ) : recording ? (
+        <RecordingPlayer recording={recording} />
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/mobile/embed/EmbeddedSessionView.tsx
+++ b/src/components/mobile/embed/EmbeddedSessionView.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+/**
+ * EmbeddedSessionView — terminal canvas only, wired to the rdv-bridge.
+ *
+ * Rendered by `/m/session/[id]/page.tsx` inside a layout that excludes
+ * MobileShell and the bottom tab bar. The native Flutter shell wraps
+ * this view and supplies its own status bar, smart-key strip, and input
+ * bar — those are NOT rendered here.
+ *
+ * On mount we install `window.rdvBridge` with handlers backed by the
+ * terminal's imperative API (`sendInput`, `scrollToBottom`, etc). On
+ * unmount we uninstall the bridge so the next route can install its
+ * own.
+ *
+ * Outbound events:
+ *   - onTerminalReady fires after the terminal mounts (microtask) so
+ *     the native shell can clear its splash screen.
+ *
+ * @see docs/superpowers/specs/2026-05-08-flutter-app-redesign-design.md §4
+ */
+
+import { useEffect, useRef } from "react";
+
+import {
+  TerminalWithKeyboard,
+  type TerminalWithKeyboardRef,
+} from "@/components/terminal/TerminalWithKeyboard";
+import {
+  installRdvBridge,
+  notifyToNative,
+  type RdvBridgeAdapter,
+  type RdvBridgeKeyMods,
+} from "@/lib/rdv-bridge";
+
+export interface EmbeddedSessionViewProps {
+  session: {
+    id: string;
+    name: string;
+    tmuxSessionName: string;
+    status: "active" | "suspended" | "closed";
+  };
+  wsUrl: string;
+  initialFontSize?: number;
+}
+
+/** Map a smart-key name + mods into the byte sequence the PTY expects. */
+function keyToBytes(name: string, mods: RdvBridgeKeyMods): string {
+  // Minimal mapping for v1 — extended in later phases as the native
+  // smart-key strip lights up more keys. Unknown names are dropped to
+  // avoid sending garbage to the PTY.
+  if (mods.ctrl && name.length === 1) {
+    // Ctrl+letter → control byte (only A-Z covered).
+    const upper = name.toUpperCase().charCodeAt(0);
+    if (upper >= 65 && upper <= 90) {
+      return String.fromCharCode(upper - 64);
+    }
+  }
+  switch (name) {
+    case "Tab":
+      return "\t";
+    case "Escape":
+    case "Esc":
+      return "\x1b";
+    case "Enter":
+      return "\r";
+    case "ArrowUp":
+      return "\x1b[A";
+    case "ArrowDown":
+      return "\x1b[B";
+    case "ArrowRight":
+      return "\x1b[C";
+    case "ArrowLeft":
+      return "\x1b[D";
+    case "Home":
+      return "\x1b[H";
+    case "End":
+      return "\x1b[F";
+    case "PageUp":
+      return "\x1b[5~";
+    case "PageDown":
+      return "\x1b[6~";
+    default:
+      return "";
+  }
+}
+
+export function EmbeddedSessionView({
+  session,
+  wsUrl,
+  initialFontSize,
+}: EmbeddedSessionViewProps) {
+  const terminalRef = useRef<TerminalWithKeyboardRef | null>(null);
+
+  useEffect(() => {
+    const adapter: RdvBridgeAdapter = {
+      input: (text) => terminalRef.current?.sendInput(text),
+      key: (name, mods) => {
+        const bytes = keyToBytes(name, mods);
+        if (bytes) terminalRef.current?.sendInput(bytes);
+      },
+      paste: (text) => terminalRef.current?.sendInput(text),
+      setFontSize: (_px) => {
+        // Phase 0 stub — pinch-zoom font size lands in Phase 2 alongside
+        // the native pinch gesture; for now we ignore so the bridge
+        // method is callable without effect.
+      },
+      scrollToBottom: () => terminalRef.current?.scrollToBottom(),
+      back: () => {
+        // Session embed has no in-WebView "back" action — native shell
+        // pops the route. Stub.
+      },
+    };
+
+    const uninstall = installRdvBridge(adapter);
+    // Fire onTerminalReady after the terminal ref resolves. Mount order
+    // means the ref is populated by this effect's first run.
+    queueMicrotask(() => void notifyToNative("onTerminalReady", {}));
+
+    return uninstall;
+  }, []);
+
+  return (
+    <div className="relative h-full w-full bg-[#1a1b26]">
+      <TerminalWithKeyboard
+        ref={terminalRef}
+        sessionId={session.id}
+        tmuxSessionName={session.tmuxSessionName}
+        sessionName={session.name}
+        wsUrl={wsUrl}
+        fontSize={initialFontSize}
+        mobileChrome="external"
+      />
+    </div>
+  );
+}

--- a/src/components/mobile/embed/EmbeddedSessionView.tsx
+++ b/src/components/mobile/embed/EmbeddedSessionView.tsx
@@ -113,8 +113,15 @@ export function EmbeddedSessionView({
     };
 
     const uninstall = installRdvBridge(adapter);
-    // Fire onTerminalReady after the terminal ref resolves. Mount order
-    // means the ref is populated by this effect's first run.
+    // onPageMounted-style signal — fires after the embed view has mounted
+    // and the bridge is installed. NOTE: xterm.js + WebSocket init happen
+    // asynchronously inside Terminal.tsx, so this event arrives BEFORE the
+    // terminal is actually ready to accept input. Phase 0 ships with this
+    // looser semantics so the bridge round-trip can be validated in
+    // Phase 1.5; Phase 1 native code that drives input should queue
+    // commands until xterm has connected (the spec mandates a
+    // SessionViewController queue gated on a future "terminal-connected"
+    // event).
     queueMicrotask(() => {
       notifyToNative("onTerminalReady", {}).catch((err) => {
         // Native-side errors shouldn't crash the WebView; surface in console

--- a/src/components/mobile/embed/EmbeddedSessionView.tsx
+++ b/src/components/mobile/embed/EmbeddedSessionView.tsx
@@ -115,7 +115,13 @@ export function EmbeddedSessionView({
     const uninstall = installRdvBridge(adapter);
     // Fire onTerminalReady after the terminal ref resolves. Mount order
     // means the ref is populated by this effect's first run.
-    queueMicrotask(() => void notifyToNative("onTerminalReady", {}));
+    queueMicrotask(() => {
+      notifyToNative("onTerminalReady", {}).catch((err) => {
+        // Native-side errors shouldn't crash the WebView; surface in console
+        // for observability while keeping the UI alive.
+        console.error("onTerminalReady notify failed", err);
+      });
+    });
 
     return uninstall;
   }, []);

--- a/src/components/mobile/embed/__tests__/EmbeddedSessionView.test.tsx
+++ b/src/components/mobile/embed/__tests__/EmbeddedSessionView.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * EmbeddedSessionView tests.
+ *
+ * Verifies that:
+ *   1. The view renders the terminal area.
+ *   2. Mounting installs window.rdvBridge.
+ *   3. Unmounting uninstalls window.rdvBridge.
+ *   4. window.rdvBridge.input forwards into the terminal's sendInput.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+
+import { EmbeddedSessionView } from "../EmbeddedSessionView";
+
+// Mock TerminalWithKeyboard — we just need its ref shape.
+vi.mock("@/components/terminal/TerminalWithKeyboard", () => {
+  const React =
+    require("react") as typeof import("react");
+  const TerminalWithKeyboard = React.forwardRef<
+    {
+      sendInput: (s: string) => void;
+      scrollToBottom: () => void;
+      focus: () => void;
+      restartAgent: () => void;
+    },
+    Record<string, unknown>
+  >(function MockTerminal(_props, ref) {
+    React.useImperativeHandle(ref, () => ({
+      sendInput: vi.fn(),
+      scrollToBottom: vi.fn(),
+      focus: vi.fn(),
+      restartAgent: vi.fn(),
+    }));
+    return React.createElement(
+      "div",
+      { "data-testid": "terminal-mock" },
+      "terminal"
+    );
+  });
+  return { TerminalWithKeyboard };
+});
+
+const session = {
+  id: "session-1",
+  name: "test session",
+  tmuxSessionName: "rdv-session-1",
+  status: "active" as const,
+};
+
+afterEach(() => {
+  cleanup();
+  delete window.rdvBridge;
+});
+
+describe("EmbeddedSessionView", () => {
+  it("renders the terminal area", () => {
+    const { getByTestId } = render(
+      <EmbeddedSessionView session={session} wsUrl="ws://localhost:6002" />
+    );
+
+    expect(getByTestId("terminal-mock")).toBeTruthy();
+  });
+
+  it("installs window.rdvBridge on mount", () => {
+    expect(window.rdvBridge).toBeUndefined();
+
+    render(<EmbeddedSessionView session={session} wsUrl="ws://localhost:6002" />);
+
+    expect(window.rdvBridge).toBeDefined();
+    expect(window.rdvBridge?.version).toBe(1);
+  });
+
+  it("uninstalls window.rdvBridge on unmount", () => {
+    const { unmount } = render(
+      <EmbeddedSessionView session={session} wsUrl="ws://localhost:6002" />
+    );
+    expect(window.rdvBridge).toBeDefined();
+
+    unmount();
+
+    expect(window.rdvBridge).toBeUndefined();
+  });
+});

--- a/src/components/mobile/embed/__tests__/EmbeddedSessionView.test.tsx
+++ b/src/components/mobile/embed/__tests__/EmbeddedSessionView.test.tsx
@@ -8,15 +8,18 @@
  *   4. window.rdvBridge.input forwards into the terminal's sendInput.
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, cleanup } from "@testing-library/react";
 
 import { EmbeddedSessionView } from "../EmbeddedSessionView";
 
-// Mock TerminalWithKeyboard — we just need its ref shape.
-vi.mock("@/components/terminal/TerminalWithKeyboard", () => {
-  const React =
-    require("react") as typeof import("react");
+// Captured spies — re-created per test in `beforeEach` so we can assert
+// against the actual instance the component held in its ref.
+let sendInputSpy: ReturnType<typeof vi.fn>;
+let scrollToBottomSpy: ReturnType<typeof vi.fn>;
+
+vi.mock("@/components/terminal/TerminalWithKeyboard", async () => {
+  const React = await import("react");
   const TerminalWithKeyboard = React.forwardRef<
     {
       sendInput: (s: string) => void;
@@ -27,10 +30,10 @@ vi.mock("@/components/terminal/TerminalWithKeyboard", () => {
     Record<string, unknown>
   >(function MockTerminal(_props, ref) {
     React.useImperativeHandle(ref, () => ({
-      sendInput: vi.fn(),
-      scrollToBottom: vi.fn(),
-      focus: vi.fn(),
-      restartAgent: vi.fn(),
+      sendInput: sendInputSpy as unknown as (s: string) => void,
+      scrollToBottom: scrollToBottomSpy as unknown as () => void,
+      focus: vi.fn() as unknown as () => void,
+      restartAgent: vi.fn() as unknown as () => void,
     }));
     return React.createElement(
       "div",
@@ -47,6 +50,11 @@ const session = {
   tmuxSessionName: "rdv-session-1",
   status: "active" as const,
 };
+
+beforeEach(() => {
+  sendInputSpy = vi.fn();
+  scrollToBottomSpy = vi.fn();
+});
 
 afterEach(() => {
   cleanup();
@@ -80,5 +88,13 @@ describe("EmbeddedSessionView", () => {
     unmount();
 
     expect(window.rdvBridge).toBeUndefined();
+  });
+
+  it("rdvBridge.input forwards to terminal sendInput", () => {
+    render(<EmbeddedSessionView session={session} wsUrl="ws://localhost:6002" />);
+
+    window.rdvBridge?.input("ls -la\n");
+
+    expect(sendInputSpy).toHaveBeenCalledWith("ls -la\n");
   });
 });

--- a/src/lib/__tests__/rdv-bridge.test.ts
+++ b/src/lib/__tests__/rdv-bridge.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for the rdv-bridge module — the JS surface the native Flutter
+ * shell drives via window.rdvBridge, and the helper that emits events
+ * back to native via window.flutter_inappwebview.callHandler.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  RDV_BRIDGE_VERSION,
+  installRdvBridge,
+  notifyToNative,
+  type RdvBridgeAdapter,
+} from "../rdv-bridge";
+
+function makeAdapter(overrides: Partial<RdvBridgeAdapter> = {}): RdvBridgeAdapter {
+  return {
+    input: vi.fn(),
+    key: vi.fn(),
+    paste: vi.fn(),
+    setFontSize: vi.fn(),
+    scrollToBottom: vi.fn(),
+    back: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("rdv-bridge", () => {
+  afterEach(() => {
+    delete window.rdvBridge;
+    delete window.flutter_inappwebview;
+  });
+
+  describe("installRdvBridge", () => {
+    it("installs window.rdvBridge with the current version", () => {
+      installRdvBridge(makeAdapter());
+
+      expect(window.rdvBridge).toBeDefined();
+      expect(window.rdvBridge?.version).toBe(RDV_BRIDGE_VERSION);
+    });
+
+    it("forwards input() calls to the adapter", () => {
+      const adapter = makeAdapter();
+      installRdvBridge(adapter);
+
+      window.rdvBridge?.input("hello");
+
+      expect(adapter.input).toHaveBeenCalledWith("hello");
+    });
+
+    it("forwards key() calls to the adapter with modifiers", () => {
+      const adapter = makeAdapter();
+      installRdvBridge(adapter);
+
+      window.rdvBridge?.key("Tab", { ctrl: true });
+
+      expect(adapter.key).toHaveBeenCalledWith("Tab", { ctrl: true });
+    });
+
+    it("forwards setFontSize, scrollToBottom, paste, back to the adapter", () => {
+      const adapter = makeAdapter();
+      installRdvBridge(adapter);
+
+      window.rdvBridge?.setFontSize(14);
+      window.rdvBridge?.scrollToBottom();
+      window.rdvBridge?.paste("clip");
+      window.rdvBridge?.back();
+
+      expect(adapter.setFontSize).toHaveBeenCalledWith(14);
+      expect(adapter.scrollToBottom).toHaveBeenCalledTimes(1);
+      expect(adapter.paste).toHaveBeenCalledWith("clip");
+      expect(adapter.back).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns an uninstall function that removes the bridge", () => {
+      const uninstall = installRdvBridge(makeAdapter());
+
+      expect(window.rdvBridge).toBeDefined();
+      uninstall();
+      expect(window.rdvBridge).toBeUndefined();
+    });
+
+    it("re-installing replaces the previous adapter", () => {
+      const first = makeAdapter();
+      const second = makeAdapter();
+
+      installRdvBridge(first);
+      installRdvBridge(second);
+
+      window.rdvBridge?.input("x");
+
+      expect(first.input).not.toHaveBeenCalled();
+      expect(second.input).toHaveBeenCalledWith("x");
+    });
+  });
+
+  describe("notifyToNative", () => {
+    it("calls window.flutter_inappwebview.callHandler when present", async () => {
+      const callHandler = vi.fn().mockResolvedValue(undefined);
+      window.flutter_inappwebview = { callHandler };
+
+      await notifyToNative("onTerminalReady", {});
+
+      expect(callHandler).toHaveBeenCalledWith("onTerminalReady", {});
+    });
+
+    it("is a no-op when window.flutter_inappwebview is absent", async () => {
+      // No window.flutter_inappwebview installed — should not throw.
+      await expect(
+        notifyToNative("onActivity", { state: "running" })
+      ).resolves.toBeUndefined();
+    });
+
+    it("forwards typed payloads", async () => {
+      const callHandler = vi.fn().mockResolvedValue(undefined);
+      window.flutter_inappwebview = { callHandler };
+
+      await notifyToNative("onSelectionChange", { text: "selected" });
+      await notifyToNative("onLinkOpen", { url: "https://example.com" });
+
+      expect(callHandler).toHaveBeenNthCalledWith(1, "onSelectionChange", {
+        text: "selected",
+      });
+      expect(callHandler).toHaveBeenNthCalledWith(2, "onLinkOpen", {
+        url: "https://example.com",
+      });
+    });
+  });
+});

--- a/src/lib/rdv-bridge.ts
+++ b/src/lib/rdv-bridge.ts
@@ -1,0 +1,113 @@
+/**
+ * rdv-bridge — JS surface for the native Flutter shell.
+ *
+ * The native WebView host calls these methods via `evaluateJavascript`
+ * to drive the embedded surface (terminal, channel, recording). The
+ * embedded surface exports an "adapter" — a set of callbacks pointing
+ * at the actual terminal / view APIs — and `installRdvBridge` glues
+ * them onto `window.rdvBridge`.
+ *
+ * Events going the other way (terminal-ready, selection-change, link-
+ * open) call `notifyToNative()` which dispatches via
+ * `window.flutter_inappwebview.callHandler` when present and is a no-op
+ * otherwise — this lets the same routes render in a desktop browser
+ * for testing.
+ *
+ * @see docs/superpowers/specs/2026-05-08-flutter-app-redesign-design.md §4
+ */
+
+/** Bumped on any breaking change to the bridge surface. */
+export const RDV_BRIDGE_VERSION = 1;
+
+export interface RdvBridgeKeyMods {
+  ctrl?: boolean;
+  alt?: boolean;
+  shift?: boolean;
+  meta?: boolean;
+}
+
+/**
+ * Adapter contract — the embedded view's hooks into its underlying
+ * controls. Every method must be safe to call multiple times and from
+ * any frame after the view has mounted.
+ */
+export interface RdvBridgeAdapter {
+  /** Write text to the terminal (session view only). */
+  input: (text: string) => void;
+  /** Send a named key with optional modifiers (session view only). */
+  key: (name: string, mods: RdvBridgeKeyMods) => void;
+  /** Paste from native clipboard into the terminal (session view only). */
+  paste: (text: string) => void;
+  /** Set terminal font size in px (session view only). */
+  setFontSize: (px: number) => void;
+  /** Scroll terminal viewport to the bottom (session view only). */
+  scrollToBottom: () => void;
+  /** Native back button pressed — embed view should clean up / leave. */
+  back: () => void;
+}
+
+/**
+ * Public shape of `window.rdvBridge`. Methods that an adapter doesn't
+ * implement (e.g., a channel embed has no `input`) are still installed,
+ * but the adapter's no-op stubs absorb the call.
+ */
+export interface RdvBridge extends RdvBridgeAdapter {
+  readonly version: number;
+}
+
+/**
+ * Install `window.rdvBridge` backed by `adapter`. Returns an uninstall
+ * function that should be called on view unmount.
+ */
+export function installRdvBridge(adapter: RdvBridgeAdapter): () => void {
+  const bridge: RdvBridge = {
+    version: RDV_BRIDGE_VERSION,
+    input: (text) => adapter.input(text),
+    key: (name, mods) => adapter.key(name, mods),
+    paste: (text) => adapter.paste(text),
+    setFontSize: (px) => adapter.setFontSize(px),
+    scrollToBottom: () => adapter.scrollToBottom(),
+    back: () => adapter.back(),
+  };
+
+  window.rdvBridge = bridge;
+
+  return () => {
+    if (window.rdvBridge === bridge) {
+      delete window.rdvBridge;
+    }
+  };
+}
+
+/** Names of events the embedded view emits to native. */
+export type NotifyName =
+  | "onTerminalReady"
+  | "onSelectionChange"
+  | "onWantsPaste"
+  | "onActivity"
+  | "onLinkOpen";
+
+/** Payload union — kept narrow on purpose; bump version to extend. */
+export type NotifyPayload =
+  | { name: "onTerminalReady"; data: Record<string, never> }
+  | { name: "onSelectionChange"; data: { text: string } }
+  | { name: "onWantsPaste"; data: Record<string, never> }
+  | {
+      name: "onActivity";
+      data: { state: "running" | "waiting" | "idle" | "error" };
+    }
+  | { name: "onLinkOpen"; data: { url: string } };
+
+/**
+ * Send an event to the native shell. No-op when not running inside a
+ * `flutter_inappwebview`-hosted WebView (so desktop browser rendering
+ * during development still works).
+ */
+export async function notifyToNative<N extends NotifyName>(
+  name: N,
+  data: Extract<NotifyPayload, { name: N }>["data"]
+): Promise<void> {
+  const handler = window.flutter_inappwebview?.callHandler;
+  if (!handler) return;
+  await handler(name, data);
+}

--- a/src/lib/rdv-bridge.ts
+++ b/src/lib/rdv-bridge.ts
@@ -107,7 +107,7 @@ export async function notifyToNative<N extends NotifyName>(
   name: N,
   data: Extract<NotifyPayload, { name: N }>["data"]
 ): Promise<void> {
-  const handler = window.flutter_inappwebview?.callHandler;
-  if (!handler) return;
-  await handler(name, data);
+  const fip = window.flutter_inappwebview;
+  if (!fip) return;
+  await fip.callHandler(name, data);
 }

--- a/src/types/rdv-bridge.d.ts
+++ b/src/types/rdv-bridge.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Global type declarations for the Flutter ↔ PWA JS bridge.
+ *
+ * `window.rdvBridge` — installed by `installRdvBridge()` when an
+ *   embedded mobile route mounts. The native shell calls into these
+ *   methods via `evaluateJavascript`.
+ *
+ * `window.flutter_inappwebview` — present only when running inside a
+ *   `flutter_inappwebview`-hosted WebView. The bridge calls
+ *   `.callHandler(name, payload)` to send events to native.
+ */
+
+import type { RdvBridge } from "@/lib/rdv-bridge";
+
+declare global {
+  interface Window {
+    rdvBridge?: RdvBridge;
+    flutter_inappwebview?: {
+      callHandler: (name: string, ...args: unknown[]) => Promise<unknown>;
+    };
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary

Phase 0 of the [Flutter app redesign](docs/superpowers/specs/2026-05-08-flutter-app-redesign-design.md) — PWA-side prerequisites for the new hybrid native + WebView Flutter mobile app. The native shell (Phase 1+) loads narrow `/m/*` routes inside its WebView and drives them via `window.rdvBridge`.

- **`window.rdvBridge`** (versioned v1) — JS adapter the native shell calls via `evaluateJavascript`. Methods: `input`, `key`, `paste`, `setFontSize`, `scrollToBottom`, `back`. Outbound events via `notifyToNative()` that no-op outside `flutter_inappwebview` (so routes still render in a desktop browser).
- **3 new routes** — `/m/session/<id>`, `/m/channel/<id>`, `/m/recording/<id>` — render only the target surface (no `MobileShell`, no bottom tab bar, no `AppShell`). Each mounts only the providers its surface needs.
- **3 embed components** — `EmbeddedSessionView`, `EmbeddedChannelView`, `EmbeddedRecordingView` — bridge existing PWA components to the rdv-bridge contract.
- **Layout split** — root `src/app/layout.tsx` extends its existing `/login`-only AppShell skip to also exclude `/m/*`. New minimal layout at `src/app/m/layout.tsx`.

Spec: `docs/superpowers/specs/2026-05-08-flutter-app-redesign-design.md` §4 + §10
Plan: `docs/superpowers/plans/2026-05-08-flutter-app-phase-0-pwa-routes.md`

## What this enables

The Phase 1 Flutter shell can `loadUrl(serverUrl + "/m/session/<id>")` inside its WebView and immediately drive the embedded terminal via `evaluateJavascript("window.rdvBridge.input('ls\\n')")`. No further PWA changes blocked on Phase 0.

## Test plan

Automated (already verified):

- [x] `bun run test:run` — 1200 passed, 1 pre-existing failure (`packages/mobile/` tsconfig issue, unrelated to this branch)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean on the 12 changed files
- [x] `bun run build` — succeeds; all 3 routes registered as `ƒ Dynamic` server-rendered
- [x] All 3 routes return `307 → /login` for unauth requests (proxy auth gating works)

Manual smoke test (please run on this PR before merging):

- [ ] Sign in to the app at `/login`
- [ ] Create a session via the normal UI; note its UUID
- [ ] Visit `/m/session/<uuid>` in a desktop browser
  - Page renders the terminal canvas full-bleed on dark bg
  - No tab bar, no smart-keys, no input bar
  - DevTools console: `window.rdvBridge` is an object with `version === 1`
  - `window.rdvBridge.input("ls\n")` runs `ls` in the terminal
  - `window.rdvBridge.key("Tab", {})` sends a tab character
- [ ] Visit `/m/channel/<channel-id>` (any existing channel id) — channel list renders, no app chrome
- [ ] Visit `/m/recording/<recording-id>` (any existing recording id) — recording plays, no app chrome

## Known limitations (deferred to later phases)

- **`onTerminalReady` fires before xterm.js connects.** The bridge event arrives at native after the embed view mounts, but before xterm.js + WebSocket are ready to accept input. Acceptable for Phase 0 (the route renders); Phase 1.5 introduces a `SessionViewController` queue that gates native-to-WebView calls on a future `terminal-connected` event. Documented inline in `EmbeddedSessionView.tsx`.
- **`/m/channel/<id>` ignores the `id`.** `ChannelProvider` doesn't yet support an `initialChannelId` prop, so the page renders the channel list. Phase 4 (deep-link routing) wires native taps and PWA `setActiveChannelId` together.
- **`setFontSize` is a stub.** Phase 2 wires the native pinch-zoom gesture through this method.
- **No outbound events emitted yet** beyond `onTerminalReady`. Phase 2 wires `onSelectionChange`, `onWantsPaste`, `onActivity`, `onLinkOpen` from the native chrome side.

## Beads

Closes Phase 0 (`remote-dev-jl8i`) and tasks `remote-dev-r65n`, `4adc`, `i3s0`, `1dfb`, `m25x`, `ekwk`, `ltoo`, `03jm`, `0yd1`, `o51n`. Phase 1 (`remote-dev-u5i7`) becomes ready once this merges.

This pull request and its description were written by Isaac.