### PR TITLE
fix(beads): resolve hydration mismatch from localStorage in useState initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   less-precise 2s-throttled scroll-up clear and 5000-line-feed
   threshold clear (closes remote-dev-xjje, follow-up to
   remote-dev-ofqf).
+- **Web**: BeadsSidebar no longer triggers a React hydration mismatch.
+  Three `useState` initializers (`collapsed`, `width`, `activeTab`) read
+  `localStorage` via `typeof window !== "undefined"` — the exact
+  anti-pattern the hydration error message warns about. Server rendered
+  the collapsed `w-12` strip while the client first render returned the
+  expanded sidebar with `style={{width:294}}`, producing "Hydration
+  failed because the server rendered HTML didn't match the client" and
+  a full tree regeneration on every load. State is now seeded from DB
+  defaults so SSR and first client render agree, and `localStorage` is
+  read in a mount-only `useEffect` with plain setters (not `setStoredX`,
+  which dispatch a `CustomEvent` the component subscribes to).
 - **Mobile**: FCM notification taps now navigate to the right session
   (or channel) and sync read-state with the server. `NotificationTapHandler`
   was defined after the refactor from `archive/mobile-flutter/` but never

--- a/src/components/beads/BeadsSidebar.tsx
+++ b/src/components/beads/BeadsSidebar.tsx
@@ -242,23 +242,36 @@ export function BeadsSidebar({
   const { updateUserSettings } = usePreferencesContext();
   const { schedules } = useScheduleContext();
 
-  // Sidebar state — localStorage for instant rendering, DB defaults for first use
-  const [collapsed, setCollapsed] = useState(() => {
-    if (typeof window !== "undefined" && localStorage.getItem("beads-sidebar-collapsed") !== null) {
-      return getStoredCollapsed();
+  // Sidebar state — seed from DB defaults so SSR and first client render match,
+  // then hydrate from localStorage in a mount-only effect below. Reading
+  // localStorage in the initializer causes a hydration mismatch when the
+  // stored value diverges from the DB default.
+  const [collapsed, setCollapsed] = useState(dbCollapsed);
+  const [width, setWidth] = useState(dbWidth);
+
+  // Selected issue for detail view (declared early so switchTab can reference it)
+  const [selectedIssue, setSelectedIssue] = useState<BeadsIssue | null>(null);
+
+  // Active tab state — seeded with SSR-safe default, hydrated from localStorage on mount.
+  const [activeTab, setActiveTab] = useState<SidebarTab>("beads");
+
+  // Hydrate sidebar state from localStorage after mount. Uses plain setters so
+  // we don't echo a cross-tab event for our own hydration.
+  useEffect(() => {
+    if (localStorage.getItem("beads-sidebar-collapsed") !== null) {
+      setCollapsed(getStoredCollapsed());
     }
-    return dbCollapsed;
-  });
-  const [width, setWidth] = useState(() => {
-    if (typeof window !== "undefined" && localStorage.getItem("beads-sidebar-width") !== null) {
-      return getStoredWidth();
+    if (localStorage.getItem("beads-sidebar-width") !== null) {
+      setWidth(getStoredWidth());
     }
-    return dbWidth;
-  });
+    if (localStorage.getItem("beads-sidebar-tab") !== null) {
+      setActiveTab(getStoredTab());
+    }
+  }, []);
 
   // Sync DB settings → local state when changed via Settings page.
   // Skip the initial mount to avoid overwriting localStorage values that the
-  // initializer already applied (the user may have toggled before prefs loaded).
+  // hydration effect above applied (the user may have toggled before prefs loaded).
   const collapsedSyncMounted = useRef(false);
   useEffect(() => {
     if (!collapsedSyncMounted.current) { collapsedSyncMounted.current = true; return; }
@@ -272,12 +285,6 @@ export function BeadsSidebar({
     setWidth(dbWidth);
     setStoredWidth(dbWidth);
   }, [dbWidth]);
-
-  // Selected issue for detail view (declared early so switchTab can reference it)
-  const [selectedIssue, setSelectedIssue] = useState<BeadsIssue | null>(null);
-
-  // Active tab state — persisted to localStorage
-  const [activeTab, setActiveTab] = useState<SidebarTab>(getStoredTab);
 
   const switchTab = useCallback((tab: SidebarTab) => {
     setActiveTab(tab);


### PR DESCRIPTION
## Summary

`BeadsSidebar.tsx` read `localStorage` inside three `useState` initializers via a `typeof window !== "undefined"` branch — exactly the anti-pattern the React hydration error message calls out. SSR rendered the collapsed `w-12` strip (`dbCollapsed` default = `true`), while the client first render read `localStorage` and returned the expanded sidebar with `style={{width:294}}`, producing:

> Hydration failed because the server rendered HTML didn't match the client.

…and a full client tree regeneration on every load for users with a non-default sidebar preference.

This PR seeds state from DB defaults (server and client agree) and hydrates from `localStorage` in a mount-only effect.

## Key decisions

- **Seed from DB defaults, hydrate in `useEffect`.** Standard React pattern for SSR + localStorage-backed UI state. One frame of "default look" is possible when `localStorage` and DB diverge, but that's strictly better than a hydration tear-down.
- **Hydration effect uses plain setters (not `setStoredX`).** The `setStoredX` helpers dispatch `CustomEvent` on `window` that the same component listens to. Calling them from the hydration effect would create a same-tab echo.
- **Existing skip-mount refs (`collapsedSyncMounted` / `widthSyncMounted`) untouched.** They still skip the first DB-sync run, so the DB-sync effects don't fight the new hydration effect.

## Known follow-up (not in this PR)

Code review surfaced a **pre-existing** race: when `userSettings` loads asynchronously after mount, the DB-sync effects fire and overwrite `localStorage` (and dispatch a cross-tab event) even when the user had a different local preference. This existed before the hydration fix — same race in the old `useState(() => localStorage || dbCollapsed)` pattern. A clean fix needs a `userSettingsLoaded` flag plumbed through `PreferencesContext` → `BeadsContext`, which is out of scope here. Filed as `remote-dev-8y2n`.

## Test plan

- [x] `bun run typecheck` clean on the changed file
- [x] `bun run lint` clean on the changed file
- [ ] Manual: reload the page with `localStorage["beads-sidebar-collapsed"] === "false"` set and confirm no hydration error in console
- [ ] Manual: toggle sidebar collapsed/expanded, reload — state persists
- [ ] Manual: resize sidebar, reload — width persists
- [ ] Manual: switch tab to schedules, reload — tab persists

Closes `remote-dev-ge5h`.

This pull request and its description were written by Isaac.