### PR TITLE
feat(mobile): hide bridge-spike entry point in release builds (remote-dev-474v)

### DIFF
--- a/mobile/lib/presentation/screens/server_picker/server_picker_screen.dart
+++ b/mobile/lib/presentation/screens/server_picker/server_picker_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -96,7 +97,10 @@ class ServerPickerScreen extends ConsumerWidget {
         backgroundColor: const Color(0xFF1A1B26),
         title: const Text('Servers', style: TextStyle(color: Colors.white)),
         actions: [
-          if (onTestBridge != null)
+          // Bridge-spike entry point is a Phase 1.5 development POC; in release
+          // builds it shows a non-interactive Cloudflare challenge that confuses
+          // users, so gate it behind kDebugMode at compile time.
+          if (kDebugMode && onTestBridge != null)
             IconButton(
               icon: const Icon(Icons.bug_report, color: Colors.white),
               tooltip: 'Test bridge',


### PR DESCRIPTION
## Summary
- Wraps the bug-icon `IconButton` in `ServerPickerScreen` with `if (kDebugMode && onTestBridge != null)` so it's tree-shaken from release builds.
- Adds `import 'package:flutter/foundation.dart';`.

`onTestBridge` callback is preserved on the widget signature; `/spike` route still reachable via direct nav for debug.

## Test plan
- [x] `flutter analyze lib/` clean
- [x] `flutter test` 188 passing, 3 pre-existing skips

Closes remote-dev-474v.

This pull request and its description were written by Isaac.