### PR TITLE
feat(mobile): per-screen WebView path scope + back-bridge smoke test (remote-dev-83as/bvlw)

### DIFF
--- a/mobile/lib/infrastructure/webview/navigation_policy.dart
+++ b/mobile/lib/infrastructure/webview/navigation_policy.dart
@@ -4,8 +4,16 @@ class NavigationPolicy {
   /// Default policy used by the in-session WebView (Phase 2). Locks the
   /// WebView to `<serverOrigin>/m/*` plus the CF Access challenge — every
   /// other URL is intercepted and opened externally.
-  const NavigationPolicy({required this.serverOrigin})
-      : _allowSsoProviders = false;
+  ///
+  /// When [allowedPathPrefixes] is supplied, the `/m/*` allow list is
+  /// further narrowed to paths starting with one of the listed prefixes.
+  /// This lets per-surface hosts (recording, channel, session) pin the
+  /// WebView to a single PWA route so a same-origin redirect to a sister
+  /// surface is intercepted instead of silently navigating in-place.
+  const NavigationPolicy({
+    required this.serverOrigin,
+    this.allowedPathPrefixes,
+  }) : _allowSsoProviders = false;
 
   /// Relaxed policy used during the Add Server / re-auth flow. Allows the
   /// well-known third-party identity providers that CF Access redirects to
@@ -16,9 +24,17 @@ class NavigationPolicy {
   /// could legitimately contain a `https://accounts.google.com/...` link
   /// that we'd then accidentally load in-place.
   const NavigationPolicy.forLogin({required this.serverOrigin})
-      : _allowSsoProviders = true;
+      : _allowSsoProviders = true,
+        allowedPathPrefixes = null;
 
   final Uri serverOrigin;
+
+  /// Optional narrower allow list. When non-null, a same-origin path must
+  /// match one of these prefixes (in addition to the `/m/*` requirement)
+  /// or it is intercepted. Ignored in the [NavigationPolicy.forLogin]
+  /// constructor — the login flow legitimately needs broad origin access.
+  final List<String>? allowedPathPrefixes;
+
   final bool _allowSsoProviders;
 
   NavigationDecision decide(Uri uri) {
@@ -36,6 +52,11 @@ class NavigationPolicy {
     }
     if (!uri.path.startsWith('/m/')) {
       return NavigationDecision.intercept;
+    }
+    final prefixes = allowedPathPrefixes;
+    if (prefixes != null) {
+      final matchesAllowed = prefixes.any(uri.path.startsWith);
+      if (!matchesAllowed) return NavigationDecision.intercept;
     }
     return NavigationDecision.allow;
   }

--- a/mobile/lib/presentation/screens/channels/channel_screen.dart
+++ b/mobile/lib/presentation/screens/channels/channel_screen.dart
@@ -27,9 +27,24 @@ import 'channels_tab_screen.dart' show channelsListProvider;
 /// job is to render the AppBar text. That keeps any list refresh from
 /// rebuilding (and remounting) the WebView subtree below.
 class ChannelScreen extends ConsumerStatefulWidget {
-  const ChannelScreen({required this.channelId, super.key});
+  const ChannelScreen({
+    required this.channelId,
+    this.bridgeFactoryOverride,
+    super.key,
+  });
 
   final String channelId;
+
+  /// Test seam — when supplied, the screen installs the returned
+  /// [BridgeController] immediately on mount instead of waiting for the
+  /// real `onWebViewCreated` (which never fires under `flutter_test`
+  /// because InAppWebView's platform plugin isn't available). The factory
+  /// receives the live [InAppWebViewController] if/when one becomes
+  /// available, or `null` when invoked from `initState` for the test
+  /// seam. Matches the `cfLoginLauncherOverride` pattern from
+  /// `presentation/screens/webview_host/reauth_screen.dart`.
+  final BridgeController Function(InAppWebViewController? controller)?
+      bridgeFactoryOverride;
 
   @override
   ConsumerState<ChannelScreen> createState() => _ChannelScreenState();
@@ -38,8 +53,22 @@ class ChannelScreen extends ConsumerStatefulWidget {
 class _ChannelScreenState extends ConsumerState<ChannelScreen> {
   BridgeController? _bridge;
 
+  @override
+  void initState() {
+    super.initState();
+    // Honor the test seam eagerly so widget tests can drive `_handleBack`
+    // without needing a real `onWebViewCreated` to fire.
+    final override = widget.bridgeFactoryOverride;
+    if (override != null) {
+      _bridge = override(null);
+    }
+  }
+
   void _onWebViewCreated(InAppWebViewController controller) {
-    final bridge = BridgeController(controller: controller);
+    final override = widget.bridgeFactoryOverride;
+    final bridge = override != null
+        ? override(controller)
+        : BridgeController(controller: controller);
     setState(() => _bridge = bridge);
     controller.addJavaScriptHandler(
       handlerName: 'onTerminalReady',
@@ -96,7 +125,10 @@ class _ChannelScreenState extends ConsumerState<ChannelScreen> {
           final url = origin.replace(path: '/m/channel/${widget.channelId}');
           return WebViewFactory().build(
             initialUrl: url,
-            policy: NavigationPolicy(serverOrigin: origin),
+            policy: NavigationPolicy(
+              serverOrigin: origin,
+              allowedPathPrefixes: const ['/m/channel/'],
+            ),
             onLinkOpen: (_) {},
             onWebViewCreated: _onWebViewCreated,
           );

--- a/mobile/lib/presentation/screens/recording/recording_screen.dart
+++ b/mobile/lib/presentation/screens/recording/recording_screen.dart
@@ -114,7 +114,10 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
           final factory = widget.webViewFactory ?? const WebViewFactory();
           return factory.build(
             initialUrl: url,
-            policy: NavigationPolicy(serverOrigin: origin),
+            policy: NavigationPolicy(
+              serverOrigin: origin,
+              allowedPathPrefixes: const ['/m/recording/'],
+            ),
             onLinkOpen: (_) {},
             onWebViewCreated: _onWebViewCreated,
           );

--- a/mobile/lib/presentation/screens/session_view/session_view_screen.dart
+++ b/mobile/lib/presentation/screens/session_view/session_view_screen.dart
@@ -269,7 +269,10 @@ class _Webview extends ConsumerWidget {
         final url = origin.replace(path: '/m/session/$sessionId');
         return WebViewFactory().build(
           initialUrl: url,
-          policy: NavigationPolicy(serverOrigin: origin),
+          policy: NavigationPolicy(
+            serverOrigin: origin,
+            allowedPathPrefixes: const ['/m/session/'],
+          ),
           onLinkOpen: (uri) {
             debugPrint('External link suppressed: $uri');
           },

--- a/mobile/lib/presentation/screens/webview_host/session_route_host.dart
+++ b/mobile/lib/presentation/screens/webview_host/session_route_host.dart
@@ -70,6 +70,7 @@ class SessionRouteHost extends ConsumerWidget {
         return WebViewHostScreen(
           initialUrl: Uri.parse('${server.url}/m/session/$sessionId'),
           serverOrigin: origin,
+          allowedPathPrefixes: const ['/m/session/'],
         );
       },
     );

--- a/mobile/lib/presentation/screens/webview_host/webview_host_screen.dart
+++ b/mobile/lib/presentation/screens/webview_host/webview_host_screen.dart
@@ -7,19 +7,31 @@ import '../../../infrastructure/webview/webview_factory.dart';
 /// Hosts an InAppWebView pointed at a `/m/<surface>/<id>` URL on the
 /// active server. Phase 1 just shows the WebView; Phase 2 layers status
 /// bar + smart-keys + input bar above it.
+///
+/// When [allowedPathPrefixes] is supplied, it is forwarded to
+/// [NavigationPolicy] so this host pins the WebView to a single PWA
+/// surface. [SessionRouteHost] passes `['/m/session/']` to keep an
+/// in-page redirect from quietly jumping into `/m/channel/<id>`.
 class WebViewHostScreen extends ConsumerWidget {
   const WebViewHostScreen({
     required this.initialUrl,
     required this.serverOrigin,
+    this.allowedPathPrefixes,
     super.key,
   });
 
   final Uri initialUrl;
   final Uri serverOrigin;
 
+  /// Optional per-surface path scope. See [NavigationPolicy].
+  final List<String>? allowedPathPrefixes;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final policy = NavigationPolicy(serverOrigin: serverOrigin);
+    final policy = NavigationPolicy(
+      serverOrigin: serverOrigin,
+      allowedPathPrefixes: allowedPathPrefixes,
+    );
     return Scaffold(
       backgroundColor: const Color(0xFF1A1B26),
       body: SafeArea(

--- a/mobile/test/infrastructure/webview/navigation_policy_test.dart
+++ b/mobile/test/infrastructure/webview/navigation_policy_test.dart
@@ -45,6 +45,174 @@ void main() {
     });
   });
 
+  group('per-screen path scope (bvlw)', () {
+    // The strict in-session policy allows any path under
+    // `<serverOrigin>/m/*`. When [allowedPathPrefixes] is supplied,
+    // each per-surface host (RecordingScreen, ChannelScreen,
+    // SessionViewScreen/SessionRouteHost) narrows that allow list to
+    // its own PWA route so a same-origin redirect into a sister
+    // surface is intercepted instead of silently navigating in-place.
+
+    test(
+      'recording-scoped policy intercepts a sister `/m/channel/*` path on '
+      'the same origin even though it is under `/m/*`',
+      () {
+        final policy = NavigationPolicy(
+          serverOrigin: Uri.parse('https://dev.example.com'),
+          allowedPathPrefixes: const ['/m/recording/'],
+        );
+        // The route the recording host is pinned to is still allowed…
+        expect(
+          policy.decide(
+            Uri.parse('https://dev.example.com/m/recording/abc'),
+          ),
+          NavigationDecision.allow,
+        );
+        // …but a sibling `/m/channel/x` on the same origin is NOT.
+        expect(
+          policy.decide(
+            Uri.parse('https://dev.example.com/m/channel/x'),
+          ),
+          NavigationDecision.intercept,
+        );
+      },
+    );
+
+    test(
+      'channel-scoped policy intercepts `/m/session/*` on the same origin',
+      () {
+        final policy = NavigationPolicy(
+          serverOrigin: Uri.parse('https://dev.example.com'),
+          allowedPathPrefixes: const ['/m/channel/'],
+        );
+        expect(
+          policy.decide(Uri.parse('https://dev.example.com/m/channel/c1')),
+          NavigationDecision.allow,
+        );
+        expect(
+          policy.decide(Uri.parse('https://dev.example.com/m/session/s1')),
+          NavigationDecision.intercept,
+        );
+      },
+    );
+
+    test(
+      'session-scoped policy intercepts `/m/recording/*` on the same origin',
+      () {
+        final policy = NavigationPolicy(
+          serverOrigin: Uri.parse('https://dev.example.com'),
+          allowedPathPrefixes: const ['/m/session/'],
+        );
+        expect(
+          policy.decide(Uri.parse('https://dev.example.com/m/session/abc')),
+          NavigationDecision.allow,
+        );
+        expect(
+          policy.decide(
+            Uri.parse('https://dev.example.com/m/recording/abc'),
+          ),
+          NavigationDecision.intercept,
+        );
+      },
+    );
+
+    test(
+      'path scope still defers to the broader rules — CF Access challenge '
+      'and external links route as in the default policy',
+      () {
+        final policy = NavigationPolicy(
+          serverOrigin: Uri.parse('https://dev.example.com'),
+          allowedPathPrefixes: const ['/m/recording/'],
+        );
+        // CF Access challenge: still allowed (must precede the path check).
+        expect(
+          policy.decide(
+            Uri.parse('https://example.cloudflareaccess.com/cdn-cgi/access'),
+          ),
+          NavigationDecision.allow,
+        );
+        // Off-origin: still routed externally.
+        expect(
+          policy.decide(Uri.parse('https://github.com/btli/remote-dev')),
+          NavigationDecision.interceptAndOpenExternally,
+        );
+        // Same-origin non-`/m/` path: still intercepted.
+        expect(
+          policy.decide(Uri.parse('https://dev.example.com/sessions')),
+          NavigationDecision.intercept,
+        );
+      },
+    );
+
+    test(
+      'multiple prefixes: any one match is enough',
+      () {
+        // Defensive: the API takes a list, so a host that legitimately
+        // hosts two surfaces (e.g. future combined route) should be able
+        // to list both.
+        final policy = NavigationPolicy(
+          serverOrigin: Uri.parse('https://dev.example.com'),
+          allowedPathPrefixes: const ['/m/recording/', '/m/channel/'],
+        );
+        expect(
+          policy.decide(
+            Uri.parse('https://dev.example.com/m/recording/r1'),
+          ),
+          NavigationDecision.allow,
+        );
+        expect(
+          policy.decide(Uri.parse('https://dev.example.com/m/channel/c1')),
+          NavigationDecision.allow,
+        );
+        expect(
+          policy.decide(Uri.parse('https://dev.example.com/m/session/s1')),
+          NavigationDecision.intercept,
+        );
+      },
+    );
+
+    test(
+      'empty prefix list rejects every `/m/*` path (no implicit fallback)',
+      () {
+        // Guard rails: an empty list means "nothing matches". This is the
+        // safe default — if a caller accidentally clears the list, they
+        // get a hard block, not a silent open-allow.
+        final policy = NavigationPolicy(
+          serverOrigin: Uri.parse('https://dev.example.com'),
+          allowedPathPrefixes: const [],
+        );
+        expect(
+          policy.decide(
+            Uri.parse('https://dev.example.com/m/recording/abc'),
+          ),
+          NavigationDecision.intercept,
+        );
+      },
+    );
+
+    test(
+      'null prefix list preserves the default `/m/*` broad behavior',
+      () {
+        // Regression: callers that don't pass allowedPathPrefixes (e.g.
+        // BridgeSpike, the default WebViewHostScreen) must continue to
+        // allow every `/m/*` path.
+        final policy = NavigationPolicy(
+          serverOrigin: Uri.parse('https://dev.example.com'),
+        );
+        expect(
+          policy.decide(
+            Uri.parse('https://dev.example.com/m/recording/abc'),
+          ),
+          NavigationDecision.allow,
+        );
+        expect(
+          policy.decide(Uri.parse('https://dev.example.com/m/channel/c1')),
+          NavigationDecision.allow,
+        );
+      },
+    );
+  });
+
   group('login policy (Add Server / re-auth)', () {
     final policy = NavigationPolicy.forLogin(
       serverOrigin: Uri.parse('https://dev.example.com'),

--- a/mobile/test/presentation/screens/channels/channel_screen_test.dart
+++ b/mobile/test/presentation/screens/channels/channel_screen_test.dart
@@ -3,8 +3,10 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:remote_dev/domain/channel.dart';
 import 'package:remote_dev/infrastructure/api/channels_api.dart';
+import 'package:remote_dev/infrastructure/webview/bridge_controller.dart';
 import 'package:remote_dev/presentation/screens/channels/channel_screen.dart';
 import 'package:remote_dev/presentation/screens/channels/channels_tab_screen.dart';
 
@@ -114,6 +116,130 @@ void main() {
     },
   );
 
+  group('back gesture bridges to the embedded PWA first', () {
+    // Smoke test for `_handleBack`: when the bridge reports it consumed
+    // the gesture (e.g. closed a thread panel inside the WebView), the
+    // native shell MUST NOT pop its route — otherwise the user gets
+    // double-back behavior. When the bridge declines, the native route
+    // must pop normally so the user can leave the channel screen.
+    //
+    // The platform `InAppWebViewController` isn't available under
+    // `flutter_test`, so we exercise this via the `bridgeFactoryOverride`
+    // test seam: it lets the test substitute a mocked [BridgeController]
+    // whose `back()` future the test controls per-case.
+
+    testWidgets(
+      'bridge.back() returns true → Navigator.maybePop is NOT called',
+      (tester) async {
+        final bridge = _MockBridge();
+        when(() => bridge.back()).thenAnswer((_) async => true);
+
+        final observer = _PopObserver();
+        await tester.pumpWidget(
+          ProviderScope(
+            child: MaterialApp(
+              navigatorObservers: [observer],
+              home: const _RootProbe(),
+              onGenerateRoute: (settings) {
+                if (settings.name == '/channel') {
+                  return MaterialPageRoute<void>(
+                    settings: settings,
+                    builder: (_) => ChannelScreen(
+                      channelId: 'c-back',
+                      bridgeFactoryOverride: (_) => bridge,
+                    ),
+                  );
+                }
+                return null;
+              },
+            ),
+          ),
+        );
+        await tester.pump();
+        // Push ChannelScreen onto the stack so a pop has somewhere to go.
+        final probeState =
+            tester.state<_RootProbeState>(find.byType(_RootProbe));
+        probeState.pushChannel();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 1));
+
+        expect(find.byType(ChannelScreen), findsOneWidget);
+        observer.popped.clear();
+
+        // Tap the AppBar back button.
+        await tester.tap(find.byIcon(Icons.arrow_back));
+        // Drain the bridge.back() microtask + the subsequent
+        // maybePop branch (which would synchronously fire if invoked).
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 1));
+        await tester.pump();
+
+        verify(() => bridge.back()).called(1);
+        expect(
+          observer.popped,
+          isEmpty,
+          reason:
+              'When the embedded PWA consumes the back gesture, the native '
+              'route must stay put — otherwise the user gets a double-back.',
+        );
+        expect(find.byType(ChannelScreen), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'bridge.back() returns false → Navigator.maybePop IS called',
+      (tester) async {
+        final bridge = _MockBridge();
+        when(() => bridge.back()).thenAnswer((_) async => false);
+
+        final observer = _PopObserver();
+        await tester.pumpWidget(
+          ProviderScope(
+            child: MaterialApp(
+              navigatorObservers: [observer],
+              home: const _RootProbe(),
+              onGenerateRoute: (settings) {
+                if (settings.name == '/channel') {
+                  return MaterialPageRoute<void>(
+                    settings: settings,
+                    builder: (_) => ChannelScreen(
+                      channelId: 'c-back',
+                      bridgeFactoryOverride: (_) => bridge,
+                    ),
+                  );
+                }
+                return null;
+              },
+            ),
+          ),
+        );
+        await tester.pump();
+        final probeState =
+            tester.state<_RootProbeState>(find.byType(_RootProbe));
+        probeState.pushChannel();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 1));
+
+        expect(find.byType(ChannelScreen), findsOneWidget);
+        observer.popped.clear();
+
+        await tester.tap(find.byIcon(Icons.arrow_back));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 1));
+        await tester.pump(const Duration(milliseconds: 300));
+
+        verify(() => bridge.back()).called(1);
+        expect(
+          observer.popped,
+          isNotEmpty,
+          reason:
+              'When the embedded PWA declines the back gesture, the native '
+              'shell must fall back to Navigator.maybePop().',
+        );
+      },
+    );
+  });
+
   testWidgets(
     'shows fallback "Channel" before list resolves, then "#name" after',
     (tester) async {
@@ -149,4 +275,45 @@ void main() {
       expect(find.text('#random'), findsOneWidget);
     },
   );
+}
+
+/// Mock [BridgeController] whose `back()` future the test controls per-case.
+///
+/// We pass `null` for the controller because we never call into the real
+/// `InAppWebViewController` from this mock — every BridgeController method
+/// we care about (`back`) is stubbed via mocktail's `noSuchMethod`. The
+/// `super` constructor needs a non-null value, so we hand it a `Mock`
+/// stand-in.
+class _MockBridge extends Mock implements BridgeController {}
+
+/// Captures `didPop` events so the test can assert whether the native
+/// route actually popped after the user tapped the AppBar back button.
+class _PopObserver extends NavigatorObserver {
+  final List<Route<dynamic>> popped = [];
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    popped.add(route);
+    super.didPop(route, previousRoute);
+  }
+}
+
+/// Lets the test push a [ChannelScreen] onto the [Navigator] stack so a
+/// subsequent `Navigator.maybePop()` has somewhere to go (an empty stack
+/// no-ops the pop, which would mask the assertion under test).
+class _RootProbe extends StatefulWidget {
+  const _RootProbe();
+  @override
+  State<_RootProbe> createState() => _RootProbeState();
+}
+
+class _RootProbeState extends State<_RootProbe> {
+  void pushChannel() {
+    Navigator.of(context).pushNamed('/channel');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: SizedBox.shrink());
+  }
 }


### PR DESCRIPTION
## Summary

### 83as — back-bridge smoke test
- `ChannelScreen` gains `bridgeFactoryOverride` constructor seam (mirrors `cfLoginLauncherOverride` in `ReauthScreen`); installs returned `BridgeController` eagerly in `initState` so widget tests drive `_handleBack` without a live WebView.
- 2 new tests: `bridge.back()==true` keeps route mounted; `bridge.back()==false` produces `didPop`.

### bvlw — per-screen path scope
- `NavigationPolicy` gains optional `allowedPathPrefixes` — narrows same-origin `/m/*` allow list when non-null.
- Wired: `RecordingScreen` → `/m/recording/`, `ChannelScreen` → `/m/channel/`, `SessionViewScreen` + `SessionRouteHost` (via `WebViewHostScreen.allowedPathPrefixes`) → `/m/session/`.
- BridgeSpike + default WebViewHost stay broad.
- 7 new policy tests: sister-surface interception, multi-prefix, empty/null, CF Access + external-link still apply.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` 297/297 (1 pre-existing skip)

Closes remote-dev-83as, remote-dev-bvlw.

This pull request and its description were written by Isaac.