### PR TITLE
chore(mobile): profile sub-screen audit (remote-dev-w5f5)

### DIFF
--- a/mobile/lib/presentation/screens/profile/about_screen.dart
+++ b/mobile/lib/presentation/screens/profile/about_screen.dart
@@ -27,7 +27,7 @@ class AboutScreen extends StatelessWidget {
             ),
             SizedBox(height: 8),
             Text(
-              'Phase 4 (development)',
+              'Version 0.1.0 (development build)',
               style: TextStyle(color: Colors.white70),
             ),
             SizedBox(height: 16),

--- a/mobile/lib/presentation/screens/profile/servers_screen.dart
+++ b/mobile/lib/presentation/screens/profile/servers_screen.dart
@@ -1,28 +1,32 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
-class ServersScreen extends StatelessWidget {
+import '../server_picker/server_picker_screen.dart';
+import '../webview_host/session_route_host.dart'
+    show activeServerProvider, serverConfigStoreProvider;
+
+/// Profile → Servers entry point.
+///
+/// Reuses the boot-time [ServerPickerScreen] so the list, add, edit, and
+/// delete flows stay in lockstep. Selecting a server here switches the
+/// active server and bounces to /home, matching the boot picker behavior.
+class ServersScreen extends ConsumerWidget {
   const ServersScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: const Color(0xFF1A1B26),
-      appBar: AppBar(
-        backgroundColor: const Color(0xFF1A1B26),
-        title: const Text('Servers', style: TextStyle(color: Colors.white)),
-        iconTheme: const IconThemeData(color: Colors.white),
-      ),
-      body: const Center(
-        child: Padding(
-          padding: EdgeInsets.all(24),
-          child: Text(
-            'Servers — manage in Phase 5; for now use the server picker '
-            'before sign-in.',
-            style: TextStyle(color: Colors.white70),
-            textAlign: TextAlign.center,
-          ),
-        ),
-      ),
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ServerPickerScreen(
+      onSelect: (server) async {
+        await ref.read(serverConfigStoreProvider).setActive(server.id);
+        ref.invalidate(activeServerProvider);
+        ref.invalidate(serversListProvider);
+        if (context.mounted) {
+          context.go('/home');
+        }
+      },
+      onAdd: () => context.push('/servers/add'),
+      onEdit: (server) => context.push('/servers/edit', extra: server),
     );
   }
 }

--- a/mobile/lib/presentation/screens/profile/servers_screen.dart
+++ b/mobile/lib/presentation/screens/profile/servers_screen.dart
@@ -10,7 +10,10 @@ import '../webview_host/session_route_host.dart'
 ///
 /// Reuses the boot-time [ServerPickerScreen] so the list, add, edit, and
 /// delete flows stay in lockstep. Selecting a server here switches the
-/// active server and bounces to /home, matching the boot picker behavior.
+/// active server and pops back to the Profile tab when this screen was
+/// pushed onto the stack; if there is nothing to pop (e.g. deep-linked at
+/// boot) we fall back to `/home` so the user lands somewhere sane instead
+/// of stranded on this picker.
 class ServersScreen extends ConsumerWidget {
   const ServersScreen({super.key});
 
@@ -21,7 +24,12 @@ class ServersScreen extends ConsumerWidget {
         await ref.read(serverConfigStoreProvider).setActive(server.id);
         ref.invalidate(activeServerProvider);
         ref.invalidate(serversListProvider);
-        if (context.mounted) {
+        if (!context.mounted) return;
+        // Prefer pop so the Profile tab (HomeShell) stays on the back stack;
+        // only force-navigate to /home when there is no prior route.
+        if (context.canPop()) {
+          context.pop();
+        } else {
           context.go('/home');
         }
       },

--- a/mobile/test/presentation/screens/profile/about_screen_test.dart
+++ b/mobile/test/presentation/screens/profile/about_screen_test.dart
@@ -10,6 +10,6 @@ void main() {
 
     expect(find.text('About'), findsOneWidget);
     expect(find.text('Remote Dev'), findsOneWidget);
-    expect(find.text('Phase 4 (development)'), findsOneWidget);
+    expect(find.text('Version 0.1.0 (development build)'), findsOneWidget);
   });
 }

--- a/mobile/test/presentation/screens/profile/servers_screen_test.dart
+++ b/mobile/test/presentation/screens/profile/servers_screen_test.dart
@@ -1,18 +1,34 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:remote_dev/application/ports/server_config_store.dart';
 import 'package:remote_dev/presentation/screens/profile/servers_screen.dart';
+import 'package:remote_dev/presentation/screens/webview_host/session_route_host.dart'
+    show serverConfigStoreProvider;
+
+class _MockStore extends Mock implements ServerConfigStore {}
 
 void main() {
-  testWidgets('ServersScreen renders title and placeholder body',
-      (tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(home: ServersScreen()),
-    );
+  // The profile-tab Servers entry now reuses ServerPickerScreen, so we just
+  // smoke-test that the screen mounts and surfaces the picker's empty state.
+  testWidgets(
+    'ServersScreen mounts the server picker (empty state)',
+    (tester) async {
+      final store = _MockStore();
+      when(store.loadAll).thenAnswer((_) async => const []);
 
-    expect(find.text('Servers'), findsOneWidget);
-    expect(
-      find.textContaining('Servers — manage in Phase 5'),
-      findsOneWidget,
-    );
-  });
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [serverConfigStoreProvider.overrideWithValue(store)],
+          child: const MaterialApp(home: ServersScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Servers'), findsOneWidget);
+      expect(find.text('No servers yet.'), findsOneWidget);
+      expect(find.text('Add a server'), findsOneWidget);
+    },
+  );
 }

--- a/mobile/test/presentation/screens/profile/servers_screen_test.dart
+++ b/mobile/test/presentation/screens/profile/servers_screen_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:remote_dev/application/ports/server_config_store.dart';
+import 'package:remote_dev/domain/server_config.dart';
 import 'package:remote_dev/presentation/screens/profile/servers_screen.dart';
 import 'package:remote_dev/presentation/screens/webview_host/session_route_host.dart'
     show serverConfigStoreProvider;
@@ -29,6 +31,129 @@ void main() {
       expect(find.text('Servers'), findsOneWidget);
       expect(find.text('No servers yet.'), findsOneWidget);
       expect(find.text('Add a server'), findsOneWidget);
+    },
+  );
+
+  // Codex review on remote-dev-w5f5: tapping a row used to call
+  // `context.go('/home')`, which nukes the Profile tab back stack. Behavior
+  // now: setActive(serverId) is called and the route is popped back to
+  // whatever pushed us (here: the synthetic `/profile` root). We use a real
+  // GoRouter so `context.canPop()` returns true and the pop branch is taken.
+  testWidgets(
+    'tapping a server activates it and pops back to the previous route',
+    (tester) async {
+      final store = _MockStore();
+      final server = ServerConfig(
+        id: 'srv-1',
+        label: 'Prod',
+        url: 'https://prod.example.com',
+        lastUsedAt: DateTime.utc(2026, 1, 1),
+      );
+      when(store.loadAll).thenAnswer((_) async => [server]);
+      when(() => store.setActive(any())).thenAnswer((_) async {});
+
+      final router = GoRouter(
+        initialLocation: '/profile',
+        routes: [
+          GoRoute(
+            path: '/profile',
+            builder: (context, _) => Scaffold(
+              appBar: AppBar(title: const Text('profile-root')),
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () => context.push('/profile/servers'),
+                  child: const Text('open-servers'),
+                ),
+              ),
+            ),
+            routes: [
+              GoRoute(
+                path: 'servers',
+                builder: (_, __) => const ServersScreen(),
+              ),
+            ],
+          ),
+          // /home target included so that, if our pop logic ever regresses
+          // to context.go('/home'), the test would still navigate somewhere
+          // valid — but the assertion below proves we did NOT take that path.
+          GoRoute(
+            path: '/home',
+            builder: (_, __) => const Scaffold(body: Text('home-root')),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [serverConfigStoreProvider.overrideWithValue(store)],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Push the Servers screen onto the stack the way the real Profile tab
+      // does (`context.push`).
+      await tester.tap(find.text('open-servers'));
+      await tester.pumpAndSettle();
+      expect(find.text('Servers'), findsOneWidget);
+      expect(find.text('Prod'), findsOneWidget);
+
+      // Tap the row.
+      await tester.tap(find.text('Prod'));
+      await tester.pumpAndSettle();
+
+      // setActive was invoked with the server's id.
+      verify(() => store.setActive('srv-1')).called(1);
+
+      // We popped back to /profile, not navigated to /home.
+      expect(find.text('open-servers'), findsOneWidget);
+      expect(find.text('home-root'), findsNothing);
+    },
+  );
+
+  // Sanity check for the canPop=false fallback: when ServersScreen is the
+  // initial route there is nothing to pop, so onSelect should fall back to
+  // `context.go('/home')`.
+  testWidgets(
+    'tapping a server falls back to /home when canPop is false',
+    (tester) async {
+      final store = _MockStore();
+      final server = ServerConfig(
+        id: 'srv-2',
+        label: 'Staging',
+        url: 'https://staging.example.com',
+        lastUsedAt: DateTime.utc(2026, 1, 1),
+      );
+      when(store.loadAll).thenAnswer((_) async => [server]);
+      when(() => store.setActive(any())).thenAnswer((_) async {});
+
+      final router = GoRouter(
+        initialLocation: '/servers',
+        routes: [
+          GoRoute(
+            path: '/servers',
+            builder: (_, __) => const ServersScreen(),
+          ),
+          GoRoute(
+            path: '/home',
+            builder: (_, __) => const Scaffold(body: Text('home-root')),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [serverConfigStoreProvider.overrideWithValue(store)],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Staging'));
+      await tester.pumpAndSettle();
+
+      verify(() => store.setActive('srv-2')).called(1);
+      expect(find.text('home-root'), findsOneWidget);
     },
   );
 }


### PR DESCRIPTION
## Summary
Audit of profile sub-screens after Epic A (CF Access auth) merge:

| Screen | State | Action |
|---|---|---|
| account | stub ("Phase 5 fills this in.") | filed remote-dev-j323 (P1) |
| github_accounts | stub | filed remote-dev-csb7 (P1) |
| appearance | stub | filed remote-dev-czsf (P2) |
| servers | wired in-place — wraps existing `ServerPickerScreen` | fixed |
| biometric_settings | functional | no-op |
| about | stale "Phase 4" copy | fixed (filed remote-dev-d2f5 for package_info_plus) |

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` 220/220
- [x] Test updates for `servers_screen_test.dart` and `about_screen_test.dart`

## Follow-ups
- remote-dev-j323 (P1): Account screen
- remote-dev-csb7 (P1): GitHub Accounts screen
- remote-dev-czsf (P2): Appearance screen
- remote-dev-d2f5 (P3): About screen real version via package_info_plus

Closes remote-dev-w5f5.

This pull request and its description were written by Isaac.