### PR TITLE
feat(mobile): live unread refresh on Channels tab via 30s polling (remote-dev-ph5b)

### DIFF
--- a/mobile/lib/presentation/screens/channels/channels_tab_screen.dart
+++ b/mobile/lib/presentation/screens/channels/channels_tab_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -6,6 +8,12 @@ import 'package:go_router/go_router.dart';
 import '../../../domain/channel.dart';
 import '../../../infrastructure/api/channels_api.dart';
 import '../shell/home_shell.dart';
+
+/// Polling cadence for live unread refresh while the Channels tab is mounted
+/// and the app is in the foreground. 30s is a deliberate trade-off: short
+/// enough that unread badges feel "live" without push, long enough to be
+/// cheap on battery and metered networks. Tune via this constant.
+const _kChannelPollInterval = Duration(seconds: 30);
 
 /// Provider for the channels API. Must be overridden in main.dart once a
 /// [RemoteDevClient] is wired for the active server (Wave 4 wiring).
@@ -27,7 +35,58 @@ class ChannelsTabScreen extends ConsumerStatefulWidget {
   ConsumerState<ChannelsTabScreen> createState() => _ChannelsTabScreenState();
 }
 
-class _ChannelsTabScreenState extends ConsumerState<ChannelsTabScreen> {
+class _ChannelsTabScreenState extends ConsumerState<ChannelsTabScreen>
+    with WidgetsBindingObserver {
+  Timer? _pollTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _startPolling();
+  }
+
+  @override
+  void dispose() {
+    _stopPolling();
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Pause polling while the app is backgrounded; resume when it comes back.
+    // Note: this does NOT pause polling when the user switches to another tab
+    // inside HomeShell — IndexedStack keeps this screen mounted. That's an
+    // acceptable trade-off (one cheap GET every 30s while foregrounded) and
+    // is tracked as a follow-up to wire tab-visibility-aware polling.
+    if (state == AppLifecycleState.resumed) {
+      if (_pollTimer == null) {
+        // Refresh immediately on return-to-foreground so unread counts are
+        // current without waiting a full interval.
+        ref.invalidate(channelsListProvider);
+        _startPolling();
+      }
+    } else if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.detached ||
+        state == AppLifecycleState.hidden) {
+      _stopPolling();
+    }
+  }
+
+  void _startPolling() {
+    _pollTimer?.cancel();
+    _pollTimer = Timer.periodic(_kChannelPollInterval, (_) {
+      if (!mounted) return;
+      ref.invalidate(channelsListProvider);
+    });
+  }
+
+  void _stopPolling() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+  }
+
   Future<void> _refresh() async {
     ref.invalidate(channelsListProvider);
     await ref.read(channelsListProvider.future);

--- a/mobile/test/presentation/screens/channels/channels_tab_screen_test.dart
+++ b/mobile/test/presentation/screens/channels/channels_tab_screen_test.dart
@@ -9,6 +9,7 @@ class _FakeChannelsApi extends Fake implements ChannelsApi {
   _FakeChannelsApi(this._channels);
   final List<Channel> _channels;
   bool _shouldThrow = false;
+  int listCallCount = 0;
 
   void setError() {
     _shouldThrow = true;
@@ -16,6 +17,7 @@ class _FakeChannelsApi extends Fake implements ChannelsApi {
 
   @override
   Future<List<Channel>> list() async {
+    listCallCount += 1;
     if (_shouldThrow) {
       throw StateError('boom');
     }
@@ -84,5 +86,83 @@ void main() {
 
     expect(find.text('Failed to load channels'), findsOneWidget);
     expect(find.text('Retry'), findsOneWidget);
+  });
+
+  testWidgets('polls channels list every 30s while mounted',
+      (tester) async {
+    final api = _FakeChannelsApi(const [
+      Channel(id: 'c1', name: 'general', unreadCount: 0),
+    ]);
+    await tester.pumpWidget(wrap(const ChannelsTabScreen(), api: api));
+    await tester.pumpAndSettle();
+
+    // Initial load fired exactly once.
+    expect(api.listCallCount, 1);
+
+    // Advance the fake clock past the 30s polling interval and let the
+    // resulting future settle.
+    await tester.pump(const Duration(seconds: 30));
+    await tester.pumpAndSettle();
+    expect(api.listCallCount, greaterThan(1));
+
+    // A second tick should fire another refresh.
+    final afterFirstTick = api.listCallCount;
+    await tester.pump(const Duration(seconds: 30));
+    await tester.pumpAndSettle();
+    expect(api.listCallCount, greaterThan(afterFirstTick));
+  });
+
+  testWidgets('cancels timer on dispose so no further polls fire',
+      (tester) async {
+    final api = _FakeChannelsApi(const [
+      Channel(id: 'c1', name: 'general', unreadCount: 0),
+    ]);
+    // Mount inside the same ProviderScope (single override), then swap the
+    // child to a benign widget. This unmounts ChannelsTabScreen and triggers
+    // dispose() while keeping the override list shape stable (Riverpod
+    // requires identical override counts across pumpWidget calls).
+    await tester.pumpWidget(wrap(const ChannelsTabScreen(), api: api));
+    await tester.pumpAndSettle();
+    expect(api.listCallCount, 1);
+
+    await tester.pumpWidget(
+      wrap(const SizedBox.shrink(), api: api),
+    );
+    await tester.pumpAndSettle();
+
+    final afterDispose = api.listCallCount;
+    await tester.pump(const Duration(seconds: 60));
+    await tester.pumpAndSettle();
+    // No additional polls should have fired after dispose.
+    expect(api.listCallCount, afterDispose);
+  });
+
+  testWidgets('stops polling when app is backgrounded and resumes on return',
+      (tester) async {
+    final api = _FakeChannelsApi(const [
+      Channel(id: 'c1', name: 'general', unreadCount: 0),
+    ]);
+    await tester.pumpWidget(wrap(const ChannelsTabScreen(), api: api));
+    await tester.pumpAndSettle();
+    expect(api.listCallCount, 1);
+
+    // Background the app — polling should stop.
+    final binding = tester.binding;
+    binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pumpAndSettle();
+
+    final afterPause = api.listCallCount;
+    await tester.pump(const Duration(seconds: 60));
+    await tester.pumpAndSettle();
+    expect(
+      api.listCallCount,
+      afterPause,
+      reason: 'No polling should happen while backgrounded',
+    );
+
+    // Resume the app — should refresh immediately and restart the timer.
+    binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pumpAndSettle();
+    expect(api.listCallCount, greaterThan(afterPause));
   });
 }


### PR DESCRIPTION
## Summary
ChannelsTabScreen now polls `channelsListProvider` every 30s while mounted, so unread badges stay live without needing pull-to-refresh.

### Implementation
- Converted to `WidgetsBindingObserver`
- `Timer.periodic(_kChannelPollInterval = 30s)` calls `ref.invalidate(channelsListProvider)`
- `didChangeAppLifecycleState`: cancels on `paused/hidden/detached`, restarts (with immediate invalidate) on `resumed`
- `dispose()` cancels timer + removes observer

### Trade-off
HomeShell uses `IndexedStack`, so the screen stays mounted across tabs — the 30s timer fires even on inactive tabs. Explicitly documented in code as a future optimization; not worth the complexity here.

### Server SSE/websocket
Real "push" updates would need cross-team backend work to expose channel events. Polling is the realistic mobile-only shippable.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` 303/303 (1 pre-existing skip)
- [x] New tests: polling fires after 30s; timer cancels on dispose; lifecycle paused stops polling, resumed restarts

Closes remote-dev-ph5b.

This pull request and its description were written by Isaac.