### PR TITLE
feat(mobile): rename app to RemoteDev (label + bundle name) (remote-dev-mx6y)

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,4 +1,4 @@
-# remote_dev (mobile)
+# RemoteDev (mobile)
 
 New Flutter mobile app for Remote Dev — replaces the deprecated `archive/mobile-flutter/`.
 

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="remote_dev"
+        android:label="RemoteDev"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -18,7 +18,7 @@
 			</dict>
 		</array>
 		<key>CFBundleDisplayName</key>
-		<string>Remote Dev</string>
+		<string>RemoteDev</string>
 		<key>CFBundleExecutable</key>
 		<string>$(EXECUTABLE_NAME)</string>
 		<key>CFBundleIdentifier</key>
@@ -26,7 +26,7 @@
 		<key>CFBundleInfoDictionaryVersion</key>
 		<string>6.0</string>
 		<key>CFBundleName</key>
-		<string>remote_dev</string>
+		<string>RemoteDev</string>
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
## Summary
- Android: `android:label` `remote_dev` → `RemoteDev`
- iOS: `CFBundleName` `remote_dev` → `RemoteDev`; `CFBundleDisplayName` `Remote Dev` → `RemoteDev`
- README title updated

Untouched: pubspec `name: remote_dev` (Dart pkg convention), bundle id `com.remotedev.app`, Dart imports.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` 188/188
- [x] `flutter build apk --debug` builds; `aapt dump badging` → `application-label:'RemoteDev'`

Closes remote-dev-mx6y.

This pull request and its description were written by Isaac.