### PR TITLE
feat(mobile): Android back gesture pops to default tab (remote-dev-5q6p)

### DIFF
--- a/mobile/lib/presentation/screens/shell/home_shell.dart
+++ b/mobile/lib/presentation/screens/shell/home_shell.dart
@@ -24,23 +24,38 @@ class _HomeShellState extends ConsumerState<HomeShell> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: const Color(0xFF1A1B26),
-      body: SafeArea(
-        bottom: false,
-        child: IndexedStack(
-          index: _active.index,
-          children: const [
-            SessionsTabScreen(),
-            ChannelsTabScreen(),
-            NotificationsTabScreen(),
-            ProfileTabScreen(),
-          ],
+    // Intercept system back gesture (Android predictive back / hardware back):
+    // when the user is on a non-default tab, pop should switch back to the
+    // sessions tab instead of letting go_router pop HomeShell off the stack
+    // (which would exit the app). Only when already on the sessions tab do we
+    // allow the system to handle the pop normally.
+    final canPop = _active == HomeTab.sessions;
+    return PopScope(
+      canPop: canPop,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
+        if (_active != HomeTab.sessions) {
+          setState(() => _active = HomeTab.sessions);
+        }
+      },
+      child: Scaffold(
+        backgroundColor: const Color(0xFF1A1B26),
+        body: SafeArea(
+          bottom: false,
+          child: IndexedStack(
+            index: _active.index,
+            children: const [
+              SessionsTabScreen(),
+              ChannelsTabScreen(),
+              NotificationsTabScreen(),
+              ProfileTabScreen(),
+            ],
+          ),
         ),
-      ),
-      bottomNavigationBar: AdaptiveBottomBar(
-        activeTab: _active,
-        onTabSelected: (tab) => setState(() => _active = tab),
+        bottomNavigationBar: AdaptiveBottomBar(
+          activeTab: _active,
+          onTabSelected: (tab) => setState(() => _active = tab),
+        ),
       ),
     );
   }

--- a/mobile/test/presentation/screens/shell/home_shell_test.dart
+++ b/mobile/test/presentation/screens/shell/home_shell_test.dart
@@ -144,4 +144,51 @@ void main() {
       expect(find.text('No sessions yet'), findsNothing);
     },
   );
+
+  testWidgets(
+    'system back on non-default tab switches to sessions tab '
+    'and consumes the pop',
+    (tester) async {
+      await tester.pumpWidget(
+        wrap(const HomeShell(initialTab: HomeTab.profile)),
+      );
+      await tester.pumpAndSettle();
+      // Profile tab is mounted on entry.
+      expect(find.text('Account'), findsOneWidget);
+      expect(find.text('No sessions yet'), findsNothing);
+
+      // Simulate Android system back gesture. PopScope.canPop is false on
+      // non-default tabs, so the route is NOT popped — onPopInvokedWithResult
+      // fires and HomeShell switches its IndexedStack back to sessions.
+      final popped = await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      // The pop was consumed (not bubbled up to the navigator), so
+      // handlePopRoute reports true (route handled) but HomeShell is still
+      // mounted with the sessions tab active.
+      expect(popped, isTrue);
+      expect(find.text('No sessions yet'), findsOneWidget);
+      // Profile-only content is no longer the active tab body.
+      expect(find.byType(HomeShell), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'system back on sessions tab does NOT switch tabs (allows app exit)',
+    (tester) async {
+      await tester.pumpWidget(wrap(const HomeShell()));
+      await tester.pumpAndSettle();
+      expect(find.text('No sessions yet'), findsOneWidget);
+
+      // On the default tab PopScope.canPop is true, so the system handles
+      // the pop. In a single-route MaterialApp test the navigator can't
+      // actually pop the root, but the key behaviour is: HomeShell does
+      // NOT trap the gesture and stays on sessions.
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(find.text('No sessions yet'), findsOneWidget);
+      expect(find.byType(HomeShell), findsOneWidget);
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- Wraps `HomeShell` Scaffold in `PopScope` (Flutter's predictive-back-compatible API).
- `canPop = _active == HomeTab.sessions` — system pop allowed only on default tab.
- On non-default tab, intercepts the pop and `setState` switches back to Sessions tab.
- `IndexedStack` semantics unchanged; `BiometricLockOverlay` from main.dart unaffected.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — 192/192 passing, 3 pre-existing skips
- [x] Two new tests in home_shell_test.dart (initialTab=profile pops to sessions; sessions tab does not trap)

Closes remote-dev-5q6p.

This pull request and its description were written by Isaac.