### PR TITLE
feat(mobile): ensure AppBar back buttons on all sub-screens (remote-dev-q029)

### DIFF
--- a/mobile/lib/presentation/router/app_router.dart
+++ b/mobile/lib/presentation/router/app_router.dart
@@ -223,6 +223,7 @@ class _EditMissingExtraScreen extends StatelessWidget {
           'Edit server',
           style: TextStyle(color: Colors.white),
         ),
+        iconTheme: const IconThemeData(color: Colors.white),
       ),
       body: Center(
         child: Padding(

--- a/mobile/lib/presentation/screens/biometric/biometric_settings_screen.dart
+++ b/mobile/lib/presentation/screens/biometric/biometric_settings_screen.dart
@@ -68,6 +68,7 @@ class _BiometricSettingsScreenState
       appBar: AppBar(
         backgroundColor: const Color(0xFF1A1B26),
         title: const Text('Security', style: TextStyle(color: Colors.white)),
+        iconTheme: const IconThemeData(color: Colors.white),
       ),
       body: _buildBody(),
     );

--- a/mobile/lib/presentation/screens/bridge_spike/bridge_spike_screen.dart
+++ b/mobile/lib/presentation/screens/bridge_spike/bridge_spike_screen.dart
@@ -61,6 +61,7 @@ class _BridgeSpikeScreenState extends ConsumerState<BridgeSpikeScreen> {
               'Bridge spike',
               style: TextStyle(color: Colors.white),
             ),
+            iconTheme: const IconThemeData(color: Colors.white),
           ),
           // Spec §4 mandate: WebView height is FIXED regardless of the
           // keyboard inset. We compute it via LayoutBuilder as

--- a/mobile/lib/presentation/screens/server_picker/add_server_screen.dart
+++ b/mobile/lib/presentation/screens/server_picker/add_server_screen.dart
@@ -205,6 +205,7 @@ class _AddServerScreenState extends ConsumerState<AddServerScreen> {
       appBar: AppBar(
         backgroundColor: const Color(0xFF1A1B26),
         title: const Text('Add server', style: TextStyle(color: Colors.white)),
+        iconTheme: const IconThemeData(color: Colors.white),
       ),
       body: Form(
         key: _formKey,

--- a/mobile/lib/presentation/screens/server_picker/edit_server_screen.dart
+++ b/mobile/lib/presentation/screens/server_picker/edit_server_screen.dart
@@ -71,6 +71,7 @@ class _EditServerScreenState extends ConsumerState<EditServerScreen> {
       appBar: AppBar(
         backgroundColor: const Color(0xFF1A1B26),
         title: const Text('Edit server', style: TextStyle(color: Colors.white)),
+        iconTheme: const IconThemeData(color: Colors.white),
       ),
       body: Form(
         key: _formKey,

--- a/mobile/lib/presentation/screens/session_view/session_status_bar.dart
+++ b/mobile/lib/presentation/screens/session_view/session_status_bar.dart
@@ -2,12 +2,22 @@ import 'package:flutter/material.dart';
 
 import 'activity_pip.dart';
 
+/// Custom 44px chrome rendered above the session WebView.
+///
+/// This screen does not use a Material [AppBar] — the WebView height is
+/// computed from a fixed budget (44 status + 44 smart-keys + 56 input)
+/// and an AppBar would push everything down (Spec §4). So we provide the
+/// back-arrow affordance inline. When [onBack] is not supplied, tapping
+/// the leading icon falls back to [Navigator.maybePop] so the route's
+/// previous entry handles the back gesture exactly like an AppBar's
+/// implicit back button would.
 class SessionStatusBar extends StatelessWidget {
   const SessionStatusBar({
     required this.projectName,
     required this.sessionName,
     required this.activity,
     this.onTap,
+    this.onBack,
     super.key,
   });
 
@@ -16,46 +26,77 @@ class SessionStatusBar extends StatelessWidget {
   final SessionActivity activity;
   final VoidCallback? onTap;
 
+  /// Override for the leading back button. When null, the button calls
+  /// `Navigator.of(context).maybePop()`.
+  final VoidCallback? onBack;
+
   @override
   Widget build(BuildContext context) {
     return Material(
       color: const Color(0xFF24283B),
-      child: InkWell(
-        onTap: onTap,
-        child: Container(
-          height: 44,
-          padding: const EdgeInsets.symmetric(horizontal: 12),
-          child: Row(
-            children: [
-              ActivityPip(activity: activity),
-              const SizedBox(width: 8),
-              if (projectName != null) ...[
-                Flexible(
-                  child: Text(
-                    projectName!,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(color: Colors.white70, fontSize: 13),
+      child: SizedBox(
+        height: 44,
+        child: Row(
+          children: [
+            IconButton(
+              icon: const Icon(Icons.arrow_back, color: Colors.white, size: 20),
+              tooltip: 'Back',
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              constraints: const BoxConstraints.tightFor(height: 44),
+              splashRadius: 20,
+              onPressed: onBack ?? () => Navigator.of(context).maybePop(),
+            ),
+            Expanded(
+              child: InkWell(
+                onTap: onTap,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  child: Row(
+                    children: [
+                      ActivityPip(activity: activity),
+                      const SizedBox(width: 8),
+                      if (projectName != null) ...[
+                        Flexible(
+                          child: Text(
+                            projectName!,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: Colors.white70,
+                              fontSize: 13,
+                            ),
+                          ),
+                        ),
+                        const Padding(
+                          padding: EdgeInsets.symmetric(horizontal: 6),
+                          child: Text(
+                            '·',
+                            style:
+                                TextStyle(color: Colors.white38, fontSize: 13),
+                          ),
+                        ),
+                      ],
+                      Flexible(
+                        child: Text(
+                          sessionName,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 13,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      const Icon(
+                        Icons.expand_more,
+                        color: Colors.white38,
+                        size: 18,
+                      ),
+                    ],
                   ),
-                ),
-                const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 6),
-                  child: Text(
-                    '·',
-                    style: TextStyle(color: Colors.white38, fontSize: 13),
-                  ),
-                ),
-              ],
-              Flexible(
-                child: Text(
-                  sessionName,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(color: Colors.white, fontSize: 13),
                 ),
               ),
-              const SizedBox(width: 8),
-              const Icon(Icons.expand_more, color: Colors.white38, size: 18),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/mobile/test/presentation/screens/profile/back_button_test.dart
+++ b/mobile/test/presentation/screens/profile/back_button_test.dart
@@ -1,0 +1,104 @@
+// Verifies that profile sub-screens reachable via `context.push` from the
+// profile tab show the implicit Material AppBar back button (BackButton)
+// thanks to `automaticallyImplyLeading: true` (the default) once a route
+// is on the back stack.
+//
+// Sister task B.1 (PR #246/follow-up) switched these sub-routes from
+// `context.go` to `context.push`, and remote-dev-q029 audits the AppBars
+// to ensure every pushed screen actually surfaces a back-arrow.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:remote_dev/presentation/screens/profile/about_screen.dart';
+import 'package:remote_dev/presentation/screens/profile/account_screen.dart';
+
+Widget _wrap({required String pushTarget, required Widget target}) {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, _) => Scaffold(
+          appBar: AppBar(title: const Text('root')),
+          body: Center(
+            child: ElevatedButton(
+              onPressed: () => context.push(pushTarget),
+              child: const Text('go'),
+            ),
+          ),
+        ),
+      ),
+      GoRoute(path: pushTarget, builder: (_, __) => target),
+    ],
+  );
+  return ProviderScope(child: MaterialApp.router(routerConfig: router));
+}
+
+void main() {
+  testWidgets(
+    'AccountScreen reached via context.push shows an implicit back button',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          pushTarget: '/home/profile/account',
+          target: const AccountScreen(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      // No back button on the root.
+      expect(find.byType(BackButton), findsNothing);
+
+      await tester.tap(find.text('go'));
+      await tester.pumpAndSettle();
+
+      // After push the AppBar should auto-imply a leading BackButton.
+      expect(find.text('Account'), findsOneWidget);
+      expect(find.byType(BackButton), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'AboutScreen reached via context.push shows an implicit back button',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          pushTarget: '/home/profile/about',
+          target: const AboutScreen(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('go'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('About'), findsOneWidget);
+      expect(find.byType(BackButton), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'tapping the implicit back button pops back to the previous route',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          pushTarget: '/home/profile/account',
+          target: const AccountScreen(),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('go'));
+      await tester.pumpAndSettle();
+
+      // Sanity check: we're on the pushed route.
+      expect(find.text('Account'), findsOneWidget);
+
+      await tester.tap(find.byType(BackButton));
+      await tester.pumpAndSettle();
+
+      // Back to root: the "go" button is visible again.
+      expect(find.text('go'), findsOneWidget);
+    },
+  );
+}

--- a/mobile/test/presentation/screens/session_view/session_status_bar_test.dart
+++ b/mobile/test/presentation/screens/session_view/session_status_bar_test.dart
@@ -51,7 +51,7 @@ void main() {
     expect(find.byType(ActivityPip), findsOneWidget);
   });
 
-  testWidgets('tap fires onTap', (tester) async {
+  testWidgets('tap on title area fires onTap', (tester) async {
     var taps = 0;
     await tester.pumpWidget(
       wrap(
@@ -64,7 +64,40 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    await tester.tap(find.byType(SessionStatusBar));
+    // Tap the session-name text directly so we hit the InkWell that wraps
+    // the project · session label rather than the leading back-button.
+    await tester.tap(find.text('s'));
     expect(taps, 1);
+  });
+
+  testWidgets('shows leading back button', (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        const SessionStatusBar(
+          projectName: 'p',
+          sessionName: 's',
+          activity: SessionActivity.idle,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+  });
+
+  testWidgets('back button fires onBack when supplied', (tester) async {
+    var backs = 0;
+    await tester.pumpWidget(
+      wrap(
+        SessionStatusBar(
+          projectName: 'p',
+          sessionName: 's',
+          activity: SessionActivity.idle,
+          onBack: () => backs++,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.arrow_back));
+    expect(backs, 1);
   });
 }


### PR DESCRIPTION
## Summary
- Adds `iconTheme: IconThemeData(color: Colors.white)` to AppBars on Tokyo Night dark backgrounds (biometric, add_server, edit_server, bridge_spike, _EditMissingExtraScreen) so the implicit back-arrow renders white.
- `SessionViewScreen` (no AppBar by design — fixed 44+44+56 height budget per spec §4): extends `SessionStatusBar` with a leading back-arrow `IconButton` (44px row height preserved). New `onBack` param defaults to `Navigator.maybePop()`.
- New widget test `back_button_test.dart` mounts a real GoRouter with root + pushed sub-route and asserts BackButton presence + functional pop.
- No `automaticallyImplyLeading: false` was found anywhere.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — 195 passing, 3 pre-existing skips

Closes remote-dev-q029.

This pull request and its description were written by Isaac.