### PR TITLE
feat(mobile): Phase 4 — Notifications/Channels/Profile + deep links + main.dart wire-up

### DIFF
--- a/docs/mobile-deep-links.md
+++ b/docs/mobile-deep-links.md
@@ -1,0 +1,56 @@
+# Mobile Deep Links
+
+## Universal Links (iOS) + App Links (Android)
+
+The app supports deep-linking via:
+1. **Universal Links** (iOS) — `https://dev.bryanli.net/m/<surface>/<id>`
+2. **App Links** (Android) — same URL pattern, autoVerify
+3. **Custom scheme** (`remotedev://`) — fallback for non-allowlisted servers
+
+### Server side: `/.well-known/apple-app-site-association`
+
+The Remote Dev server (`https://dev.bryanli.net`) must serve, at `/.well-known/apple-app-site-association` (no extension, `Content-Type: application/json`):
+
+```json
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["TEAMID.com.remotedev.app"],
+        "components": [
+          { "/": "/m/session/*" },
+          { "/": "/m/channel/*" },
+          { "/": "/m/recording/*" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Replace `TEAMID` with your Apple Developer Team ID.
+
+### Server side: `/.well-known/assetlinks.json`
+
+Served at `/.well-known/assetlinks.json` (`Content-Type: application/json`):
+
+```json
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "com.remotedev.app",
+    "sha256_cert_fingerprints": ["XX:YY:..."]
+  }
+}]
+```
+
+The SHA-256 fingerprint comes from the Android signing keystore (`keytool -list -v -keystore <ks>`). For Play App Signing, use the upload + app signing certificate fingerprints from Play Console.
+
+### Custom scheme
+
+For self-hosted Remote Dev servers not in the app's domain allowlist, the app falls back to `remotedev://session/<id>` etc. — see P4.7.
+
+### Multi-server caveat
+
+Universal Links / App Links require domains to be listed in the app's entitlements / manifest at COMPILE TIME. Users with arbitrary self-hosted Remote Dev servers cannot use Universal/App Links — they fall back to the custom scheme.

--- a/docs/mobile-deep-links.md
+++ b/docs/mobile-deep-links.md
@@ -1,0 +1,127 @@
+# Mobile Deep Links
+
+The Remote Dev mobile app supports deep linking from `https://dev.bryanli.net/m/*` URLs into the native Flutter app on both iOS and Android. When a user taps such a link in Mail, Slack, Messages, etc., the OS opens the native app directly (rather than the browser) and routes to the appropriate screen.
+
+URL scheme:
+
+```
+https://dev.bryanli.net/m/<route>
+```
+
+Examples:
+
+- `https://dev.bryanli.net/m/channels/<channelId>` — open a channel
+- `https://dev.bryanli.net/m/notifications` — open notifications
+- `https://dev.bryanli.net/m/sessions/<sessionId>` — open a session
+
+For the OS to route the link to the app (rather than the browser), the server must publish two static JSON files under `/.well-known/`:
+
+- `apple-app-site-association` (iOS Universal Links)
+- `assetlinks.json` (Android App Links)
+
+Both files must be served over HTTPS, with `Content-Type: application/json`, and **without** any redirects.
+
+## iOS — Universal Links
+
+iOS uses the `Associated Domains` entitlement together with the `apple-app-site-association` (AASA) file at `https://dev.bryanli.net/.well-known/apple-app-site-association`.
+
+### App-side configuration
+
+The iOS app declares the associated domain in the Xcode project / `Runner.entitlements`:
+
+```xml
+<key>com.apple.developer.associated-domains</key>
+<array>
+    <string>applinks:dev.bryanli.net</string>
+</array>
+```
+
+### Server-side `apple-app-site-association`
+
+```json
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["<TEAM_ID>.net.bryanli.dev.remoteDev"],
+        "components": [
+          {
+            "/": "/m/*",
+            "comment": "Matches every path under /m/"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- `<TEAM_ID>` is the 10-character Apple Developer Team ID. This is obtained in Phase 5 once the app is registered on App Store Connect.
+- The bundle identifier (`net.bryanli.dev.remoteDev`) must match the iOS app's `PRODUCT_BUNDLE_IDENTIFIER`.
+- iOS fetches and caches AASA on app install; updates require a reinstall (or use of the CDN-served variant on iOS 14+).
+
+## Android — App Links
+
+Android uses the `<intent-filter android:autoVerify="true">` directive together with an `assetlinks.json` file at `https://dev.bryanli.net/.well-known/assetlinks.json`.
+
+### App-side configuration
+
+The Flutter app's `mobile/android/app/src/main/AndroidManifest.xml` adds an autoVerified intent-filter to `MainActivity`:
+
+```xml
+<intent-filter android:autoVerify="true">
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="https"
+          android:host="dev.bryanli.net"
+          android:pathPrefix="/m/" />
+</intent-filter>
+```
+
+`autoVerify="true"` instructs Android to fetch the server's `assetlinks.json` on install and verify the app is associated with the domain. If verification succeeds, links open directly in the app. If it fails (missing file, fingerprint mismatch, redirect, etc.), links still work but go through the system's "Open with…" chooser.
+
+### Server-side `assetlinks.json`
+
+```json
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "net.bryanli.dev.remote_dev",
+      "sha256_cert_fingerprints": [
+        "<APP_SIGNING_SHA256>"
+      ]
+    }
+  }
+]
+```
+
+- `package_name` must match the Android app's `applicationId` from `mobile/android/app/build.gradle`.
+- `<APP_SIGNING_SHA256>` is the SHA-256 fingerprint of the certificate that signs the APK installed on devices. For Play-Store-distributed apps this is the **Play App Signing** certificate (visible in Play Console → App integrity), not the upload certificate. For sideload/dev builds, it's the local debug or release keystore fingerprint.
+- Multiple fingerprints can be listed (e.g., debug + release + Play App Signing) — Android verifies if **any** match.
+- Get a local fingerprint via:
+
+  ```bash
+  keytool -list -v -keystore <keystore.jks> -alias <alias> | grep SHA256
+  ```
+
+- Verify the configuration with Google's validator:
+
+  ```
+  https://digitalassetlinks.googleapis.com/v1/statements:list?source.web.site=https://dev.bryanli.net&relation=delegate_permission/common.handle_all_urls
+  ```
+
+### Troubleshooting verification
+
+- `adb shell pm get-app-links net.bryanli.dev.remote_dev` shows the verification state for an installed build.
+- If status is `verified`, App Links route directly. If `legacy_failure` or anything else, links fall back to the chooser.
+- Fix: ensure no redirects on the JSON file, correct `Content-Type: application/json`, correct package name, and a fingerprint that matches whatever signs the installed APK.
+
+## Phase 5 follow-ups
+
+- [ ] Obtain Apple Team ID once the app is registered, finalize AASA.
+- [ ] Obtain Play App Signing SHA-256 once the app is uploaded to Play Console, finalize `assetlinks.json`.
+- [ ] Land both files on `dev.bryanli.net` under `/.well-known/`.
+- [ ] Re-test on physical devices that links open the app directly (not the browser).

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,13 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Custom scheme: remotedev://... -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="remotedev" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,15 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- App Links: https://dev.bryanli.net/m/* -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https"
+                      android:host="dev.bryanli.net"
+                      android:pathPrefix="/m/" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
+		7E1A00010000000000000001 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -120,6 +121,7 @@
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
+				7E1A00010000000000000001 /* Runner.entitlements */,
 			);
 			path = Runner;
 			sourceTree = "<group>";
@@ -365,6 +367,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -544,6 +547,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -566,6 +570,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -6,6 +6,17 @@
 		<true/>
 		<key>CFBundleDevelopmentRegion</key>
 		<string>$(DEVELOPMENT_LANGUAGE)</string>
+		<key>CFBundleURLTypes</key>
+		<array>
+			<dict>
+				<key>CFBundleURLName</key>
+				<string>com.remotedev.app</string>
+				<key>CFBundleURLSchemes</key>
+				<array>
+					<string>remotedev</string>
+				</array>
+			</dict>
+		</array>
 		<key>CFBundleDisplayName</key>
 		<string>Remote Dev</string>
 		<key>CFBundleExecutable</key>

--- a/mobile/ios/Runner/Runner.entitlements
+++ b/mobile/ios/Runner/Runner.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:dev.bryanli.net</string>
+	</array>
+</dict>
+</plist>

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -1,9 +1,25 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'infrastructure/deep_link/app_link_listener.dart';
 import 'presentation/router/app_router.dart';
 
 final appRouterProvider = Provider<AppRouter>((ref) => AppRouter());
+
+/// Boots the [AppLinkListener] eagerly on first read. Read once at startup
+/// (e.g. from `main()` via a `ProviderContainer`) so that custom-scheme deep
+/// links are picked up from cold-start onward.
+final appLinkListenerProvider = Provider<AppLinkListener>((ref) {
+  final router = ref.read(appRouterProvider);
+  final listener = AppLinkListener(router: router);
+  unawaited(listener.start());
+  ref.onDispose(() {
+    unawaited(listener.stop());
+  });
+  return listener;
+});
 
 class RemoteDevApp extends ConsumerWidget {
   const RemoteDevApp({super.key});

--- a/mobile/lib/application/ports/channels_port.dart
+++ b/mobile/lib/application/ports/channels_port.dart
@@ -1,0 +1,10 @@
+import '../../domain/channel.dart';
+
+abstract class ChannelsPort {
+  /// List channels visible to the current user. The implementation is
+  /// expected to flatten any server-side groupings into a single list.
+  Future<List<Channel>> list();
+
+  /// Archive the channel with the given id (DELETE /api/channels/:id).
+  Future<void> archive(String id);
+}

--- a/mobile/lib/application/ports/notifications_port.dart
+++ b/mobile/lib/application/ports/notifications_port.dart
@@ -1,4 +1,16 @@
+import '../../domain/notification.dart';
+
 abstract class NotificationsPort {
   /// Mark notifications as read. No-op when [ids] is empty.
   Future<void> markRead(List<String> ids);
+
+  /// List notifications, optionally filtered (`'all'`, `'unread'`,
+  /// `'mentions'`).
+  Future<List<AppNotification>> list({String? filter});
+
+  /// Dismiss (delete) a single notification.
+  Future<void> dismiss(String id);
+
+  /// Mark all notifications read.
+  Future<void> markAllRead();
 }

--- a/mobile/lib/domain/channel.dart
+++ b/mobile/lib/domain/channel.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'channel.freezed.dart';
+part 'channel.g.dart';
+
+@freezed
+class Channel with _$Channel {
+  const factory Channel({
+    required String id,
+    required String name,
+    @Default(0) int unreadCount,
+    String? projectId,
+  }) = _Channel;
+
+  factory Channel.fromJson(Map<String, dynamic> json) =>
+      _$ChannelFromJson(json);
+}

--- a/mobile/lib/domain/channel.freezed.dart
+++ b/mobile/lib/domain/channel.freezed.dart
@@ -1,0 +1,220 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'channel.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Channel _$ChannelFromJson(Map<String, dynamic> json) {
+  return _Channel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Channel {
+  String get id => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+  int get unreadCount => throw _privateConstructorUsedError;
+  String? get projectId => throw _privateConstructorUsedError;
+
+  /// Serializes this Channel to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Channel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ChannelCopyWith<Channel> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ChannelCopyWith<$Res> {
+  factory $ChannelCopyWith(Channel value, $Res Function(Channel) then) =
+      _$ChannelCopyWithImpl<$Res, Channel>;
+  @useResult
+  $Res call({String id, String name, int unreadCount, String? projectId});
+}
+
+/// @nodoc
+class _$ChannelCopyWithImpl<$Res, $Val extends Channel>
+    implements $ChannelCopyWith<$Res> {
+  _$ChannelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Channel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? unreadCount = null,
+    Object? projectId = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      unreadCount: null == unreadCount
+          ? _value.unreadCount
+          : unreadCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      projectId: freezed == projectId
+          ? _value.projectId
+          : projectId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ChannelImplCopyWith<$Res> implements $ChannelCopyWith<$Res> {
+  factory _$$ChannelImplCopyWith(
+          _$ChannelImpl value, $Res Function(_$ChannelImpl) then) =
+      __$$ChannelImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String id, String name, int unreadCount, String? projectId});
+}
+
+/// @nodoc
+class __$$ChannelImplCopyWithImpl<$Res>
+    extends _$ChannelCopyWithImpl<$Res, _$ChannelImpl>
+    implements _$$ChannelImplCopyWith<$Res> {
+  __$$ChannelImplCopyWithImpl(
+      _$ChannelImpl _value, $Res Function(_$ChannelImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Channel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? unreadCount = null,
+    Object? projectId = freezed,
+  }) {
+    return _then(_$ChannelImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      unreadCount: null == unreadCount
+          ? _value.unreadCount
+          : unreadCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      projectId: freezed == projectId
+          ? _value.projectId
+          : projectId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ChannelImpl implements _Channel {
+  const _$ChannelImpl(
+      {required this.id,
+      required this.name,
+      this.unreadCount = 0,
+      this.projectId});
+
+  factory _$ChannelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ChannelImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String name;
+  @override
+  @JsonKey()
+  final int unreadCount;
+  @override
+  final String? projectId;
+
+  @override
+  String toString() {
+    return 'Channel(id: $id, name: $name, unreadCount: $unreadCount, projectId: $projectId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ChannelImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.unreadCount, unreadCount) ||
+                other.unreadCount == unreadCount) &&
+            (identical(other.projectId, projectId) ||
+                other.projectId == projectId));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, id, name, unreadCount, projectId);
+
+  /// Create a copy of Channel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ChannelImplCopyWith<_$ChannelImpl> get copyWith =>
+      __$$ChannelImplCopyWithImpl<_$ChannelImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ChannelImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Channel implements Channel {
+  const factory _Channel(
+      {required final String id,
+      required final String name,
+      final int unreadCount,
+      final String? projectId}) = _$ChannelImpl;
+
+  factory _Channel.fromJson(Map<String, dynamic> json) = _$ChannelImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get name;
+  @override
+  int get unreadCount;
+  @override
+  String? get projectId;
+
+  /// Create a copy of Channel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ChannelImplCopyWith<_$ChannelImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/mobile/lib/domain/channel.g.dart
+++ b/mobile/lib/domain/channel.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'channel.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ChannelImpl _$$ChannelImplFromJson(Map<String, dynamic> json) =>
+    _$ChannelImpl(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      unreadCount: (json['unreadCount'] as num?)?.toInt() ?? 0,
+      projectId: json['projectId'] as String?,
+    );
+
+Map<String, dynamic> _$$ChannelImplToJson(_$ChannelImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'unreadCount': instance.unreadCount,
+      'projectId': instance.projectId,
+    };

--- a/mobile/lib/domain/notification.dart
+++ b/mobile/lib/domain/notification.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'notification.freezed.dart';
+part 'notification.g.dart';
+
+@freezed
+class AppNotification with _$AppNotification {
+  const factory AppNotification({
+    required String id,
+    required String title,
+    required String body,
+    required DateTime createdAt,
+    @Default(false) bool read,
+    String? sessionId,
+    String? channelId,
+    @Default('default') String kind,
+  }) = _AppNotification;
+
+  factory AppNotification.fromJson(Map<String, dynamic> json) =>
+      _$AppNotificationFromJson(json);
+}

--- a/mobile/lib/domain/notification.freezed.dart
+++ b/mobile/lib/domain/notification.freezed.dart
@@ -1,0 +1,315 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'notification.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+AppNotification _$AppNotificationFromJson(Map<String, dynamic> json) {
+  return _AppNotification.fromJson(json);
+}
+
+/// @nodoc
+mixin _$AppNotification {
+  String get id => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  String get body => throw _privateConstructorUsedError;
+  DateTime get createdAt => throw _privateConstructorUsedError;
+  bool get read => throw _privateConstructorUsedError;
+  String? get sessionId => throw _privateConstructorUsedError;
+  String? get channelId => throw _privateConstructorUsedError;
+  String get kind => throw _privateConstructorUsedError;
+
+  /// Serializes this AppNotification to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of AppNotification
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AppNotificationCopyWith<AppNotification> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AppNotificationCopyWith<$Res> {
+  factory $AppNotificationCopyWith(
+          AppNotification value, $Res Function(AppNotification) then) =
+      _$AppNotificationCopyWithImpl<$Res, AppNotification>;
+  @useResult
+  $Res call(
+      {String id,
+      String title,
+      String body,
+      DateTime createdAt,
+      bool read,
+      String? sessionId,
+      String? channelId,
+      String kind});
+}
+
+/// @nodoc
+class _$AppNotificationCopyWithImpl<$Res, $Val extends AppNotification>
+    implements $AppNotificationCopyWith<$Res> {
+  _$AppNotificationCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AppNotification
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? body = null,
+    Object? createdAt = null,
+    Object? read = null,
+    Object? sessionId = freezed,
+    Object? channelId = freezed,
+    Object? kind = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      body: null == body
+          ? _value.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as String,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      read: null == read
+          ? _value.read
+          : read // ignore: cast_nullable_to_non_nullable
+              as bool,
+      sessionId: freezed == sessionId
+          ? _value.sessionId
+          : sessionId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      channelId: freezed == channelId
+          ? _value.channelId
+          : channelId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      kind: null == kind
+          ? _value.kind
+          : kind // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$AppNotificationImplCopyWith<$Res>
+    implements $AppNotificationCopyWith<$Res> {
+  factory _$$AppNotificationImplCopyWith(_$AppNotificationImpl value,
+          $Res Function(_$AppNotificationImpl) then) =
+      __$$AppNotificationImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String title,
+      String body,
+      DateTime createdAt,
+      bool read,
+      String? sessionId,
+      String? channelId,
+      String kind});
+}
+
+/// @nodoc
+class __$$AppNotificationImplCopyWithImpl<$Res>
+    extends _$AppNotificationCopyWithImpl<$Res, _$AppNotificationImpl>
+    implements _$$AppNotificationImplCopyWith<$Res> {
+  __$$AppNotificationImplCopyWithImpl(
+      _$AppNotificationImpl _value, $Res Function(_$AppNotificationImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AppNotification
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? body = null,
+    Object? createdAt = null,
+    Object? read = null,
+    Object? sessionId = freezed,
+    Object? channelId = freezed,
+    Object? kind = null,
+  }) {
+    return _then(_$AppNotificationImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      body: null == body
+          ? _value.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as String,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      read: null == read
+          ? _value.read
+          : read // ignore: cast_nullable_to_non_nullable
+              as bool,
+      sessionId: freezed == sessionId
+          ? _value.sessionId
+          : sessionId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      channelId: freezed == channelId
+          ? _value.channelId
+          : channelId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      kind: null == kind
+          ? _value.kind
+          : kind // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$AppNotificationImpl implements _AppNotification {
+  const _$AppNotificationImpl(
+      {required this.id,
+      required this.title,
+      required this.body,
+      required this.createdAt,
+      this.read = false,
+      this.sessionId,
+      this.channelId,
+      this.kind = 'default'});
+
+  factory _$AppNotificationImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AppNotificationImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String title;
+  @override
+  final String body;
+  @override
+  final DateTime createdAt;
+  @override
+  @JsonKey()
+  final bool read;
+  @override
+  final String? sessionId;
+  @override
+  final String? channelId;
+  @override
+  @JsonKey()
+  final String kind;
+
+  @override
+  String toString() {
+    return 'AppNotification(id: $id, title: $title, body: $body, createdAt: $createdAt, read: $read, sessionId: $sessionId, channelId: $channelId, kind: $kind)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AppNotificationImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.body, body) || other.body == body) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.read, read) || other.read == read) &&
+            (identical(other.sessionId, sessionId) ||
+                other.sessionId == sessionId) &&
+            (identical(other.channelId, channelId) ||
+                other.channelId == channelId) &&
+            (identical(other.kind, kind) || other.kind == kind));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, title, body, createdAt, read,
+      sessionId, channelId, kind);
+
+  /// Create a copy of AppNotification
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AppNotificationImplCopyWith<_$AppNotificationImpl> get copyWith =>
+      __$$AppNotificationImplCopyWithImpl<_$AppNotificationImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$AppNotificationImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _AppNotification implements AppNotification {
+  const factory _AppNotification(
+      {required final String id,
+      required final String title,
+      required final String body,
+      required final DateTime createdAt,
+      final bool read,
+      final String? sessionId,
+      final String? channelId,
+      final String kind}) = _$AppNotificationImpl;
+
+  factory _AppNotification.fromJson(Map<String, dynamic> json) =
+      _$AppNotificationImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get title;
+  @override
+  String get body;
+  @override
+  DateTime get createdAt;
+  @override
+  bool get read;
+  @override
+  String? get sessionId;
+  @override
+  String? get channelId;
+  @override
+  String get kind;
+
+  /// Create a copy of AppNotification
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AppNotificationImplCopyWith<_$AppNotificationImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/mobile/lib/domain/notification.g.dart
+++ b/mobile/lib/domain/notification.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notification.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$AppNotificationImpl _$$AppNotificationImplFromJson(
+        Map<String, dynamic> json) =>
+    _$AppNotificationImpl(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      body: json['body'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      read: json['read'] as bool? ?? false,
+      sessionId: json['sessionId'] as String?,
+      channelId: json['channelId'] as String?,
+      kind: json['kind'] as String? ?? 'default',
+    );
+
+Map<String, dynamic> _$$AppNotificationImplToJson(
+        _$AppNotificationImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'body': instance.body,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'read': instance.read,
+      'sessionId': instance.sessionId,
+      'channelId': instance.channelId,
+      'kind': instance.kind,
+    };

--- a/mobile/lib/infrastructure/api/channels_api.dart
+++ b/mobile/lib/infrastructure/api/channels_api.dart
@@ -1,0 +1,55 @@
+import '../../application/ports/api_client_port.dart';
+import '../../application/ports/channels_port.dart';
+import '../../domain/channel.dart';
+
+class ChannelsApi implements ChannelsPort {
+  ChannelsApi(this._client);
+
+  final ApiClientPort _client;
+
+  @override
+  Future<List<Channel>> list() async {
+    final raw = await _client.get('/api/channels');
+
+    // Shape A: { channels: [...] } — flat list (anticipated future shape /
+    // tests).
+    if (raw is Map<String, dynamic> && raw['channels'] is List) {
+      return (raw['channels'] as List)
+          .cast<Map<String, dynamic>>()
+          .map(Channel.fromJson)
+          .toList(growable: false);
+    }
+
+    // Shape B: { groups: [{ channels: [...] }] } — current server response.
+    // Flatten group-nested channels into a single list, preserving group
+    // order then per-group channel order.
+    if (raw is Map<String, dynamic> && raw['groups'] is List) {
+      final out = <Channel>[];
+      for (final group in (raw['groups'] as List)) {
+        if (group is Map<String, dynamic> && group['channels'] is List) {
+          for (final ch in (group['channels'] as List)) {
+            if (ch is Map<String, dynamic>) {
+              out.add(Channel.fromJson(ch));
+            }
+          }
+        }
+      }
+      return List.unmodifiable(out);
+    }
+
+    // Shape C: bare array.
+    if (raw is List) {
+      return raw
+          .cast<Map<String, dynamic>>()
+          .map(Channel.fromJson)
+          .toList(growable: false);
+    }
+
+    return const [];
+  }
+
+  @override
+  Future<void> archive(String id) async {
+    await _client.delete('/api/channels/$id');
+  }
+}

--- a/mobile/lib/infrastructure/api/notifications_api.dart
+++ b/mobile/lib/infrastructure/api/notifications_api.dart
@@ -1,5 +1,6 @@
 import '../../application/ports/api_client_port.dart';
 import '../../application/ports/notifications_port.dart';
+import '../../domain/notification.dart';
 
 class NotificationsApi implements NotificationsPort {
   NotificationsApi(this._client);
@@ -10,5 +11,35 @@ class NotificationsApi implements NotificationsPort {
   Future<void> markRead(List<String> ids) async {
     if (ids.isEmpty) return;
     await _client.patch('/api/notifications', body: {'ids': ids});
+  }
+
+  @override
+  Future<List<AppNotification>> list({String? filter}) async {
+    final query = filter == null || filter == 'all' ? '' : '?filter=$filter';
+    final raw = await _client.get('/api/notifications$query');
+    // Tolerate {notifications: [...]} or [...].
+    if (raw is Map<String, dynamic> && raw['notifications'] is List) {
+      return (raw['notifications'] as List)
+          .cast<Map<String, dynamic>>()
+          .map(AppNotification.fromJson)
+          .toList(growable: false);
+    }
+    if (raw is List) {
+      return raw
+          .cast<Map<String, dynamic>>()
+          .map(AppNotification.fromJson)
+          .toList(growable: false);
+    }
+    return const [];
+  }
+
+  @override
+  Future<void> dismiss(String id) async {
+    await _client.delete('/api/notifications/$id');
+  }
+
+  @override
+  Future<void> markAllRead() async {
+    await _client.patch('/api/notifications', body: {'all': true});
   }
 }

--- a/mobile/lib/infrastructure/deep_link/app_link_listener.dart
+++ b/mobile/lib/infrastructure/deep_link/app_link_listener.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:app_links/app_links.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../presentation/router/app_router.dart';
+import 'deep_link_router.dart';
+
+/// Listens to incoming deep-links from the [AppLinks] plugin and dispatches
+/// matching [AppRoute] values via [AppRouter.navigateTo].
+///
+/// Lifecycle:
+///   - [start]: fetch the initial link (cold-start) and subscribe to the
+///     uri-link stream (warm-start).
+///   - [stop]: cancel the stream subscription.
+class AppLinkListener {
+  AppLinkListener({required this.router, AppLinks? links})
+      : _links = links ?? AppLinks();
+
+  final AppRouter router;
+  final AppLinks _links;
+  StreamSubscription<Uri>? _sub;
+
+  Future<void> start() async {
+    try {
+      final initial = await _links.getInitialLink();
+      if (initial != null) {
+        _navigate(initial);
+      }
+    } catch (e) {
+      debugPrint('[DeepLink] getInitialLink failed: $e');
+    }
+    await _sub?.cancel();
+    _sub = _links.uriLinkStream.listen(
+      _navigate,
+      onError: (Object e) {
+        debugPrint('[DeepLink] uriLinkStream error: $e');
+      },
+    );
+  }
+
+  void _navigate(Uri uri) {
+    final route = DeepLinkRouter.routeFor(uri);
+    if (route != null) {
+      router.navigateTo(route);
+    } else {
+      debugPrint('[DeepLink] no route for $uri');
+    }
+  }
+
+  Future<void> stop() async {
+    await _sub?.cancel();
+    _sub = null;
+  }
+}

--- a/mobile/lib/infrastructure/deep_link/deep_link_router.dart
+++ b/mobile/lib/infrastructure/deep_link/deep_link_router.dart
@@ -1,0 +1,58 @@
+import '../../presentation/router/app_route.dart';
+
+/// Translates incoming deep-link URIs into [AppRoute] values.
+///
+/// Pure-function — no I/O, no side effects. Easy to unit-test.
+class DeepLinkRouter {
+  /// Translate a deep-link URI into an [AppRoute], or `null` if the URI
+  /// doesn't match any known surface.
+  ///
+  /// Accepts both:
+  ///   - `remotedev://<surface>/<id?>` (custom scheme)
+  ///   - `https://<server>/m/<surface>/<id?>` (Universal/App Links)
+  ///
+  /// Surfaces:
+  ///   - `session/<id>`       → [SessionRoute]
+  ///   - `channel/<id>`       → [ChannelRoute]
+  ///   - `recording/<id>`     → [RecordingRoute]
+  ///   - `notifications`      → [NotificationsRoute]
+  ///   - `home`               → [HomeRoute]
+  static AppRoute? routeFor(Uri uri) {
+    // For custom-scheme URIs the host is the surface name and any path
+    // segments are the rest. For https URIs the path is /m/<surface>/<id>.
+    final List<String> parts;
+    if (uri.scheme == 'remotedev') {
+      parts = <String>[uri.host, ...uri.pathSegments]
+          .where((s) => s.isNotEmpty)
+          .toList();
+    } else {
+      var segs = uri.pathSegments.where((s) => s.isNotEmpty).toList();
+      if (segs.isNotEmpty && segs.first == 'm') {
+        segs = segs.sublist(1);
+      }
+      parts = segs;
+    }
+
+    if (parts.isEmpty) return null;
+    final surface = parts.first;
+    final id = parts.length > 1 ? parts[1] : null;
+
+    switch (surface) {
+      case 'session':
+        if (id != null && id.isNotEmpty) return AppRoute.session(id);
+        return null;
+      case 'channel':
+        if (id != null && id.isNotEmpty) return AppRoute.channel(id);
+        return null;
+      case 'recording':
+        if (id != null && id.isNotEmpty) return AppRoute.recording(id);
+        return null;
+      case 'notifications':
+        return const AppRoute.notifications();
+      case 'home':
+        return const AppRoute.home();
+      default:
+        return null;
+    }
+  }
+}

--- a/mobile/lib/infrastructure/webview/bridge_controller.dart
+++ b/mobile/lib/infrastructure/webview/bridge_controller.dart
@@ -45,6 +45,12 @@ class BridgeController {
   /// Equivalent to `window.rdvBridge.setFontSize(px)`.
   void setFontSize(int px) => _exec('window.rdvBridge.setFontSize($px)');
 
+  /// Equivalent to `window.rdvBridge.back()`. Used by native back affordances
+  /// (e.g. ChannelScreen AppBar leading icon) to give the embedded PWA a
+  /// chance to consume the gesture (close an open thread, dismiss a modal,
+  /// etc.) before native pops the route.
+  void back() => _exec('window.rdvBridge.back()');
+
   void _exec(String js) {
     if (_ready) {
       controller.evaluateJavascript(source: js);

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2,7 +2,93 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app.dart';
+import 'application/ports/api_client_port.dart';
+import 'infrastructure/api/channels_api.dart';
+import 'infrastructure/api/notifications_api.dart';
+import 'infrastructure/api/project_tree_api.dart';
+import 'infrastructure/api/remote_dev_client.dart';
+import 'infrastructure/api/sessions_api.dart';
 import 'infrastructure/push/fcm_push_service.dart';
+import 'infrastructure/push/push_token_registrar.dart';
+import 'presentation/router/app_router.dart' show pushTokenRegistrarProvider;
+import 'presentation/screens/channels/channels_tab_screen.dart'
+    show channelsApiProvider;
+import 'presentation/screens/notifications/notifications_tab_screen.dart'
+    show notificationsApiProvider;
+import 'presentation/screens/sessions/project_tree_sheet.dart'
+    show projectTreeApiProvider;
+import 'presentation/screens/sessions/sessions_tab_screen.dart'
+    show sessionsApiProvider;
+import 'presentation/screens/webview_host/session_route_host.dart'
+    show activeServerProvider, secureStorageProvider, serverConfigStoreProvider;
+
+/// Thrown by [_apiClientProvider] when no active server has been chosen.
+///
+/// The router's initial location is `/servers`, so users are expected to
+/// pick a server before navigating to any screen that consumes one of the
+/// API providers. The screens (`SessionsTabScreen`, `ChannelsTabScreen`,
+/// `NotificationsTabScreen`) all wrap their data fetches with `AsyncValue`
+/// error/retry views, so a stray read here surfaces a clear error rather
+/// than a silent crash.
+class NoActiveServerError extends Error {
+  NoActiveServerError();
+
+  @override
+  String toString() =>
+      'No active server. Sign in via the server picker first.';
+}
+
+/// Internal: synchronous [ApiClientPort] bound to the current active server.
+///
+/// Re-evaluates whenever [activeServerProvider] resolves to a different
+/// server, which transparently rebinds every dependent API provider.
+final _apiClientProvider = Provider<ApiClientPort>((ref) {
+  final server = ref.watch(activeServerProvider).value;
+  if (server == null) {
+    throw NoActiveServerError();
+  }
+  final storage = ref.watch(secureStorageProvider);
+  return RemoteDevClient(
+    serverOrigin: Uri.parse(server.url),
+    serverId: server.id,
+    storage: storage,
+  );
+});
+
+/// Overrides for the deferred `*ApiProvider`s and `pushTokenRegistrarProvider`.
+///
+/// Exposed so tests can apply the same wiring without duplicating the list.
+List<Override> buildServerScopedOverrides() {
+  return <Override>[
+    sessionsApiProvider.overrideWith(
+      (ref) => SessionsApi(ref.watch(_apiClientProvider)),
+    ),
+    projectTreeApiProvider.overrideWith(
+      (ref) => ProjectTreeApi(ref.watch(_apiClientProvider)),
+    ),
+    channelsApiProvider.overrideWith(
+      (ref) => ChannelsApi(ref.watch(_apiClientProvider)),
+    ),
+    notificationsApiProvider.overrideWith(
+      (ref) => NotificationsApi(ref.watch(_apiClientProvider)),
+    ),
+    pushTokenRegistrarProvider.overrideWith(
+      (ref) => PushTokenRegistrar(
+        push: FcmPushService(),
+        serverStore: ref.watch(serverConfigStoreProvider),
+        clientFactory: (server) => RemoteDevClient(
+          serverOrigin: Uri.parse(server.url),
+          serverId: server.id,
+          storage: ref.read(secureStorageProvider),
+        ),
+        // TODO(P5): replace with a stable per-device UUID persisted in
+        // secure storage so the server can dedupe devices across token
+        // rotations and reinstalls.
+        deviceId: 'placeholder-device-id',
+      ),
+    ),
+  ];
+}
 
 void main() {
   // Non-blocking push init — runs in the background; failures are logged
@@ -12,7 +98,9 @@ void main() {
   // Build a ProviderContainer up-front so we can eagerly start the deep-link
   // listener before runApp. This ensures custom-scheme links delivered during
   // cold-start are routed correctly.
-  final container = ProviderContainer();
+  final container = ProviderContainer(
+    overrides: buildServerScopedOverrides(),
+  );
   // Read for side effect — kicks off AppLinkListener.start().
   container.read(appLinkListenerProvider);
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -9,5 +9,17 @@ void main() {
   // and don't prevent the UI from launching.
   Future<void>.microtask(() => FcmPushService().initialize());
 
-  runApp(const ProviderScope(child: RemoteDevApp()));
+  // Build a ProviderContainer up-front so we can eagerly start the deep-link
+  // listener before runApp. This ensures custom-scheme links delivered during
+  // cold-start are routed correctly.
+  final container = ProviderContainer();
+  // Read for side effect — kicks off AppLinkListener.start().
+  container.read(appLinkListenerProvider);
+
+  runApp(
+    UncontrolledProviderScope(
+      container: container,
+      child: const RemoteDevApp(),
+    ),
+  );
 }

--- a/mobile/lib/presentation/router/app_route.dart
+++ b/mobile/lib/presentation/router/app_route.dart
@@ -16,7 +16,7 @@ sealed class AppRoute {
         AddServerRoute() => '/servers/add',
         HomeRoute() => '/home',
         SessionRoute(:final id) => '/home/session/$id',
-        ChannelRoute(:final id) => '/m/channel/$id',
+        ChannelRoute(:final id) => '/home/channel/$id',
         RecordingRoute(:final id) => '/m/recording/$id',
         NotificationsRoute() => '/notifications',
         ReauthRoute() => '/reauth',

--- a/mobile/lib/presentation/router/app_router.dart
+++ b/mobile/lib/presentation/router/app_router.dart
@@ -4,6 +4,11 @@ import 'package:go_router/go_router.dart';
 
 import '../../infrastructure/push/push_token_registrar.dart';
 import '../screens/bridge_spike/bridge_spike_screen.dart';
+import '../screens/profile/about_screen.dart';
+import '../screens/profile/account_screen.dart';
+import '../screens/profile/appearance_screen.dart';
+import '../screens/profile/github_accounts_screen.dart';
+import '../screens/profile/servers_screen.dart';
 import '../screens/server_picker/add_server_screen.dart';
 import '../screens/server_picker/server_picker_screen.dart';
 import '../screens/session_view/session_view_screen.dart';
@@ -77,6 +82,36 @@ class AppRouter {
           path: '/home/session/:id',
           builder: (context, state) => SessionViewScreen(
             sessionId: state.pathParameters['id']!,
+          ),
+        ),
+        GoRoute(
+          path: '/home/profile/account',
+          builder: (context, state) => Consumer(
+            builder: (context, ref, _) => const AccountScreen(),
+          ),
+        ),
+        GoRoute(
+          path: '/home/profile/github',
+          builder: (context, state) => Consumer(
+            builder: (context, ref, _) => const GitHubAccountsScreen(),
+          ),
+        ),
+        GoRoute(
+          path: '/home/profile/appearance',
+          builder: (context, state) => Consumer(
+            builder: (context, ref, _) => const AppearanceScreen(),
+          ),
+        ),
+        GoRoute(
+          path: '/home/profile/servers',
+          builder: (context, state) => Consumer(
+            builder: (context, ref, _) => const ServersScreen(),
+          ),
+        ),
+        GoRoute(
+          path: '/home/profile/about',
+          builder: (context, state) => Consumer(
+            builder: (context, ref, _) => const AboutScreen(),
           ),
         ),
         // Legacy WebView-host route, kept for the embedded WebView's own

--- a/mobile/lib/presentation/router/app_router.dart
+++ b/mobile/lib/presentation/router/app_router.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../infrastructure/push/push_token_registrar.dart';
 import '../screens/bridge_spike/bridge_spike_screen.dart';
+import '../screens/channels/channel_screen.dart';
 import '../screens/profile/about_screen.dart';
 import '../screens/profile/account_screen.dart';
 import '../screens/profile/appearance_screen.dart';
@@ -85,6 +86,12 @@ class AppRouter {
           ),
         ),
         GoRoute(
+          path: '/home/channel/:id',
+          builder: (context, state) => ChannelScreen(
+            channelId: state.pathParameters['id']!,
+          ),
+        ),
+        GoRoute(
           path: '/home/profile/account',
           builder: (context, state) => Consumer(
             builder: (context, ref, _) => const AccountScreen(),
@@ -121,12 +128,6 @@ class AppRouter {
           path: '/m/session/:id',
           builder: (context, state) => SessionRouteHost(
             sessionId: state.pathParameters['id']!,
-          ),
-        ),
-        GoRoute(
-          path: '/m/channel/:id',
-          builder: (context, state) => _PlaceholderScreen(
-            name: 'Channel ${state.pathParameters['id']}',
           ),
         ),
         GoRoute(

--- a/mobile/lib/presentation/screens/channels/channel_screen.dart
+++ b/mobile/lib/presentation/screens/channels/channel_screen.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../infrastructure/webview/bridge_controller.dart';
+import '../../../infrastructure/webview/navigation_policy.dart';
+import '../../../infrastructure/webview/webview_factory.dart';
+import '../webview_host/session_route_host.dart' show activeServerProvider;
+
+/// Native chrome around the embedded WebView at `/m/channel/<id>`.
+///
+/// Mirrors the `SessionViewScreen` pattern from Phase 2:
+/// - Native AppBar (channel name + back button).
+/// - Body is the InAppWebView pointed at `<server>/m/channel/<id>`.
+/// - `onTerminalReady` registered in `onWebViewCreated` (Spec §2.2 rule 1).
+/// - All native→WebView calls go through [BridgeController] (Spec §2.2 rule 2).
+///
+/// Phase 4 scope: AppBar + WebView only. The richer bridge handlers
+/// (`onLinkOpen`, `onSelectionChange`, etc.) land in Phase 5 once the channel
+/// PWA exposes them.
+class ChannelScreen extends ConsumerStatefulWidget {
+  const ChannelScreen({required this.channelId, super.key});
+
+  final String channelId;
+
+  @override
+  ConsumerState<ChannelScreen> createState() => _ChannelScreenState();
+}
+
+class _ChannelScreenState extends ConsumerState<ChannelScreen> {
+  BridgeController? _bridge;
+
+  void _onWebViewCreated(InAppWebViewController controller) {
+    final bridge = BridgeController(controller: controller);
+    setState(() => _bridge = bridge);
+    controller.addJavaScriptHandler(
+      handlerName: 'onTerminalReady',
+      callback: (_) {
+        bridge.markReady();
+        return null;
+      },
+    );
+  }
+
+  Future<void> _handleBack() async {
+    // Signal the embedded PWA so it can close any open thread/modal first.
+    // The bridge call queues if the PWA hasn't fired onTerminalReady yet,
+    // so it's safe to invoke unconditionally. We then pop the native route
+    // — the WebView decides whether to consume the gesture before this.
+    _bridge?.back();
+    if (!mounted) return;
+    await Navigator.of(context).maybePop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final asyncServer = ref.watch(activeServerProvider);
+    return Scaffold(
+      backgroundColor: const Color(0xFF1A1B26),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF1A1B26),
+        title: const Text('Channel', style: TextStyle(color: Colors.white)),
+        iconTheme: const IconThemeData(color: Colors.white),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: _handleBack,
+        ),
+      ),
+      body: asyncServer.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Text(
+            'Failed to load: $e',
+            style: const TextStyle(color: Colors.white70),
+          ),
+        ),
+        data: (server) {
+          if (server == null) {
+            return const Center(
+              child: Text(
+                'No active server.',
+                style: TextStyle(color: Colors.white70),
+              ),
+            );
+          }
+          final origin = Uri.parse(server.url);
+          final url = origin.replace(path: '/m/channel/${widget.channelId}');
+          return WebViewFactory().build(
+            initialUrl: url,
+            policy: NavigationPolicy(serverOrigin: origin),
+            onLinkOpen: (_) {},
+            onWebViewCreated: _onWebViewCreated,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/screens/channels/channels_tab_screen.dart
+++ b/mobile/lib/presentation/screens/channels/channels_tab_screen.dart
@@ -1,0 +1,335 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../domain/channel.dart';
+import '../../../infrastructure/api/channels_api.dart';
+
+/// Provider for the channels API. Must be overridden in main.dart once a
+/// [RemoteDevClient] is wired for the active server (Wave 4 wiring).
+final channelsApiProvider = Provider<ChannelsApi>((ref) {
+  throw UnimplementedError(
+    'channelsApiProvider must be overridden with ChannelsApi(client) in main.dart',
+  );
+});
+
+final channelsListProvider =
+    FutureProvider.autoDispose<List<Channel>>((ref) async {
+  return ref.watch(channelsApiProvider).list();
+});
+
+class ChannelsTabScreen extends ConsumerStatefulWidget {
+  const ChannelsTabScreen({super.key});
+
+  @override
+  ConsumerState<ChannelsTabScreen> createState() => _ChannelsTabScreenState();
+}
+
+class _ChannelsTabScreenState extends ConsumerState<ChannelsTabScreen> {
+  Future<void> _refresh() async {
+    ref.invalidate(channelsListProvider);
+    await ref.read(channelsListProvider.future);
+  }
+
+  Future<void> _archive(Channel channel) async {
+    final api = ref.read(channelsApiProvider);
+    try {
+      await api.archive(channel.id);
+      await _refresh();
+      if (!mounted) return;
+      _showSnack('Channel archived');
+    } catch (e) {
+      if (!mounted) return;
+      _showSnack('Failed to archive: $e');
+    }
+  }
+
+  Future<bool> _confirmArchive(Channel channel) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: const Color(0xFF24283B),
+        title: const Text(
+          'Archive channel?',
+          style: TextStyle(color: Colors.white),
+        ),
+        content: Text(
+          '"${channel.name}" will be archived.',
+          style: const TextStyle(color: Colors.white70),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            style:
+                TextButton.styleFrom(foregroundColor: const Color(0xFFF7768E)),
+            child: const Text('Archive'),
+          ),
+        ],
+      ),
+    );
+    return result ?? false;
+  }
+
+  void _showSnack(String msg) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(msg), duration: const Duration(seconds: 2)),
+    );
+  }
+
+  void _onTapChannel(Channel channel) {
+    // P4.3 lands the actual /home/channel/:id route; for now we route to it
+    // and the router falls back gracefully if the route is not registered.
+    context.go('/home/channel/${channel.id}');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final asyncChannels = ref.watch(channelsListProvider);
+
+    return Scaffold(
+      backgroundColor: const Color(0xFF1A1B26),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF1A1B26),
+        title: const Text('Channels', style: TextStyle(color: Colors.white)),
+      ),
+      body: asyncChannels.when(
+        loading: () => const Center(
+          child: CupertinoActivityIndicator(color: Colors.white70),
+        ),
+        error: (err, _) => _ErrorView(
+          message: 'Failed to load channels',
+          detail: '$err',
+          onRetry: _refresh,
+        ),
+        data: (channels) {
+          if (channels.isEmpty) {
+            return _EmptyState(onRefresh: _refresh);
+          }
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            color: const Color(0xFF7AA2F7),
+            backgroundColor: const Color(0xFF24283B),
+            child: ListView.separated(
+              physics: const AlwaysScrollableScrollPhysics(),
+              itemCount: channels.length,
+              separatorBuilder: (_, __) => const Divider(
+                color: Color(0xFF2F334D),
+                height: 1,
+              ),
+              itemBuilder: (context, i) {
+                final c = channels[i];
+                return _ChannelRow(
+                  channel: c,
+                  onTap: () => _onTapChannel(c),
+                  onArchive: () => _archive(c),
+                  confirmArchive: () => _confirmArchive(c),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ChannelRow extends StatelessWidget {
+  const _ChannelRow({
+    required this.channel,
+    required this.onTap,
+    required this.onArchive,
+    required this.confirmArchive,
+  });
+
+  final Channel channel;
+  final VoidCallback onTap;
+  final VoidCallback onArchive;
+  final Future<bool> Function() confirmArchive;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: ValueKey('channel-${channel.id}'),
+      direction: DismissDirection.endToStart,
+      dismissThresholds: const {DismissDirection.endToStart: 0.6},
+      confirmDismiss: (_) async {
+        final ok = await confirmArchive();
+        if (ok) {
+          onArchive();
+        }
+        // Always return false: the row is removed when the list refetches.
+        return false;
+      },
+      background: const SizedBox.shrink(),
+      secondaryBackground: _SwipeBackground(),
+      child: ListTile(
+        onTap: onTap,
+        leading: const Icon(Icons.tag, color: Colors.white54),
+        title: Text(
+          channel.name,
+          style: const TextStyle(color: Colors.white),
+          overflow: TextOverflow.ellipsis,
+        ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (channel.unreadCount > 0)
+              _UnreadBadge(count: channel.unreadCount),
+            const SizedBox(width: 8),
+            const Icon(Icons.chevron_right, color: Colors.white38),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _UnreadBadge extends StatelessWidget {
+  const _UnreadBadge({required this.count});
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = count > 99 ? '99+' : '$count';
+    return Container(
+      constraints: const BoxConstraints(minWidth: 22, minHeight: 22),
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+      decoration: const BoxDecoration(
+        color: Color(0xFFF7768E),
+        shape: BoxShape.circle,
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _SwipeBackground extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: const Color(0xFFF7768E),
+      alignment: Alignment.centerRight,
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: const Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.archive_outlined, color: Colors.white),
+          SizedBox(width: 8),
+          Text(
+            'Archive',
+            style: TextStyle(color: Colors.white, fontWeight: FontWeight.w600),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.onRefresh});
+  final Future<void> Function() onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: onRefresh,
+      color: const Color(0xFF7AA2F7),
+      backgroundColor: const Color(0xFF24283B),
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: const [
+          SizedBox(height: 96),
+          Icon(
+            Icons.forum_outlined,
+            size: 48,
+            color: Colors.white24,
+          ),
+          SizedBox(height: 16),
+          Center(
+            child: Text(
+              'No channels yet',
+              style: TextStyle(color: Colors.white70, fontSize: 16),
+            ),
+          ),
+          SizedBox(height: 8),
+          Center(
+            child: Text(
+              'Channels will appear here once a project is selected.',
+              style: TextStyle(color: Colors.white38, fontSize: 13),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({
+    required this.message,
+    required this.detail,
+    required this.onRetry,
+  });
+  final String message;
+  final String detail;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: onRetry,
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 96),
+          const Icon(
+            Icons.error_outline,
+            size: 48,
+            color: Color(0xFFF7768E),
+          ),
+          const SizedBox(height: 16),
+          Center(
+            child: Text(
+              message,
+              style: const TextStyle(color: Colors.white70, fontSize: 16),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Text(
+              detail,
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: Colors.white38, fontSize: 12),
+            ),
+          ),
+          const SizedBox(height: 24),
+          Center(
+            child: TextButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh, color: Color(0xFF7AA2F7)),
+              label: const Text(
+                'Retry',
+                style: TextStyle(color: Color(0xFF7AA2F7)),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/screens/notifications/notifications_tab_screen.dart
+++ b/mobile/lib/presentation/screens/notifications/notifications_tab_screen.dart
@@ -106,7 +106,7 @@ class _NotificationsTabScreenState
     if (notif.sessionId != null && notif.sessionId!.isNotEmpty) {
       context.go('/home/session/${notif.sessionId}');
     } else if (notif.channelId != null && notif.channelId!.isNotEmpty) {
-      context.go('/m/channel/${notif.channelId}');
+      context.go('/home/channel/${notif.channelId}');
     }
     // Otherwise remain on the tab.
   }

--- a/mobile/lib/presentation/screens/notifications/notifications_tab_screen.dart
+++ b/mobile/lib/presentation/screens/notifications/notifications_tab_screen.dart
@@ -1,0 +1,450 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../domain/notification.dart';
+import '../../../infrastructure/api/notifications_api.dart';
+
+/// Provider for the notifications API. Must be overridden in main.dart /
+/// app.dart once a [RemoteDevClient] is wired for the active server.
+final notificationsApiProvider = Provider<NotificationsApi>((ref) {
+  throw UnimplementedError(
+    'notificationsApiProvider must be overridden with NotificationsApi(client) in main.dart',
+  );
+});
+
+/// Filter applied to the notifications list.
+enum NotificationFilter {
+  all('all', 'All'),
+  unread('unread', 'Unread'),
+  mentions('mentions', 'Mentions');
+
+  const NotificationFilter(this.queryValue, this.label);
+  final String queryValue;
+  final String label;
+}
+
+/// Family-keyed list provider — re-fetches when the filter changes.
+final notificationsListProvider = FutureProvider.autoDispose
+    .family<List<AppNotification>, NotificationFilter>((ref, filter) async {
+  return ref.watch(notificationsApiProvider).list(filter: filter.queryValue);
+});
+
+class NotificationsTabScreen extends ConsumerStatefulWidget {
+  const NotificationsTabScreen({super.key});
+
+  @override
+  ConsumerState<NotificationsTabScreen> createState() =>
+      _NotificationsTabScreenState();
+}
+
+class _NotificationsTabScreenState
+    extends ConsumerState<NotificationsTabScreen> {
+  NotificationFilter _filter = NotificationFilter.all;
+
+  Future<void> _refresh() async {
+    ref.invalidate(notificationsListProvider(_filter));
+    await ref.read(notificationsListProvider(_filter).future);
+  }
+
+  void _selectFilter(NotificationFilter filter) {
+    if (filter == _filter) return;
+    setState(() => _filter = filter);
+  }
+
+  Future<void> _markAllRead() async {
+    final api = ref.read(notificationsApiProvider);
+    try {
+      await api.markAllRead();
+      await _refresh();
+      if (!mounted) return;
+      _showSnack('Marked all as read');
+    } catch (e) {
+      if (!mounted) return;
+      _showSnack('Failed to mark all read: $e');
+    }
+  }
+
+  Future<void> _markRead(AppNotification notif) async {
+    if (notif.read) return;
+    final api = ref.read(notificationsApiProvider);
+    try {
+      await api.markRead([notif.id]);
+      await _refresh();
+    } catch (e) {
+      if (!mounted) return;
+      _showSnack('Failed to mark read: $e');
+    }
+  }
+
+  Future<void> _dismiss(AppNotification notif) async {
+    final api = ref.read(notificationsApiProvider);
+    try {
+      await api.dismiss(notif.id);
+      await _refresh();
+      if (!mounted) return;
+      _showSnack('Notification dismissed');
+    } catch (e) {
+      if (!mounted) return;
+      _showSnack('Failed to dismiss: $e');
+    }
+  }
+
+  void _showSnack(String msg) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(msg), duration: const Duration(seconds: 2)),
+    );
+  }
+
+  void _onTapNotification(AppNotification notif) {
+    // Mark read first (fire-and-forget); navigation should not block on it.
+    if (!notif.read) {
+      // ignore: discarded_futures
+      _markRead(notif);
+    }
+    if (notif.sessionId != null && notif.sessionId!.isNotEmpty) {
+      context.go('/home/session/${notif.sessionId}');
+    } else if (notif.channelId != null && notif.channelId!.isNotEmpty) {
+      context.go('/m/channel/${notif.channelId}');
+    }
+    // Otherwise remain on the tab.
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final asyncList = ref.watch(notificationsListProvider(_filter));
+
+    return Scaffold(
+      backgroundColor: const Color(0xFF1A1B26),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF1A1B26),
+        title: const Text(
+          'Notifications',
+          style: TextStyle(color: Colors.white),
+        ),
+        actions: [
+          TextButton(
+            onPressed: _markAllRead,
+            child: const Text(
+              'Mark all read',
+              style: TextStyle(color: Color(0xFF7AA2F7)),
+            ),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          _FilterChipRow(active: _filter, onSelected: _selectFilter),
+          Expanded(
+            child: asyncList.when(
+              loading: () => const Center(
+                child: CupertinoActivityIndicator(color: Colors.white70),
+              ),
+              error: (err, _) => _ErrorView(
+                message: 'Failed to load notifications',
+                detail: '$err',
+                onRetry: _refresh,
+              ),
+              data: (items) {
+                if (items.isEmpty) {
+                  return _EmptyState(filter: _filter, onRefresh: _refresh);
+                }
+                return RefreshIndicator(
+                  onRefresh: _refresh,
+                  color: const Color(0xFF7AA2F7),
+                  backgroundColor: const Color(0xFF24283B),
+                  child: ListView.separated(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    itemCount: items.length,
+                    separatorBuilder: (_, __) => const Divider(
+                      color: Color(0xFF2F334D),
+                      height: 1,
+                    ),
+                    itemBuilder: (context, i) {
+                      final n = items[i];
+                      return _NotificationRow(
+                        notification: n,
+                        onTap: () => _onTapNotification(n),
+                        onDismiss: () => _dismiss(n),
+                        onMarkRead: () => _markRead(n),
+                      );
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FilterChipRow extends StatelessWidget {
+  const _FilterChipRow({required this.active, required this.onSelected});
+
+  final NotificationFilter active;
+  final ValueChanged<NotificationFilter> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      child: Row(
+        children: [
+          for (final filter in NotificationFilter.values) ...[
+            FilterChip(
+              label: Text(filter.label),
+              selected: filter == active,
+              onSelected: (_) => onSelected(filter),
+              backgroundColor: const Color(0xFF24283B),
+              selectedColor: const Color(0xFF7AA2F7),
+              checkmarkColor: const Color(0xFF1A1B26),
+              labelStyle: TextStyle(
+                color: filter == active
+                    ? const Color(0xFF1A1B26)
+                    : Colors.white70,
+                fontWeight: FontWeight.w600,
+              ),
+              side: const BorderSide(color: Color(0xFF2F334D)),
+            ),
+            const SizedBox(width: 8),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _NotificationRow extends StatelessWidget {
+  const _NotificationRow({
+    required this.notification,
+    required this.onTap,
+    required this.onDismiss,
+    required this.onMarkRead,
+  });
+
+  final AppNotification notification;
+  final VoidCallback onTap;
+  final VoidCallback onDismiss;
+  final VoidCallback onMarkRead;
+
+  @override
+  Widget build(BuildContext context) {
+    final isUnread = !notification.read;
+    return Dismissible(
+      key: ValueKey('notif-${notification.id}'),
+      // Right-to-left swipe (endToStart) → dismiss / delete (red).
+      // Left-to-right swipe (startToEnd) → mark read (green).
+      background: const _SwipeBackground(
+        color: Color(0xFF9ECE6A),
+        icon: Icons.mark_email_read,
+        label: 'Read',
+        alignment: Alignment.centerLeft,
+      ),
+      secondaryBackground: const _SwipeBackground(
+        color: Color(0xFFF7768E),
+        icon: Icons.delete_outline,
+        label: 'Dismiss',
+        alignment: Alignment.centerRight,
+      ),
+      confirmDismiss: (direction) async {
+        if (direction == DismissDirection.endToStart) {
+          onDismiss();
+        } else {
+          onMarkRead();
+        }
+        // Always return false; the row is removed when the list refetches.
+        return false;
+      },
+      child: ListTile(
+        onTap: onTap,
+        leading: SizedBox(
+          width: 12,
+          height: 12,
+          child: Center(
+            child: isUnread
+                ? Container(
+                    width: 8,
+                    height: 8,
+                    decoration: const BoxDecoration(
+                      color: Color(0xFF7AA2F7),
+                      shape: BoxShape.circle,
+                    ),
+                  )
+                : const SizedBox.shrink(),
+          ),
+        ),
+        title: Text(
+          notification.title,
+          style: TextStyle(
+            color: Colors.white,
+            fontWeight: isUnread ? FontWeight.w600 : FontWeight.w400,
+          ),
+          overflow: TextOverflow.ellipsis,
+        ),
+        subtitle: Text(
+          notification.body,
+          style: const TextStyle(color: Colors.white60, fontSize: 12),
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        trailing: const Icon(Icons.chevron_right, color: Colors.white38),
+      ),
+    );
+  }
+}
+
+class _SwipeBackground extends StatelessWidget {
+  const _SwipeBackground({
+    required this.color,
+    required this.icon,
+    required this.label,
+    required this.alignment,
+  });
+
+  final Color color;
+  final IconData icon;
+  final String label;
+  final Alignment alignment;
+
+  @override
+  Widget build(BuildContext context) {
+    final isLeft = alignment == Alignment.centerLeft;
+    return Container(
+      color: color,
+      alignment: alignment,
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: isLeft
+            ? [
+                Icon(icon, color: Colors.white),
+                const SizedBox(width: 8),
+                Text(
+                  label,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ]
+            : [
+                Text(
+                  label,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Icon(icon, color: Colors.white),
+              ],
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.filter, required this.onRefresh});
+
+  final NotificationFilter filter;
+  final Future<void> Function() onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    final message = switch (filter) {
+      NotificationFilter.all => 'No notifications',
+      NotificationFilter.unread => 'No unread notifications',
+      NotificationFilter.mentions => 'No mentions',
+    };
+    return RefreshIndicator(
+      onRefresh: onRefresh,
+      color: const Color(0xFF7AA2F7),
+      backgroundColor: const Color(0xFF24283B),
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 96),
+          const Icon(
+            Icons.notifications_none,
+            size: 48,
+            color: Colors.white24,
+          ),
+          const SizedBox(height: 16),
+          Center(
+            child: Text(
+              message,
+              style: const TextStyle(color: Colors.white70, fontSize: 16),
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Center(
+            child: Text(
+              'Pull down to refresh.',
+              style: TextStyle(color: Colors.white38, fontSize: 13),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({
+    required this.message,
+    required this.detail,
+    required this.onRetry,
+  });
+
+  final String message;
+  final String detail;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: onRetry,
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 96),
+          const Icon(
+            Icons.error_outline,
+            size: 48,
+            color: Color(0xFFF7768E),
+          ),
+          const SizedBox(height: 16),
+          Center(
+            child: Text(
+              message,
+              style: const TextStyle(color: Colors.white70, fontSize: 16),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Text(
+              detail,
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: Colors.white38, fontSize: 12),
+            ),
+          ),
+          const SizedBox(height: 24),
+          Center(
+            child: TextButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh, color: Color(0xFF7AA2F7)),
+              label: const Text(
+                'Retry',
+                style: TextStyle(color: Color(0xFF7AA2F7)),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/screens/profile/about_screen.dart
+++ b/mobile/lib/presentation/screens/profile/about_screen.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+class AboutScreen extends StatelessWidget {
+  const AboutScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF1A1B26),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF1A1B26),
+        title: const Text('About', style: TextStyle(color: Colors.white)),
+        iconTheme: const IconThemeData(color: Colors.white),
+      ),
+      body: const Padding(
+        padding: EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Remote Dev',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 20,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            SizedBox(height: 8),
+            Text(
+              'Phase 4 (development)',
+              style: TextStyle(color: Colors.white70),
+            ),
+            SizedBox(height: 16),
+            Text(
+              'A web-based terminal interface for AI-driven development.',
+              style: TextStyle(color: Colors.white70),
+            ),
+            SizedBox(height: 24),
+            Text(
+              'Author',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            SizedBox(height: 4),
+            Text(
+              'Built by the Remote Dev team.',
+              style: TextStyle(color: Colors.white70),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/screens/profile/account_screen.dart
+++ b/mobile/lib/presentation/screens/profile/account_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class AccountScreen extends StatelessWidget {
+  const AccountScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF1A1B26),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF1A1B26),
+        title: const Text('Account', style: TextStyle(color: Colors.white)),
+        iconTheme: const IconThemeData(color: Colors.white),
+      ),
+      body: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            'Account details — Phase 5 fills this in.',
+            style: TextStyle(color: Colors.white70),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/screens/profile/appearance_screen.dart
+++ b/mobile/lib/presentation/screens/profile/appearance_screen.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class AppearanceScreen extends StatelessWidget {
+  const AppearanceScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF1A1B26),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF1A1B26),
+        title: const Text(
+          'Appearance',
+          style: TextStyle(color: Colors.white),
+        ),
+        iconTheme: const IconThemeData(color: Colors.white),
+      ),
+      body: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            'Appearance — Phase 5 fills this in.',
+            style: TextStyle(color: Colors.white70),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/screens/profile/github_accounts_screen.dart
+++ b/mobile/lib/presentation/screens/profile/github_accounts_screen.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class GitHubAccountsScreen extends StatelessWidget {
+  const GitHubAccountsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF1A1B26),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF1A1B26),
+        title: const Text(
+          'GitHub accounts',
+          style: TextStyle(color: Colors.white),
+        ),
+        iconTheme: const IconThemeData(color: Colors.white),
+      ),
+      body: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            'GitHub accounts — Phase 5 fills this in.',
+            style: TextStyle(color: Colors.white70),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/screens/profile/profile_tab_screen.dart
+++ b/mobile/lib/presentation/screens/profile/profile_tab_screen.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+class ProfileTabScreen extends ConsumerWidget {
+  const ProfileTabScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF1A1B26),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF1A1B26),
+        title: const Text('Profile', style: TextStyle(color: Colors.white)),
+      ),
+      body: ListView(
+        children: [
+          _ProfileRow(
+            icon: Icons.person,
+            label: 'Account',
+            onTap: () => context.go('/home/profile/account'),
+          ),
+          _ProfileRow(
+            icon: Icons.code,
+            label: 'GitHub accounts',
+            onTap: () => context.go('/home/profile/github'),
+          ),
+          _ProfileRow(
+            icon: Icons.palette_outlined,
+            label: 'Appearance',
+            onTap: () => context.go('/home/profile/appearance'),
+          ),
+          _ProfileRow(
+            icon: Icons.cloud_outlined,
+            label: 'Servers',
+            onTap: () => context.go('/home/profile/servers'),
+          ),
+          _ProfileRow(
+            icon: Icons.info_outline,
+            label: 'About',
+            onTap: () => context.go('/home/profile/about'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProfileRow extends StatelessWidget {
+  const _ProfileRow({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(icon, color: Colors.white70),
+      title: Text(label, style: const TextStyle(color: Colors.white)),
+      trailing: const Icon(Icons.chevron_right, color: Colors.white38),
+      onTap: onTap,
+    );
+  }
+}

--- a/mobile/lib/presentation/screens/profile/servers_screen.dart
+++ b/mobile/lib/presentation/screens/profile/servers_screen.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class ServersScreen extends StatelessWidget {
+  const ServersScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF1A1B26),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF1A1B26),
+        title: const Text('Servers', style: TextStyle(color: Colors.white)),
+        iconTheme: const IconThemeData(color: Colors.white),
+      ),
+      body: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            'Servers — manage in Phase 5; for now use the server picker '
+            'before sign-in.',
+            style: TextStyle(color: Colors.white70),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/presentation/screens/shell/home_shell.dart
+++ b/mobile/lib/presentation/screens/shell/home_shell.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../channels/channels_tab_screen.dart';
 import '../sessions/sessions_tab_screen.dart';
 import 'adaptive_bottom_bar.dart';
 
@@ -24,7 +25,7 @@ class _HomeShellState extends ConsumerState<HomeShell> {
           index: _active.index,
           children: const [
             SessionsTabScreen(),
-            _ComingSoon(name: 'Channels'),
+            ChannelsTabScreen(),
             _ComingSoon(name: 'Notifications'),
             _ComingSoon(name: 'Profile'),
           ],

--- a/mobile/lib/presentation/screens/shell/home_shell.dart
+++ b/mobile/lib/presentation/screens/shell/home_shell.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../profile/profile_tab_screen.dart';
 import '../sessions/sessions_tab_screen.dart';
 import 'adaptive_bottom_bar.dart';
 
@@ -26,7 +27,7 @@ class _HomeShellState extends ConsumerState<HomeShell> {
             SessionsTabScreen(),
             _ComingSoon(name: 'Channels'),
             _ComingSoon(name: 'Notifications'),
-            _ComingSoon(name: 'Profile'),
+            ProfileTabScreen(),
           ],
         ),
       ),

--- a/mobile/lib/presentation/screens/shell/home_shell.dart
+++ b/mobile/lib/presentation/screens/shell/home_shell.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../notifications/notifications_tab_screen.dart';
 import '../sessions/sessions_tab_screen.dart';
 import 'adaptive_bottom_bar.dart';
 
@@ -25,7 +26,7 @@ class _HomeShellState extends ConsumerState<HomeShell> {
           children: const [
             SessionsTabScreen(),
             _ComingSoon(name: 'Channels'),
-            _ComingSoon(name: 'Notifications'),
+            NotificationsTabScreen(),
             _ComingSoon(name: 'Profile'),
           ],
         ),

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -41,6 +41,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   archive:
     dependency: transitive
     description:
@@ -576,6 +608,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: "4ff85b2a16724029dd9e5bbb5a94b6918f9973f74ba571c949d2002801879cf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   hooks:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -38,6 +38,9 @@ dependencies:
   firebase_core: ^3.6.0
   firebase_messaging: ^15.1.3
 
+  # Deep links (Phase 4)
+  app_links: ^6.3.2
+
   # Models
   freezed_annotation: ^2.4.4
   json_annotation: ^4.9.0

--- a/mobile/test/infrastructure/api/channels_api_test.dart
+++ b/mobile/test/infrastructure/api/channels_api_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:remote_dev/application/ports/api_client_port.dart';
+import 'package:remote_dev/infrastructure/api/channels_api.dart';
+
+class _MockApiClient extends Mock implements ApiClientPort {}
+
+void main() {
+  late _MockApiClient client;
+  late ChannelsApi api;
+
+  setUp(() {
+    client = _MockApiClient();
+    api = ChannelsApi(client);
+  });
+
+  group('list()', () {
+    test('parses { channels: [...] } shape', () async {
+      when(() => client.get('/api/channels')).thenAnswer(
+        (_) async => {
+          'channels': [
+            {
+              'id': 'ch-1',
+              'name': 'general',
+              'unreadCount': 3,
+              'projectId': 'proj-a',
+            },
+            {
+              'id': 'ch-2',
+              'name': 'random',
+              'unreadCount': 0,
+              'projectId': 'proj-a',
+            },
+          ],
+        },
+      );
+
+      final channels = await api.list();
+
+      expect(channels, hasLength(2));
+      expect(channels[0].id, 'ch-1');
+      expect(channels[0].name, 'general');
+      expect(channels[0].unreadCount, 3);
+      expect(channels[0].projectId, 'proj-a');
+      expect(channels[1].unreadCount, 0);
+    });
+
+    test('parses bare-array shape', () async {
+      when(() => client.get('/api/channels')).thenAnswer(
+        (_) async => [
+          {
+            'id': 'ch-3',
+            'name': 'announcements',
+            'unreadCount': 1,
+          },
+        ],
+      );
+
+      final channels = await api.list();
+
+      expect(channels, hasLength(1));
+      expect(channels[0].id, 'ch-3');
+      expect(channels[0].name, 'announcements');
+      expect(channels[0].unreadCount, 1);
+      expect(channels[0].projectId, isNull);
+    });
+
+    test('flattens { groups: [{ channels: [...] }] } server shape', () async {
+      when(() => client.get('/api/channels')).thenAnswer(
+        (_) async => {
+          'groups': [
+            {
+              'id': 'grp-1',
+              'name': 'Channels',
+              'channels': [
+                {
+                  'id': 'ch-1',
+                  'name': 'general',
+                  'unreadCount': 5,
+                  'projectId': 'proj-a',
+                },
+                {
+                  'id': 'ch-2',
+                  'name': 'random',
+                  'unreadCount': 0,
+                  'projectId': 'proj-a',
+                },
+              ],
+            },
+            {
+              'id': 'grp-2',
+              'name': 'Direct Messages',
+              'channels': [
+                {
+                  'id': 'ch-3',
+                  'name': 'alice',
+                  'unreadCount': 2,
+                  'projectId': 'proj-a',
+                },
+              ],
+            },
+          ],
+        },
+      );
+
+      final channels = await api.list();
+
+      expect(channels, hasLength(3));
+      expect(channels[0].id, 'ch-1');
+      expect(channels[1].id, 'ch-2');
+      expect(channels[2].id, 'ch-3');
+      expect(channels[2].name, 'alice');
+      expect(channels[2].unreadCount, 2);
+    });
+
+    test('defaults unreadCount to 0 when missing', () async {
+      when(() => client.get('/api/channels')).thenAnswer(
+        (_) async => {
+          'channels': [
+            {
+              'id': 'ch-1',
+              'name': 'general',
+            },
+          ],
+        },
+      );
+
+      final channels = await api.list();
+      expect(channels, hasLength(1));
+      expect(channels[0].unreadCount, 0);
+    });
+
+    test('returns empty list on unrecognised shape', () async {
+      when(() => client.get('/api/channels'))
+          .thenAnswer((_) async => 'unexpected');
+
+      final channels = await api.list();
+      expect(channels, isEmpty);
+    });
+
+    test('returns empty list on empty groups response', () async {
+      when(() => client.get('/api/channels')).thenAnswer(
+        (_) async => {'groups': <dynamic>[]},
+      );
+
+      final channels = await api.list();
+      expect(channels, isEmpty);
+    });
+  });
+
+  group('archive()', () {
+    test('DELETEs /api/channels/:id', () async {
+      when(() => client.delete(any())).thenAnswer((_) async {});
+
+      await api.archive('ch-42');
+
+      verify(() => client.delete('/api/channels/ch-42')).called(1);
+    });
+  });
+}

--- a/mobile/test/infrastructure/api/notifications_api_test.dart
+++ b/mobile/test/infrastructure/api/notifications_api_test.dart
@@ -18,24 +18,133 @@ void main() {
     api = NotificationsApi(client);
   });
 
-  test('markRead PATCHes the right path with the ids list', () async {
-    when(() => client.patch(any(), body: any(named: 'body')))
-        .thenAnswer((_) async => null);
+  group('markRead()', () {
+    test('PATCHes the right path with the ids list', () async {
+      when(() => client.patch(any(), body: any(named: 'body')))
+          .thenAnswer((_) async => null);
 
-    await api.markRead(['n1', 'n2']);
+      await api.markRead(['n1', 'n2']);
 
-    verify(
-      () => client.patch(
-        '/api/notifications',
-        body: {
-          'ids': ['n1', 'n2'],
-        },
-      ),
-    ).called(1);
+      verify(
+        () => client.patch(
+          '/api/notifications',
+          body: {
+            'ids': ['n1', 'n2'],
+          },
+        ),
+      ).called(1);
+    });
+
+    test('with empty list is a no-op (no API call)', () async {
+      await api.markRead(const []);
+      verifyNever(() => client.patch(any(), body: any(named: 'body')));
+    });
   });
 
-  test('markRead with empty list is a no-op (no API call)', () async {
-    await api.markRead(const []);
-    verifyNever(() => client.patch(any(), body: any(named: 'body')));
+  group('list()', () {
+    test('parses wrapped {notifications: [...]} response', () async {
+      when(() => client.get('/api/notifications')).thenAnswer(
+        (_) async => {
+          'notifications': [
+            {
+              'id': 'n1',
+              'title': 'New message',
+              'body': 'Hello there',
+              'createdAt': '2026-05-08T10:00:00.000Z',
+              'read': false,
+              'sessionId': 'sess-1',
+              'kind': 'message',
+            },
+            {
+              'id': 'n2',
+              'title': 'Build done',
+              'body': 'Pipeline succeeded',
+              'createdAt': '2026-05-08T11:00:00.000Z',
+              'read': true,
+            },
+          ],
+        },
+      );
+
+      final list = await api.list();
+
+      expect(list, hasLength(2));
+      expect(list[0].id, 'n1');
+      expect(list[0].read, isFalse);
+      expect(list[0].sessionId, 'sess-1');
+      expect(list[0].kind, 'message');
+      expect(list[1].id, 'n2');
+      expect(list[1].read, isTrue);
+      expect(list[1].kind, 'default');
+    });
+
+    test('parses bare-array response', () async {
+      when(() => client.get('/api/notifications')).thenAnswer(
+        (_) async => [
+          {
+            'id': 'n3',
+            'title': 'Plain',
+            'body': 'Body',
+            'createdAt': '2026-05-08T12:00:00.000Z',
+          },
+        ],
+      );
+
+      final list = await api.list();
+      expect(list, hasLength(1));
+      expect(list[0].id, 'n3');
+      expect(list[0].read, isFalse);
+    });
+
+    test('appends ?filter= for non-default filters', () async {
+      when(() => client.get(any())).thenAnswer((_) async => const []);
+
+      await api.list(filter: 'unread');
+      verify(() => client.get('/api/notifications?filter=unread')).called(1);
+
+      await api.list(filter: 'mentions');
+      verify(() => client.get('/api/notifications?filter=mentions')).called(1);
+    });
+
+    test('omits query string for filter=all and null', () async {
+      when(() => client.get(any())).thenAnswer((_) async => const []);
+
+      await api.list(filter: 'all');
+      await api.list();
+
+      verify(() => client.get('/api/notifications')).called(2);
+    });
+
+    test('returns empty list on unexpected response shape', () async {
+      when(() => client.get(any())).thenAnswer((_) async => 'oops');
+      final list = await api.list();
+      expect(list, isEmpty);
+    });
+  });
+
+  group('dismiss()', () {
+    test('DELETEs /api/notifications/:id', () async {
+      when(() => client.delete(any())).thenAnswer((_) async {});
+
+      await api.dismiss('n1');
+
+      verify(() => client.delete('/api/notifications/n1')).called(1);
+    });
+  });
+
+  group('markAllRead()', () {
+    test('PATCHes /api/notifications with {all: true}', () async {
+      when(() => client.patch(any(), body: any(named: 'body')))
+          .thenAnswer((_) async => null);
+
+      await api.markAllRead();
+
+      verify(
+        () => client.patch(
+          '/api/notifications',
+          body: {'all': true},
+        ),
+      ).called(1);
+    });
   });
 }

--- a/mobile/test/infrastructure/deep_link/deep_link_router_test.dart
+++ b/mobile/test/infrastructure/deep_link/deep_link_router_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/infrastructure/deep_link/deep_link_router.dart';
+import 'package:remote_dev/presentation/router/app_route.dart';
+
+void main() {
+  group('DeepLinkRouter.routeFor', () {
+    test('remotedev://session/<id>', () {
+      final r = DeepLinkRouter.routeFor(Uri.parse('remotedev://session/abc'));
+      expect(r, isA<SessionRoute>());
+      expect((r! as SessionRoute).id, 'abc');
+    });
+
+    test('remotedev://channel/<id>', () {
+      final r = DeepLinkRouter.routeFor(Uri.parse('remotedev://channel/xyz'));
+      expect(r, isA<ChannelRoute>());
+      expect((r! as ChannelRoute).id, 'xyz');
+    });
+
+    test('remotedev://recording/<id>', () {
+      final r =
+          DeepLinkRouter.routeFor(Uri.parse('remotedev://recording/123'));
+      expect(r, isA<RecordingRoute>());
+      expect((r! as RecordingRoute).id, '123');
+    });
+
+    test('remotedev://notifications', () {
+      final r =
+          DeepLinkRouter.routeFor(Uri.parse('remotedev://notifications'));
+      expect(r, isA<NotificationsRoute>());
+    });
+
+    test('remotedev://home', () {
+      final r = DeepLinkRouter.routeFor(Uri.parse('remotedev://home'));
+      expect(r, isA<HomeRoute>());
+    });
+
+    test('https://server/m/session/<id>', () {
+      final r = DeepLinkRouter.routeFor(
+        Uri.parse('https://dev.example.com/m/session/abc'),
+      );
+      expect(r, isA<SessionRoute>());
+      expect((r! as SessionRoute).id, 'abc');
+    });
+
+    test('https://server/m/channel/<id>', () {
+      final r = DeepLinkRouter.routeFor(
+        Uri.parse('https://dev.example.com/m/channel/xyz'),
+      );
+      expect(r, isA<ChannelRoute>());
+      expect((r! as ChannelRoute).id, 'xyz');
+    });
+
+    test('https://server/m/recording/<id>', () {
+      final r = DeepLinkRouter.routeFor(
+        Uri.parse('https://dev.example.com/m/recording/777'),
+      );
+      expect(r, isA<RecordingRoute>());
+      expect((r! as RecordingRoute).id, '777');
+    });
+
+    test('https://server/m/notifications', () {
+      final r = DeepLinkRouter.routeFor(
+        Uri.parse('https://dev.example.com/m/notifications'),
+      );
+      expect(r, isA<NotificationsRoute>());
+    });
+
+    test('returns null for unknown surface', () {
+      final r =
+          DeepLinkRouter.routeFor(Uri.parse('remotedev://unknown/whatever'));
+      expect(r, isNull);
+    });
+
+    test('returns null for empty path on custom scheme', () {
+      final r = DeepLinkRouter.routeFor(Uri.parse('remotedev://'));
+      expect(r, isNull);
+    });
+
+    test('returns null for missing id on session', () {
+      final r = DeepLinkRouter.routeFor(Uri.parse('remotedev://session'));
+      expect(r, isNull);
+    });
+
+    test('returns null for missing id on channel', () {
+      final r = DeepLinkRouter.routeFor(Uri.parse('remotedev://channel'));
+      expect(r, isNull);
+    });
+
+    test('returns null for missing id on recording', () {
+      final r = DeepLinkRouter.routeFor(Uri.parse('remotedev://recording'));
+      expect(r, isNull);
+    });
+
+    test('returns null for https root with no /m/ segment', () {
+      final r = DeepLinkRouter.routeFor(
+        Uri.parse('https://dev.example.com/'),
+      );
+      expect(r, isNull);
+    });
+  });
+}

--- a/mobile/test/main_wireup_test.dart
+++ b/mobile/test/main_wireup_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:remote_dev/app.dart';
+import 'package:remote_dev/application/ports/server_config_store.dart';
+import 'package:remote_dev/domain/server_config.dart';
+import 'package:remote_dev/main.dart' show buildServerScopedOverrides;
+import 'package:remote_dev/presentation/screens/webview_host/session_route_host.dart'
+    show serverConfigStoreProvider;
+
+class _StubStore extends Mock implements ServerConfigStore {
+  @override
+  Future<List<ServerConfig>> loadAll() async => const [];
+
+  @override
+  Future<ServerConfig?> loadActive() async => null;
+}
+
+void main() {
+  testWidgets('RemoteDevApp boots with main wire-up overrides applied',
+      (tester) async {
+    // Apply the same overrides main.dart uses; with no active server,
+    // the server picker is the initial route. The picker doesn't consume
+    // the API providers so no override should fire NoActiveServerError
+    // at boot.
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          serverConfigStoreProvider.overrideWithValue(_StubStore()),
+          ...buildServerScopedOverrides(),
+        ],
+        child: const RemoteDevApp(),
+      ),
+    );
+
+    // Pump once to let the first frame render. We avoid pumpAndSettle
+    // because some downstream FutureProviders may not resolve in the
+    // happy-path test runner (e.g. without a real network stack), and
+    // we only care that boot doesn't throw.
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+
+    // One more pump to let the empty server picker resolve.
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(find.text('No servers yet.'), findsOneWidget);
+  });
+}

--- a/mobile/test/presentation/router/app_router_test.dart
+++ b/mobile/test/presentation/router/app_router_test.dart
@@ -6,7 +6,7 @@ void main() {
     expect(const AppRoute.serverPicker().toPath(), '/servers');
     expect(const AppRoute.addServer().toPath(), '/servers/add');
     expect(const AppRoute.session('abc').toPath(), '/home/session/abc');
-    expect(const AppRoute.channel('xyz').toPath(), '/m/channel/xyz');
+    expect(const AppRoute.channel('xyz').toPath(), '/home/channel/xyz');
     expect(const AppRoute.recording('123').toPath(), '/m/recording/123');
     expect(const AppRoute.notifications().toPath(), '/notifications');
     expect(const AppRoute.reauth().toPath(), '/reauth');

--- a/mobile/test/presentation/screens/channels/channel_screen_test.dart
+++ b/mobile/test/presentation/screens/channels/channel_screen_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/presentation/screens/channels/channel_screen.dart';
+
+/// Smoke test: the channel screen mounts and renders the native AppBar.
+///
+/// We deliberately do NOT call `pumpAndSettle` — InAppWebView's platform
+/// channel cannot be exercised in widget tests. The AppBar is the part of
+/// the widget tree we care about for P4.3, so verifying it mounts is
+/// sufficient for the unit test layer.
+void main() {
+  testWidgets('ChannelScreen mounts with the channel AppBar', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: ChannelScreen(channelId: 'test-channel'),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('Channel'), findsAtLeast(1));
+    expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+  });
+}

--- a/mobile/test/presentation/screens/channels/channels_tab_screen_test.dart
+++ b/mobile/test/presentation/screens/channels/channels_tab_screen_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/domain/channel.dart';
+import 'package:remote_dev/infrastructure/api/channels_api.dart';
+import 'package:remote_dev/presentation/screens/channels/channels_tab_screen.dart';
+
+class _FakeChannelsApi extends Fake implements ChannelsApi {
+  _FakeChannelsApi(this._channels);
+  final List<Channel> _channels;
+  bool _shouldThrow = false;
+
+  void setError() {
+    _shouldThrow = true;
+  }
+
+  @override
+  Future<List<Channel>> list() async {
+    if (_shouldThrow) {
+      throw StateError('boom');
+    }
+    return _channels;
+  }
+
+  @override
+  Future<void> archive(String id) async {}
+}
+
+void main() {
+  Widget wrap(Widget child, {required _FakeChannelsApi api}) => ProviderScope(
+        overrides: [
+          channelsApiProvider.overrideWithValue(api),
+        ],
+        child: MaterialApp(home: child),
+      );
+
+  testWidgets('shows empty state when no channels', (tester) async {
+    final api = _FakeChannelsApi(const []);
+    await tester.pumpWidget(wrap(const ChannelsTabScreen(), api: api));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No channels yet'), findsOneWidget);
+    expect(find.byIcon(Icons.forum_outlined), findsOneWidget);
+  });
+
+  testWidgets('renders rows for each channel', (tester) async {
+    final api = _FakeChannelsApi(const [
+      Channel(id: 'c1', name: 'general', unreadCount: 0),
+      Channel(id: 'c2', name: 'random', unreadCount: 0),
+      Channel(id: 'c3', name: 'announcements', unreadCount: 0),
+    ]);
+
+    await tester.pumpWidget(wrap(const ChannelsTabScreen(), api: api));
+    await tester.pumpAndSettle();
+
+    expect(find.text('general'), findsOneWidget);
+    expect(find.text('random'), findsOneWidget);
+    expect(find.text('announcements'), findsOneWidget);
+  });
+
+  testWidgets('renders unread badge for channels with unread > 0',
+      (tester) async {
+    final api = _FakeChannelsApi(const [
+      Channel(id: 'c1', name: 'general', unreadCount: 0),
+      Channel(id: 'c2', name: 'busy', unreadCount: 7),
+      Channel(id: 'c3', name: 'super-busy', unreadCount: 142),
+    ]);
+
+    await tester.pumpWidget(wrap(const ChannelsTabScreen(), api: api));
+    await tester.pumpAndSettle();
+
+    // Unread channels render a count.
+    expect(find.text('7'), findsOneWidget);
+    // Capped at 99+.
+    expect(find.text('99+'), findsOneWidget);
+    // The zero-unread channel must not render '0' badge text.
+    expect(find.text('0'), findsNothing);
+  });
+
+  testWidgets('shows error view when list fails', (tester) async {
+    final api = _FakeChannelsApi(const [])..setError();
+    await tester.pumpWidget(wrap(const ChannelsTabScreen(), api: api));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Failed to load channels'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+  });
+}

--- a/mobile/test/presentation/screens/notifications/notifications_tab_screen_test.dart
+++ b/mobile/test/presentation/screens/notifications/notifications_tab_screen_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:remote_dev/domain/notification.dart';
+import 'package:remote_dev/infrastructure/api/notifications_api.dart';
+import 'package:remote_dev/presentation/screens/notifications/notifications_tab_screen.dart';
+
+class _MockNotificationsApi extends Mock implements NotificationsApi {}
+
+Widget _wrap(NotificationsApi api) {
+  return ProviderScope(
+    overrides: [
+      notificationsApiProvider.overrideWithValue(api),
+    ],
+    child: const MaterialApp(home: NotificationsTabScreen()),
+  );
+}
+
+AppNotification _notif({
+  String id = 'n1',
+  String title = 'Title',
+  String body = 'Body',
+  bool read = false,
+  String? sessionId,
+  String? channelId,
+  String kind = 'default',
+}) {
+  return AppNotification(
+    id: id,
+    title: title,
+    body: body,
+    createdAt: DateTime.utc(2026, 5, 8, 10),
+    read: read,
+    sessionId: sessionId,
+    channelId: channelId,
+    kind: kind,
+  );
+}
+
+void main() {
+  late _MockNotificationsApi api;
+
+  setUp(() {
+    api = _MockNotificationsApi();
+  });
+
+  testWidgets('renders empty state when list is empty', (tester) async {
+    when(() => api.list(filter: any(named: 'filter')))
+        .thenAnswer((_) async => const <AppNotification>[]);
+
+    await tester.pumpWidget(_wrap(api));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No notifications'), findsOneWidget);
+    expect(find.text('Pull down to refresh.'), findsOneWidget);
+  });
+
+  testWidgets('renders rows + filter chips', (tester) async {
+    when(() => api.list(filter: any(named: 'filter'))).thenAnswer(
+      (_) async => [
+        _notif(id: 'n1', title: 'First', body: 'Hello'),
+        _notif(id: 'n2', title: 'Second', body: 'World', read: true),
+      ],
+    );
+
+    await tester.pumpWidget(_wrap(api));
+    await tester.pumpAndSettle();
+
+    // Filter chips
+    expect(find.text('All'), findsOneWidget);
+    expect(find.text('Unread'), findsOneWidget);
+    expect(find.text('Mentions'), findsOneWidget);
+
+    // Notification rows
+    expect(find.text('First'), findsOneWidget);
+    expect(find.text('Second'), findsOneWidget);
+    expect(find.text('Hello'), findsOneWidget);
+    expect(find.text('World'), findsOneWidget);
+  });
+
+  testWidgets('tapping a chip refetches with the right filter',
+      (tester) async {
+    final filterCalls = <String?>[];
+    when(() => api.list(filter: any(named: 'filter'))).thenAnswer(
+      (invocation) async {
+        filterCalls.add(invocation.namedArguments[#filter] as String?);
+        return const <AppNotification>[];
+      },
+    );
+
+    await tester.pumpWidget(_wrap(api));
+    await tester.pumpAndSettle();
+    expect(filterCalls.last, 'all');
+
+    // Tap the Unread chip.
+    await tester.tap(find.text('Unread'));
+    await tester.pumpAndSettle();
+    expect(filterCalls.last, 'unread');
+
+    // Tap the Mentions chip.
+    await tester.tap(find.text('Mentions'));
+    await tester.pumpAndSettle();
+    expect(filterCalls.last, 'mentions');
+  });
+
+  testWidgets('shows error view + retry on failure', (tester) async {
+    when(() => api.list(filter: any(named: 'filter')))
+        .thenThrow(Exception('boom'));
+
+    await tester.pumpWidget(_wrap(api));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Failed to load notifications'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+  });
+
+  testWidgets('Mark all read triggers API + refetch', (tester) async {
+    var calls = 0;
+    when(() => api.list(filter: any(named: 'filter'))).thenAnswer((_) async {
+      calls += 1;
+      return const <AppNotification>[];
+    });
+    when(() => api.markAllRead()).thenAnswer((_) async {});
+
+    await tester.pumpWidget(_wrap(api));
+    await tester.pumpAndSettle();
+    expect(calls, 1);
+
+    await tester.tap(find.text('Mark all read'));
+    await tester.pumpAndSettle();
+
+    verify(() => api.markAllRead()).called(1);
+    expect(calls, greaterThanOrEqualTo(2));
+  });
+}

--- a/mobile/test/presentation/screens/profile/about_screen_test.dart
+++ b/mobile/test/presentation/screens/profile/about_screen_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/presentation/screens/profile/about_screen.dart';
+
+void main() {
+  testWidgets('AboutScreen renders title and product info', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: AboutScreen()),
+    );
+
+    expect(find.text('About'), findsOneWidget);
+    expect(find.text('Remote Dev'), findsOneWidget);
+    expect(find.text('Phase 4 (development)'), findsOneWidget);
+  });
+}

--- a/mobile/test/presentation/screens/profile/account_screen_test.dart
+++ b/mobile/test/presentation/screens/profile/account_screen_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/presentation/screens/profile/account_screen.dart';
+
+void main() {
+  testWidgets('AccountScreen renders title and placeholder body',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: AccountScreen()),
+    );
+
+    expect(find.text('Account'), findsOneWidget);
+    expect(
+      find.text('Account details — Phase 5 fills this in.'),
+      findsOneWidget,
+    );
+  });
+}

--- a/mobile/test/presentation/screens/profile/appearance_screen_test.dart
+++ b/mobile/test/presentation/screens/profile/appearance_screen_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/presentation/screens/profile/appearance_screen.dart';
+
+void main() {
+  testWidgets('AppearanceScreen renders title and placeholder body',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: AppearanceScreen()),
+    );
+
+    expect(find.text('Appearance'), findsOneWidget);
+    expect(
+      find.text('Appearance — Phase 5 fills this in.'),
+      findsOneWidget,
+    );
+  });
+}

--- a/mobile/test/presentation/screens/profile/github_accounts_screen_test.dart
+++ b/mobile/test/presentation/screens/profile/github_accounts_screen_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/presentation/screens/profile/github_accounts_screen.dart';
+
+void main() {
+  testWidgets('GitHubAccountsScreen renders title and placeholder body',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: GitHubAccountsScreen()),
+    );
+
+    expect(find.text('GitHub accounts'), findsOneWidget);
+    expect(
+      find.text('GitHub accounts — Phase 5 fills this in.'),
+      findsOneWidget,
+    );
+  });
+}

--- a/mobile/test/presentation/screens/profile/profile_tab_screen_test.dart
+++ b/mobile/test/presentation/screens/profile/profile_tab_screen_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:remote_dev/presentation/screens/profile/profile_tab_screen.dart';
+
+Widget _wrap() {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(path: '/', builder: (_, __) => const ProfileTabScreen()),
+      // Stub destinations so taps don't crash.
+      GoRoute(
+        path: '/home/profile/account',
+        builder: (_, __) => const Scaffold(body: Text('account')),
+      ),
+      GoRoute(
+        path: '/home/profile/github',
+        builder: (_, __) => const Scaffold(body: Text('github')),
+      ),
+      GoRoute(
+        path: '/home/profile/appearance',
+        builder: (_, __) => const Scaffold(body: Text('appearance')),
+      ),
+      GoRoute(
+        path: '/home/profile/servers',
+        builder: (_, __) => const Scaffold(body: Text('servers')),
+      ),
+      GoRoute(
+        path: '/home/profile/about',
+        builder: (_, __) => const Scaffold(body: Text('about')),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    child: MaterialApp.router(routerConfig: router),
+  );
+}
+
+void main() {
+  testWidgets('ProfileTabScreen renders title and 5 settings rows',
+      (tester) async {
+    await tester.pumpWidget(_wrap());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Profile'), findsOneWidget);
+    expect(find.text('Account'), findsOneWidget);
+    expect(find.text('GitHub accounts'), findsOneWidget);
+    expect(find.text('Appearance'), findsOneWidget);
+    expect(find.text('Servers'), findsOneWidget);
+    expect(find.text('About'), findsOneWidget);
+  });
+
+  testWidgets('ProfileTabScreen tapping Account navigates to /home/profile/account',
+      (tester) async {
+    await tester.pumpWidget(_wrap());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Account'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('account'), findsOneWidget);
+  });
+}

--- a/mobile/test/presentation/screens/profile/servers_screen_test.dart
+++ b/mobile/test/presentation/screens/profile/servers_screen_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/presentation/screens/profile/servers_screen.dart';
+
+void main() {
+  testWidgets('ServersScreen renders title and placeholder body',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: ServersScreen()),
+    );
+
+    expect(find.text('Servers'), findsOneWidget);
+    expect(
+      find.textContaining('Servers — manage in Phase 5'),
+      findsOneWidget,
+    );
+  });
+}

--- a/mobile/test/presentation/screens/shell/home_shell_test.dart
+++ b/mobile/test/presentation/screens/shell/home_shell_test.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/domain/notification.dart';
 import 'package:remote_dev/domain/session_summary.dart';
+import 'package:remote_dev/infrastructure/api/notifications_api.dart';
 import 'package:remote_dev/infrastructure/api/sessions_api.dart';
+import 'package:remote_dev/presentation/screens/notifications/notifications_tab_screen.dart';
 import 'package:remote_dev/presentation/screens/sessions/sessions_tab_screen.dart';
 import 'package:remote_dev/presentation/screens/shell/home_shell.dart';
 
@@ -20,12 +23,27 @@ class _FakeSessionsApi extends Fake implements SessionsApi {
   Future<void> close(String id) async {}
 }
 
+class _FakeNotificationsApi extends Fake implements NotificationsApi {
+  @override
+  Future<List<AppNotification>> list({String? filter}) async => const [];
+
+  @override
+  Future<void> markRead(List<String> ids) async {}
+
+  @override
+  Future<void> dismiss(String id) async {}
+
+  @override
+  Future<void> markAllRead() async {}
+}
+
 void main() {
   Widget wrap(Widget child, {List<SessionSummary>? sessions}) => ProviderScope(
         overrides: [
           sessionsApiProvider.overrideWithValue(
             _FakeSessionsApi(sessions ?? const []),
           ),
+          notificationsApiProvider.overrideWithValue(_FakeNotificationsApi()),
         ],
         child: MaterialApp(home: child),
       );
@@ -35,7 +53,9 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Sessions'), findsWidgets);
     expect(find.text('Channels'), findsOneWidget);
-    expect(find.text('Notifications'), findsOneWidget);
+    // 'Notifications' now appears both as a bottom-nav label and as the
+    // NotificationsTabScreen AppBar title (rendered in the IndexedStack).
+    expect(find.text('Notifications'), findsWidgets);
     expect(find.text('Profile'), findsOneWidget);
   });
 
@@ -56,12 +76,12 @@ void main() {
   testWidgets('tap Notifications switches body', (tester) async {
     await tester.pumpWidget(wrap(const HomeShell()));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Notifications'));
+    // The bottom-nav label is the only 'Notifications' Text not inside an
+    // AppBar; tapping it activates the tab.
+    await tester.tap(find.text('Notifications').first);
     await tester.pumpAndSettle();
-    expect(
-      find.textContaining('Notifications — coming in Phase 4'),
-      findsOneWidget,
-    );
+    // Empty state from the live NotificationsTabScreen.
+    expect(find.text('No notifications'), findsOneWidget);
   });
 
   testWidgets('tap Profile switches body', (tester) async {

--- a/mobile/test/presentation/screens/shell/home_shell_test.dart
+++ b/mobile/test/presentation/screens/shell/home_shell_test.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/domain/channel.dart';
 import 'package:remote_dev/domain/session_summary.dart';
+import 'package:remote_dev/infrastructure/api/channels_api.dart';
 import 'package:remote_dev/infrastructure/api/sessions_api.dart';
+import 'package:remote_dev/presentation/screens/channels/channels_tab_screen.dart';
 import 'package:remote_dev/presentation/screens/sessions/sessions_tab_screen.dart';
 import 'package:remote_dev/presentation/screens/shell/home_shell.dart';
 
@@ -20,11 +23,30 @@ class _FakeSessionsApi extends Fake implements SessionsApi {
   Future<void> close(String id) async {}
 }
 
+class _FakeChannelsApi extends Fake implements ChannelsApi {
+  _FakeChannelsApi(this._channels);
+  final List<Channel> _channels;
+
+  @override
+  Future<List<Channel>> list() async => _channels;
+
+  @override
+  Future<void> archive(String id) async {}
+}
+
 void main() {
-  Widget wrap(Widget child, {List<SessionSummary>? sessions}) => ProviderScope(
+  Widget wrap(
+    Widget child, {
+    List<SessionSummary>? sessions,
+    List<Channel>? channels,
+  }) =>
+      ProviderScope(
         overrides: [
           sessionsApiProvider.overrideWithValue(
             _FakeSessionsApi(sessions ?? const []),
+          ),
+          channelsApiProvider.overrideWithValue(
+            _FakeChannelsApi(channels ?? const []),
           ),
         ],
         child: MaterialApp(home: child),
@@ -45,12 +67,14 @@ void main() {
     expect(find.text('No sessions yet'), findsOneWidget);
   });
 
-  testWidgets('tap Channels switches body', (tester) async {
+  testWidgets('tap Channels switches body to ChannelsTabScreen',
+      (tester) async {
     await tester.pumpWidget(wrap(const HomeShell()));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Channels'));
     await tester.pumpAndSettle();
-    expect(find.textContaining('Channels — coming in Phase 4'), findsOneWidget);
+    // ChannelsTabScreen renders the empty state when no channels.
+    expect(find.text('No channels yet'), findsOneWidget);
   });
 
   testWidgets('tap Notifications switches body', (tester) async {

--- a/mobile/test/presentation/screens/shell/home_shell_test.dart
+++ b/mobile/test/presentation/screens/shell/home_shell_test.dart
@@ -36,7 +36,9 @@ void main() {
     expect(find.text('Sessions'), findsWidgets);
     expect(find.text('Channels'), findsOneWidget);
     expect(find.text('Notifications'), findsOneWidget);
-    expect(find.text('Profile'), findsOneWidget);
+    // 'Profile' appears in the bottom bar AND in the ProfileTabScreen's
+    // AppBar (since IndexedStack keeps all children in the tree).
+    expect(find.text('Profile'), findsWidgets);
   });
 
   testWidgets('initial body is sessions tab (empty state)', (tester) async {
@@ -64,11 +66,16 @@ void main() {
     );
   });
 
-  testWidgets('tap Profile switches body', (tester) async {
+  testWidgets('tap Profile switches body to ProfileTabScreen', (tester) async {
     await tester.pumpWidget(wrap(const HomeShell()));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Profile'));
     await tester.pumpAndSettle();
-    expect(find.textContaining('Profile — coming in Phase 4'), findsOneWidget);
+    // ProfileTabScreen renders its 5 settings rows.
+    expect(find.text('Account'), findsOneWidget);
+    expect(find.text('GitHub accounts'), findsOneWidget);
+    expect(find.text('Appearance'), findsOneWidget);
+    expect(find.text('Servers'), findsOneWidget);
+    expect(find.text('About'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary

Phase 4 — fills in the 3 non-Sessions tabs, adds deep-link routing, and finally wires the deferred Riverpod providers in `main.dart` so the app actually works against a real Remote Dev server.

- **P4.1** Native Notifications tab — filter chips (All/Unread/Mentions), swipe-to-dismiss + swipe-to-mark-read, pull-to-refresh, tap → mark-read + nav.
- **P4.2** Native Channels list — unread badges, swipe-to-archive, tap → ChannelScreen. Tolerates server's wrapped `{groups: [{channels: [...]}]}` shape (production fix from the implementer).
- **P4.3** `ChannelScreen` — native AppBar around `/m/channel/<id>` WebView; `BridgeController.back()` signals the PWA on native back.
- **P4.4** Native Profile tab + 5 sub-screens (Account / GitHub accounts / Appearance / Servers / About) — scaffolds; Phase 5 fills the real content.
- **P4.5** iOS Universal Links — `applinks:dev.bryanli.net` in `Runner.entitlements`.
- **P4.6** Android App Links — `<intent-filter android:autoVerify="true">` for `https://dev.bryanli.net/m/*`.
- **P4.7** `remotedev://` custom scheme + `DeepLinkRouter` (pure URI → `AppRoute` translator) + `AppLinkListener` (subscribes to `app_links` `Stream<Uri>`, dispatches via `AppRouter.navigateTo`).
- **Wave 4** `main.dart` wire-up — `ProviderContainer` with overrides for sessions/projectTree/channels/notifications APIs + `pushTokenRegistrarProvider`, all backed by a `RemoteDevClient` bound to the active server via `_apiClientProvider` (which watches `activeServerProvider`).

Spec: `docs/superpowers/specs/2026-05-08-flutter-app-redesign-design.md`
Plan: `docs/superpowers/plans/2026-05-08-flutter-app-phase-4-channels-deep-links.md`

## Architectural rules respected

- All `addJavaScriptHandler` registrations remain in `onWebViewCreated`.
- `BridgeController` is the only path for native→WebView calls.
- `AppRouter.navigateTo(AppRoute)` is the single sink — both FCM tap-handler (Phase 3) and deep-link listener (Phase 4) converge here.
- Single quotes, `debugPrint` in presentation only.

## Ship gate

- [x] `flutter test` — 160 passing + 1 skipped
- [x] `flutter analyze` — 0 issues
- [x] `flutter build apk --debug` — succeeds (23s)
- [x] All 7 P4 bd issues closed; epic `remote-dev-9ngw` closed

## Manual smoke (the human runs after merge + Firebase setup)

1. Install the APK + run `docs/mobile-firebase-setup.md` to land real `google-services.json` / `GoogleService-Info.plist`.
2. Launch — server picker. Add a server → tap to activate → land on Sessions tab.
3. Switch to Channels tab → list populates from `/api/channels` → tap a channel → ChannelScreen renders the embedded WebView.
4. Switch to Notifications tab → list populates → swipe to dismiss/mark-read.
5. Switch to Profile tab → 5 settings rows render.
6. Test deep-links: `xcrun simctl openurl booted remotedev://session/<uuid>` (iOS sim) / `adb shell am start -W -a android.intent.action.VIEW -d "remotedev://session/<uuid>" com.remotedev.app` (Android) → should open the session view.

## Known limitations (deferred to Phase 5)

- `deviceId` in `pushTokenRegistrarProvider` is hard-coded `'placeholder-device-id'`. Phase 5 generates + persists a stable per-device UUID via secure storage.
- `ChannelScreen` AppBar title is hardcoded "Channel" — Phase 5 fetches the real name.
- Profile sub-screens are scaffolds; Phase 5 fills real content.
- Real `apple-app-site-association` + `assetlinks.json` server-side files need to be deployed (Phase 5 with the actual Team ID + Play App Signing fingerprint).
- iOS APNs push entitlement + App Store metadata — Phase 5.

## Beads

Closes Phase 4 (`remote-dev-9ngw`) and tasks `kd6s`, `egm3`, `dpfe`, `urmf`, `b89s`, `xnz2`, `kksj`. Phase 5 (`remote-dev-pddf`) becomes ready once this merges.

This pull request and its description were written by Isaac.