### PR TITLE
feat(mobile): Appearance profile screen (remote-dev-czsf)

### DIFF
--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'application/state/appearance_provider.dart';
 import 'application/state/reauth_signal_provider.dart';
 import 'infrastructure/deep_link/app_link_listener.dart';
 import 'presentation/router/app_router.dart';
@@ -36,6 +37,7 @@ class RemoteDevApp extends ConsumerWidget {
       if (previous == null || next == previous) return;
       router.config.go('/reauth');
     });
+    final appearance = ref.watch(appearanceSettingsProvider);
     return MaterialApp.router(
       title: 'Remote Dev',
       theme: ThemeData(
@@ -48,8 +50,23 @@ class RemoteDevApp extends ConsumerWidget {
       // Layer the lock overlay above every route so backgrounding any
       // screen still re-locks. Using `builder` (not wrapping `MaterialApp`)
       // ensures Navigator + Overlay sit above MediaQuery & Theme.
-      builder: (context, child) =>
-          BiometricLockOverlay(child: child ?? const SizedBox()),
+      //
+      // We also override MediaQuery here to honor the user's appearance
+      // preferences app-wide:
+      //   - `disableAnimations` propagates Reduce Motion to every Material
+      //     widget that respects accessibility flags.
+      //   - `textScaler` applies the user's font-scale slider to all text
+      //     in native Flutter chrome (PWA WebView text uses its own bridge).
+      builder: (context, child) {
+        final mq = MediaQuery.of(context);
+        return MediaQuery(
+          data: mq.copyWith(
+            disableAnimations: mq.disableAnimations || appearance.reduceMotion,
+            textScaler: TextScaler.linear(appearance.fontScale),
+          ),
+          child: BiometricLockOverlay(child: child ?? const SizedBox()),
+        );
+      },
     );
   }
 }

--- a/mobile/lib/application/state/appearance_provider.dart
+++ b/mobile/lib/application/state/appearance_provider.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../domain/appearance_settings.dart';
+
+/// Storage keys used by [AppearanceNotifier]. Stable across versions.
+class AppearancePrefsKeys {
+  static const fontScale = 'appearance.fontScale';
+  static const reduceMotion = 'appearance.reduceMotion';
+  static const cursorBlink = 'appearance.cursorBlink';
+}
+
+/// StateNotifier that owns the device-local [AppearanceSettings] and
+/// persists every change to [SharedPreferences].
+///
+/// Hydration is asynchronous: the notifier starts at defaults and transitions
+/// to the persisted state as soon as `SharedPreferences.getInstance()` resolves.
+/// Tests can pre-seed with [SharedPreferences.setMockInitialValues] and then
+/// `await tester.pumpAndSettle()` to observe the hydrated state, or pass an
+/// already-hydrated [SharedPreferences] via [AppearanceNotifier.test].
+class AppearanceNotifier extends StateNotifier<AppearanceSettings> {
+  AppearanceNotifier() : super(const AppearanceSettings()) {
+    _hydrate();
+  }
+
+  /// Test seam: construct with an already-resolved [SharedPreferences] so
+  /// widget tests don't have to await hydration.
+  AppearanceNotifier.test(SharedPreferences prefs)
+      : _prefs = prefs,
+        super(_readFromPrefs(prefs));
+
+  SharedPreferences? _prefs;
+
+  Future<void> _hydrate() async {
+    final prefs = await SharedPreferences.getInstance();
+    _prefs = prefs;
+    final hydrated = _readFromPrefs(prefs);
+    if (mounted) {
+      state = hydrated;
+    }
+  }
+
+  static AppearanceSettings _readFromPrefs(SharedPreferences prefs) {
+    final rawScale = prefs.getDouble(AppearancePrefsKeys.fontScale);
+    final scale = rawScale == null
+        ? AppearanceSettings.defaultFontScale
+        : _clampScale(rawScale);
+    return AppearanceSettings(
+      fontScale: scale,
+      reduceMotion:
+          prefs.getBool(AppearancePrefsKeys.reduceMotion) ?? false,
+      cursorBlink: prefs.getBool(AppearancePrefsKeys.cursorBlink) ?? true,
+    );
+  }
+
+  static double _clampScale(double v) {
+    if (v < AppearanceSettings.minFontScale) {
+      return AppearanceSettings.minFontScale;
+    }
+    if (v > AppearanceSettings.maxFontScale) {
+      return AppearanceSettings.maxFontScale;
+    }
+    return v;
+  }
+
+  Future<void> setFontScale(double value) async {
+    final clamped = _clampScale(value);
+    state = state.copyWith(fontScale: clamped);
+    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    _prefs = prefs;
+    await prefs.setDouble(AppearancePrefsKeys.fontScale, clamped);
+  }
+
+  Future<void> setReduceMotion(bool value) async {
+    state = state.copyWith(reduceMotion: value);
+    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    _prefs = prefs;
+    await prefs.setBool(AppearancePrefsKeys.reduceMotion, value);
+  }
+
+  Future<void> setCursorBlink(bool value) async {
+    state = state.copyWith(cursorBlink: value);
+    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    _prefs = prefs;
+    await prefs.setBool(AppearancePrefsKeys.cursorBlink, value);
+  }
+}
+
+/// App-wide appearance preferences. Read with `ref.watch`, mutate via
+/// `ref.read(appearanceSettingsProvider.notifier).setX(...)`.
+final appearanceSettingsProvider =
+    StateNotifierProvider<AppearanceNotifier, AppearanceSettings>(
+  (ref) => AppearanceNotifier(),
+);

--- a/mobile/lib/application/state/appearance_provider.dart
+++ b/mobile/lib/application/state/appearance_provider.dart
@@ -18,6 +18,10 @@ class AppearancePrefsKeys {
 /// Tests can pre-seed with [SharedPreferences.setMockInitialValues] and then
 /// `await tester.pumpAndSettle()` to observe the hydrated state, or pass an
 /// already-hydrated [SharedPreferences] via [AppearanceNotifier.test].
+///
+/// If the user mutates settings before hydration completes, the user's value
+/// wins: hydration becomes a no-op once `_userTouched` flips true. This avoids
+/// clobbering an early tap on a slow device.
 class AppearanceNotifier extends StateNotifier<AppearanceSettings> {
   AppearanceNotifier() : super(const AppearanceSettings()) {
     _hydrate();
@@ -27,24 +31,38 @@ class AppearanceNotifier extends StateNotifier<AppearanceSettings> {
   /// widget tests don't have to await hydration.
   AppearanceNotifier.test(SharedPreferences prefs)
       : _prefs = prefs,
+        _hydrated = true,
         super(_readFromPrefs(prefs));
 
   SharedPreferences? _prefs;
+  bool _hydrated = false;
+  bool _userTouched = false;
+
+  /// Visible for tests: true once hydration has completed (or was bypassed
+  /// via the [AppearanceNotifier.test] seam).
+  bool get isHydrated => _hydrated;
 
   Future<void> _hydrate() async {
     final prefs = await SharedPreferences.getInstance();
     _prefs = prefs;
+    if (_userTouched) {
+      // User beat us to a write — keep their state, just remember the prefs
+      // handle so future setters don't need to re-await getInstance().
+      _hydrated = true;
+      return;
+    }
     final hydrated = _readFromPrefs(prefs);
     if (mounted) {
       state = hydrated;
     }
+    _hydrated = true;
   }
 
   static AppearanceSettings _readFromPrefs(SharedPreferences prefs) {
     final rawScale = prefs.getDouble(AppearancePrefsKeys.fontScale);
     final scale = rawScale == null
         ? AppearanceSettings.defaultFontScale
-        : _clampScale(rawScale);
+        : _quantizeScale(_clampScale(rawScale));
     return AppearanceSettings(
       fontScale: scale,
       reduceMotion:
@@ -63,15 +81,21 @@ class AppearanceNotifier extends StateNotifier<AppearanceSettings> {
     return v;
   }
 
+  /// Round to 2 decimal places to keep stored values stable across reads
+  /// (avoids tiny float drift like 1.1500000000000001 from slider drags).
+  static double _quantizeScale(double v) => (v * 100).round() / 100;
+
   Future<void> setFontScale(double value) async {
-    final clamped = _clampScale(value);
-    state = state.copyWith(fontScale: clamped);
+    _userTouched = true;
+    final quantized = _quantizeScale(_clampScale(value));
+    state = state.copyWith(fontScale: quantized);
     final prefs = _prefs ?? await SharedPreferences.getInstance();
     _prefs = prefs;
-    await prefs.setDouble(AppearancePrefsKeys.fontScale, clamped);
+    await prefs.setDouble(AppearancePrefsKeys.fontScale, quantized);
   }
 
   Future<void> setReduceMotion(bool value) async {
+    _userTouched = true;
     state = state.copyWith(reduceMotion: value);
     final prefs = _prefs ?? await SharedPreferences.getInstance();
     _prefs = prefs;
@@ -79,6 +103,7 @@ class AppearanceNotifier extends StateNotifier<AppearanceSettings> {
   }
 
   Future<void> setCursorBlink(bool value) async {
+    _userTouched = true;
     state = state.copyWith(cursorBlink: value);
     final prefs = _prefs ?? await SharedPreferences.getInstance();
     _prefs = prefs;

--- a/mobile/lib/domain/appearance_settings.dart
+++ b/mobile/lib/domain/appearance_settings.dart
@@ -1,0 +1,52 @@
+/// Device-local appearance preferences for the mobile app.
+///
+/// These are non-sensitive UI prefs persisted via [SharedPreferences]. They
+/// drive font scale, motion reduction, and terminal cursor blink behavior.
+class AppearanceSettings {
+  const AppearanceSettings({
+    this.fontScale = 1.0,
+    this.reduceMotion = false,
+    this.cursorBlink = true,
+  });
+
+  /// Multiplier applied to base font sizes. Clamped to [minFontScale,
+  /// maxFontScale] when written through the provider.
+  final double fontScale;
+
+  /// When true, animations should be shortened or disabled.
+  final bool reduceMotion;
+
+  /// When true, the terminal cursor blinks.
+  final bool cursorBlink;
+
+  static const double minFontScale = 0.85;
+  static const double maxFontScale = 1.30;
+  static const double defaultFontScale = 1.0;
+
+  AppearanceSettings copyWith({
+    double? fontScale,
+    bool? reduceMotion,
+    bool? cursorBlink,
+  }) =>
+      AppearanceSettings(
+        fontScale: fontScale ?? this.fontScale,
+        reduceMotion: reduceMotion ?? this.reduceMotion,
+        cursorBlink: cursorBlink ?? this.cursorBlink,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AppearanceSettings &&
+          other.fontScale == fontScale &&
+          other.reduceMotion == reduceMotion &&
+          other.cursorBlink == cursorBlink;
+
+  @override
+  int get hashCode => Object.hash(fontScale, reduceMotion, cursorBlink);
+
+  @override
+  String toString() =>
+      'AppearanceSettings(fontScale: $fontScale, reduceMotion: $reduceMotion, '
+      'cursorBlink: $cursorBlink)';
+}

--- a/mobile/lib/presentation/screens/profile/appearance_screen.dart
+++ b/mobile/lib/presentation/screens/profile/appearance_screen.dart
@@ -1,28 +1,184 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class AppearanceScreen extends StatelessWidget {
+import '../../../application/state/appearance_provider.dart';
+import '../../../domain/appearance_settings.dart';
+
+/// Tokyo Night palette anchors used across the appearance screen.
+const _bg = Color(0xFF1A1B26);
+const _surface = Color(0xFF24283B);
+const _accent = Color(0xFF7AA2F7);
+const _muted = Color(0xFF565F89);
+const _textPrimary = Colors.white;
+const _textSecondary = Color(0xFFC0CAF5);
+
+class AppearanceScreen extends ConsumerWidget {
   const AppearanceScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settings = ref.watch(appearanceSettingsProvider);
+    final notifier = ref.read(appearanceSettingsProvider.notifier);
+
     return Scaffold(
-      backgroundColor: const Color(0xFF1A1B26),
+      backgroundColor: _bg,
       appBar: AppBar(
-        backgroundColor: const Color(0xFF1A1B26),
-        title: const Text(
-          'Appearance',
-          style: TextStyle(color: Colors.white),
-        ),
-        iconTheme: const IconThemeData(color: Colors.white),
+        backgroundColor: _bg,
+        title: const Text('Appearance', style: TextStyle(color: _textPrimary)),
+        iconTheme: const IconThemeData(color: _textPrimary),
+        elevation: 0,
       ),
-      body: const Center(
-        child: Padding(
-          padding: EdgeInsets.all(24),
-          child: Text(
-            'Appearance — Phase 5 fills this in.',
-            style: TextStyle(color: Colors.white70),
-            textAlign: TextAlign.center,
+      body: ListView(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        children: [
+          _SectionHeader(label: 'Display'),
+          _FontScaleTile(
+            value: settings.fontScale,
+            onChanged: notifier.setFontScale,
           ),
+          const Divider(color: _muted, height: 1),
+          _SwitchTile(
+            key: const Key('appearance.reduceMotion'),
+            icon: Icons.motion_photos_off_outlined,
+            label: 'Reduce motion',
+            description: 'Shorten or disable animations.',
+            value: settings.reduceMotion,
+            onChanged: notifier.setReduceMotion,
+          ),
+          const Divider(color: _muted, height: 1),
+          _SwitchTile(
+            key: const Key('appearance.cursorBlink'),
+            icon: Icons.text_fields,
+            label: 'Cursor blink',
+            description: 'Blink the terminal cursor.',
+            value: settings.cursorBlink,
+            onChanged: notifier.setCursorBlink,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      child: Text(
+        label.toUpperCase(),
+        style: const TextStyle(
+          color: _muted,
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 1.2,
+        ),
+      ),
+    );
+  }
+}
+
+class _FontScaleTile extends StatelessWidget {
+  const _FontScaleTile({required this.value, required this.onChanged});
+
+  final double value;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: _surface,
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.format_size, color: _textSecondary),
+              const SizedBox(width: 12),
+              const Expanded(
+                child: Text(
+                  'Font scale',
+                  style: TextStyle(color: _textPrimary, fontSize: 16),
+                ),
+              ),
+              Text(
+                '${value.toStringAsFixed(2)}x',
+                style: const TextStyle(color: _textSecondary, fontSize: 14),
+              ),
+            ],
+          ),
+          SliderTheme(
+            data: SliderTheme.of(context).copyWith(
+              activeTrackColor: _accent,
+              inactiveTrackColor: _muted,
+              thumbColor: _accent,
+              overlayColor: _accent.withValues(alpha: 0.2),
+              valueIndicatorColor: _accent,
+              valueIndicatorTextStyle: const TextStyle(color: _bg),
+            ),
+            child: Slider(
+              key: const Key('appearance.fontScale'),
+              min: AppearanceSettings.minFontScale,
+              max: AppearanceSettings.maxFontScale,
+              divisions: 9, // 0.05 steps across 0.85 → 1.30
+              label: '${value.toStringAsFixed(2)}x',
+              value: value.clamp(
+                AppearanceSettings.minFontScale,
+                AppearanceSettings.maxFontScale,
+              ),
+              onChanged: onChanged,
+            ),
+          ),
+          const Padding(
+            padding: EdgeInsets.only(top: 4),
+            child: Text(
+              'Adjust app and terminal text size.',
+              style: TextStyle(color: _muted, fontSize: 12),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SwitchTile extends StatelessWidget {
+  const _SwitchTile({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.description,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final IconData icon;
+  final String label;
+  final String description;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: _surface,
+      child: SwitchListTile(
+        value: value,
+        onChanged: onChanged,
+        activeThumbColor: _accent,
+        secondary: Icon(icon, color: _textSecondary),
+        title: Text(
+          label,
+          style: const TextStyle(color: _textPrimary, fontSize: 16),
+        ),
+        subtitle: Text(
+          description,
+          style: const TextStyle(color: _muted, fontSize: 12),
         ),
       ),
     );

--- a/mobile/test/application/state/appearance_provider_test.dart
+++ b/mobile/test/application/state/appearance_provider_test.dart
@@ -119,4 +119,51 @@ void main() {
     expect(notifier.state.reduceMotion, isTrue);
     expect(notifier.state.cursorBlink, isTrue); // default
   });
+
+  test('user write before hydrate resolves wins (no clobber)', () async {
+    // Seed prefs with non-default values. If hydrate ran unconditionally
+    // it would overwrite the user's tap.
+    SharedPreferences.setMockInitialValues({
+      AppearancePrefsKeys.fontScale: 1.20,
+      AppearancePrefsKeys.reduceMotion: true,
+      AppearancePrefsKeys.cursorBlink: false,
+    });
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    // Synchronously (before async hydrate completes) flip a setting.
+    final notifier = container.read(appearanceSettingsProvider.notifier);
+    final pending = notifier.setReduceMotion(false);
+
+    // Now allow hydrate microtasks to flush.
+    await pending;
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+
+    // User's explicit choice must survive — not be replaced by the
+    // hydrated `true` from prefs.
+    expect(
+      container.read(appearanceSettingsProvider).reduceMotion,
+      isFalse,
+    );
+    expect(notifier.isHydrated, isTrue);
+  });
+
+  test('font scale is quantized to 2 decimal places', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final notifier = container.read(appearanceSettingsProvider.notifier);
+    // Slider drift: 1.1500000000000001 → 1.15
+    await notifier.setFontScale(1.1500000000000001);
+
+    expect(container.read(appearanceSettingsProvider).fontScale, 1.15);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getDouble(AppearancePrefsKeys.fontScale), 1.15);
+
+    // 1.234 → 1.23
+    await notifier.setFontScale(1.234);
+    expect(container.read(appearanceSettingsProvider).fontScale, 1.23);
+  });
 }

--- a/mobile/test/application/state/appearance_provider_test.dart
+++ b/mobile/test/application/state/appearance_provider_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/application/state/appearance_provider.dart';
+import 'package:remote_dev/domain/appearance_settings.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('hydrates with defaults when prefs are empty', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    // Pump the microtask queue so async hydration completes.
+    await Future<void>.delayed(Duration.zero);
+
+    final state = container.read(appearanceSettingsProvider);
+    expect(state.fontScale, AppearanceSettings.defaultFontScale);
+    expect(state.reduceMotion, isFalse);
+    expect(state.cursorBlink, isTrue);
+  });
+
+  test('writes each preference to SharedPreferences', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final notifier = container.read(appearanceSettingsProvider.notifier);
+    await notifier.setFontScale(1.15);
+    await notifier.setReduceMotion(true);
+    await notifier.setCursorBlink(false);
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getDouble(AppearancePrefsKeys.fontScale), 1.15);
+    expect(prefs.getBool(AppearancePrefsKeys.reduceMotion), isTrue);
+    expect(prefs.getBool(AppearancePrefsKeys.cursorBlink), isFalse);
+
+    final state = container.read(appearanceSettingsProvider);
+    expect(state.fontScale, 1.15);
+    expect(state.reduceMotion, isTrue);
+    expect(state.cursorBlink, isFalse);
+  });
+
+  test('clamps font scale to allowed range', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final notifier = container.read(appearanceSettingsProvider.notifier);
+    await notifier.setFontScale(5.0);
+    expect(
+      container.read(appearanceSettingsProvider).fontScale,
+      AppearanceSettings.maxFontScale,
+    );
+
+    await notifier.setFontScale(0.1);
+    expect(
+      container.read(appearanceSettingsProvider).fontScale,
+      AppearanceSettings.minFontScale,
+    );
+  });
+
+  test('rehydrates persisted values via the test seam', () async {
+    SharedPreferences.setMockInitialValues({
+      AppearancePrefsKeys.fontScale: 1.10,
+      AppearancePrefsKeys.reduceMotion: true,
+      AppearancePrefsKeys.cursorBlink: false,
+    });
+    final prefs = await SharedPreferences.getInstance();
+
+    final container = ProviderContainer(
+      overrides: [
+        appearanceSettingsProvider.overrideWith(
+          (ref) => AppearanceNotifier.test(prefs),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final state = container.read(appearanceSettingsProvider);
+    expect(state.fontScale, 1.10);
+    expect(state.reduceMotion, isTrue);
+    expect(state.cursorBlink, isFalse);
+  });
+
+  test('clamps an out-of-range persisted font scale on hydrate', () async {
+    SharedPreferences.setMockInitialValues({
+      AppearancePrefsKeys.fontScale: 9.99,
+    });
+    final prefs = await SharedPreferences.getInstance();
+
+    final container = ProviderContainer(
+      overrides: [
+        appearanceSettingsProvider.overrideWith(
+          (ref) => AppearanceNotifier.test(prefs),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      container.read(appearanceSettingsProvider).fontScale,
+      AppearanceSettings.maxFontScale,
+    );
+  });
+
+  test('AppearanceNotifier.test seam reads prefs synchronously', () async {
+    SharedPreferences.setMockInitialValues({
+      AppearancePrefsKeys.fontScale: 1.05,
+      AppearancePrefsKeys.reduceMotion: true,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final notifier = AppearanceNotifier.test(prefs);
+    addTearDown(notifier.dispose);
+
+    expect(notifier.state.fontScale, 1.05);
+    expect(notifier.state.reduceMotion, isTrue);
+    expect(notifier.state.cursorBlink, isTrue); // default
+  });
+}

--- a/mobile/test/domain/appearance_settings_test.dart
+++ b/mobile/test/domain/appearance_settings_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/domain/appearance_settings.dart';
+
+void main() {
+  test('default values match the documented defaults', () {
+    const s = AppearanceSettings();
+    expect(s.fontScale, 1.0);
+    expect(s.reduceMotion, isFalse);
+    expect(s.cursorBlink, isTrue);
+  });
+
+  test('copyWith only mutates the supplied fields', () {
+    const s = AppearanceSettings();
+    final copy = s.copyWith(fontScale: 1.2);
+    expect(copy.fontScale, 1.2);
+    expect(copy.reduceMotion, s.reduceMotion);
+    expect(copy.cursorBlink, s.cursorBlink);
+  });
+
+  test('value equality compares all fields', () {
+    expect(
+      const AppearanceSettings(fontScale: 1.1),
+      const AppearanceSettings(fontScale: 1.1),
+    );
+    expect(
+      const AppearanceSettings(fontScale: 1.1) ==
+          const AppearanceSettings(fontScale: 1.0),
+      isFalse,
+    );
+  });
+}

--- a/mobile/test/presentation/screens/profile/appearance_screen_test.dart
+++ b/mobile/test/presentation/screens/profile/appearance_screen_test.dart
@@ -1,18 +1,130 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/application/state/appearance_provider.dart';
+import 'package:remote_dev/domain/appearance_settings.dart';
 import 'package:remote_dev/presentation/screens/profile/appearance_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<ProviderContainer> _pump(WidgetTester tester) async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  final container = ProviderContainer(
+    overrides: [
+      appearanceSettingsProvider.overrideWith(
+        (ref) => AppearanceNotifier.test(prefs),
+      ),
+    ],
+  );
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(home: AppearanceScreen()),
+    ),
+  );
+  return container;
+}
 
 void main() {
-  testWidgets('AppearanceScreen renders title and placeholder body',
-      (tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(home: AppearanceScreen()),
-    );
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('renders title and all three controls', (tester) async {
+    final container = await _pump(tester);
+    addTearDown(container.dispose);
 
     expect(find.text('Appearance'), findsOneWidget);
+    expect(find.text('Font scale'), findsOneWidget);
+    expect(find.text('Reduce motion'), findsOneWidget);
+    expect(find.text('Cursor blink'), findsOneWidget);
+    expect(find.byType(Slider), findsOneWidget);
+    expect(find.byType(SwitchListTile), findsNWidgets(2));
+  });
+
+  testWidgets('defaults match AppearanceSettings defaults', (tester) async {
+    final container = await _pump(tester);
+    addTearDown(container.dispose);
+
+    final state = container.read(appearanceSettingsProvider);
+    expect(state.fontScale, AppearanceSettings.defaultFontScale);
+    expect(state.reduceMotion, isFalse);
+    expect(state.cursorBlink, isTrue);
+
+    // Default switch states reflect those values in the UI.
+    final reduceMotion = tester.widget<SwitchListTile>(
+      find.descendant(
+        of: find.byKey(const Key('appearance.reduceMotion')),
+        matching: find.byType(SwitchListTile),
+      ),
+    );
+    expect(reduceMotion.value, isFalse);
+
+    final cursorBlink = tester.widget<SwitchListTile>(
+      find.descendant(
+        of: find.byKey(const Key('appearance.cursorBlink')),
+        matching: find.byType(SwitchListTile),
+      ),
+    );
+    expect(cursorBlink.value, isTrue);
+  });
+
+  testWidgets('toggling reduce motion writes to provider state',
+      (tester) async {
+    final container = await _pump(tester);
+    addTearDown(container.dispose);
+
     expect(
-      find.text('Appearance — Phase 5 fills this in.'),
-      findsOneWidget,
+      container.read(appearanceSettingsProvider).reduceMotion,
+      isFalse,
+    );
+
+    await tester.tap(find.byKey(const Key('appearance.reduceMotion')));
+    await tester.pumpAndSettle();
+
+    expect(
+      container.read(appearanceSettingsProvider).reduceMotion,
+      isTrue,
+    );
+  });
+
+  testWidgets('toggling cursor blink writes to provider state',
+      (tester) async {
+    final container = await _pump(tester);
+    addTearDown(container.dispose);
+
+    expect(
+      container.read(appearanceSettingsProvider).cursorBlink,
+      isTrue,
+    );
+
+    await tester.tap(find.byKey(const Key('appearance.cursorBlink')));
+    await tester.pumpAndSettle();
+
+    expect(
+      container.read(appearanceSettingsProvider).cursorBlink,
+      isFalse,
+    );
+  });
+
+  testWidgets('dragging the slider updates the font scale', (tester) async {
+    final container = await _pump(tester);
+    addTearDown(container.dispose);
+
+    final initial = container.read(appearanceSettingsProvider).fontScale;
+    expect(initial, AppearanceSettings.defaultFontScale);
+
+    // Drag right to increase scale. The exact magnitude depends on layout
+    // but a positive drag must monotonically increase font scale.
+    await tester.drag(
+      find.byKey(const Key('appearance.fontScale')),
+      const Offset(200, 0),
+    );
+    await tester.pumpAndSettle();
+
+    final after = container.read(appearanceSettingsProvider).fontScale;
+    expect(after, greaterThan(initial));
+    expect(
+      after,
+      lessThanOrEqualTo(AppearanceSettings.maxFontScale),
     );
   });
 }


### PR DESCRIPTION
## Summary
Replaces the Phase 5 stub with a real Appearance settings screen.

### Settings
- **Font scale** — slider 0.85x–1.30x (9 divisions, 0.05 step), default 1.0
- **Reduce motion** — switch, default false
- **Cursor blink** — switch, default true

### Persistence
`shared_preferences` (already a dep at `^2.3.3`):
- `appearance.fontScale`
- `appearance.reduceMotion`
- `appearance.cursorBlink`

Out-of-range persisted font scales are clamped on hydrate (covered by test). Each write clamps and persists.

### Files
- New: `domain/appearance_settings.dart`, `application/state/appearance_provider.dart`, two test files
- Modified: `presentation/screens/profile/appearance_screen.dart`, existing screen test
- `AppearanceNotifier.test(prefs)` seam for widget tests

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` 255/255 (14 new appearance tests)

Closes remote-dev-czsf.

This pull request and its description were written by Isaac.