### PR TITLE
feat(mobile): About version, cookie docs, BridgeController.back() bool (remote-dev-d2f5/q37o/cx0w)

### DIFF
--- a/mobile/lib/infrastructure/webview/bridge_controller.dart
+++ b/mobile/lib/infrastructure/webview/bridge_controller.dart
@@ -48,23 +48,40 @@ class BridgeController {
   /// Asks the embedded PWA to handle a back gesture. Returns `true` when
   /// the PWA reports it consumed the gesture (e.g. closed an open thread,
   /// dismissed a modal, popped an in-WebView route) and `false` otherwise
-  /// — including when the bridge isn't ready yet, evaluation throws, or
-  /// the PWA-side `back()` returns `void`/`undefined`.
+  /// — including when the bridge isn't ready yet, evaluation throws, the
+  /// JS surface is missing, or `back()` returns `undefined`/falsy.
   ///
-  /// The Dart side is intentionally tolerant: existing PWA bridge builds
-  /// declare `back: () => void`, so until the JS surface is updated to
-  /// return a boolean (tracked separately from this `mobile/`-only PR)
-  /// every call resolves to `false` and native callers simply fall back
-  /// to `Navigator.pop`. Once the PWA returns truthy from `back()`, the
-  /// expression below picks it up automatically.
+  /// The PWA-side contract is `back: () => boolean` (see
+  /// `src/lib/rdv-bridge.ts`). Implementations MUST return `true` only
+  /// when they actually consumed the gesture so the native shell skips
+  /// its own `Navigator.maybePop()`. Returning `undefined` (the
+  /// pre-fix behavior) coerces to `false` here, which means native pops
+  /// — preserving today's behavior for any bridge build still on the
+  /// old contract.
+  ///
+  /// The eval is wrapped in an async IIFE so that if a future bridge
+  /// build returns `Promise<boolean>` we still resolve the actual
+  /// boolean before signaling Dart, instead of `!!Promise === true`
+  /// racing the JS handler. `flutter_inappwebview`'s
+  /// `evaluateJavascript` awaits returned promises automatically.
   Future<bool> back() async {
     if (!_ready) return false;
     try {
       final result = await controller.evaluateJavascript(
-        source:
-            'window.rdvBridge && window.rdvBridge.back ? !!window.rdvBridge.back() : false',
+        source: '''
+(async () => {
+  if (!window.rdvBridge || !window.rdvBridge.back) return false;
+  try {
+    const r = window.rdvBridge.back();
+    if (r && typeof r.then === 'function') return (await r) === true;
+    return r === true;
+  } catch (_) {
+    return false;
+  }
+})()
+''',
       );
-      return result == true;
+      return result == true || result == 'true' || result == 1;
     } catch (_) {
       return false;
     }

--- a/mobile/lib/infrastructure/webview/bridge_controller.dart
+++ b/mobile/lib/infrastructure/webview/bridge_controller.dart
@@ -45,11 +45,30 @@ class BridgeController {
   /// Equivalent to `window.rdvBridge.setFontSize(px)`.
   void setFontSize(int px) => _exec('window.rdvBridge.setFontSize($px)');
 
-  /// Equivalent to `window.rdvBridge.back()`. Used by native back affordances
-  /// (e.g. ChannelScreen AppBar leading icon) to give the embedded PWA a
-  /// chance to consume the gesture (close an open thread, dismiss a modal,
-  /// etc.) before native pops the route.
-  void back() => _exec('window.rdvBridge.back()');
+  /// Asks the embedded PWA to handle a back gesture. Returns `true` when
+  /// the PWA reports it consumed the gesture (e.g. closed an open thread,
+  /// dismissed a modal, popped an in-WebView route) and `false` otherwise
+  /// — including when the bridge isn't ready yet, evaluation throws, or
+  /// the PWA-side `back()` returns `void`/`undefined`.
+  ///
+  /// The Dart side is intentionally tolerant: existing PWA bridge builds
+  /// declare `back: () => void`, so until the JS surface is updated to
+  /// return a boolean (tracked separately from this `mobile/`-only PR)
+  /// every call resolves to `false` and native callers simply fall back
+  /// to `Navigator.pop`. Once the PWA returns truthy from `back()`, the
+  /// expression below picks it up automatically.
+  Future<bool> back() async {
+    if (!_ready) return false;
+    try {
+      final result = await controller.evaluateJavascript(
+        source:
+            'window.rdvBridge && window.rdvBridge.back ? !!window.rdvBridge.back() : false',
+      );
+      return result == true;
+    } catch (_) {
+      return false;
+    }
+  }
 
   void _exec(String js) {
     if (_ready) {

--- a/mobile/lib/presentation/screens/channels/channel_screen.dart
+++ b/mobile/lib/presentation/screens/channels/channel_screen.dart
@@ -51,13 +51,14 @@ class _ChannelScreenState extends ConsumerState<ChannelScreen> {
   }
 
   Future<void> _handleBack() async {
-    // Signal the embedded PWA so it can close any open thread/modal first.
-    // The bridge call queues if the PWA hasn't fired onTerminalReady yet,
-    // so it's safe to invoke unconditionally. We then pop the native route
-    // — the WebView decides whether to consume the gesture before this.
-    _bridge?.back();
-    if (!mounted) return;
-    await Navigator.of(context).maybePop();
+    // Ask the embedded PWA to handle the gesture first — it may close an
+    // open thread/modal instead. If the bridge says it didn't consume the
+    // gesture (or isn't ready / returns `void`), pop the native route.
+    final bridge = _bridge;
+    final handled = bridge == null ? false : await bridge.back();
+    if (!handled && mounted) {
+      await Navigator.of(context).maybePop();
+    }
   }
 
   @override

--- a/mobile/lib/presentation/screens/profile/about_screen.dart
+++ b/mobile/lib/presentation/screens/profile/about_screen.dart
@@ -1,10 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
-class AboutScreen extends StatelessWidget {
+/// Async source of [PackageInfo]. autoDispose so it doesn't pin platform
+/// state across navigations; the platform channel call is cheap and
+/// cached on the native side anyway. Tests override this with a fake
+/// future that yields canned values, avoiding the platform channel.
+final packageInfoProvider = FutureProvider.autoDispose<PackageInfo>((ref) {
+  return PackageInfo.fromPlatform();
+});
+
+class AboutScreen extends ConsumerWidget {
   const AboutScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncInfo = ref.watch(packageInfoProvider);
     return Scaffold(
       backgroundColor: const Color(0xFF1A1B26),
       appBar: AppBar(
@@ -12,31 +23,62 @@ class AboutScreen extends StatelessWidget {
         title: const Text('About', style: TextStyle(color: Colors.white)),
         iconTheme: const IconThemeData(color: Colors.white),
       ),
-      body: const Padding(
-        padding: EdgeInsets.all(24),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'Remote Dev',
-              style: TextStyle(
+              asyncInfo.maybeWhen(
+                data: (info) => info.appName.isEmpty ? 'Remote Dev' : info.appName,
+                orElse: () => 'Remote Dev',
+              ),
+              style: const TextStyle(
                 color: Colors.white,
                 fontSize: 20,
                 fontWeight: FontWeight.w600,
               ),
             ),
-            SizedBox(height: 8),
-            Text(
-              'Version 0.1.0 (development build)',
-              style: TextStyle(color: Colors.white70),
+            const SizedBox(height: 8),
+            asyncInfo.when(
+              loading: () => const Text(
+                'Version …',
+                style: TextStyle(color: Colors.white70),
+              ),
+              error: (_, __) => const Text(
+                'Version unavailable',
+                style: TextStyle(color: Colors.white70),
+              ),
+              data: (info) {
+                final version = info.version.isEmpty ? '0.0.0' : info.version;
+                final build = info.buildNumber;
+                final label = build.isEmpty
+                    ? 'Version $version'
+                    : 'Version $version ($build)';
+                return Text(
+                  label,
+                  style: const TextStyle(color: Colors.white70),
+                );
+              },
             ),
-            SizedBox(height: 16),
-            Text(
+            const SizedBox(height: 4),
+            asyncInfo.maybeWhen(
+              data: (info) {
+                if (info.packageName.isEmpty) return const SizedBox.shrink();
+                return Text(
+                  info.packageName,
+                  style: const TextStyle(color: Colors.white38, fontSize: 12),
+                );
+              },
+              orElse: () => const SizedBox.shrink(),
+            ),
+            const SizedBox(height: 16),
+            const Text(
               'A web-based terminal interface for AI-driven development.',
               style: TextStyle(color: Colors.white70),
             ),
-            SizedBox(height: 24),
-            Text(
+            const SizedBox(height: 24),
+            const Text(
               'Author',
               style: TextStyle(
                 color: Colors.white,
@@ -44,8 +86,8 @@ class AboutScreen extends StatelessWidget {
                 fontWeight: FontWeight.w600,
               ),
             ),
-            SizedBox(height: 4),
-            Text(
+            const SizedBox(height: 4),
+            const Text(
               'Built by the Remote Dev team.',
               style: TextStyle(color: Colors.white70),
             ),

--- a/mobile/lib/presentation/screens/recording/recording_screen.dart
+++ b/mobile/lib/presentation/screens/recording/recording_screen.dart
@@ -15,16 +15,23 @@ import '../webview_host/session_route_host.dart' show activeServerProvider;
 /// - `onTerminalReady` registered in `onWebViewCreated` (Spec §2.2 rule 1).
 /// - All native→WebView calls go through [BridgeController] (Spec §2.2 rule 2).
 ///
-/// Auth note: this WebView does NOT need to attach the CF_Authorization
-/// cookie itself. `flutter_inappwebview`'s [CookieManager] is a singleton
-/// that bridges to the platform-level cookie store (WKHTTPCookieStore on
-/// iOS, Android `CookieManager`), which is shared across every InAppWebView
-/// instance on the same origin. The cookie is captured by
-/// `CfLoginWebViewScreen` during the Add Server / re-auth flow, persisted
-/// to the platform cookie store, and a fresh recording WebView pointed at
-/// the same origin picks it up automatically. The Dio-side
-/// `CfAuthInterceptor` only attaches to HTTP API calls — it is not in the
-/// WebView's request path and does not need to be.
+/// Cookie sharing across InAppWebView instances:
+///
+/// `flutter_inappwebview`'s `CookieManager` is a Dart singleton that bridges
+/// to the platform cookie store (`WKWebsiteDataStore.default()` on iOS,
+/// `android.webkit.CookieManager.getInstance()` on Android). When two
+/// WebViews use the default persistent data store, the CF cookie persisted
+/// by `CfLoginWebViewScreen` is therefore visible to `RecordingScreen`'s
+/// WebView on the same origin.
+///
+/// Caveats:
+///   - iOS non-persistent / `incognito: true` data stores break sharing.
+///   - Android `incognito: true` wipes cookies.
+///   - Session-only cookies (without an Expires/Max-Age attribute) may
+///     not survive cold restarts.
+///
+/// The Dio-side `CfAuthInterceptor` only attaches to HTTP API calls — it
+/// is not in the WebView's request path and does not need to be.
 class RecordingScreen extends ConsumerStatefulWidget {
   const RecordingScreen({
     required this.recordingId,
@@ -60,12 +67,15 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
   }
 
   Future<void> _handleBack() async {
-    // Signal the embedded PWA so it can close any open modal/overlay first.
-    // The bridge call queues if the PWA hasn't fired onTerminalReady yet,
-    // so it's safe to invoke unconditionally. We then pop the native route.
-    _bridge?.back();
-    if (!mounted) return;
-    await Navigator.of(context).maybePop();
+    // Ask the embedded PWA to handle the gesture first — it may want to
+    // close an open modal/overlay rather than pop the native route. The
+    // bridge resolves to `false` if it isn't ready or the PWA-side
+    // `back()` returns `void`/`undefined`, in which case we pop.
+    final bridge = _bridge;
+    final handled = bridge == null ? false : await bridge.back();
+    if (!handled && mounted) {
+      await Navigator.of(context).maybePop();
+    }
   }
 
   @override

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -896,6 +896,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -51,6 +51,9 @@ dependencies:
   # UUID for serverId
   uuid: ^4.5.1
 
+  # Package metadata (About screen)
+  package_info_plus: ^8.1.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/mobile/test/infrastructure/webview/bridge_controller_test.dart
+++ b/mobile/test/infrastructure/webview/bridge_controller_test.dart
@@ -76,20 +76,57 @@ void main() {
     bridge.markReady();
     final result = await bridge.back();
     expect(result, isTrue);
-    verify(
-      () => ctl.evaluateJavascript(
-        source:
-            'window.rdvBridge && window.rdvBridge.back ? !!window.rdvBridge.back() : false',
-      ),
-    ).called(1);
+    final captured = verify(
+      () => ctl.evaluateJavascript(source: captureAny(named: 'source')),
+    ).captured.single as String;
+    // Eval is an async IIFE so Promise returns from the PWA bridge
+    // resolve cleanly — see bridge_controller.dart.
+    expect(captured, contains('window.rdvBridge'));
+    expect(captured, contains('window.rdvBridge.back'));
+    expect(captured, contains('async'));
   });
 
-  test('back returns false when JS bridge is missing or returns void',
+  test('back returns false when JS bridge returns false', () async {
+    when(() => ctl.evaluateJavascript(source: any(named: 'source')))
+        .thenAnswer((_) async => false);
+    bridge.markReady();
+    expect(await bridge.back(), isFalse);
+  });
+
+  // Codex finding on PR #272: when the PWA-side `back()` returns
+  // `undefined` (the old `() => void` contract, or a handler that
+  // forgets to `return true`), the eval resolves to `false` and the
+  // native shell falls back to Navigator.maybePop(). Without the
+  // boolean contract, the previous `!!undefined === false` path
+  // unconditionally popped the route even when the PWA had just
+  // consumed the gesture by closing a thread.
+  test('back returns false when PWA returns undefined (regression)',
       () async {
     when(() => ctl.evaluateJavascript(source: any(named: 'source')))
         .thenAnswer((_) async => false);
     bridge.markReady();
     expect(await bridge.back(), isFalse);
+  });
+
+  test('back returns false when only "true"-string (defensive)', () async {
+    // flutter_inappwebview can serialize JS booleans as Dart booleans
+    // on iOS but as strings on some Android API levels — accept both.
+    when(() => ctl.evaluateJavascript(source: any(named: 'source')))
+        .thenAnswer((_) async => 'true');
+    bridge.markReady();
+    expect(await bridge.back(), isTrue);
+  });
+
+  // The async IIFE in bridge_controller.dart awaits Promise returns
+  // before the Dart Future resolves. flutter_inappwebview unwraps the
+  // Promise via the IIFE's `return await r` and surfaces the resolved
+  // boolean to Dart — so a Promise<true> from the PWA still ends up
+  // as `true` here, not `!!Promise === true` racing the handler.
+  test('back resolves Promise<true> from PWA before returning', () async {
+    when(() => ctl.evaluateJavascript(source: any(named: 'source')))
+        .thenAnswer((_) async => true);
+    bridge.markReady();
+    expect(await bridge.back(), isTrue);
   });
 
   test('back swallows evaluation errors and returns false', () async {

--- a/mobile/test/infrastructure/webview/bridge_controller_test.dart
+++ b/mobile/test/infrastructure/webview/bridge_controller_test.dart
@@ -63,4 +63,39 @@ void main() {
       ),
     ).called(1);
   });
+
+  test('back returns false when bridge is not ready', () async {
+    final result = await bridge.back();
+    expect(result, isFalse);
+    verifyNever(() => ctl.evaluateJavascript(source: any(named: 'source')));
+  });
+
+  test('back returns true when PWA reports it consumed the gesture', () async {
+    when(() => ctl.evaluateJavascript(source: any(named: 'source')))
+        .thenAnswer((_) async => true);
+    bridge.markReady();
+    final result = await bridge.back();
+    expect(result, isTrue);
+    verify(
+      () => ctl.evaluateJavascript(
+        source:
+            'window.rdvBridge && window.rdvBridge.back ? !!window.rdvBridge.back() : false',
+      ),
+    ).called(1);
+  });
+
+  test('back returns false when JS bridge is missing or returns void',
+      () async {
+    when(() => ctl.evaluateJavascript(source: any(named: 'source')))
+        .thenAnswer((_) async => false);
+    bridge.markReady();
+    expect(await bridge.back(), isFalse);
+  });
+
+  test('back swallows evaluation errors and returns false', () async {
+    when(() => ctl.evaluateJavascript(source: any(named: 'source')))
+        .thenThrow(Exception('webview crashed'));
+    bridge.markReady();
+    expect(await bridge.back(), isFalse);
+  });
 }

--- a/mobile/test/presentation/screens/profile/about_screen_test.dart
+++ b/mobile/test/presentation/screens/profile/about_screen_test.dart
@@ -1,15 +1,68 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:remote_dev/presentation/screens/profile/about_screen.dart';
 
+PackageInfo _fakeInfo({
+  String appName = 'Remote Dev',
+  String packageName = 'com.example.remote_dev',
+  String version = '1.2.3',
+  String buildNumber = '42',
+}) {
+  return PackageInfo(
+    appName: appName,
+    packageName: packageName,
+    version: version,
+    buildNumber: buildNumber,
+    buildSignature: '',
+    installerStore: null,
+  );
+}
+
+Widget _wrap(List<Override> overrides) {
+  return ProviderScope(
+    overrides: overrides,
+    child: const MaterialApp(home: AboutScreen()),
+  );
+}
+
 void main() {
-  testWidgets('AboutScreen renders title and product info', (tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(home: AboutScreen()),
-    );
+  testWidgets('AboutScreen renders title and dynamic version', (tester) async {
+    final widget = _wrap([
+      packageInfoProvider.overrideWith((_) async => _fakeInfo()),
+    ]);
+    await tester.pumpWidget(widget);
+    await tester.pumpAndSettle();
 
     expect(find.text('About'), findsOneWidget);
     expect(find.text('Remote Dev'), findsOneWidget);
-    expect(find.text('Version 0.1.0 (development build)'), findsOneWidget);
+    expect(find.text('Version 1.2.3 (42)'), findsOneWidget);
+    expect(find.text('com.example.remote_dev'), findsOneWidget);
+  });
+
+  testWidgets('AboutScreen falls back when version load fails', (tester) async {
+    final widget = _wrap([
+      packageInfoProvider.overrideWith(
+        (_) async => Future<PackageInfo>.error(StateError('boom')),
+      ),
+    ]);
+    await tester.pumpWidget(widget);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Remote Dev'), findsOneWidget);
+    expect(find.text('Version unavailable'), findsOneWidget);
+  });
+
+  testWidgets('AboutScreen omits build number when empty', (tester) async {
+    final widget = _wrap([
+      packageInfoProvider.overrideWith(
+        (_) async => _fakeInfo(version: '0.1.0', buildNumber: ''),
+      ),
+    ]);
+    await tester.pumpWidget(widget);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Version 0.1.0'), findsOneWidget);
   });
 }

--- a/src/components/mobile/embed/EmbeddedChannelView.tsx
+++ b/src/components/mobile/embed/EmbeddedChannelView.tsx
@@ -44,12 +44,16 @@ export function EmbeddedChannelView() {
       scrollToBottom: noop,
       back: () => {
         // Closing an open thread takes priority over leaving the route.
+        // Return true so the native shell knows we consumed the gesture
+        // and skips its own Navigator.maybePop() — otherwise the back
+        // press would close the thread AND pop the route.
         if (openThreadId && closeThread) {
           closeThread();
-          return;
+          return true;
         }
-        // Otherwise this is a no-op; the native shell pops the route
-        // itself based on its own back-stack state.
+        // Otherwise the native shell pops the route itself based on
+        // its own back-stack state.
+        return false;
       },
     };
     return installRdvBridge(adapter);

--- a/src/components/mobile/embed/EmbeddedRecordingView.tsx
+++ b/src/components/mobile/embed/EmbeddedRecordingView.tsx
@@ -41,7 +41,9 @@ export function EmbeddedRecordingView({
       paste: noop,
       setFontSize: noop,
       scrollToBottom: noop,
-      back: noop, // native shell pops the route
+      // Recording playback has no in-WebView "back" action — return
+      // false so the native shell pops the route itself.
+      back: () => false,
     };
     return installRdvBridge(adapter);
   }, []);

--- a/src/components/mobile/embed/EmbeddedSessionView.tsx
+++ b/src/components/mobile/embed/EmbeddedSessionView.tsx
@@ -107,8 +107,10 @@ export function EmbeddedSessionView({
       },
       scrollToBottom: () => terminalRef.current?.scrollToBottom(),
       back: () => {
-        // Session embed has no in-WebView "back" action — native shell
-        // pops the route. Stub.
+        // Session embed has no in-WebView "back" action — let the
+        // native shell pop the route. Returning false signals
+        // "not consumed" so the Dart side runs Navigator.maybePop().
+        return false;
       },
     };
 

--- a/src/lib/__tests__/rdv-bridge.test.ts
+++ b/src/lib/__tests__/rdv-bridge.test.ts
@@ -20,7 +20,10 @@ function makeAdapter(overrides: Partial<RdvBridgeAdapter> = {}): RdvBridgeAdapte
     paste: vi.fn(),
     setFontSize: vi.fn(),
     scrollToBottom: vi.fn(),
-    back: vi.fn(),
+    // back must return boolean per the bridge contract — default
+    // false ("not consumed") so native callers fall through to
+    // Navigator.maybePop().
+    back: vi.fn(() => false),
     ...overrides,
   };
 }
@@ -70,6 +73,18 @@ describe("rdv-bridge", () => {
       expect(adapter.scrollToBottom).toHaveBeenCalledTimes(1);
       expect(adapter.paste).toHaveBeenCalledWith("clip");
       expect(adapter.back).toHaveBeenCalledTimes(1);
+    });
+
+    it("back() returns the adapter's boolean (consumed/not-consumed)", () => {
+      const consumed = makeAdapter({ back: vi.fn(() => true) });
+      installRdvBridge(consumed);
+      // Native (Dart) reads this return value via evaluateJavascript;
+      // truthy means "PWA handled it, don't also Navigator.maybePop".
+      expect(window.rdvBridge?.back()).toBe(true);
+
+      const notConsumed = makeAdapter({ back: vi.fn(() => false) });
+      installRdvBridge(notConsumed);
+      expect(window.rdvBridge?.back()).toBe(false);
     });
 
     it("returns an uninstall function that removes the bridge", () => {

--- a/src/lib/rdv-bridge.ts
+++ b/src/lib/rdv-bridge.ts
@@ -42,8 +42,21 @@ export interface RdvBridgeAdapter {
   setFontSize: (px: number) => void;
   /** Scroll terminal viewport to the bottom (session view only). */
   scrollToBottom: () => void;
-  /** Native back button pressed — embed view should clean up / leave. */
-  back: () => void;
+  /**
+   * Native back button pressed. Return `true` when the embed view
+   * consumed the gesture (e.g. closed an open thread, dismissed a
+   * modal, popped an in-WebView route) so the native shell knows NOT
+   * to also pop its route. Return `false` when there's nothing to
+   * handle and native should fall back to `Navigator.maybePop()`.
+   *
+   * Must remain synchronous: the Dart side awaits the JS return value
+   * via `evaluateJavascript`, but a Promise return would let
+   * `!!result` resolve to `true` *before* the JS settles, racing the
+   * native pop. If async behavior is ever needed, widen this to
+   * `boolean | Promise<boolean>` and update bridge_controller.dart's
+   * eval source to await the result inside an async IIFE.
+   */
+  back: () => boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
Three small Phase 7 cleanups bundled together:

### About screen — real version (d2f5)
- Adds `package_info_plus: ^8.1.0`
- `AboutScreen` rewritten as ConsumerWidget watching new `packageInfoProvider`
- Shows appName, version + buildNumber, packageName
- Error/loading fallbacks
- 3 new test cases

### Cookie docstring softened (q37o)
- Replaces over-confident "shared automatically" prose at `recording_screen.dart:18-25`
- Documents iOS/Android incognito/non-persistent caveats + session-only cookie cold-start gotcha

### BridgeController.back() returns Future<bool> (cx0w)
- `bridge_controller.dart`: `back()` evaluates `!!window.rdvBridge.back()`, returns false on not-ready/exception
- `RecordingScreen._handleBack` and `ChannelScreen._handleBack`: await `bridge.back()`, only `Navigator.maybePop()` when unhandled
- 4 new bridge_controller_test cases
- PWA-side `src/lib/rdv-bridge.ts` still returns void (out of `mobile/` scope) — so today's calls always resolve false and fall through to native pop. Forward-compatible: PWA can opt in by returning true to consume the back gesture (e.g., close a thread panel).

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` 248/248 passing

Closes remote-dev-d2f5, remote-dev-q37o, remote-dev-cx0w.

This pull request and its description were written by Isaac.