### PR TITLE
feat(mobile): reauth flow re-runs CF Access login (remote-dev-d9st)

### DIFF
--- a/mobile/lib/presentation/router/app_router.dart
+++ b/mobile/lib/presentation/router/app_router.dart
@@ -193,8 +193,17 @@ class AppRouter {
         ),
         GoRoute(
           path: '/reauth',
-          builder: (context, state) => ReauthScreen(
-            onReauthenticate: () => context.go('/servers'),
+          builder: (context, state) => Consumer(
+            builder: (context, ref, _) => ReauthScreen(
+              onSuccess: () {
+                // Fresh cookie has been persisted; refresh the active
+                // server provider so any consumer that already cached a
+                // null/expired session re-reads, then bounce home.
+                ref.invalidate(activeServerProvider);
+                context.go('/home');
+              },
+              onCancel: () => context.go('/servers'),
+            ),
           ),
         ),
         GoRoute(

--- a/mobile/lib/presentation/screens/webview_host/reauth_screen.dart
+++ b/mobile/lib/presentation/screens/webview_host/reauth_screen.dart
@@ -1,9 +1,98 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class ReauthScreen extends StatelessWidget {
-  const ReauthScreen({required this.onReauthenticate, super.key});
+import '../server_picker/cf_login_webview_screen.dart';
+import 'session_route_host.dart'
+    show activeServerProvider, secureStorageProvider;
 
-  final VoidCallback onReauthenticate;
+/// Screen we land on whenever Dio sees a 401/403 from the active server
+/// (see `CfAuthInterceptor` + `reauthSignalProvider`). It re-runs the
+/// CF Access WebView login flow against the *active* server, persists the
+/// fresh `CF_Authorization` cookie back into secure storage under the same
+/// `cf_authorization` key the Add Server flow uses, then bounces back to
+/// `/home` so the user resumes where they were.
+///
+/// Two callbacks are accepted so the router can decide where the user
+/// goes after success / cancel:
+///   * [onSuccess] — fired after the new cookie is persisted. Typically
+///     `() => context.go('/home')`.
+///   * [onCancel] — fired when the user backs out of the WebView. Typically
+///     `() => context.go('/servers')` so they can pick a different server.
+///
+/// If there is no active server (edge case — e.g. a stale `/reauth` deep
+/// link after the user wiped their server list), we render a small
+/// "no active server" panel that punts to [onCancel].
+class ReauthScreen extends ConsumerWidget {
+  const ReauthScreen({
+    required this.onSuccess,
+    required this.onCancel,
+    this.cfLoginLauncherOverride,
+    super.key,
+  });
+
+  /// Called after the new cookie is persisted. The router should navigate
+  /// the user back into the app (`/home`).
+  final VoidCallback onSuccess;
+
+  /// Called when the user dismisses the WebView or when there's no active
+  /// server to reauth against. The router should send them to `/servers`.
+  final VoidCallback onCancel;
+
+  /// Test seam — replaces the embedded [CfLoginWebViewScreen] body with a
+  /// fake widget so unit tests don't have to host a real InAppWebView.
+  /// The override receives the same [serverUrl], [onSuccess], [onCancel]
+  /// callbacks the real WebView would.
+  final Widget Function({
+    required Uri serverUrl,
+    required void Function(String cookieValue) onSuccess,
+    required VoidCallback onCancel,
+  })? cfLoginLauncherOverride;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncServer = ref.watch(activeServerProvider);
+    return asyncServer.when(
+      loading: () => const Scaffold(
+        backgroundColor: Color(0xFF1A1B26),
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (e, _) => _NoActiveServer(onCancel: onCancel, message: '$e'),
+      data: (server) {
+        if (server == null) {
+          return _NoActiveServer(onCancel: onCancel);
+        }
+        final serverUrl = Uri.parse(server.url);
+        Future<void> handleSuccess(String cookieValue) async {
+          // Persist the fresh cookie under the same key the Add Server flow
+          // writes to (`cf_authorization`) so `CfAuthInterceptor` picks it
+          // up on its next request.
+          final storage = ref.read(secureStorageProvider);
+          await storage.write(server.id, 'cf_authorization', cookieValue);
+          onSuccess();
+        }
+
+        if (cfLoginLauncherOverride != null) {
+          return cfLoginLauncherOverride!(
+            serverUrl: serverUrl,
+            onSuccess: handleSuccess,
+            onCancel: onCancel,
+          );
+        }
+        return CfLoginWebViewScreen(
+          serverUrl: serverUrl,
+          onSuccess: handleSuccess,
+          onCancel: onCancel,
+        );
+      },
+    );
+  }
+}
+
+class _NoActiveServer extends StatelessWidget {
+  const _NoActiveServer({required this.onCancel, this.message});
+
+  final VoidCallback onCancel;
+  final String? message;
 
   @override
   Widget build(BuildContext context) {
@@ -16,22 +105,29 @@ class ReauthScreen extends StatelessWidget {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                const Icon(Icons.lock_outline, size: 64, color: Color(0xFF7AA2F7)),
+                const Icon(
+                  Icons.lock_outline,
+                  size: 64,
+                  color: Color(0xFF7AA2F7),
+                ),
                 const SizedBox(height: 24),
                 const Text(
-                  'Authentication needed',
+                  'No active server',
                   style: TextStyle(color: Colors.white, fontSize: 22),
                 ),
                 const SizedBox(height: 12),
-                const Text(
-                  'Your session expired. Sign in again to continue.',
+                Text(
+                  message ??
+                      'Sign in to a server to continue. '
+                          'Your saved servers are still available on the '
+                          'next screen.',
                   textAlign: TextAlign.center,
-                  style: TextStyle(color: Colors.white70),
+                  style: const TextStyle(color: Colors.white70),
                 ),
                 const SizedBox(height: 32),
                 ElevatedButton(
-                  onPressed: onReauthenticate,
-                  child: const Text('Re-authenticate'),
+                  onPressed: onCancel,
+                  child: const Text('Choose a server'),
                 ),
               ],
             ),

--- a/mobile/test/presentation/screens/webview_host/reauth_screen_test.dart
+++ b/mobile/test/presentation/screens/webview_host/reauth_screen_test.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:remote_dev/application/ports/server_config_store.dart';
+import 'package:remote_dev/domain/server_config.dart';
+import 'package:remote_dev/infrastructure/storage/flutter_secure_storage_port.dart';
+import 'package:remote_dev/presentation/screens/webview_host/reauth_screen.dart';
+import 'package:remote_dev/presentation/screens/webview_host/session_route_host.dart'
+    show secureStorageProvider, serverConfigStoreProvider;
+
+class _MockStore extends Mock implements ServerConfigStore {}
+
+class _FakeStorage extends Fake implements FlutterSecureStoragePort {
+  final Map<String, String> writes = <String, String>{};
+
+  @override
+  Future<void> write(String serverId, String key, String value) async {
+    writes['$serverId/$key'] = value;
+  }
+}
+
+ServerConfig _config({String id = 'srv-1', String url = 'https://dev.example.com'}) =>
+    ServerConfig(
+      id: id,
+      label: 'Work',
+      url: url,
+      lastUsedAt: DateTime.utc(2025, 1, 1),
+    );
+
+void main() {
+  Future<void> pumpReauth(
+    WidgetTester tester, {
+    required _MockStore store,
+    _FakeStorage? storage,
+    VoidCallback? onSuccess,
+    VoidCallback? onCancel,
+    Widget Function({
+      required Uri serverUrl,
+      required void Function(String cookieValue) onSuccess,
+      required VoidCallback onCancel,
+    })? cfLoginLauncherOverride,
+  }) {
+    return tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          serverConfigStoreProvider.overrideWithValue(store),
+          if (storage != null)
+            secureStorageProvider.overrideWithValue(storage),
+        ],
+        child: MaterialApp(
+          home: ReauthScreen(
+            onSuccess: onSuccess ?? () {},
+            onCancel: onCancel ?? () {},
+            cfLoginLauncherOverride: cfLoginLauncherOverride,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets(
+    'renders no-active-server panel when activeServerProvider has no server',
+    (tester) async {
+      final store = _MockStore();
+      when(store.loadActive).thenAnswer((_) async => null);
+
+      var cancelled = 0;
+      await pumpReauth(
+        tester,
+        store: store,
+        onCancel: () => cancelled++,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No active server'), findsOneWidget);
+      // Tapping the CTA invokes onCancel.
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Choose a server'));
+      await tester.pump();
+      expect(cancelled, 1);
+    },
+  );
+
+  testWidgets(
+    'embeds CF login WebView when an active server is present',
+    (tester) async {
+      final store = _MockStore();
+      when(store.loadActive).thenAnswer((_) async => _config());
+
+      Uri? capturedUrl;
+      await pumpReauth(
+        tester,
+        store: store,
+        cfLoginLauncherOverride: ({
+          required Uri serverUrl,
+          required void Function(String) onSuccess,
+          required VoidCallback onCancel,
+        }) {
+          capturedUrl = serverUrl;
+          return const _FakeWebView();
+        },
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(_FakeWebView), findsOneWidget);
+      expect(capturedUrl, Uri.parse('https://dev.example.com'));
+      // The "no active server" UI should NOT be shown.
+      expect(find.text('No active server'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'on CF login success, persists cookie under cf_authorization and calls onSuccess',
+    (tester) async {
+      final store = _MockStore();
+      final storage = _FakeStorage();
+      when(store.loadActive).thenAnswer((_) async => _config(id: 'srv-42'));
+
+      var successCount = 0;
+      late void Function(String) capturedOnSuccess;
+      await pumpReauth(
+        tester,
+        store: store,
+        storage: storage,
+        onSuccess: () => successCount++,
+        cfLoginLauncherOverride: ({
+          required Uri serverUrl,
+          required void Function(String) onSuccess,
+          required VoidCallback onCancel,
+        }) {
+          capturedOnSuccess = onSuccess;
+          return const _FakeWebView();
+        },
+      );
+      await tester.pumpAndSettle();
+
+      // Simulate the WebView harvesting a fresh cookie.
+      capturedOnSuccess('fresh-jwt');
+      // Allow the async write + onSuccess callback to complete.
+      await tester.pumpAndSettle();
+
+      expect(storage.writes['srv-42/cf_authorization'], 'fresh-jwt');
+      expect(successCount, 1);
+    },
+  );
+
+  testWidgets(
+    'on CF login cancel, propagates to onCancel without writing storage',
+    (tester) async {
+      final store = _MockStore();
+      final storage = _FakeStorage();
+      when(store.loadActive).thenAnswer((_) async => _config());
+
+      var cancelled = 0;
+      late VoidCallback capturedOnCancel;
+      await pumpReauth(
+        tester,
+        store: store,
+        storage: storage,
+        onCancel: () => cancelled++,
+        cfLoginLauncherOverride: ({
+          required Uri serverUrl,
+          required void Function(String) onSuccess,
+          required VoidCallback onCancel,
+        }) {
+          capturedOnCancel = onCancel;
+          return const _FakeWebView();
+        },
+      );
+      await tester.pumpAndSettle();
+
+      capturedOnCancel();
+      await tester.pumpAndSettle();
+
+      expect(cancelled, 1);
+      expect(storage.writes, isEmpty);
+    },
+  );
+}
+
+class _FakeWebView extends StatelessWidget {
+  const _FakeWebView();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      backgroundColor: Color(0xFF1A1B26),
+      body: Center(child: Text('fake-webview')),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- `ReauthScreen` rewritten as `ConsumerWidget`. With an active server, embeds `CfLoginWebViewScreen` directly (option a — no shared-body extraction needed).
- On success, persists fresh cookie to secure storage at `server.<id>.cf_authorization` (matching A.1/A.2), invalidates `activeServerProvider`, and routes to `/home`.
- On cancel, routes to `/servers`. With no active server, shows a "No active server" panel with the same exit.
- `cfLoginLauncherOverride` test seam added to keep widget tests off the real WebView.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — 220 passing, 1 pre-existing skip
- [x] 4 new widget tests covering all branches

Closes remote-dev-d9st. Epic A (CF Access auth) is fully wired end-to-end now.

This pull request and its description were written by Isaac.