### PR TITLE
fix(secrets): collapse provider surface to Phase only (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Secrets**: Collapsed secrets provider surface area to Phase only —
+  removed unused type members, config interfaces, and factory branches
+  for `vault`, `aws-secrets-manager`, and `1password`. The UI was
+  already restricted in commit 39e5c23; this removes the corresponding
+  dead backend surface so the type system reflects what actually works.
+  `SUPPORTED_SECRETS_PROVIDERS` alias dropped; callers now import
+  `SECRETS_PROVIDERS` directly. Closes #175.
+
 ### Added (Phase 9 — mobile final follow-ups)
 
 - **Mobile**: Live unread count refresh on the Channels tab via 30 s

--- a/src/components/profiles/ProfileSecretsTab.tsx
+++ b/src/components/profiles/ProfileSecretsTab.tsx
@@ -24,14 +24,14 @@ import {
 } from "lucide-react";
 import { useProfileContext } from "@/contexts/ProfileContext";
 import type { ProfileSecretsProviderType, ProfileSecretsConfig } from "@/types/agent";
-import { SUPPORTED_SECRETS_PROVIDERS } from "@/types/secrets";
+import { SECRETS_PROVIDERS } from "@/types/secrets";
 
 interface ProfileSecretsTabProps {
   profileId: string;
 }
 
 const PROVIDER_OPTIONS: { value: ProfileSecretsProviderType; label: string }[] =
-  SUPPORTED_SECRETS_PROVIDERS.map((provider) => ({
+  SECRETS_PROVIDERS.map((provider) => ({
     value: provider.type as ProfileSecretsProviderType,
     label: provider.name,
   }));

--- a/src/components/profiles/ProfileSecretsTab.tsx
+++ b/src/components/profiles/ProfileSecretsTab.tsx
@@ -32,7 +32,7 @@ interface ProfileSecretsTabProps {
 
 const PROVIDER_OPTIONS: { value: ProfileSecretsProviderType; label: string }[] =
   SECRETS_PROVIDERS.map((provider) => ({
-    value: provider.type as ProfileSecretsProviderType,
+    value: provider.type,
     label: provider.name,
   }));
 

--- a/src/components/secrets/SecretsConfigView.tsx
+++ b/src/components/secrets/SecretsConfigView.tsx
@@ -38,7 +38,7 @@ import { useSecretsContext } from "@/contexts/SecretsContext";
 import { usePreferencesContext } from "@/contexts/PreferencesContext";
 import { useProjectTree } from "@/contexts/ProjectTreeContext";
 import {
-  SUPPORTED_SECRETS_PROVIDERS,
+  SECRETS_PROVIDERS,
   getProviderInfo,
   type SecretsProviderType,
   type SecretsValidationResult,
@@ -398,7 +398,7 @@ export function SecretsConfigView({ initialFolderId, onClose }: SecretsConfigVie
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent className="bg-card border-border">
-                      {SUPPORTED_SECRETS_PROVIDERS.map((p) => (
+                      {SECRETS_PROVIDERS.map((p) => (
                         <SelectItem
                           key={p.type}
                           value={p.type}

--- a/src/components/settings/sections/SecretsSection.tsx
+++ b/src/components/settings/sections/SecretsSection.tsx
@@ -35,7 +35,7 @@ import { useSecretsContext } from "@/contexts/SecretsContext";
 import { usePreferencesContext } from "@/contexts/PreferencesContext";
 import { useProjectTree } from "@/contexts/ProjectTreeContext";
 import {
-  SUPPORTED_SECRETS_PROVIDERS,
+  SECRETS_PROVIDERS,
   getProviderInfo,
   type SecretsProviderType,
   type SecretsValidationResult,
@@ -348,7 +348,7 @@ export function SecretsSection() {
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent className="bg-card border-border">
-                      {SUPPORTED_SECRETS_PROVIDERS.map((p) => (
+                      {SECRETS_PROVIDERS.map((p) => (
                         <SelectItem
                           key={p.type}
                           value={p.type}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -975,7 +975,7 @@ export const profileSecretsConfig = sqliteTable(
     userId: text("user_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
-    provider: text("provider").notNull(), // "phase" | "vault" | "aws-secrets-manager" | "1password"
+    provider: text("provider").notNull(), // "phase"
     // Provider-specific config as JSON:
     // Phase: { "app": "my-app", "env": "development", "serviceToken": "pss_..." }
     providerConfig: text("provider_config").notNull(),

--- a/src/services/agent-profile-service.ts
+++ b/src/services/agent-profile-service.ts
@@ -1131,6 +1131,14 @@ export async function fetchProfileSecrets(
     return null;
   }
 
+  if (!isProviderSupported(config.provider)) {
+    log.warn("Skipping profile secrets fetch: unsupported provider in DB", {
+      profileId,
+      provider: config.provider,
+    });
+    return null;
+  }
+
   const provider = createSecretsProvider({
     provider: config.provider as ProfileSecretsProviderType,
     config: providerConfig,

--- a/src/services/secrets/provider-factory.ts
+++ b/src/services/secrets/provider-factory.ts
@@ -2,7 +2,7 @@
  * Secrets Provider Factory
  *
  * Factory pattern for creating secrets provider instances.
- * Supports Phase.dev with stubs for future providers.
+ * Supports the Phase.dev provider.
  */
 
 import type { SecretsProviderClient, ProviderFactoryInput } from "./types";
@@ -20,27 +20,6 @@ export function createSecretsProvider(input: ProviderFactoryInput): SecretsProvi
     case "phase":
       return new PhaseSecretsProvider(config);
 
-    case "vault":
-      throw new SecretsServiceError(
-        "HashiCorp Vault provider is not yet implemented",
-        "PROVIDER_NOT_IMPLEMENTED",
-        "vault"
-      );
-
-    case "aws-secrets-manager":
-      throw new SecretsServiceError(
-        "AWS Secrets Manager provider is not yet implemented",
-        "PROVIDER_NOT_IMPLEMENTED",
-        "aws-secrets-manager"
-      );
-
-    case "1password":
-      throw new SecretsServiceError(
-        "1Password provider is not yet implemented",
-        "PROVIDER_NOT_IMPLEMENTED",
-        "1password"
-      );
-
     default:
       throw new SecretsServiceError(
         `Unknown secrets provider: ${provider}`,
@@ -51,7 +30,10 @@ export function createSecretsProvider(input: ProviderFactoryInput): SecretsProvi
 }
 
 /**
- * Check if a provider is supported
+ * Check if a provider is supported.
+ *
+ * Retained as a runtime guard for DB drift — old rows could carry a
+ * provider string that is no longer in the type union.
  */
 export function isProviderSupported(provider: string): boolean {
   return provider === "phase";
@@ -62,16 +44,4 @@ export function isProviderSupported(provider: string): boolean {
  */
 export function getSupportedProviders(): SecretsProviderType[] {
   return ["phase"];
-}
-
-/**
- * Get list of all providers including coming soon (for UI)
- */
-export function getAllProviders(): { type: SecretsProviderType; supported: boolean }[] {
-  return [
-    { type: "phase", supported: true },
-    { type: "vault", supported: false },
-    { type: "aws-secrets-manager", supported: false },
-    { type: "1password", supported: false },
-  ];
 }

--- a/src/services/secrets/types.ts
+++ b/src/services/secrets/types.ts
@@ -2,7 +2,8 @@
  * Secrets Provider Interface
  *
  * Defines the contract that all secrets providers must implement.
- * This abstraction allows easy addition of new providers (Vault, AWS, 1Password).
+ * Phase.dev is the only supported provider; the interface is retained so
+ * additional providers can be added without rewriting call sites.
  */
 
 import type { SecretValue, SecretsValidationResult } from "@/types/secrets";

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -169,7 +169,7 @@ export interface ProfileCredentials {
 /**
  * Secrets provider type (matches SecretsProviderType from secrets module).
  */
-export type ProfileSecretsProviderType = "phase" | "vault" | "aws-secrets-manager" | "1password";
+export type ProfileSecretsProviderType = "phase";
 
 /**
  * Profile-level secrets configuration.

--- a/src/types/secrets.test.ts
+++ b/src/types/secrets.test.ts
@@ -1,25 +1,8 @@
 import { describe, expect, it } from "vitest";
-import {
-  SECRETS_PROVIDERS,
-  SUPPORTED_SECRETS_PROVIDERS,
-} from "./secrets";
+import { SECRETS_PROVIDERS } from "./secrets";
 
-describe("SUPPORTED_SECRETS_PROVIDERS", () => {
-  it("only exposes providers that are actually supported", () => {
-    expect(SUPPORTED_SECRETS_PROVIDERS.map((provider) => provider.type)).toEqual([
-      "phase",
-    ]);
-  });
-
-  it("marks unsupported providers as not supported in the full catalog", () => {
-    const unsupportedProviders = SECRETS_PROVIDERS
-      .filter((provider) => !provider.supported)
-      .map((provider) => provider.type);
-
-    expect(unsupportedProviders).toEqual([
-      "vault",
-      "aws-secrets-manager",
-      "1password",
-    ]);
+describe("SECRETS_PROVIDERS", () => {
+  it("exposes phase as the only supported provider", () => {
+    expect(SECRETS_PROVIDERS.map((provider) => provider.type)).toEqual(["phase"]);
   });
 });

--- a/src/types/secrets.ts
+++ b/src/types/secrets.ts
@@ -2,13 +2,13 @@
  * Secrets Management Type Definitions
  *
  * Implements a provider abstraction for external secrets managers.
- * Supports Phase.dev initially, with extensibility for Vault, AWS, 1Password.
+ * Phase.dev is the only supported provider.
  */
 
 /**
  * Supported secrets providers
  */
-export type SecretsProviderType = "phase" | "vault" | "aws-secrets-manager" | "1password";
+export type SecretsProviderType = "phase";
 
 /**
  * Individual secret value
@@ -27,34 +27,6 @@ export interface PhaseProviderConfig {
   path?: string;
   serviceToken: string;
 }
-
-export interface VaultProviderConfig {
-  url: string;
-  path: string;
-  token: string;
-}
-
-export interface AWSSecretsProviderConfig {
-  region: string;
-  secretId: string;
-  accessKeyId?: string;
-  secretAccessKey?: string;
-}
-
-export interface OnePasswordProviderConfig {
-  vault: string;
-  item: string;
-  serviceAccountToken: string;
-}
-
-/**
- * Union of all provider configs
- */
-export type ProviderConfig =
-  | { provider: "phase"; config: PhaseProviderConfig }
-  | { provider: "vault"; config: VaultProviderConfig }
-  | { provider: "aws-secrets-manager"; config: AWSSecretsProviderConfig }
-  | { provider: "1password"; config: OnePasswordProviderConfig };
 
 /**
  * Generic provider config for storage
@@ -114,7 +86,6 @@ export interface SecretsProviderInfo {
   name: string;
   description: string;
   icon: string;
-  supported: boolean;
   configFields: SecretsConfigField[];
 }
 
@@ -140,7 +111,6 @@ export const SECRETS_PROVIDERS: SecretsProviderInfo[] = [
     name: "Phase",
     description: "End-to-end encrypted secrets management",
     icon: "shield",
-    supported: true,
     configFields: [
       {
         key: "serviceToken",
@@ -179,108 +149,7 @@ export const SECRETS_PROVIDERS: SecretsProviderInfo[] = [
       },
     ],
   },
-  {
-    type: "vault",
-    name: "HashiCorp Vault",
-    description: "Manage secrets and protect sensitive data",
-    icon: "lock",
-    supported: false,
-    configFields: [
-      {
-        key: "url",
-        label: "Vault URL",
-        type: "text",
-        placeholder: "https://vault.example.com",
-        required: true,
-      },
-      {
-        key: "token",
-        label: "Token",
-        type: "password",
-        placeholder: "hvs.xxxxx",
-        required: true,
-      },
-      {
-        key: "path",
-        label: "Secret Path",
-        type: "text",
-        placeholder: "secret/data/myapp",
-        required: true,
-      },
-    ],
-  },
-  {
-    type: "aws-secrets-manager",
-    name: "AWS Secrets Manager",
-    description: "Rotate, manage, and retrieve database credentials and secrets",
-    icon: "cloud",
-    supported: false,
-    configFields: [
-      {
-        key: "region",
-        label: "AWS Region",
-        type: "text",
-        placeholder: "us-east-1",
-        required: true,
-      },
-      {
-        key: "secretId",
-        label: "Secret ID/ARN",
-        type: "text",
-        placeholder: "my-app/production",
-        required: true,
-      },
-      {
-        key: "accessKeyId",
-        label: "Access Key ID",
-        type: "password",
-        placeholder: "AKIA...",
-        required: false,
-        helpText: "Optional: Uses default credentials if not provided",
-      },
-      {
-        key: "secretAccessKey",
-        label: "Secret Access Key",
-        type: "password",
-        required: false,
-      },
-    ],
-  },
-  {
-    type: "1password",
-    name: "1Password",
-    description: "Enterprise password management",
-    icon: "key",
-    supported: false,
-    configFields: [
-      {
-        key: "serviceAccountToken",
-        label: "Service Account Token",
-        type: "password",
-        placeholder: "ops_...",
-        required: true,
-      },
-      {
-        key: "vault",
-        label: "Vault Name",
-        type: "text",
-        placeholder: "Development",
-        required: true,
-      },
-      {
-        key: "item",
-        label: "Item Name",
-        type: "text",
-        placeholder: "API Keys",
-        required: true,
-      },
-    ],
-  },
 ];
-
-export const SUPPORTED_SECRETS_PROVIDERS = SECRETS_PROVIDERS.filter(
-  (provider) => provider.supported
-);
 
 /**
  * Get provider info by type


### PR DESCRIPTION
## Summary

- Closes #175.
- Removes type members, config interfaces, factory branches, and `SECRETS_PROVIDERS` entries for `vault`, `aws-secrets-manager`, and `1password`.
- UI was already restricted to Phase in commit 39e5c23; this removes the corresponding dead backend surface so the type system reflects what actually works.
- `SUPPORTED_SECRETS_PROVIDERS` alias dropped; the three UI call sites now import `SECRETS_PROVIDERS` directly.
- `isProviderSupported` / `getSupportedProviders` retained as DB-drift guards (legacy rows could carry a stale provider string).
- `PROVIDER_NOT_IMPLEMENTED` error code intentionally left in `src/lib/errors.ts` (out of scope).
- No DB migration — column stays `text`; the schema comment is updated.

## Files (9 changed, +29 / −197)

- `src/types/secrets.ts` — type narrowed, three config interfaces deleted, `ProviderConfig` union deleted (unused), `supported` field removed, alias dropped.
- `src/types/agent.ts` — `ProfileSecretsProviderType` narrowed to `"phase"`.
- `src/services/secrets/provider-factory.ts` — three case branches and `getAllProviders()` removed.
- `src/types/secrets.test.ts` — test collapsed to assert phase-only.
- `src/db/schema.ts` — comment on `provider` column updated.
- `src/components/profiles/ProfileSecretsTab.tsx`, `src/components/secrets/SecretsConfigView.tsx`, `src/components/settings/sections/SecretsSection.tsx` — import rename only.
- `CHANGELOG.md` — `### Changed` entry.

## Test plan

- [x] `bun run typecheck` — passes.
- [x] `bun run test:run -- src/types/secrets.test.ts` — 1 test passes.
- [x] `bun run lint` — 10 pre-existing errors in unrelated files (`SessionsTab.tsx`, `useTerminalWsUrl.ts`); no new errors introduced.
- [x] grep confirms no remaining references to removed provider names or symbols in `src/`.

This pull request and its description were written by Isaac.