### PR TITLE
chore: release v0.3.9 — Flutter mobile usability + identity (Phase 6-9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9] - 2026-05-10
+
 ### Changed
 
 - **Secrets**: Collapsed secrets provider surface area to Phase only —

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-dev",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Web-based terminal interface with persistent tmux sessions and GitHub integration",
   "author": "Remote Dev Team",
   "private": true,


### PR DESCRIPTION
## Summary
- Bump `package.json` 0.3.8 → 0.3.9
- Move CHANGELOG `[Unreleased]` → `[0.3.9] - 2026-05-10`
- Phase 6-9 mobile work delivered via PRs #265-281

## Test plan
- [x] APK builds clean on master (184 MB, 6.2s build)
- [x] APK runs on emulator (Phase 9 emulator screenshot verified — clean Servers screen, RemoteDev label, Tokyo Night)
- [x] Mobile: `flutter analyze` clean, `flutter test` 305/305

## Release flow
After merge: tag v0.3.9, `gh release create` with the fresh APK attached.

This pull request and its description were written by Isaac.