### PR TITLE
feat(mobile): GitHub Accounts profile screen (remote-dev-csb7)

### DIFF
--- a/mobile/lib/domain/github_account.dart
+++ b/mobile/lib/domain/github_account.dart
@@ -1,0 +1,84 @@
+/// A linked GitHub account exposed by `/api/github/accounts`.
+///
+/// The server returns each account as
+/// `{providerAccountId, userId, login, displayName, avatarUrl, email,
+///   isDefault, createdAt, updatedAt, needsReauth}`. The mobile UI only
+/// needs an opaque id, the @login handle, an avatar URL, and the default
+/// flag — everything else is stripped.
+///
+/// We accept both `id` and `providerAccountId` keys so the model survives
+/// any future shape simplification on the server side.
+///
+/// Plain immutable class instead of freezed — small, no copyWith/union
+/// surface, and avoids the build_runner dependency.
+class GitHubAccount {
+  const GitHubAccount({
+    required this.id,
+    required this.login,
+    this.avatarUrl,
+    required this.isDefault,
+  });
+
+  /// Stable identifier for PATCH/DELETE endpoints. In the current server
+  /// implementation this is the GitHub numeric user ID as a string
+  /// (a.k.a. `providerAccountId`).
+  final String id;
+
+  /// GitHub @username. Rendered with a leading `@` in the UI; we store
+  /// the bare login here.
+  final String login;
+
+  /// GitHub avatar URL. May be missing or empty when the user has no
+  /// avatar set; we normalize to `null` so call sites can branch with
+  /// `account.avatarUrl == null` without also checking for empty strings.
+  final String? avatarUrl;
+
+  /// True iff this account is the user's current default. Exactly one
+  /// account per user can be default at a time; the server guarantees
+  /// this invariant on writes.
+  final bool isDefault;
+
+  /// Decode from the JSON shape returned by `/api/github/accounts`.
+  ///
+  /// Throws [FormatException] when neither `id` nor `providerAccountId`
+  /// is present, or when `login` is missing — both are load-bearing for
+  /// the UI (no id = can't PATCH/DELETE, no login = nothing to render).
+  factory GitHubAccount.fromJson(Map<String, dynamic> json) {
+    final rawId = json['id'] ?? json['providerAccountId'];
+    if (rawId is! String || rawId.isEmpty) {
+      throw const FormatException(
+        'GitHubAccount.fromJson: missing `id`/`providerAccountId`',
+      );
+    }
+    final login = json['login'];
+    if (login is! String || login.isEmpty) {
+      throw const FormatException(
+        'GitHubAccount.fromJson: missing `login`',
+      );
+    }
+    final avatar = json['avatarUrl'];
+    return GitHubAccount(
+      id: rawId,
+      login: login,
+      avatarUrl: avatar is String && avatar.isNotEmpty ? avatar : null,
+      isDefault: json['isDefault'] as bool? ?? false,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GitHubAccount &&
+        other.id == id &&
+        other.login == login &&
+        other.avatarUrl == avatarUrl &&
+        other.isDefault == isDefault;
+  }
+
+  @override
+  int get hashCode => Object.hash(id, login, avatarUrl, isDefault);
+
+  @override
+  String toString() =>
+      'GitHubAccount(id: $id, login: $login, isDefault: $isDefault)';
+}

--- a/mobile/lib/infrastructure/api/github_accounts_api.dart
+++ b/mobile/lib/infrastructure/api/github_accounts_api.dart
@@ -1,0 +1,60 @@
+import '../../application/ports/api_client_port.dart';
+import '../../domain/github_account.dart';
+
+/// Wraps `/api/github/accounts` for the mobile profile screen.
+///
+/// The server returns either a bare `[...]` array or a wrapped
+/// `{accounts: [...], folderBindings: {...}}` shape (the current
+/// implementation uses the wrapped form). [list] accepts both so the
+/// mobile client doesn't have to care if the server shape ever changes.
+///
+/// PATCH uses an action discriminator (`{action: "set-default"}`)
+/// rather than a property-style body. We hide that detail behind a
+/// typed [setDefault] method so callers only pass an account id.
+class GitHubAccountsApi {
+  GitHubAccountsApi(this._client);
+
+  final ApiClientPort _client;
+
+  /// Returns every GitHub account linked to the active server's user,
+  /// in the order returned by the server (default-first by convention).
+  ///
+  /// Throws [FormatException] when the response shape is unrecognized.
+  Future<List<GitHubAccount>> list() async {
+    final raw = await _client.get('/api/github/accounts');
+    final list = _extractAccounts(raw);
+    return list
+        .map((m) => GitHubAccount.fromJson(m))
+        .toList(growable: false);
+  }
+
+  /// Marks [id] as the user's default GitHub account. The server
+  /// guarantees the previous default is automatically unset.
+  Future<void> setDefault(String id) async {
+    await _client.patch(
+      '/api/github/accounts/$id',
+      body: const {'action': 'set-default'},
+    );
+  }
+
+  /// Unlinks [id] from the active server's user. Irreversible — the
+  /// caller is expected to confirm with the user before invoking.
+  Future<void> unlink(String id) async {
+    await _client.delete('/api/github/accounts/$id');
+  }
+
+  List<Map<String, dynamic>> _extractAccounts(dynamic raw) {
+    if (raw is List) {
+      return raw.cast<Map<String, dynamic>>();
+    }
+    if (raw is Map<String, dynamic>) {
+      final inner = raw['accounts'];
+      if (inner is List) {
+        return inner.cast<Map<String, dynamic>>();
+      }
+    }
+    throw const FormatException(
+      'Unexpected /api/github/accounts response shape',
+    );
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -6,6 +6,7 @@ import 'application/ports/api_client_port.dart';
 import 'application/state/reauth_signal_provider.dart';
 import 'infrastructure/api/account_api.dart';
 import 'infrastructure/api/channels_api.dart';
+import 'infrastructure/api/github_accounts_api.dart';
 import 'infrastructure/api/notifications_api.dart';
 import 'infrastructure/api/project_tree_api.dart';
 import 'infrastructure/api/remote_dev_client.dart';
@@ -25,6 +26,8 @@ import 'presentation/screens/notifications/notifications_tab_screen.dart'
     show notificationsApiProvider;
 import 'presentation/screens/profile/account_screen.dart'
     show accountApiProvider;
+import 'presentation/screens/profile/github_accounts_screen.dart'
+    show githubAccountsApiProvider;
 import 'presentation/screens/sessions/project_tree_sheet.dart'
     show projectTreeApiProvider;
 import 'presentation/screens/sessions/sessions_tab_screen.dart'
@@ -89,6 +92,9 @@ List<Override> buildServerScopedOverrides({required String deviceId}) {
     ),
     accountApiProvider.overrideWith(
       (ref) => AccountApi(ref.watch(_apiClientProvider)),
+    ),
+    githubAccountsApiProvider.overrideWith(
+      (ref) => GitHubAccountsApi(ref.watch(_apiClientProvider)),
     ),
     pushTokenRegistrarProvider.overrideWith(
       (ref) => PushTokenRegistrar(

--- a/mobile/lib/presentation/screens/profile/github_accounts_screen.dart
+++ b/mobile/lib/presentation/screens/profile/github_accounts_screen.dart
@@ -1,10 +1,133 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class GitHubAccountsScreen extends StatelessWidget {
+import '../../../domain/github_account.dart';
+import '../../../domain/server_config.dart';
+import '../../../infrastructure/api/github_accounts_api.dart';
+import '../webview_host/session_route_host.dart' show activeServerProvider;
+
+/// Provider for the [GitHubAccountsApi]. Must be overridden in main.dart's
+/// [buildServerScopedOverrides] once a [RemoteDevClient] is wired for the
+/// active server. Mirrors the [accountApiProvider] / [sessionsApiProvider]
+/// pattern.
+final githubAccountsApiProvider = Provider<GitHubAccountsApi>((ref) {
+  throw UnimplementedError(
+    'githubAccountsApiProvider must be overridden with '
+    'GitHubAccountsApi(client) in main.dart',
+  );
+});
+
+/// Loads the active server's linked GitHub accounts. autoDispose so a
+/// sign-out (which invalidates [activeServerProvider]) drops the cached
+/// list immediately.
+final githubAccountsFutureProvider =
+    FutureProvider.autoDispose<List<GitHubAccount>>((ref) async {
+  return ref.watch(githubAccountsApiProvider).list();
+});
+
+class GitHubAccountsScreen extends ConsumerStatefulWidget {
   const GitHubAccountsScreen({super.key});
 
   @override
+  ConsumerState<GitHubAccountsScreen> createState() =>
+      _GitHubAccountsScreenState();
+}
+
+class _GitHubAccountsScreenState extends ConsumerState<GitHubAccountsScreen> {
+  /// Per-row mutation flag — set while a PATCH/DELETE is in flight so we
+  /// can disable the row and avoid double-fires from rapid taps.
+  String? _busyId;
+
+  Future<void> _refresh() async {
+    ref.invalidate(githubAccountsFutureProvider);
+    await ref.read(githubAccountsFutureProvider.future);
+  }
+
+  Future<void> _setDefault(GitHubAccount account) async {
+    if (account.isDefault) return;
+    if (_busyId != null) return;
+    setState(() => _busyId = account.id);
+    try {
+      await ref.read(githubAccountsApiProvider).setDefault(account.id);
+      if (!mounted) return;
+      await _refresh();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Could not set default: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _busyId = null);
+    }
+  }
+
+  Future<void> _confirmAndUnlink(GitHubAccount account) async {
+    if (_busyId != null) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: const Color(0xFF24283B),
+        title: Text(
+          'Unlink @${account.login}?',
+          style: const TextStyle(color: Colors.white),
+        ),
+        content: const Text(
+          'Projects bound to this account will be unbound.',
+          style: TextStyle(color: Colors.white70),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            style: TextButton.styleFrom(
+              foregroundColor: const Color(0xFFF7768E),
+            ),
+            child: const Text('Unlink'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    setState(() => _busyId = account.id);
+    try {
+      await ref.read(githubAccountsApiProvider).unlink(account.id);
+      if (!mounted) return;
+      await _refresh();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Could not unlink: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _busyId = null);
+    }
+  }
+
+  Future<void> _openLinkFlow(ServerConfig server) async {
+    final didLink = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => _GitHubLinkWebView(server: server),
+        fullscreenDialog: true,
+      ),
+    );
+    // Refresh on close regardless — the user might have linked an account
+    // and then dismissed via the system gesture, in which case `didLink`
+    // is null but the list is still stale.
+    if (!mounted) return;
+    if (didLink == true || didLink == null) {
+      await _refresh();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final asyncServer = ref.watch(activeServerProvider);
     return Scaffold(
       backgroundColor: const Color(0xFF1A1B26),
       appBar: AppBar(
@@ -15,14 +138,391 @@ class GitHubAccountsScreen extends StatelessWidget {
         ),
         iconTheme: const IconThemeData(color: Colors.white),
       ),
-      body: const Center(
-        child: Padding(
-          padding: EdgeInsets.all(24),
-          child: Text(
-            'GitHub accounts — Phase 5 fills this in.',
-            style: TextStyle(color: Colors.white70),
-            textAlign: TextAlign.center,
+      // Resolve the active server FIRST. Mirrors AccountScreen — conflating
+      // loading/error with "no server" would render the empty-state CTA
+      // every time storage is still warming up, which is the wrong signal.
+      body: asyncServer.when(
+        loading: () => const Center(
+          child: CupertinoActivityIndicator(color: Colors.white70),
+        ),
+        error: (err, _) => _ErrorView(
+          message: 'Failed to resolve active server',
+          detail: '$err',
+          onRetry: _refresh,
+        ),
+        data: (server) {
+          if (server == null) {
+            return const _NoActiveServerView();
+          }
+          final asyncAccounts = ref.watch(githubAccountsFutureProvider);
+          return asyncAccounts.when(
+            loading: () => const Center(
+              child: CupertinoActivityIndicator(color: Colors.white70),
+            ),
+            error: (err, _) => _ErrorView(
+              message: 'Failed to load GitHub accounts',
+              detail: '$err',
+              onRetry: _refresh,
+            ),
+            data: (accounts) {
+              if (accounts.isEmpty) {
+                return _EmptyState(
+                  onLink: () => _openLinkFlow(server),
+                );
+              }
+              return RefreshIndicator(
+                onRefresh: _refresh,
+                child: ListView.separated(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  itemCount: accounts.length + 1,
+                  separatorBuilder: (_, __) => const Divider(
+                    color: Color(0xFF2F334D),
+                    height: 1,
+                    indent: 72,
+                  ),
+                  itemBuilder: (context, index) {
+                    if (index == accounts.length) {
+                      return Padding(
+                        padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
+                        child: OutlinedButton.icon(
+                          onPressed: () => _openLinkFlow(server),
+                          icon: const Icon(Icons.add),
+                          label: const Text('Link another GitHub account'),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: const Color(0xFF7AA2F7),
+                            side: const BorderSide(color: Color(0xFF2F334D)),
+                            padding:
+                                const EdgeInsets.symmetric(vertical: 14),
+                          ),
+                        ),
+                      );
+                    }
+                    final account = accounts[index];
+                    return _AccountTile(
+                      account: account,
+                      busy: _busyId == account.id,
+                      onTap: () => _setDefault(account),
+                      onLongPress: () => _confirmAndUnlink(account),
+                    );
+                  },
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _AccountTile extends StatelessWidget {
+  const _AccountTile({
+    required this.account,
+    required this.busy,
+    required this.onTap,
+    required this.onLongPress,
+  });
+
+  final GitHubAccount account;
+  final bool busy;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      onTap: busy ? null : onTap,
+      onLongPress: busy ? null : onLongPress,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
+      leading: _Avatar(account: account),
+      title: Text(
+        '@${account.login}',
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 16,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      trailing: busy
+          ? const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color: Colors.white70,
+              ),
+            )
+          : (account.isDefault ? const _DefaultBadge() : null),
+    );
+  }
+}
+
+class _Avatar extends StatelessWidget {
+  const _Avatar({required this.account});
+  final GitHubAccount account;
+
+  @override
+  Widget build(BuildContext context) {
+    final fallback = CircleAvatar(
+      radius: 20,
+      backgroundColor: const Color(0xFF2F334D),
+      child: Text(
+        account.login.isNotEmpty ? account.login[0].toUpperCase() : '?',
+        style: const TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+    final url = account.avatarUrl;
+    if (url == null) return fallback;
+    return CircleAvatar(
+      radius: 20,
+      backgroundColor: const Color(0xFF2F334D),
+      // Use foregroundImage so a load failure cleanly falls back to the
+      // child monogram (backgroundImage hides the child unconditionally,
+      // which would leave broken avatars showing a blank circle).
+      foregroundImage: NetworkImage(url),
+      child: Text(
+        account.login.isNotEmpty ? account.login[0].toUpperCase() : '?',
+        style: const TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _DefaultBadge extends StatelessWidget {
+  const _DefaultBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: const Color(0xFF24283B),
+        border: Border.all(color: const Color(0xFF7AA2F7)),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: const Text(
+        'default',
+        style: TextStyle(
+          color: Color(0xFF7AA2F7),
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.4,
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.onLink});
+  final VoidCallback onLink;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.link_off, size: 48, color: Colors.white24),
+            const SizedBox(height: 16),
+            const Text(
+              'No linked GitHub accounts',
+              style: TextStyle(color: Colors.white70, fontSize: 16),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Link a GitHub account to clone repositories and create '
+              'worktrees from this device.',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Colors.white38, fontSize: 13),
+            ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: onLink,
+              icon: const Icon(Icons.add),
+              label: const Text('Link a GitHub account'),
+              style: FilledButton.styleFrom(
+                backgroundColor: const Color(0xFF7AA2F7),
+                foregroundColor: const Color(0xFF1A1B26),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 20,
+                  vertical: 14,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NoActiveServerView extends StatelessWidget {
+  const _NoActiveServerView();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.cloud_off, size: 48, color: Colors.white24),
+            SizedBox(height: 16),
+            Text(
+              'No active server',
+              style: TextStyle(color: Colors.white70, fontSize: 16),
+            ),
+            SizedBox(height: 8),
+            Text(
+              'Pick a server before managing GitHub accounts.',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Colors.white38, fontSize: 13),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({
+    required this.message,
+    required this.detail,
+    required this.onRetry,
+  });
+  final String message;
+  final String detail;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: onRetry,
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 96),
+          const Icon(Icons.error_outline, size: 48, color: Color(0xFFF7768E)),
+          const SizedBox(height: 16),
+          Center(
+            child: Text(
+              message,
+              style: const TextStyle(color: Colors.white70, fontSize: 16),
+            ),
           ),
+          const SizedBox(height: 8),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Text(
+              detail,
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: Colors.white38, fontSize: 12),
+            ),
+          ),
+          const SizedBox(height: 24),
+          Center(
+            child: TextButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh, color: Color(0xFF7AA2F7)),
+              label: const Text(
+                'Retry',
+                style: TextStyle(color: Color(0xFF7AA2F7)),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Full-screen WebView for the GitHub OAuth link flow.
+///
+/// Loads `<server>/api/auth/github/link` (which kicks off the server-side
+/// OAuth dance) and pops the route as soon as the WebView returns to a
+/// URL that signals the link succeeded — either:
+///   1. The intermediate `/api/auth/github/callback?code=&state=` URL,
+///      which the server hits before redirecting to `/`, or
+///   2. The final `/?github=connected` redirect target.
+///
+/// Either signal counts: the server only emits both *after* it has
+/// already persisted the linked account, so popping on the first one we
+/// see is safe.
+class _GitHubLinkWebView extends StatefulWidget {
+  const _GitHubLinkWebView({required this.server});
+  final ServerConfig server;
+
+  @override
+  State<_GitHubLinkWebView> createState() => _GitHubLinkWebViewState();
+}
+
+class _GitHubLinkWebViewState extends State<_GitHubLinkWebView> {
+  bool _completed = false;
+
+  void _maybeFinish(WebUri? url) {
+    if (_completed) return;
+    if (url == null) return;
+    final raw = url.toString();
+    final isCallback = raw.contains('/api/auth/github/callback');
+    final isConnected = url.queryParameters['github'] == 'connected';
+    if (!isCallback && !isConnected) return;
+    _completed = true;
+    if (!mounted) return;
+    Navigator.of(context).pop(true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final linkUrl =
+        Uri.parse(widget.server.url).resolve('/api/auth/github/link');
+    return Scaffold(
+      backgroundColor: const Color(0xFF1A1B26),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF1A1B26),
+        foregroundColor: Colors.white,
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () {
+            if (_completed) return;
+            _completed = true;
+            Navigator.of(context).pop(false);
+          },
+        ),
+        title: const Text(
+          'Link GitHub account',
+          style: TextStyle(color: Colors.white),
+        ),
+      ),
+      body: SafeArea(
+        child: InAppWebView(
+          initialUrlRequest: URLRequest(url: WebUri(linkUrl.toString())),
+          initialSettings: InAppWebViewSettings(
+            useShouldOverrideUrlLoading: true,
+            applicationNameForUserAgent: 'RemoteDevMobile/0.1.0',
+          ),
+          // Both hooks fire during the OAuth dance — onLoadStop is the
+          // primary signal, but on Android the callback redirect often
+          // resolves so fast we never see an onLoadStop for it. The
+          // navigation hook catches that case.
+          shouldOverrideUrlLoading: (controller, action) async {
+            _maybeFinish(action.request.url);
+            return NavigationActionPolicy.ALLOW;
+          },
+          onLoadStop: (controller, url) async {
+            _maybeFinish(url);
+          },
         ),
       ),
     );

--- a/mobile/lib/presentation/screens/profile/github_accounts_screen.dart
+++ b/mobile/lib/presentation/screens/profile/github_accounts_screen.dart
@@ -468,16 +468,45 @@ class _GitHubLinkWebView extends StatefulWidget {
   State<_GitHubLinkWebView> createState() => _GitHubLinkWebViewState();
 }
 
+/// Strict origin + path/query check for the OAuth completion URL.
+///
+/// Defends against the WebView popping "success" on an attacker-controlled
+/// page that merely contains `/api/auth/github/callback` as a substring or
+/// adds a `?github=connected` query under a different origin. Both signals
+/// must come from the same host (and matching port, when both sides specify
+/// one) as the active server. Visible for testing.
+@visibleForTesting
+bool isOAuthCallback(Uri uri, Uri serverOrigin) {
+  // Same origin: host must match exactly.
+  if (uri.host.isEmpty || uri.host != serverOrigin.host) return false;
+  // If both sides declare an explicit port, require equality. If only one
+  // side does, treat the implicit port as the scheme default — Uri.port
+  // returns the default for the URI's scheme when none is set, so a
+  // straight `port` comparison handles that.
+  if (uri.hasPort != serverOrigin.hasPort) {
+    if (uri.port != serverOrigin.port) return false;
+  } else if (uri.hasPort && uri.port != serverOrigin.port) {
+    return false;
+  }
+  // Exact callback path.
+  if (uri.path == '/api/auth/github/callback') return true;
+  // Or root path with `?github=connected`.
+  if ((uri.path == '/' || uri.path.isEmpty) &&
+      uri.queryParameters['github'] == 'connected') {
+    return true;
+  }
+  return false;
+}
+
 class _GitHubLinkWebViewState extends State<_GitHubLinkWebView> {
   bool _completed = false;
 
   void _maybeFinish(WebUri? url) {
     if (_completed) return;
     if (url == null) return;
-    final raw = url.toString();
-    final isCallback = raw.contains('/api/auth/github/callback');
-    final isConnected = url.queryParameters['github'] == 'connected';
-    if (!isCallback && !isConnected) return;
+    final serverOrigin = Uri.tryParse(widget.server.url);
+    if (serverOrigin == null) return;
+    if (!isOAuthCallback(url, serverOrigin)) return;
     _completed = true;
     if (!mounted) return;
     Navigator.of(context).pop(true);

--- a/mobile/lib/presentation/screens/profile/github_accounts_screen.dart
+++ b/mobile/lib/presentation/screens/profile/github_accounts_screen.dart
@@ -477,7 +477,8 @@ class _GitHubLinkWebView extends StatefulWidget {
 /// one) as the active server. Visible for testing.
 @visibleForTesting
 bool isOAuthCallback(Uri uri, Uri serverOrigin) {
-  // Same origin: host must match exactly.
+  // Same origin: scheme and host must match exactly.
+  if (uri.scheme != serverOrigin.scheme) return false;
   if (uri.host.isEmpty || uri.host != serverOrigin.host) return false;
   // If both sides declare an explicit port, require equality. If only one
   // side does, treat the implicit port as the scheme default — Uri.port

--- a/mobile/test/infrastructure/api/github_accounts_api_test.dart
+++ b/mobile/test/infrastructure/api/github_accounts_api_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:remote_dev/application/ports/api_client_port.dart';
+import 'package:remote_dev/infrastructure/api/github_accounts_api.dart';
+
+class _MockApiClient extends Mock implements ApiClientPort {}
+
+void main() {
+  late _MockApiClient client;
+  late GitHubAccountsApi api;
+
+  setUp(() {
+    client = _MockApiClient();
+    api = GitHubAccountsApi(client);
+  });
+
+  group('list()', () {
+    test('parses wrapped {accounts: [...]} response (server default shape)',
+        () async {
+      when(() => client.get('/api/github/accounts')).thenAnswer(
+        (_) async => {
+          'accounts': [
+            {
+              'providerAccountId': '123',
+              'login': 'octocat',
+              'avatarUrl': 'https://avatars.example/octocat.png',
+              'isDefault': true,
+            },
+            {
+              'providerAccountId': '456',
+              'login': 'hubot',
+              'avatarUrl': null,
+              'isDefault': false,
+            },
+          ],
+          'folderBindings': <String, String>{},
+        },
+      );
+
+      final accounts = await api.list();
+      expect(accounts, hasLength(2));
+      expect(accounts[0].id, '123');
+      expect(accounts[0].login, 'octocat');
+      expect(accounts[0].avatarUrl, 'https://avatars.example/octocat.png');
+      expect(accounts[0].isDefault, isTrue);
+      expect(accounts[1].id, '456');
+      expect(accounts[1].avatarUrl, isNull);
+      expect(accounts[1].isDefault, isFalse);
+    });
+
+    test('parses bare array response', () async {
+      when(() => client.get('/api/github/accounts')).thenAnswer(
+        (_) async => [
+          {
+            'id': 'abc',
+            'login': 'lone',
+            'avatarUrl': '',
+            'isDefault': false,
+          },
+        ],
+      );
+
+      final accounts = await api.list();
+      expect(accounts, hasLength(1));
+      expect(accounts.single.id, 'abc');
+      // Empty avatar string should normalize to null so the UI can branch
+      // on `avatarUrl == null` without also checking for empties.
+      expect(accounts.single.avatarUrl, isNull);
+    });
+
+    test('throws FormatException on unrecognized response shape', () async {
+      when(() => client.get('/api/github/accounts'))
+          .thenAnswer((_) async => 'oops');
+      expect(api.list(), throwsA(isA<FormatException>()));
+    });
+
+    test('throws FormatException when an entry is missing both id keys',
+        () async {
+      when(() => client.get('/api/github/accounts')).thenAnswer(
+        (_) async => {
+          'accounts': [
+            {'login': 'orphan', 'isDefault': false},
+          ],
+        },
+      );
+      expect(api.list(), throwsA(isA<FormatException>()));
+    });
+  });
+
+  group('setDefault()', () {
+    test('sends PATCH to /api/github/accounts/:id with action discriminator',
+        () async {
+      when(
+        () => client.patch(
+          any(),
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer((_) async => {'success': true});
+
+      await api.setDefault('123');
+
+      final capturedPath = verify(
+        () => client.patch(
+          captureAny(),
+          body: captureAny(named: 'body'),
+        ),
+      ).captured;
+      expect(capturedPath[0], '/api/github/accounts/123');
+      // The current server contract uses an action discriminator rather
+      // than a property-style body — assert that explicitly so a future
+      // server change forces this test to fail loudly.
+      expect(capturedPath[1], {'action': 'set-default'});
+    });
+  });
+
+  group('unlink()', () {
+    test('sends DELETE to /api/github/accounts/:id', () async {
+      when(() => client.delete(any())).thenAnswer((_) async {});
+
+      await api.unlink('456');
+
+      verify(() => client.delete('/api/github/accounts/456')).called(1);
+    });
+  });
+}

--- a/mobile/test/presentation/screens/profile/github_accounts_screen_test.dart
+++ b/mobile/test/presentation/screens/profile/github_accounts_screen_test.dart
@@ -1,18 +1,262 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:remote_dev/domain/github_account.dart';
+import 'package:remote_dev/domain/server_config.dart';
+import 'package:remote_dev/infrastructure/api/github_accounts_api.dart';
 import 'package:remote_dev/presentation/screens/profile/github_accounts_screen.dart';
+import 'package:remote_dev/presentation/screens/webview_host/session_route_host.dart'
+    show activeServerProvider;
+
+class _MockGitHubAccountsApi extends Mock implements GitHubAccountsApi {}
+
+ServerConfig _server() => ServerConfig(
+      id: 'srv-1',
+      label: 'My Server',
+      url: 'https://rdv.example',
+      lastUsedAt: DateTime.utc(2026, 1, 1),
+    );
+
+Widget _wrap({
+  required GitHubAccountsApi api,
+  ServerConfig? server,
+  bool serverPending = false,
+}) {
+  return ProviderScope(
+    overrides: [
+      githubAccountsApiProvider.overrideWithValue(api),
+      activeServerProvider.overrideWith(
+        (ref) => serverPending
+            ? Completer<ServerConfig?>().future
+            : SynchronousFuture<ServerConfig?>(server),
+      ),
+    ],
+    child: const MaterialApp(home: GitHubAccountsScreen()),
+  );
+}
 
 void main() {
-  testWidgets('GitHubAccountsScreen renders title and placeholder body',
+  late _MockGitHubAccountsApi api;
+
+  setUp(() {
+    api = _MockGitHubAccountsApi();
+  });
+
+  testWidgets('shows loading indicator while accounts are in flight',
       (tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(home: GitHubAccountsScreen()),
+    final completer = Completer<List<GitHubAccount>>();
+    when(() => api.list()).thenAnswer((_) => completer.future);
+
+    await tester.pumpWidget(_wrap(api: api, server: _server()));
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump();
+
+    expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+  });
+
+  testWidgets('renders empty state with link CTA when list is empty',
+      (tester) async {
+    when(() => api.list()).thenAnswer((_) async => const []);
+
+    await tester.pumpWidget(_wrap(api: api, server: _server()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No linked GitHub accounts'), findsOneWidget);
+    expect(find.text('Link a GitHub account'), findsOneWidget);
+  });
+
+  testWidgets('renders error view with retry on failure', (tester) async {
+    when(() => api.list()).thenThrow(StateError('boom'));
+
+    await tester.pumpWidget(_wrap(api: api, server: _server()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Failed to load GitHub accounts'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+  });
+
+  testWidgets('renders @login rows and the default badge', (tester) async {
+    when(() => api.list()).thenAnswer(
+      (_) async => const [
+        GitHubAccount(
+          id: '1',
+          login: 'octocat',
+          avatarUrl: null,
+          isDefault: true,
+        ),
+        GitHubAccount(
+          id: '2',
+          login: 'hubot',
+          avatarUrl: null,
+          isDefault: false,
+        ),
+      ],
     );
 
-    expect(find.text('GitHub accounts'), findsOneWidget);
-    expect(
-      find.text('GitHub accounts — Phase 5 fills this in.'),
-      findsOneWidget,
+    await tester.pumpWidget(_wrap(api: api, server: _server()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('@octocat'), findsOneWidget);
+    expect(find.text('@hubot'), findsOneWidget);
+    // Exactly one row has the default badge.
+    expect(find.text('default'), findsOneWidget);
+  });
+
+  testWidgets('tapping a non-default row calls setDefault and refreshes',
+      (tester) async {
+    var listCalls = 0;
+    when(() => api.list()).thenAnswer((_) async {
+      listCalls++;
+      // First call: hubot is non-default. After setDefault, second call
+      // returns hubot as default — verifies the screen re-fetches.
+      if (listCalls == 1) {
+        return const [
+          GitHubAccount(
+            id: '1',
+            login: 'octocat',
+            avatarUrl: null,
+            isDefault: true,
+          ),
+          GitHubAccount(
+            id: '2',
+            login: 'hubot',
+            avatarUrl: null,
+            isDefault: false,
+          ),
+        ];
+      }
+      return const [
+        GitHubAccount(
+          id: '1',
+          login: 'octocat',
+          avatarUrl: null,
+          isDefault: false,
+        ),
+        GitHubAccount(
+          id: '2',
+          login: 'hubot',
+          avatarUrl: null,
+          isDefault: true,
+        ),
+      ];
+    });
+    when(() => api.setDefault('2')).thenAnswer((_) async {});
+
+    await tester.pumpWidget(_wrap(api: api, server: _server()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('@hubot'));
+    await tester.pumpAndSettle();
+
+    verify(() => api.setDefault('2')).called(1);
+    expect(listCalls, greaterThanOrEqualTo(2));
+  });
+
+  testWidgets('tapping the already-default row is a no-op', (tester) async {
+    when(() => api.list()).thenAnswer(
+      (_) async => const [
+        GitHubAccount(
+          id: '1',
+          login: 'octocat',
+          avatarUrl: null,
+          isDefault: true,
+        ),
+      ],
     );
+
+    await tester.pumpWidget(_wrap(api: api, server: _server()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('@octocat'));
+    await tester.pumpAndSettle();
+
+    verifyNever(() => api.setDefault(any()));
+  });
+
+  testWidgets('long-press shows confirm dialog; cancel does not call unlink',
+      (tester) async {
+    when(() => api.list()).thenAnswer(
+      (_) async => const [
+        GitHubAccount(
+          id: '1',
+          login: 'octocat',
+          avatarUrl: null,
+          isDefault: true,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(_wrap(api: api, server: _server()));
+    await tester.pumpAndSettle();
+
+    await tester.longPress(find.text('@octocat'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Unlink @octocat?'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    verifyNever(() => api.unlink(any()));
+  });
+
+  testWidgets('long-press → confirm calls unlink and refreshes',
+      (tester) async {
+    var listCalls = 0;
+    when(() => api.list()).thenAnswer((_) async {
+      listCalls++;
+      if (listCalls == 1) {
+        return const [
+          GitHubAccount(
+            id: '1',
+            login: 'octocat',
+            avatarUrl: null,
+            isDefault: true,
+          ),
+        ];
+      }
+      return const [];
+    });
+    when(() => api.unlink('1')).thenAnswer((_) async {});
+
+    await tester.pumpWidget(_wrap(api: api, server: _server()));
+    await tester.pumpAndSettle();
+
+    await tester.longPress(find.text('@octocat'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Unlink'));
+    await tester.pumpAndSettle();
+
+    verify(() => api.unlink('1')).called(1);
+    // Confirms the post-unlink refresh ran and re-rendered with the
+    // empty-state CTA.
+    expect(find.text('No linked GitHub accounts'), findsOneWidget);
+  });
+
+  testWidgets('shows loading indicator while activeServerProvider is in '
+      'flight (does NOT fall through to no-active-server)', (tester) async {
+    when(() => api.list()).thenAnswer((_) async => const []);
+
+    await tester.pumpWidget(_wrap(api: api, serverPending: true));
+    await tester.pump();
+
+    expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+    expect(find.text('No active server'), findsNothing);
+  });
+
+  testWidgets('shows no-active-server view when server is null',
+      (tester) async {
+    when(() => api.list()).thenAnswer((_) async => const []);
+
+    await tester.pumpWidget(_wrap(api: api, server: null));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No active server'), findsOneWidget);
+    expect(find.text('No linked GitHub accounts'), findsNothing);
   });
 }

--- a/mobile/test/presentation/screens/profile/github_accounts_screen_test.dart
+++ b/mobile/test/presentation/screens/profile/github_accounts_screen_test.dart
@@ -327,5 +327,15 @@ void main() {
         isFalse,
       );
     });
+
+    test('rejects scheme mismatch (http callback against https origin)', () {
+      expect(
+        isOAuthCallback(
+          Uri.parse('http://rdv.example/api/auth/github/callback'),
+          serverOrigin,
+        ),
+        isFalse,
+      );
+    });
   });
 }

--- a/mobile/test/presentation/screens/profile/github_accounts_screen_test.dart
+++ b/mobile/test/presentation/screens/profile/github_accounts_screen_test.dart
@@ -259,4 +259,73 @@ void main() {
     expect(find.text('No active server'), findsOneWidget);
     expect(find.text('No linked GitHub accounts'), findsNothing);
   });
+
+  group('isOAuthCallback', () {
+    final serverOrigin = Uri.parse('https://rdv.example');
+
+    test('rejects callback path on a foreign origin', () {
+      expect(
+        isOAuthCallback(
+          Uri.parse('https://evil.test/api/auth/github/callback'),
+          serverOrigin,
+        ),
+        isFalse,
+      );
+    });
+
+    test('accepts exact callback path on the active server origin', () {
+      expect(
+        isOAuthCallback(
+          Uri.parse('https://rdv.example/api/auth/github/callback?code=abc'),
+          serverOrigin,
+        ),
+        isTrue,
+      );
+    });
+
+    test('accepts root with ?github=connected on the active server origin',
+        () {
+      expect(
+        isOAuthCallback(
+          Uri.parse('https://rdv.example/?github=connected'),
+          serverOrigin,
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects ?github=connected on a foreign origin', () {
+      expect(
+        isOAuthCallback(
+          Uri.parse('https://evil.test/?github=connected'),
+          serverOrigin,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects callback path nested under a different prefix', () {
+      // Same host, but the path is not exactly the callback path — used to
+      // pass the loose substring match.
+      expect(
+        isOAuthCallback(
+          Uri.parse(
+            'https://rdv.example/some/random/path/api/auth/github/callback',
+          ),
+          serverOrigin,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects mismatched explicit ports on the same host', () {
+      expect(
+        isOAuthCallback(
+          Uri.parse('https://rdv.example:8443/api/auth/github/callback'),
+          Uri.parse('https://rdv.example:443'),
+        ),
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary
Replaces the Phase 5 stub with a full GitHub Accounts management screen.

### Features
- List linked accounts: avatar + `@<login>` + "default" badge
- **Tap row** → set as default (PATCH `{action: "set-default"}`) + refresh
- **Long-press row** → "Unlink @<login>?" dialog → DELETE + refresh
- **Empty state** → "Link a GitHub account" CTA opens in-app `flutter_inappwebview` at `<server>/api/auth/github/link`. Pops on first sight of `/api/auth/github/callback` or `?github=connected` (covers both `onLoadStop` and `shouldOverrideUrlLoading` for Android's fast redirect). List refreshes on close.

### API contract notes
- Server's PATCH uses `{action: "set-default"}` discriminator (not `{isDefault: true}`)
- Response shape: `{accounts: [...], folderBindings: {...}}` — `list()` accepts wrapped + bare-array shapes
- Account id field is `providerAccountId` server-side; `GitHubAccount.fromJson` accepts both

### Files
- New: `domain/github_account.dart`, `infrastructure/api/github_accounts_api.dart`, 2 test files
- Modified: `screens/profile/github_accounts_screen.dart`, `main.dart` (provider wire-up)

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — 257/257 (16 new GH-account tests)

Closes remote-dev-csb7.

This pull request and its description were written by Isaac.