### PR TITLE
fix(mobile): wire FCM notification tap handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Mobile**: FCM notification taps now navigate to the right session
+  (or channel) and sync read-state with the server. `NotificationTapHandler`
+  was defined after the refactor from `archive/mobile-flutter/` but never
+  wired up — `FirebaseMessaging.onMessageOpenedApp` and `getInitialMessage`
+  had no subscribers, so taps were silently dropped. Wired the handler
+  eagerly from `main.dart` via a new `notificationTapHandlerProvider`, and
+  restored the legacy mark-read-on-tap behavior so the web client sees the
+  tap as a read event.
 - **Scripts**: `rdv` and the blue/green deploy webhook no longer leak
   server processes on stop/restart. `Bun.spawn("bun", "run", "tsx",
   "src/server/index.ts", ...)` produces a 3-deep process tree (bun

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -7,8 +7,11 @@ import 'application/state/appearance_provider.dart';
 import 'application/state/reauth_signal_provider.dart';
 import 'infrastructure/deep_link/app_link_listener.dart';
 import 'infrastructure/deep_link/deep_link_stream_provider.dart';
+import 'infrastructure/push/notification_tap_handler.dart';
 import 'presentation/router/app_router.dart';
 import 'presentation/screens/biometric/biometric_lock_overlay.dart';
+import 'presentation/screens/notifications/notifications_tab_screen.dart'
+    show notificationsApiProvider;
 
 final appRouterProvider = Provider<AppRouter>((ref) => AppRouter());
 
@@ -22,6 +25,33 @@ final appLinkListenerProvider = Provider<AppLinkListener>((ref) {
   final listener =
       AppLinkListener(router: router, linkStream: stream, links: links);
   unawaited(listener.start());
+  ref.onDispose(() {
+    unawaited(listener.stop());
+  });
+  return listener;
+});
+
+/// Boots the [NotificationTapHandler] eagerly on first read. Subscribes to
+/// `FirebaseMessaging.onMessageOpenedApp` and drains `getInitialMessage()`
+/// so cold-start taps route to the correct surface. Read once at startup
+/// from `main()` via a `ProviderContainer`.
+final notificationTapHandlerProvider =
+    Provider<NotificationTapHandler>((ref) {
+  final router = ref.read(appRouterProvider);
+  final listener = NotificationTapHandler(
+    router: router,
+    onMarkRead: (id) async {
+      // Swallow every failure mode: no server bound (NoActiveServerError),
+      // cold-start race, or network error — tap navigation must still
+      // succeed even when the read-state sync can't happen.
+      try {
+        await ref.read(notificationsApiProvider).markRead([id]);
+      } catch (e) {
+        debugPrint('[Push] mark-read on tap failed: $e');
+      }
+    },
+  );
+  unawaited(listener.initialize());
   ref.onDispose(() {
     unawaited(listener.stop());
   });

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -41,14 +41,11 @@ final notificationTapHandlerProvider =
   final listener = NotificationTapHandler(
     router: router,
     onMarkRead: (id) async {
-      // Swallow every failure mode: no server bound (NoActiveServerError),
-      // cold-start race, or network error — tap navigation must still
-      // succeed even when the read-state sync can't happen.
-      try {
-        await ref.read(notificationsApiProvider).markRead([id]);
-      } catch (e) {
-        debugPrint('[Push] mark-read on tap failed: $e');
-      }
+      // `notificationsApiProvider` throws `NoActiveServerError`
+      // synchronously when no server is bound; inside this async body that
+      // becomes a rejected Future, which the handler's own `.catchError`
+      // logs and swallows. Don't double-handle here.
+      await ref.read(notificationsApiProvider).markRead([id]);
     },
   );
   unawaited(listener.initialize());

--- a/mobile/lib/infrastructure/push/notification_tap_handler.dart
+++ b/mobile/lib/infrastructure/push/notification_tap_handler.dart
@@ -9,9 +9,16 @@ import '../../presentation/router/app_router.dart';
 /// Translates FCM notification taps into native AppRoute navigations.
 /// Spec §5: payload's sessionId | channelId | notificationId.
 class NotificationTapHandler {
-  NotificationTapHandler({required this.router});
+  NotificationTapHandler({required this.router, this.onMarkRead});
 
   final AppRouter router;
+
+  /// Optional fire-and-forget hook invoked with `data['notificationId']` so
+  /// the tap registers as a read event on the server (parity with legacy
+  /// `archive/mobile-flutter` and the web client). Errors are swallowed —
+  /// missing server / network failure must never block navigation.
+  final Future<void> Function(String notificationId)? onMarkRead;
+
   StreamSubscription<RemoteMessage>? _openedSub;
 
   /// Wire up the three FCM lifecycle entry points. Idempotent.
@@ -38,6 +45,20 @@ class NotificationTapHandler {
   void navigateForPayload(Map<String, dynamic> data) => _navigate(data);
 
   void _navigate(Map<String, dynamic> data) {
+    final notificationId = data['notificationId']?.toString();
+    if (notificationId != null &&
+        notificationId.isNotEmpty &&
+        onMarkRead != null) {
+      // Fire-and-forget: don't block navigation, swallow errors so cold-start
+      // taps still navigate even when no server is bound or the network is
+      // unreachable.
+      // ignore: discarded_futures
+      onMarkRead!(notificationId).catchError((Object e) {
+        debugPrint('[Push] mark-read on tap failed: $e');
+        return null;
+      });
+    }
+
     final sessionId = data['sessionId']?.toString();
     final channelId = data['channelId']?.toString();
     if (sessionId != null && sessionId.isNotEmpty) {

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -138,6 +138,10 @@ void main() async {
   );
   // Read for side effect — kicks off AppLinkListener.start().
   container.read(appLinkListenerProvider);
+  // Read for side effect — wires FirebaseMessaging.onMessageOpenedApp and
+  // getInitialMessage so notification taps navigate to the correct surface
+  // and sync read-state with the server.
+  container.read(notificationTapHandlerProvider);
 
   runApp(
     UncontrolledProviderScope(

--- a/mobile/test/infrastructure/push/notification_tap_handler_test.dart
+++ b/mobile/test/infrastructure/push/notification_tap_handler_test.dart
@@ -60,4 +60,69 @@ void main() {
             as AppRoute;
     expect(captured, isA<ChannelRoute>());
   });
+
+  test('payload with notificationId calls onMarkRead with that id', () async {
+    final calls = <String>[];
+    final h = NotificationTapHandler(
+      router: router,
+      onMarkRead: (id) async {
+        calls.add(id);
+      },
+    );
+    h.navigateForPayload({
+      'notificationId': 'notif-42',
+      'sessionId': 'sess-1',
+    });
+    // onMarkRead is fire-and-forget — let the microtask drain.
+    await Future<void>.delayed(Duration.zero);
+    expect(calls, ['notif-42']);
+    verify(() => router.navigateTo(any())).called(1);
+  });
+
+  test('payload without notificationId does not call onMarkRead', () async {
+    var called = false;
+    final h = NotificationTapHandler(
+      router: router,
+      onMarkRead: (id) async {
+        called = true;
+      },
+    );
+    h.navigateForPayload({'sessionId': 'sess-1'});
+    await Future<void>.delayed(Duration.zero);
+    expect(called, isFalse);
+    verify(() => router.navigateTo(any())).called(1);
+  });
+
+  test('empty notificationId does not call onMarkRead', () async {
+    var called = false;
+    final h = NotificationTapHandler(
+      router: router,
+      onMarkRead: (id) async {
+        called = true;
+      },
+    );
+    h.navigateForPayload({'notificationId': '', 'sessionId': 'sess-1'});
+    await Future<void>.delayed(Duration.zero);
+    expect(called, isFalse);
+  });
+
+  test('onMarkRead failure does not throw and does not block navigation',
+      () async {
+    final h = NotificationTapHandler(
+      router: router,
+      onMarkRead: (id) async {
+        throw StateError('boom');
+      },
+    );
+    // Must not throw.
+    h.navigateForPayload({
+      'notificationId': 'notif-1',
+      'sessionId': 'sess-1',
+    });
+    await Future<void>.delayed(Duration.zero);
+    final captured =
+        verify(() => router.navigateTo(captureAny())).captured.single
+            as AppRoute;
+    expect(captured, isA<SessionRoute>());
+  });
 }


### PR DESCRIPTION
## Summary

- Restores FCM notification tap → session navigation on the Flutter mobile app, which was silently broken after the refactor from `archive/mobile-flutter/`.
- Restores legacy mark-read-on-tap so the web client sees a notification tap as a read event (parity with the archived `push_notification_service.dart`).

## Root cause

`mobile/lib/infrastructure/push/notification_tap_handler.dart` was added with the correct routing logic but **never instantiated**. `main.dart` only called `FcmPushService().initialize()` (Firebase init + permissions) and `container.read(appLinkListenerProvider)` (custom-scheme deep links only). `FirebaseMessaging.onMessageOpenedApp` and `getInitialMessage()` had no subscribers, so taps were dropped.

Server FCM payload (from `src/services/notification-service.ts` `dispatchPush()`) includes `{notificationId, type, sessionId?, sessionName?}` in `data`. The legacy handler at `archive/mobile-flutter/lib/infrastructure/push/push_notification_service.dart:149-168` marked the notification read on tap; the new handler dropped this.

## Fix

- New `notificationTapHandlerProvider` in `mobile/lib/app.dart` mirrors `appLinkListenerProvider`: builds the handler with an `onMarkRead` callback bound to `notificationsApiProvider.markRead`, eagerly calls `initialize()` via `unawaited`, disposes via `ref.onDispose`.
- `main.dart` eager-reads the provider after `appLinkListenerProvider`.
- `NotificationTapHandler` now accepts an optional `onMarkRead(notificationId)` callback. Called fire-and-forget; `.catchError` swallows failures (no server bound, network error) so navigation always succeeds.
- 4 new unit tests in `notification_tap_handler_test.dart` cover the mark-read paths; all 9 tests pass.

## Test plan

- [x] `flutter analyze` → No issues
- [x] `flutter test` → 321 tests pass (9/9 in the tap-handler file)
- [ ] Manual verification on a device with FCM configured: send a push to a session, tap from background, confirm navigation to `/home/session/<id>` and that the notification appears read in the web client.

Closes remote-dev-bken.