### PR TITLE
feat(mobile): notifications deep-link opens home shell with notifications tab (remote-dev-0jfw)

### DIFF
--- a/mobile/lib/presentation/router/app_router.dart
+++ b/mobile/lib/presentation/router/app_router.dart
@@ -17,6 +17,7 @@ import '../screens/server_picker/add_server_screen.dart';
 import '../screens/server_picker/edit_server_screen.dart';
 import '../screens/server_picker/server_picker_screen.dart';
 import '../screens/session_view/session_view_screen.dart';
+import '../screens/shell/adaptive_bottom_bar.dart';
 import '../screens/shell/home_shell.dart';
 import '../screens/webview_host/reauth_screen.dart';
 import '../screens/webview_host/session_route_host.dart';
@@ -178,7 +179,8 @@ class AppRouter {
         ),
         GoRoute(
           path: '/notifications',
-          builder: (_, __) => const _PlaceholderScreen(name: 'Notifications'),
+          builder: (_, __) =>
+              const HomeShell(initialTab: HomeTab.notifications),
         ),
         GoRoute(
           path: '/reauth',
@@ -193,25 +195,6 @@ class AppRouter {
           ),
         ),
       ],
-    );
-  }
-}
-
-class _PlaceholderScreen extends StatelessWidget {
-  const _PlaceholderScreen({required this.name});
-
-  final String name;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: const Color(0xFF1A1B26),
-      body: Center(
-        child: Text(
-          name,
-          style: const TextStyle(color: Colors.white, fontSize: 18),
-        ),
-      ),
     );
   }
 }

--- a/mobile/lib/presentation/screens/shell/home_shell.dart
+++ b/mobile/lib/presentation/screens/shell/home_shell.dart
@@ -8,14 +8,19 @@ import '../sessions/sessions_tab_screen.dart';
 import 'adaptive_bottom_bar.dart';
 
 class HomeShell extends ConsumerStatefulWidget {
-  const HomeShell({super.key});
+  const HomeShell({this.initialTab, super.key});
+
+  /// Tab to display on first build. Defaults to [HomeTab.sessions].
+  /// Used by deep-link / push-notification tap routes that target a specific
+  /// tab inside the shell (e.g. `/notifications` → notifications tab).
+  final HomeTab? initialTab;
 
   @override
   ConsumerState<HomeShell> createState() => _HomeShellState();
 }
 
 class _HomeShellState extends ConsumerState<HomeShell> {
-  HomeTab _active = HomeTab.sessions;
+  late HomeTab _active = widget.initialTab ?? HomeTab.sessions;
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/test/presentation/screens/shell/home_shell_test.dart
+++ b/mobile/test/presentation/screens/shell/home_shell_test.dart
@@ -10,6 +10,7 @@ import 'package:remote_dev/infrastructure/api/sessions_api.dart';
 import 'package:remote_dev/presentation/screens/channels/channels_tab_screen.dart';
 import 'package:remote_dev/presentation/screens/notifications/notifications_tab_screen.dart';
 import 'package:remote_dev/presentation/screens/sessions/sessions_tab_screen.dart';
+import 'package:remote_dev/presentation/screens/shell/adaptive_bottom_bar.dart';
 import 'package:remote_dev/presentation/screens/shell/home_shell.dart';
 
 class _FakeSessionsApi extends Fake implements SessionsApi {
@@ -116,4 +117,31 @@ void main() {
     expect(find.text('Servers'), findsOneWidget);
     expect(find.text('About'), findsOneWidget);
   });
+
+  testWidgets(
+    'initialTab=notifications opens HomeShell on the notifications tab',
+    (tester) async {
+      await tester.pumpWidget(
+        wrap(const HomeShell(initialTab: HomeTab.notifications)),
+      );
+      await tester.pumpAndSettle();
+      // NotificationsTabScreen empty-state copy is visible immediately.
+      expect(find.text('No notifications'), findsOneWidget);
+      // Sessions empty-state should NOT be visible — only the active tab
+      // mounts its primary content.
+      expect(find.text('No sessions yet'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'initialTab=channels opens HomeShell on the channels tab',
+    (tester) async {
+      await tester.pumpWidget(
+        wrap(const HomeShell(initialTab: HomeTab.channels)),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('No channels yet'), findsOneWidget);
+      expect(find.text('No sessions yet'), findsNothing);
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- Adds optional `initialTab` constructor param to `HomeShell` (defaults to `HomeTab.sessions`).
- `/notifications` route now builds `HomeShell(initialTab: HomeTab.notifications)` instead of the dead `_PlaceholderScreen`.
- Push taps via `NotificationTapHandler` now land on the live notifications tab inside the shell with bottom nav visible.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — 190 passing, 3 pre-existing skips
- [x] Two new widget tests for `initialTab` behavior

Closes remote-dev-0jfw.

This pull request and its description were written by Isaac.