### PR TITLE
feat(mobile): WebView page-load progress indicator (remote-dev-72dh)

### DIFF
--- a/mobile/lib/infrastructure/webview/webview_factory.dart
+++ b/mobile/lib/infrastructure/webview/webview_factory.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 import 'navigation_policy.dart';
@@ -13,12 +14,16 @@ class WebViewFactory {
   ///   passes their handlers via [onWebViewCreated]; this factory does
   ///   not register handlers itself (Phase 2 wires the bridge).
   /// - Rule 5: navigation policy enforced via shouldOverrideUrlLoading.
-  InAppWebView build({
+  ///
+  /// Returns [Widget] (not [InAppWebView] specifically) so test fakes can
+  /// return a lightweight stand-in without triggering the platform plugin.
+  Widget build({
     required Uri initialUrl,
     required NavigationPolicy policy,
     required OnLinkOpen onLinkOpen,
     void Function(InAppWebViewController controller)? onWebViewCreated,
     void Function(InAppWebViewController controller, WebUri? url)? onLoadStop,
+    ValueChanged<int>? onProgressChanged,
   }) {
     return InAppWebView(
       initialUrlRequest: URLRequest(url: WebUri(initialUrl.toString())),
@@ -39,6 +44,12 @@ class WebViewFactory {
       ),
       onWebViewCreated: onWebViewCreated,
       onLoadStop: onLoadStop,
+      // Page-load progress (0-100). Hosts use this to render a thin
+      // LinearProgressIndicator until the embedded PWA reports complete.
+      // See bd remote-dev-72dh.
+      onProgressChanged: onProgressChanged == null
+          ? null
+          : (controller, progress) => onProgressChanged(progress),
       shouldOverrideUrlLoading: (controller, action) async {
         final uri = action.request.url?.uriValue;
         if (uri == null) return NavigationActionPolicy.CANCEL;

--- a/mobile/lib/presentation/screens/channels/channel_screen.dart
+++ b/mobile/lib/presentation/screens/channels/channel_screen.dart
@@ -32,6 +32,7 @@ class ChannelScreen extends ConsumerStatefulWidget {
   const ChannelScreen({
     required this.channelId,
     this.bridgeFactoryOverride,
+    this.webViewFactory,
     super.key,
   });
 
@@ -48,12 +49,19 @@ class ChannelScreen extends ConsumerStatefulWidget {
   final BridgeController Function(InAppWebViewController? controller)?
       bridgeFactoryOverride;
 
+  /// Test seam — defaults to a real [WebViewFactory]. Tests can substitute
+  /// a fake factory that controls `onProgressChanged` to drive the AppBar
+  /// progress indicator without needing a real WebView.
+  final WebViewFactory? webViewFactory;
+
   @override
   ConsumerState<ChannelScreen> createState() => _ChannelScreenState();
 }
 
 class _ChannelScreenState extends ConsumerState<ChannelScreen> {
   BridgeController? _bridge;
+  // Page-load progress (0-100). 100 hides the AppBar indicator.
+  int _progress = 100;
 
   @override
   void initState() {
@@ -116,6 +124,17 @@ class _ChannelScreenState extends ConsumerState<ChannelScreen> {
           icon: const Icon(Icons.arrow_back),
           onPressed: _handleBack,
         ),
+        bottom: _progress < 100
+            ? PreferredSize(
+                preferredSize: const Size.fromHeight(2),
+                child: LinearProgressIndicator(
+                  value: _progress / 100,
+                  minHeight: 2,
+                  backgroundColor: Colors.transparent,
+                  color: const Color(0xFF7AA2F7),
+                ),
+              )
+            : null,
       ),
       body: asyncServer.when(
         loading: () => const Center(child: CircularProgressIndicator()),
@@ -136,7 +155,8 @@ class _ChannelScreenState extends ConsumerState<ChannelScreen> {
           }
           final origin = Uri.parse(server.url);
           final url = origin.replace(path: '/m/channel/${widget.channelId}');
-          return WebViewFactory().build(
+          final factory = widget.webViewFactory ?? const WebViewFactory();
+          return factory.build(
             initialUrl: url,
             policy: NavigationPolicy(
               serverOrigin: origin,
@@ -144,6 +164,9 @@ class _ChannelScreenState extends ConsumerState<ChannelScreen> {
             ),
             onLinkOpen: (_) {},
             onWebViewCreated: _onWebViewCreated,
+            onProgressChanged: (p) {
+              if (mounted) setState(() => _progress = p);
+            },
           );
         },
       ),

--- a/mobile/lib/presentation/screens/recording/recording_screen.dart
+++ b/mobile/lib/presentation/screens/recording/recording_screen.dart
@@ -55,6 +55,9 @@ class RecordingScreen extends ConsumerStatefulWidget {
 
 class _RecordingScreenState extends ConsumerState<RecordingScreen> {
   BridgeController? _bridge;
+  // Page-load progress (0-100). 100 means the embedded PWA finished
+  // loading; the AppBar progress indicator is hidden in that state.
+  int _progress = 100;
 
   void _onWebViewCreated(InAppWebViewController controller) {
     final bridge = BridgeController(controller: controller);
@@ -104,6 +107,17 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
           icon: const Icon(Icons.arrow_back),
           onPressed: _handleBack,
         ),
+        bottom: _progress < 100
+            ? PreferredSize(
+                preferredSize: const Size.fromHeight(2),
+                child: LinearProgressIndicator(
+                  value: _progress / 100,
+                  minHeight: 2,
+                  backgroundColor: Colors.transparent,
+                  color: const Color(0xFF7AA2F7),
+                ),
+              )
+            : null,
       ),
       body: asyncServer.when(
         loading: () => const Center(child: CircularProgressIndicator()),
@@ -133,6 +147,9 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
             ),
             onLinkOpen: (_) {},
             onWebViewCreated: _onWebViewCreated,
+            onProgressChanged: (p) {
+              if (mounted) setState(() => _progress = p);
+            },
           );
         },
       ),

--- a/mobile/test/presentation/screens/channels/channel_screen_test.dart
+++ b/mobile/test/presentation/screens/channels/channel_screen_test.dart
@@ -1,14 +1,21 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:remote_dev/application/ports/server_config_store.dart';
 import 'package:remote_dev/domain/channel.dart';
+import 'package:remote_dev/domain/server_config.dart';
 import 'package:remote_dev/infrastructure/api/channels_api.dart';
 import 'package:remote_dev/infrastructure/webview/bridge_controller.dart';
+import 'package:remote_dev/infrastructure/webview/navigation_policy.dart';
+import 'package:remote_dev/infrastructure/webview/webview_factory.dart';
 import 'package:remote_dev/presentation/screens/channels/channel_screen.dart';
 import 'package:remote_dev/presentation/screens/channels/channels_tab_screen.dart';
+import 'package:remote_dev/presentation/screens/webview_host/session_route_host.dart'
+    show serverConfigStoreProvider;
 
 /// `ChannelScreen` is a thin native wrapper around an embedded WebView
 /// pointed at `<server>/m/channel/<id>` — the real message list, send
@@ -41,6 +48,42 @@ class _DelayedChannelsApi extends Fake implements ChannelsApi {
   @override
   Future<void> archive(String id) async {}
 }
+
+class _MockStore extends Mock implements ServerConfigStore {}
+
+/// Same shape as `_RecordingWebViewFactory` — captures the
+/// `onProgressChanged` callback the screen wires into [WebViewFactory.build]
+/// so the test can simulate page-load progress events.
+class _ChannelWebViewFactory implements WebViewFactory {
+  ValueChanged<int>? capturedOnProgressChanged;
+
+  @override
+  Widget build({
+    required Uri initialUrl,
+    required NavigationPolicy policy,
+    required OnLinkOpen onLinkOpen,
+    void Function(InAppWebViewController controller)? onWebViewCreated,
+    void Function(InAppWebViewController controller, WebUri? url)? onLoadStop,
+    ValueChanged<int>? onProgressChanged,
+  }) {
+    capturedOnProgressChanged = onProgressChanged;
+    // SizedBox stand-in — the real InAppWebView's platform plugin isn't
+    // available under flutter_test and would replace the host subtree
+    // with an ErrorWidget.
+    return const SizedBox.shrink();
+  }
+}
+
+ServerConfig _serverConfig({
+  String id = 'srv-1',
+  String url = 'https://dev.example.com',
+}) =>
+    ServerConfig(
+      id: id,
+      label: 'Work',
+      url: url,
+      lastUsedAt: DateTime.utc(2025, 1, 1),
+    );
 
 void main() {
   testWidgets('ChannelScreen mounts with the channel AppBar', (tester) async {
@@ -239,6 +282,64 @@ void main() {
       },
     );
   });
+
+  testWidgets(
+    'AppBar LinearProgressIndicator shows on partial progress and hides at 100',
+    (tester) async {
+      // bd remote-dev-72dh: WebViewFactory exposes an onProgressChanged hook
+      // that drives a thin progress bar at the AppBar bottom. Partial values
+      // render the indicator; 100 hides it.
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (details) {
+        if (details.exceptionAsString().contains('InAppWebViewPlatform')) {
+          return;
+        }
+        originalOnError?.call(details);
+      };
+      addTearDown(() => FlutterError.onError = originalOnError);
+
+      final store = _MockStore();
+      when(store.loadActive).thenAnswer((_) async => _serverConfig());
+      final factory = _ChannelWebViewFactory();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            serverConfigStoreProvider.overrideWithValue(store),
+          ],
+          child: MaterialApp(
+            home: ChannelScreen(
+              channelId: 'c-progress',
+              webViewFactory: factory,
+            ),
+          ),
+        ),
+      );
+      // Flush the active-server FutureProvider microtasks so `build` runs.
+      for (var i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+
+      // Initial: progress=100 → no indicator.
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+      expect(factory.capturedOnProgressChanged, isNotNull);
+
+      // Partial progress event → indicator appears with the Tokyo Night blue.
+      factory.capturedOnProgressChanged!(60);
+      await tester.pump();
+      final indicators = tester.widgetList<LinearProgressIndicator>(
+        find.byType(LinearProgressIndicator),
+      );
+      expect(indicators, hasLength(1));
+      expect(indicators.first.value, closeTo(0.6, 1e-9));
+      expect(indicators.first.color, equals(const Color(0xFF7AA2F7)));
+
+      // Completion → indicator hides.
+      factory.capturedOnProgressChanged!(100);
+      await tester.pump();
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+    },
+  );
 
   testWidgets(
     'shows fallback "Channel" before list resolves, then "#name" after',

--- a/mobile/test/presentation/screens/recording/recording_screen_test.dart
+++ b/mobile/test/presentation/screens/recording/recording_screen_test.dart
@@ -20,27 +20,25 @@ class _MockStore extends Mock implements ServerConfigStore {}
 class _RecordingWebViewFactory implements WebViewFactory {
   Uri? capturedUrl;
   NavigationPolicy? capturedPolicy;
+  ValueChanged<int>? capturedOnProgressChanged;
 
   @override
-  InAppWebView build({
+  Widget build({
     required Uri initialUrl,
     required NavigationPolicy policy,
     required OnLinkOpen onLinkOpen,
     void Function(InAppWebViewController controller)? onWebViewCreated,
     void Function(InAppWebViewController controller, WebUri? url)? onLoadStop,
+    ValueChanged<int>? onProgressChanged,
   }) {
     capturedUrl = initialUrl;
     capturedPolicy = policy;
-    // We can't return a real InAppWebView from a fake without the platform
-    // channel, but we _can_ return a stub one — flutter_test never paints
-    // its platform view, and the assertions below run before any pump that
-    // would force creation. Use SizedBox via a wrapper — but the build
-    // method's return type is InAppWebView. Constructing one with a bogus
-    // URL won't error in widget tests because the platform plugin is never
-    // initialized; the widget tree just won't lay out the native side.
-    return InAppWebView(
-      initialUrlRequest: URLRequest(url: WebUri(initialUrl.toString())),
-    );
+    capturedOnProgressChanged = onProgressChanged;
+    // Avoid constructing a real `InAppWebView` here — its platform plugin
+    // isn't available under flutter_test and the resulting throw replaces
+    // the host subtree with an ErrorWidget, hiding the AppBar we're
+    // asserting on. A `SizedBox` is enough for the tests below.
+    return const SizedBox.shrink();
   }
 }
 
@@ -151,6 +149,59 @@ void main() {
         ),
         equals(NavigationDecision.allow),
       );
+    },
+  );
+
+  testWidgets(
+    'AppBar LinearProgressIndicator shows on partial progress and hides at 100',
+    (tester) async {
+      // Verifies the bd remote-dev-72dh wiring: WebViewFactory.build receives an
+      // onProgressChanged callback; partial values render the thin indicator on
+      // the AppBar bottom; 100 hides it.
+      suppressInAppWebViewErrors(tester);
+
+      final store = _MockStore();
+      when(store.loadActive).thenAnswer(
+        (_) async => _config(url: 'https://dev.example.com'),
+      );
+      final factory = _RecordingWebViewFactory();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            serverConfigStoreProvider.overrideWithValue(store),
+          ],
+          child: MaterialApp(
+            home: RecordingScreen(
+              recordingId: 'rec-progress',
+              webViewFactory: factory,
+            ),
+          ),
+        ),
+      );
+      // Flush the FutureProvider microtasks so the data branch builds.
+      for (var i = 0; i < 5; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+
+      // Initial state: progress=100 → no indicator on AppBar bottom.
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+      expect(factory.capturedOnProgressChanged, isNotNull);
+
+      // Simulate a partial page-load progress event from the WebView.
+      factory.capturedOnProgressChanged!(60);
+      await tester.pump();
+      final indicators = tester.widgetList<LinearProgressIndicator>(
+        find.byType(LinearProgressIndicator),
+      );
+      expect(indicators, hasLength(1));
+      expect(indicators.first.value, closeTo(0.6, 1e-9));
+      expect(indicators.first.color, equals(const Color(0xFF7AA2F7)));
+
+      // Complete: 100 hides the indicator.
+      factory.capturedOnProgressChanged!(100);
+      await tester.pump();
+      expect(find.byType(LinearProgressIndicator), findsNothing);
     },
   );
 }


### PR DESCRIPTION
## Summary
Adds a 2px Tokyo Night `#7AA2F7` `LinearProgressIndicator` to the AppBar `bottom:` of WebView host screens, driven by `InAppWebView.onProgressChanged`.

### Per-screen disposition
- **RecordingScreen** ✓ wired
- **ChannelScreen** ✓ wired (also got a `webViewFactory` test seam matching CfLoginWebView/Recording precedent)
- **SessionViewScreen** — skipped (option b in task spec): xterm.js loads via WebSocket, not the WebView page-progress mechanism
- **bridge_spike / webview_host** — skipped (optional)

### WebViewFactory change
- Adds optional `ValueChanged<int>? onProgressChanged` parameter
- Return type widened from `InAppWebView` to `Widget` so test fakes can return `SizedBox.shrink()` (avoids flutter_test platform plugin crash)

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` 302/302 (with 2 new screen widget tests asserting indicator value 0.6 + color, and hidden at 100)

Closes remote-dev-72dh.

This pull request and its description were written by Isaac.