### PR TITLE
feat(mobile): use push instead of go for sub-routes (remote-dev-xmbh)

### DIFF
--- a/mobile/lib/presentation/router/app_router.dart
+++ b/mobile/lib/presentation/router/app_router.dart
@@ -62,12 +62,14 @@ class AppRouter {
                   context.go('/home');
                 }
               },
-              onAdd: () => context.go('/servers/add'),
+              // push sub-routes so the server picker stays on the back
+              // stack and the AppBar shows an implicit back arrow.
+              onAdd: () => context.push('/servers/add'),
               onEdit: (server) => context.push(
                 '/servers/edit',
                 extra: server,
               ),
-              onTestBridge: () => context.go('/spike'),
+              onTestBridge: () => context.push('/spike'),
             ),
           ),
         ),
@@ -78,7 +80,14 @@ class AppRouter {
               onSaved: (server) {
                 ref.invalidate(serversListProvider);
                 ref.invalidate(activeServerProvider);
-                context.go('/servers');
+                // Prefer pop so the picker beneath us survives. Fall back
+                // to go for direct deep-link cold-starts where add is
+                // the root of the stack.
+                if (context.canPop()) {
+                  context.pop();
+                } else {
+                  context.go('/servers');
+                }
               },
             ),
           ),

--- a/mobile/lib/presentation/screens/channels/channels_tab_screen.dart
+++ b/mobile/lib/presentation/screens/channels/channels_tab_screen.dart
@@ -82,9 +82,9 @@ class _ChannelsTabScreenState extends ConsumerState<ChannelsTabScreen> {
   }
 
   void _onTapChannel(Channel channel) {
-    // P4.3 lands the actual /home/channel/:id route; for now we route to it
-    // and the router falls back gracefully if the route is not registered.
-    context.go('/home/channel/${channel.id}');
+    // push so the channel view has an implicit back arrow that pops
+    // to the Channels tab inside HomeShell.
+    context.push('/home/channel/${channel.id}');
   }
 
   @override

--- a/mobile/lib/presentation/screens/notifications/notifications_tab_screen.dart
+++ b/mobile/lib/presentation/screens/notifications/notifications_tab_screen.dart
@@ -104,9 +104,11 @@ class _NotificationsTabScreenState
       _markRead(notif);
     }
     if (notif.sessionId != null && notif.sessionId!.isNotEmpty) {
-      context.go('/home/session/${notif.sessionId}');
+      // push so the session view has an implicit back arrow that pops
+      // to the Notifications tab inside HomeShell.
+      context.push('/home/session/${notif.sessionId}');
     } else if (notif.channelId != null && notif.channelId!.isNotEmpty) {
-      context.go('/home/channel/${notif.channelId}');
+      context.push('/home/channel/${notif.channelId}');
     }
     // Otherwise remain on the tab.
   }

--- a/mobile/lib/presentation/screens/profile/profile_tab_screen.dart
+++ b/mobile/lib/presentation/screens/profile/profile_tab_screen.dart
@@ -18,32 +18,34 @@ class ProfileTabScreen extends ConsumerWidget {
           _ProfileRow(
             icon: Icons.person,
             label: 'Account',
-            onTap: () => context.go('/home/profile/account'),
+            // push so the AppBar shows an implicit back arrow that pops
+            // to the Profile tab inside HomeShell.
+            onTap: () => context.push('/home/profile/account'),
           ),
           _ProfileRow(
             icon: Icons.code,
             label: 'GitHub accounts',
-            onTap: () => context.go('/home/profile/github'),
+            onTap: () => context.push('/home/profile/github'),
           ),
           _ProfileRow(
             icon: Icons.palette_outlined,
             label: 'Appearance',
-            onTap: () => context.go('/home/profile/appearance'),
+            onTap: () => context.push('/home/profile/appearance'),
           ),
           _ProfileRow(
             icon: Icons.cloud_outlined,
             label: 'Servers',
-            onTap: () => context.go('/home/profile/servers'),
+            onTap: () => context.push('/home/profile/servers'),
           ),
           _ProfileRow(
             icon: Icons.lock_outline,
             label: 'Security',
-            onTap: () => context.go('/home/profile/biometric'),
+            onTap: () => context.push('/home/profile/biometric'),
           ),
           _ProfileRow(
             icon: Icons.info_outline,
             label: 'About',
-            onTap: () => context.go('/home/profile/about'),
+            onTap: () => context.push('/home/profile/about'),
           ),
         ],
       ),

--- a/mobile/lib/presentation/screens/sessions/sessions_tab_screen.dart
+++ b/mobile/lib/presentation/screens/sessions/sessions_tab_screen.dart
@@ -106,12 +106,14 @@ class _SessionsTabScreenState extends ConsumerState<SessionsTabScreen> {
     if (created != null && mounted) {
       // Refresh the list and navigate to the session view.
       ref.invalidate(sessionsListProvider);
-      context.go('/home/session/${created.id}');
+      // push so the session view has an implicit back arrow that pops
+      // to the Sessions tab inside HomeShell.
+      context.push('/home/session/${created.id}');
     }
   }
 
   void _onTapSession(SessionSummary session) {
-    context.go('/home/session/${session.id}');
+    context.push('/home/session/${session.id}');
   }
 
   @override


### PR DESCRIPTION
## Summary
- Profile sub-routes (Account, GitHub, Appearance, Servers, Security, About) now `push` instead of `go` so the route stack carries a back entry.
- Sessions/channels/notifications drill-downs to detail screens use `push`.
- `/servers/add` and `/spike` use `push`; AddServer save uses `canPop`+`pop` with `/servers` fallback.

## Calls intentionally left as `go`
- Top-level transitions (picker → /home, reauth → /servers, cold-start fallbacks)
- FCM cold-start tap-handler (changing to push on empty stack would break cold-start UX)

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — 188 passing, 3 pre-existing skips

Sets up B.2 (implicit AppBar back buttons) and B.3 (Android back gesture). Closes remote-dev-xmbh.

This pull request and its description were written by Isaac.