### PR TITLE
feat(mobile): CF Access WebView login during Add Server (remote-dev-hgrq)

### DIFF
--- a/mobile/lib/infrastructure/webview/navigation_policy.dart
+++ b/mobile/lib/infrastructure/webview/navigation_policy.dart
@@ -1,14 +1,38 @@
 enum NavigationDecision { allow, interceptAndOpenExternally, intercept }
 
 class NavigationPolicy {
-  const NavigationPolicy({required this.serverOrigin});
+  /// Default policy used by the in-session WebView (Phase 2). Locks the
+  /// WebView to `<serverOrigin>/m/*` plus the CF Access challenge — every
+  /// other URL is intercepted and opened externally.
+  const NavigationPolicy({required this.serverOrigin})
+      : _allowSsoProviders = false;
+
+  /// Relaxed policy used during the Add Server / re-auth flow. Allows the
+  /// well-known third-party identity providers that CF Access redirects to
+  /// (Google, Microsoft, Okta), in addition to the server origin (any path,
+  /// not just `/m/*`) and CF Access itself.
+  ///
+  /// We don't use this on the live session view because terminal output
+  /// could legitimately contain a `https://accounts.google.com/...` link
+  /// that we'd then accidentally load in-place.
+  const NavigationPolicy.forLogin({required this.serverOrigin})
+      : _allowSsoProviders = true;
 
   final Uri serverOrigin;
+  final bool _allowSsoProviders;
 
   NavigationDecision decide(Uri uri) {
     if (_isCfAccessChallenge(uri)) return NavigationDecision.allow;
+    if (_allowSsoProviders && _isSsoProvider(uri)) {
+      return NavigationDecision.allow;
+    }
     if (uri.origin != serverOrigin.origin) {
       return NavigationDecision.interceptAndOpenExternally;
+    }
+    if (_allowSsoProviders) {
+      // Login flow: any path on the server origin is fair game (the form
+      // post lands on `/`, not `/m/*`).
+      return NavigationDecision.allow;
     }
     if (!uri.path.startsWith('/m/')) {
       return NavigationDecision.intercept;
@@ -20,5 +44,16 @@ class NavigationPolicy {
     final host = uri.host.toLowerCase();
     return host.endsWith('.cloudflareaccess.com') ||
         host == 'cloudflareaccess.com';
+  }
+
+  /// Hosts that CF Access commonly federates to. Kept narrow so we don't
+  /// accidentally turn the WebView into an open browser.
+  static bool _isSsoProvider(Uri uri) {
+    final host = uri.host.toLowerCase();
+    return host == 'accounts.google.com' ||
+        host == 'login.microsoftonline.com' ||
+        host == 'login.live.com' ||
+        host == 'okta.com' ||
+        host.endsWith('.okta.com');
   }
 }

--- a/mobile/lib/presentation/screens/server_picker/add_server_screen.dart
+++ b/mobile/lib/presentation/screens/server_picker/add_server_screen.dart
@@ -4,7 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../../domain/server_config.dart';
-import '../webview_host/session_route_host.dart' show serverConfigStoreProvider;
+import '../webview_host/session_route_host.dart'
+    show secureStorageProvider, serverConfigStoreProvider;
+import 'cf_login_webview_screen.dart';
 import 'server_picker_screen.dart' show serversListProvider;
 
 /// Probes a candidate server URL with a short-timeout unauthenticated GET
@@ -48,10 +50,19 @@ Future<bool> defaultHealthProbe(String rawUrl) async {
   }
 }
 
+/// Bridge typedef so tests can stub the CF login push without rendering an
+/// actual InAppWebView. Returns the harvested `CF_Authorization` cookie
+/// value, or `null` if the user cancelled.
+typedef CfLoginLauncher = Future<String?> Function(
+  BuildContext context,
+  Uri serverUrl,
+);
+
 class AddServerScreen extends ConsumerStatefulWidget {
   const AddServerScreen({
     required this.onSaved,
     this.healthProbeOverride,
+    this.cfLoginLauncher,
     super.key,
   });
 
@@ -59,6 +70,11 @@ class AddServerScreen extends ConsumerStatefulWidget {
 
   /// Test seam — replaces [defaultHealthProbe] when supplied.
   final Future<bool> Function(String url)? healthProbeOverride;
+
+  /// Test seam — replaces the CF Access WebView push when supplied. In
+  /// production we push [CfLoginWebViewScreen] and resolve with the
+  /// harvested cookie (or `null` if the user backed out).
+  final CfLoginLauncher? cfLoginLauncher;
 
   @override
   ConsumerState<AddServerScreen> createState() => _AddServerScreenState();
@@ -74,6 +90,26 @@ class _AddServerScreenState extends ConsumerState<AddServerScreen> {
   Future<bool> _runProbe(String url) async {
     final probe = widget.healthProbeOverride ?? defaultHealthProbe;
     return probe(url);
+  }
+
+  Future<String?> _runCfLogin(BuildContext context, Uri serverUrl) async {
+    final launcher = widget.cfLoginLauncher ?? _defaultCfLoginLauncher;
+    return launcher(context, serverUrl);
+  }
+
+  static Future<String?> _defaultCfLoginLauncher(
+    BuildContext context,
+    Uri serverUrl,
+  ) {
+    return Navigator.of(context).push<String?>(
+      MaterialPageRoute<String?>(
+        builder: (routeCtx) => CfLoginWebViewScreen(
+          serverUrl: serverUrl,
+          onSuccess: (cookie) => Navigator.of(routeCtx).pop(cookie),
+          onCancel: () => Navigator.of(routeCtx).pop(),
+        ),
+      ),
+    );
   }
 
   Future<void> _save() async {
@@ -96,13 +132,33 @@ class _AddServerScreenState extends ConsumerState<AddServerScreen> {
           return;
         }
       }
-      final store = ref.read(serverConfigStoreProvider);
+
+      // Open the CF Access WebView and wait for the user to either
+      // complete sign-in (we get back a cookie) or cancel (null).
+      if (!mounted) return;
+      final cookie = await _runCfLogin(context, Uri.parse(url));
+      if (!mounted) return;
+      if (cookie == null) {
+        setState(() {
+          _probeError = 'Sign-in cancelled.';
+        });
+        return;
+      }
+
       final config = ServerConfig(
         id: const Uuid().v4(),
         label: _labelCtrl.text.trim(),
         url: url,
         lastUsedAt: DateTime.now(),
       );
+
+      // Persist the cookie BEFORE upserting the server record so that any
+      // listener that reacts to a new server (e.g. Dio building a client
+      // for it) finds the cookie already in place.
+      final storage = ref.read(secureStorageProvider);
+      await storage.write(config.id, 'cf_authorization', cookie);
+
+      final store = ref.read(serverConfigStoreProvider);
       await store.upsert(config);
       await store.setActive(config.id);
       ref.invalidate(serversListProvider);

--- a/mobile/lib/presentation/screens/server_picker/cf_login_webview_screen.dart
+++ b/mobile/lib/presentation/screens/server_picker/cf_login_webview_screen.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../infrastructure/webview/navigation_policy.dart';
+import '../../../infrastructure/webview/webview_factory.dart';
+
+/// Returns the value of the `CF_Authorization` cookie from a list of
+/// cookies (case-insensitive name match per HTTP spec, but in practice CF
+/// always emits it as `CF_Authorization`).
+///
+/// Exposed at top-level so it can be unit-tested without spinning up a
+/// real WebView.
+String? extractCfAuthorizationCookie(List<Cookie> cookies) {
+  for (final cookie in cookies) {
+    if (cookie.name.toLowerCase() == 'cf_authorization') {
+      final value = cookie.value;
+      if (value is String && value.isNotEmpty) return value;
+    }
+  }
+  return null;
+}
+
+/// Returns true if [uri]'s host is the CF Access challenge subdomain
+/// rather than the server origin. We use this to skip cookie reads while
+/// the user is still being challenged — CF only sets `CF_Authorization`
+/// on the *server origin* once the challenge completes and the redirect
+/// lands back there.
+bool isCfAccessChallengeHost(Uri uri) {
+  final host = uri.host.toLowerCase();
+  return host.endsWith('.cloudflareaccess.com') ||
+      host == 'cloudflareaccess.com';
+}
+
+/// Full-screen WebView shown after Add Server health-probe succeeds.
+///
+/// Loads the server URL, lets the user complete a CF Access challenge
+/// (incl. Google/Microsoft/Okta SSO redirects), and as soon as the
+/// WebView returns to the server origin AND `CF_Authorization` is
+/// present in CookieManager, calls [onSuccess] with the cookie value.
+///
+/// Spec §3 — the WebView is the source-of-truth for the cookie; the
+/// caller is responsible for relaying it into `flutter_secure_storage`
+/// for Dio's `_AuthInterceptor` to read on every request.
+class CfLoginWebViewScreen extends ConsumerStatefulWidget {
+  const CfLoginWebViewScreen({
+    required this.serverUrl,
+    required this.onSuccess,
+    required this.onCancel,
+    this.cookieManager,
+    this.webViewFactory,
+    super.key,
+  });
+
+  final Uri serverUrl;
+  final void Function(String cookieValue) onSuccess;
+  final VoidCallback onCancel;
+
+  /// Test seam — defaults to [CookieManager.instance()] in production.
+  final CookieManager? cookieManager;
+
+  /// Test seam — defaults to a real [WebViewFactory]. Tests can substitute
+  /// a fake factory that returns an empty widget so the unit suite doesn't
+  /// have to host a real WebView.
+  final WebViewFactory? webViewFactory;
+
+  @override
+  ConsumerState<CfLoginWebViewScreen> createState() =>
+      _CfLoginWebViewScreenState();
+}
+
+class _CfLoginWebViewScreenState extends ConsumerState<CfLoginWebViewScreen> {
+  bool _completed = false;
+
+  Future<void> _maybeHarvestCookie(Uri? currentUrl) async {
+    if (_completed) return;
+    if (currentUrl == null) return;
+    // Don't try to read cookies while we're still on the CF Access
+    // subdomain — the cookie is only set on the server origin.
+    if (isCfAccessChallengeHost(currentUrl)) return;
+    if (currentUrl.origin != widget.serverUrl.origin) return;
+
+    final manager = widget.cookieManager ?? CookieManager.instance();
+    final cookies = await manager.getCookies(
+      url: WebUri(widget.serverUrl.toString()),
+    );
+    final value = extractCfAuthorizationCookie(cookies);
+    if (value == null) return;
+    if (!mounted || _completed) return;
+    _completed = true;
+    widget.onSuccess(value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final policy = NavigationPolicy.forLogin(serverOrigin: widget.serverUrl);
+    final factory = widget.webViewFactory ?? const WebViewFactory();
+    return Scaffold(
+      backgroundColor: const Color(0xFF1A1B26),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF1A1B26),
+        foregroundColor: Colors.white,
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () {
+            if (_completed) return;
+            _completed = true;
+            widget.onCancel();
+          },
+        ),
+        title: Text(
+          'Sign in to ${widget.serverUrl.host}',
+          style: const TextStyle(color: Colors.white),
+        ),
+      ),
+      body: SafeArea(
+        child: factory.build(
+          initialUrl: widget.serverUrl,
+          policy: policy,
+          onLinkOpen: (uri) {
+            // No-op during login: the navigation policy already allow-lists
+            // the SSO providers we expect, so anything intercepted here is
+            // an unexpected outbound link we deliberately drop.
+            debugPrint('CF login: external link suppressed: $uri');
+          },
+          onLoadStop: (controller, url) async {
+            await _maybeHarvestCookie(url?.uriValue);
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/test/infrastructure/webview/navigation_policy_test.dart
+++ b/mobile/test/infrastructure/webview/navigation_policy_test.dart
@@ -2,33 +2,102 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:remote_dev/infrastructure/webview/navigation_policy.dart';
 
 void main() {
-  final policy = NavigationPolicy(serverOrigin: Uri.parse('https://dev.example.com'));
-
-  test('allows /m/* on the server origin', () {
-    expect(
-      policy.decide(Uri.parse('https://dev.example.com/m/session/abc')),
-      NavigationDecision.allow,
+  group('default policy (in-session)', () {
+    final policy = NavigationPolicy(
+      serverOrigin: Uri.parse('https://dev.example.com'),
     );
+
+    test('allows /m/* on the server origin', () {
+      expect(
+        policy.decide(Uri.parse('https://dev.example.com/m/session/abc')),
+        NavigationDecision.allow,
+      );
+    });
+
+    test('intercepts non-/m/ on the server origin', () {
+      expect(
+        policy.decide(Uri.parse('https://dev.example.com/sessions')),
+        NavigationDecision.intercept,
+      );
+    });
+
+    test('allows Cloudflare Access challenge URLs', () {
+      expect(
+        policy.decide(Uri.parse('https://example.cloudflareaccess.com/login')),
+        NavigationDecision.allow,
+      );
+    });
+
+    test('opens external links externally', () {
+      expect(
+        policy.decide(Uri.parse('https://github.com/btli/remote-dev')),
+        NavigationDecision.interceptAndOpenExternally,
+      );
+    });
+
+    test('does NOT allow Google SSO in the default policy', () {
+      // Terminal output could contain a google.com link; we deliberately
+      // don't auto-load those in-place during a session.
+      expect(
+        policy.decide(Uri.parse('https://accounts.google.com/o/oauth2/auth')),
+        NavigationDecision.interceptAndOpenExternally,
+      );
+    });
   });
 
-  test('intercepts non-/m/ on the server origin', () {
-    expect(
-      policy.decide(Uri.parse('https://dev.example.com/sessions')),
-      NavigationDecision.intercept,
+  group('login policy (Add Server / re-auth)', () {
+    final policy = NavigationPolicy.forLogin(
+      serverOrigin: Uri.parse('https://dev.example.com'),
     );
-  });
 
-  test('allows Cloudflare Access challenge URLs', () {
-    expect(
-      policy.decide(Uri.parse('https://example.cloudflareaccess.com/login')),
-      NavigationDecision.allow,
-    );
-  });
+    test('allows the server origin (any path, not just /m/)', () {
+      expect(
+        policy.decide(Uri.parse('https://dev.example.com/')),
+        NavigationDecision.allow,
+      );
+      expect(
+        policy.decide(Uri.parse('https://dev.example.com/login')),
+        NavigationDecision.allow,
+      );
+    });
 
-  test('opens external links externally', () {
-    expect(
-      policy.decide(Uri.parse('https://github.com/btli/remote-dev')),
-      NavigationDecision.interceptAndOpenExternally,
-    );
+    test('allows Cloudflare Access challenge URLs', () {
+      final uri = Uri.parse(
+        'https://example.cloudflareaccess.com/cdn-cgi/access/login',
+      );
+      expect(policy.decide(uri), NavigationDecision.allow);
+    });
+
+    test('allows Google SSO', () {
+      final uri = Uri.parse(
+        'https://accounts.google.com/o/oauth2/auth?response_type=code',
+      );
+      expect(policy.decide(uri), NavigationDecision.allow);
+    });
+
+    test('allows Microsoft SSO (microsoftonline + live)', () {
+      final ms = Uri.parse(
+        'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+      );
+      expect(policy.decide(ms), NavigationDecision.allow);
+      expect(
+        policy.decide(Uri.parse('https://login.live.com/oauth20_authorize.srf')),
+        NavigationDecision.allow,
+      );
+    });
+
+    test('allows Okta (any subdomain)', () {
+      expect(
+        policy.decide(Uri.parse('https://myco.okta.com/login/sso_iwa_auth')),
+        NavigationDecision.allow,
+      );
+    });
+
+    test('still intercepts random external URLs externally', () {
+      expect(
+        policy.decide(Uri.parse('https://example.com/')),
+        NavigationDecision.interceptAndOpenExternally,
+      );
+    });
   });
 }

--- a/mobile/test/presentation/screens/server_picker/add_server_screen_test.dart
+++ b/mobile/test/presentation/screens/server_picker/add_server_screen_test.dart
@@ -2,15 +2,30 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:remote_dev/application/ports/secure_storage_port.dart';
 import 'package:remote_dev/application/ports/server_config_store.dart';
 import 'package:remote_dev/domain/server_config.dart';
+import 'package:remote_dev/infrastructure/storage/flutter_secure_storage_port.dart';
 import 'package:remote_dev/presentation/screens/server_picker/add_server_screen.dart';
 import 'package:remote_dev/presentation/screens/webview_host/session_route_host.dart'
-    show serverConfigStoreProvider;
+    show secureStorageProvider, serverConfigStoreProvider;
 
 class _MockStore extends Mock implements ServerConfigStore {}
 
 class _FakeServerConfig extends Fake implements ServerConfig {}
+
+class _FakeStorage extends Fake implements FlutterSecureStoragePort {
+  final Map<String, String> writes = <String, String>{};
+
+  @override
+  Future<void> write(String serverId, String key, String value) async {
+    writes['$serverId/$key'] = value;
+  }
+
+  // The other SecureStoragePort methods aren't exercised by these tests;
+  // delegate to the abstract Fake error-on-call default by leaving them
+  // unimplemented here.
+}
 
 void main() {
   setUpAll(() {
@@ -21,17 +36,24 @@ void main() {
     WidgetTester tester, {
     required _MockStore store,
     required Future<bool> Function(String) probe,
+    required CfLoginLauncher cfLogin,
+    SecureStoragePort? storage,
     void Function(ServerConfig)? onSaved,
   }) {
     return tester.pumpWidget(
       ProviderScope(
         overrides: [
           serverConfigStoreProvider.overrideWithValue(store),
+          if (storage != null)
+            secureStorageProvider.overrideWithValue(
+              storage as FlutterSecureStoragePort,
+            ),
         ],
         child: MaterialApp(
           home: AddServerScreen(
             onSaved: onSaved ?? (_) {},
             healthProbeOverride: probe,
+            cfLoginLauncher: cfLogin,
           ),
         ),
       ),
@@ -39,18 +61,25 @@ void main() {
   }
 
   testWidgets(
-    'happy path: probe returns true, server is upserted + activated',
+    'happy path: probe true, CF login returns cookie, server upserted',
     (tester) async {
       final store = _MockStore();
+      final storage = _FakeStorage();
       when(() => store.upsert(any())).thenAnswer((_) async {});
       when(() => store.setActive(any())).thenAnswer((_) async {});
       when(store.loadAll).thenAnswer((_) async => const []);
 
       ServerConfig? saved;
+      Uri? capturedLoginUrl;
       await pumpAddServer(
         tester,
         store: store,
+        storage: storage,
         probe: (_) async => true,
+        cfLogin: (ctx, url) async {
+          capturedLoginUrl = url;
+          return 'jwt-token';
+        },
         onSaved: (cfg) => saved = cfg,
       );
 
@@ -70,16 +99,17 @@ void main() {
       expect(saved, isNotNull);
       expect(saved!.label, 'Work');
       expect(saved!.url, 'https://dev.example.com');
+      expect(capturedLoginUrl, Uri.parse('https://dev.example.com'));
+      // Cookie was persisted under the new server's id.
+      expect(storage.writes['${saved!.id}/cf_authorization'], 'jwt-token');
     },
   );
 
   testWidgets(
-    'unreachable URL: shows confirm dialog; cancel skips upsert',
-    // Skipped: real Dio timeout (5s) exceeds pumpAndSettle tolerance —
-    // covered by manual smoke test on device.
-    skip: true,
+    'CF login cancelled: server is NOT saved and we surface the cancellation',
     (tester) async {
       final store = _MockStore();
+      final storage = _FakeStorage();
       when(() => store.upsert(any())).thenAnswer((_) async {});
       when(() => store.setActive(any())).thenAnswer((_) async {});
 
@@ -87,7 +117,9 @@ void main() {
       await pumpAddServer(
         tester,
         store: store,
-        probe: (_) async => false,
+        storage: storage,
+        probe: (_) async => true,
+        cfLogin: (_, __) async => null,
         onSaved: (cfg) => saved = cfg,
       );
 
@@ -100,67 +132,22 @@ void main() {
         'Work',
       );
       await tester.tap(find.widgetWithText(ElevatedButton, 'Save'));
-      await tester.pumpAndSettle();
-
-      expect(find.text("Can't reach this server"), findsOneWidget);
-      // Inline error is also shown on the form.
-      expect(
-        find.textContaining("Couldn't reach"),
-        findsWidgets,
-      );
-
-      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
       await tester.pumpAndSettle();
 
       verifyNever(() => store.upsert(any()));
       verifyNever(() => store.setActive(any()));
       expect(saved, isNull);
+      expect(storage.writes, isEmpty);
+      expect(find.text('Sign-in cancelled.'), findsOneWidget);
     },
   );
 
   testWidgets(
-    'unreachable URL: confirm "Save anyway" persists the server',
-    // Skipped: real Dio timeout (5s) exceeds pumpAndSettle tolerance —
-    // covered by manual smoke test on device.
-    skip: true,
-    (tester) async {
-      final store = _MockStore();
-      when(() => store.upsert(any())).thenAnswer((_) async {});
-      when(() => store.setActive(any())).thenAnswer((_) async {});
-
-      ServerConfig? saved;
-      await pumpAddServer(
-        tester,
-        store: store,
-        probe: (_) async => false,
-        onSaved: (cfg) => saved = cfg,
-      );
-
-      await tester.enterText(
-        find.widgetWithText(TextFormField, 'Server URL'),
-        'https://dev.example.com',
-      );
-      await tester.enterText(
-        find.widgetWithText(TextFormField, 'Label'),
-        'Work',
-      );
-      await tester.tap(find.widgetWithText(ElevatedButton, 'Save'));
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.widgetWithText(TextButton, 'Save anyway'));
-      await tester.pumpAndSettle();
-
-      verify(() => store.upsert(any())).called(1);
-      verify(() => store.setActive(any())).called(1);
-      expect(saved, isNotNull);
-    },
-  );
-
-  testWidgets(
-    'invalid URL fails form validation before probing',
+    'invalid URL fails form validation before probing or launching login',
     (tester) async {
       final store = _MockStore();
       var probeCalls = 0;
+      var loginCalls = 0;
 
       await pumpAddServer(
         tester,
@@ -168,6 +155,10 @@ void main() {
         probe: (_) async {
           probeCalls += 1;
           return true;
+        },
+        cfLogin: (_, __) async {
+          loginCalls += 1;
+          return 'jwt';
         },
       );
 
@@ -187,6 +178,7 @@ void main() {
         findsOneWidget,
       );
       expect(probeCalls, 0);
+      expect(loginCalls, 0);
       verifyNever(() => store.upsert(any()));
     },
   );

--- a/mobile/test/presentation/screens/server_picker/cf_login_webview_screen_test.dart
+++ b/mobile/test/presentation/screens/server_picker/cf_login_webview_screen_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/presentation/screens/server_picker/cf_login_webview_screen.dart';
+
+void main() {
+  group('extractCfAuthorizationCookie', () {
+    test('returns the cookie value when present', () {
+      final cookies = [
+        Cookie(name: 'other', value: 'x'),
+        Cookie(name: 'CF_Authorization', value: 'jwt-token'),
+      ];
+      expect(extractCfAuthorizationCookie(cookies), 'jwt-token');
+    });
+
+    test('matches cookie name case-insensitively', () {
+      final cookies = [
+        Cookie(name: 'cf_authorization', value: 'lower-case-token'),
+      ];
+      expect(extractCfAuthorizationCookie(cookies), 'lower-case-token');
+    });
+
+    test('returns null when CF_Authorization is absent', () {
+      final cookies = [
+        Cookie(name: 'session', value: 'foo'),
+        Cookie(name: 'csrftoken', value: 'bar'),
+      ];
+      expect(extractCfAuthorizationCookie(cookies), isNull);
+    });
+
+    test('returns null when value is empty', () {
+      final cookies = [Cookie(name: 'CF_Authorization', value: '')];
+      expect(extractCfAuthorizationCookie(cookies), isNull);
+    });
+
+    test('returns null on empty cookie list', () {
+      expect(extractCfAuthorizationCookie(const []), isNull);
+    });
+  });
+
+  group('isCfAccessChallengeHost', () {
+    test('matches the cloudflareaccess.com apex and subdomains', () {
+      final challenge = Uri.parse(
+        'https://example.cloudflareaccess.com/cdn-cgi/access/login',
+      );
+      expect(isCfAccessChallengeHost(challenge), isTrue);
+      expect(
+        isCfAccessChallengeHost(Uri.parse('https://cloudflareaccess.com/')),
+        isTrue,
+      );
+    });
+
+    test('does not match the server origin', () {
+      expect(
+        isCfAccessChallengeHost(Uri.parse('https://dev.example.com/')),
+        isFalse,
+      );
+    });
+
+    test('does not match unrelated SSO providers', () {
+      expect(
+        isCfAccessChallengeHost(Uri.parse('https://accounts.google.com/')),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- New `CfLoginWebViewScreen` opens a full-screen WebView at the new server URL after the Add Server health probe.
- WebView allows CF Access challenges + well-known SSO providers (Google, Microsoft, Okta) and any path on the server origin.
- On successful return to server origin, harvests `CF_Authorization` cookie via `CookieManager.getCookies()` and persists to secure storage.
- Cookie key: `cf_authorization` (matches existing `CookieReader.captureCfAuthorization` convention — A.2 will read from the same key).
- New `NavigationPolicy.forLogin(...)` constructor — default in-session policy unchanged.
- Cookie persisted before `serverConfigStore.upsert` so listeners see it from the start.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` 204 passing, 1 pre-existing skip
- [x] New tests: navigation_policy login allow-list, cookie extraction helpers, AddServer cancel-doesn't-save

## Follow-ups
- A.2 (Dio injection) reads from `server.<id>.cf_authorization` secure-storage key
- Live WebView widget test deliberately skipped (flutter_inappwebview doesn't render in test harness)

Closes remote-dev-hgrq.

This pull request and its description were written by Isaac.