### PR TITLE
fix(terminal): PWA tap-to-click on xterm mouse-mode TUIs (remote-dev-e07i)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,18 +47,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mouse-mode TUIs (Claude Code clickable buttons, vim, less, lazygit,
   tmux mouse). The previous implementation dispatched synthesized
   mousedown/mouseup on `.xterm-screen` and relied on bubbling up to
-  `terminal.element` where xterm registers its mousedown listener. On
-  installed PWAs (iOS Safari standalone) that bubble was not reliably
-  reaching the parent listener — pinch-zoom and scroll worked (those
-  bypass xterm's mouse pipeline) but mouse-mode TUI buttons silently
-  dropped clicks. Synthesized events now dispatch on `terminal.element`
-  directly, with the mouseup routed through `document` so xterm's
-  document-level listener (registered inside its mousedown handler)
-  catches the UP report. Added `detail: 1` and `composed: true` to the
-  event init for SelectionService click-count + shadow-DOM crossing
-  defensiveness. Includes a new integration test that mounts a real
-  `@xterm/xterm` Terminal and verifies the full tap → SGR mouse report
-  pipeline end-to-end (`useTouchInteractions.realXterm.test.ts`).
+  `terminal.element` (where xterm binds its mousedown listener). On
+  installed PWAs (iOS Safari standalone) that bubble did not reliably
+  reach the parent listener, so mouse-mode TUI buttons silently dropped
+  clicks (pinch-zoom and scroll still worked since they bypass xterm's
+  mouse pipeline). Synthesized events now dispatch on `terminal.element`
+  directly, with mouseup routed through `document` so xterm's
+  document-level mouseup listener catches the UP report. Added
+  `detail: 1` and `composed: true` for SelectionService click-count and
+  shadow-DOM crossing. Added an integration test mounting a real
+  `@xterm/xterm` Terminal that verifies the full tap → SGR mouse report
+  pipeline (`useTouchInteractions.realXterm.test.ts`).
   (remote-dev-e07i)
 - **Mobile**: FCM notification taps now navigate to the right session
   (or channel) and sync read-state with the server. `NotificationTapHandler`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defaults so SSR and first client render agree, and `localStorage` is
   read in a mount-only `useEffect` with plain setters (not `setStoredX`,
   which dispatch a `CustomEvent` the component subscribes to).
+- **Mobile/Terminal**: PWA tap-to-click now reliably reaches xterm.js
+  mouse-mode TUIs (Claude Code clickable buttons, vim, less, lazygit,
+  tmux mouse). The previous implementation dispatched synthesized
+  mousedown/mouseup on `.xterm-screen` and relied on bubbling up to
+  `terminal.element` where xterm registers its mousedown listener. On
+  installed PWAs (iOS Safari standalone) that bubble was not reliably
+  reaching the parent listener — pinch-zoom and scroll worked (those
+  bypass xterm's mouse pipeline) but mouse-mode TUI buttons silently
+  dropped clicks. Synthesized events now dispatch on `terminal.element`
+  directly, with the mouseup routed through `document` so xterm's
+  document-level listener (registered inside its mousedown handler)
+  catches the UP report. Added `detail: 1` and `composed: true` to the
+  event init for SelectionService click-count + shadow-DOM crossing
+  defensiveness. Includes a new integration test that mounts a real
+  `@xterm/xterm` Terminal and verifies the full tap → SGR mouse report
+  pipeline end-to-end (`useTouchInteractions.realXterm.test.ts`).
+  (remote-dev-e07i)
 - **Mobile**: FCM notification taps now navigate to the right session
   (or channel) and sync read-state with the server. `NotificationTapHandler`
   was defined after the refactor from `archive/mobile-flutter/` but never

--- a/src/components/terminal/useTouchInteractions.realXterm.test.ts
+++ b/src/components/terminal/useTouchInteractions.realXterm.test.ts
@@ -137,21 +137,17 @@ function makeRealTerminal(): Harness {
     });
   }
 
-  // Enable VT200 mouse tracking + SGR encoding. The DECSET sequence is
-  // parsed asynchronously, so callers MUST await writeReady() (defined
-  // below) before driving the tap.
-
   // SGR press: \x1b[<{button};{col};{row}M  (uppercase M for press)
   // SGR release: \x1b[<{button};{col};{row}m (lowercase m for release)
-  const matchSgr = (joined: string, col: number, row: number, finalByte: "M" | "m") => {
-    // Button 0 = left, no modifiers → just "0".
-    const needle = `\x1b[<0;${col};${row}${finalByte}`;
-    return joined.includes(needle);
-  };
+  // Button 0 = left, no modifiers → just "0".
+  const matchSgr = (joined: string, col: number, row: number, finalByte: "M" | "m") =>
+    joined.includes(`\x1b[<0;${col};${row}${finalByte}`);
 
+  // DECSET 1000 (VT200 button events) + 1006 (SGR encoding). The sequence
+  // is parsed asynchronously by xterm, so callers must await this before
+  // driving the tap.
   const enableSgrMouseMode = () =>
     new Promise<void>((resolve) => {
-      // VT200 button events (1000) + SGR encoding (1006).
       term.write("\x1b[?1000h\x1b[?1006h", () => resolve());
     });
 
@@ -249,6 +245,12 @@ describe("synthesizeTap against real xterm.js (integration)", () => {
     // report. With mousedown dispatched directly on `terminal.element`,
     // .xterm-screen never sees the event (it's a *child*, not on the
     // bubble path), so the SGR report still fires.
+    //
+    // Scope: this only guards the *mousedown* dispatch target. The mouseup
+    // path (dispatched on `document`) is covered by the press+release
+    // assertions in the preceding tests — if mouseup ever regressed back to
+    // `.xterm-screen` or the host element, those tests would lose
+    // `hasSgrRelease`.
     await harness.enableSgrMouseMode();
     harness.screen.addEventListener(
       "mousedown",

--- a/src/components/terminal/useTouchInteractions.realXterm.test.ts
+++ b/src/components/terminal/useTouchInteractions.realXterm.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Integration tests for `createTouchInteractions.synthesizeTap()` against a
+ * real `@xterm/xterm` Terminal instance — NOT a fake.
+ *
+ * The unit tests in `./useTouchInteractions.test.ts` cover the JS state
+ * machine (modes, timing, dispatch target). They verify that
+ * `dispatchMouse` is *called*; they do NOT verify that real xterm.js then
+ * forwards the synthesized event as an SGR mouse report. This file fills
+ * that gap.
+ *
+ * The bug we're guarding against (remote-dev-e07i): on installed PWA (iOS
+ * Safari standalone), the prior implementation dispatched mousedown/mouseup
+ * on `.xterm-screen` and relied on bubbling up to the actual listener host
+ * (`.terminal.xterm`). Pinch-to-zoom and our touch-scroll handler worked
+ * because they don't go through xterm's mouse pipeline, but mouse-mode TUIs
+ * (Claude Code's clickable buttons, vim, tmux mouse, lazygit) silently
+ * dropped the click. The fix dispatches mousedown on `terminal.element`
+ * directly and routes mouseup through the owning document — matching where
+ * xterm registers its real-mouse listeners.
+ *
+ * happy-dom doesn't run layout, so we monkey-patch the screen's bounding
+ * rect and the internal CharSize / RenderService dimensions to non-zero
+ * values. This is a known cost of testing browser-coupled libraries
+ * headlessly; we accept the coupling because the alternative (a full
+ * Playwright run) is much heavier and CI-fragile.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Terminal } from "@xterm/xterm";
+
+import { createTouchInteractions } from "./useTouchInteractions";
+
+interface RenderDims {
+  css: {
+    cell: { width: number; height: number };
+    canvas: { width: number; height: number };
+  };
+  device: {
+    cell: { width: number; height: number };
+    canvas: { width: number; height: number };
+  };
+}
+
+interface XTermCore {
+  _charSizeService?: { width: number; height: number };
+  _renderService?: { dimensions?: RenderDims };
+  coreMouseService?: { areMouseEventsActive?: boolean };
+}
+
+interface XTermPrivates {
+  _core: XTermCore;
+}
+
+const COLS = 80;
+const ROWS = 24;
+const CELL_W = 8;
+const CELL_H = 16;
+// Screen origin in viewport coords. Non-zero to shake out (0,0) bugs.
+const SCREEN_LEFT = 100;
+const SCREEN_TOP = 50;
+
+interface Harness {
+  term: Terminal;
+  parent: HTMLElement;
+  screen: HTMLElement;
+  collected: string[];
+  /** Enable VT200 + SGR mouse mode and wait for the parser to finish. */
+  enableSgrMouseMode: () => Promise<void>;
+  /** Returns true when `data` contains an SGR mouse press at (col,row), 1-indexed per xterm's report format. */
+  hasSgrPress: (col: number, row: number) => boolean;
+  /** Returns true when `data` contains an SGR mouse release at (col,row). */
+  hasSgrRelease: (col: number, row: number) => boolean;
+  dispose: () => void;
+}
+
+function makeRealTerminal(): Harness {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+
+  const term = new Terminal({ allowProposedApi: true, cols: COLS, rows: ROWS });
+  const collected: string[] = [];
+  term.onData((d) => collected.push(d));
+
+  term.open(parent);
+
+  // Monkey-patch the screen element's bounding rect so getMouseReportCoords
+  // gets a real value. happy-dom returns all zeros otherwise.
+  const screen = term.element!.querySelector(".xterm-screen") as HTMLElement;
+  Object.defineProperty(screen, "getBoundingClientRect", {
+    value: () => ({
+      left: SCREEN_LEFT,
+      top: SCREEN_TOP,
+      right: SCREEN_LEFT + COLS * CELL_W,
+      bottom: SCREEN_TOP + ROWS * CELL_H,
+      width: COLS * CELL_W,
+      height: ROWS * CELL_H,
+      x: SCREEN_LEFT,
+      y: SCREEN_TOP,
+      toJSON: () => "",
+    }),
+    configurable: true,
+  });
+  // xterm reads `getComputedStyle(screen).padding-{left,top}` to subtract
+  // padding from click coords. In happy-dom both come back as the empty
+  // string, which `parseInt("")` turns into NaN — propagating NaN through
+  // the entire (col,row) calculation. Pin them to "0".
+  screen.style.paddingLeft = "0px";
+  screen.style.paddingTop = "0px";
+
+  // The CoreBrowserTerminal's bindMouse passes the click through
+  // `_mouseService.getMouseReportCoords` which requires:
+  //   - _charSizeService.hasValidSize (width > 0 && height > 0)
+  //   - _renderService.dimensions.css.{cell,canvas}.{width,height} > 0
+  // Patch both directly. We're reaching into private state on purpose — the
+  // alternative is a full layout-capable DOM (Playwright) which is overkill
+  // for verifying the JS dispatch contract.
+  const core = (term as unknown as XTermPrivates)._core;
+  if (core._charSizeService) {
+    core._charSizeService.width = CELL_W;
+    core._charSizeService.height = CELL_H;
+  }
+  // `_renderService.dimensions` is a getter delegating to the active
+  // renderer. In happy-dom no renderer paints, so we replace the getter
+  // outright. Use `defineProperty` because the original is read-only.
+  if (core._renderService) {
+    Object.defineProperty(core._renderService, "dimensions", {
+      configurable: true,
+      get: (): RenderDims => ({
+        css: {
+          cell: { width: CELL_W, height: CELL_H },
+          canvas: { width: COLS * CELL_W, height: ROWS * CELL_H },
+        },
+        device: {
+          cell: { width: CELL_W, height: CELL_H },
+          canvas: { width: COLS * CELL_W, height: ROWS * CELL_H },
+        },
+      }),
+    });
+  }
+
+  // Enable VT200 mouse tracking + SGR encoding. The DECSET sequence is
+  // parsed asynchronously, so callers MUST await writeReady() (defined
+  // below) before driving the tap.
+
+  // SGR press: \x1b[<{button};{col};{row}M  (uppercase M for press)
+  // SGR release: \x1b[<{button};{col};{row}m (lowercase m for release)
+  const matchSgr = (joined: string, col: number, row: number, finalByte: "M" | "m") => {
+    // Button 0 = left, no modifiers → just "0".
+    const needle = `\x1b[<0;${col};${row}${finalByte}`;
+    return joined.includes(needle);
+  };
+
+  const enableSgrMouseMode = () =>
+    new Promise<void>((resolve) => {
+      // VT200 button events (1000) + SGR encoding (1006).
+      term.write("\x1b[?1000h\x1b[?1006h", () => resolve());
+    });
+
+  return {
+    term,
+    parent,
+    screen,
+    collected,
+    enableSgrMouseMode,
+    hasSgrPress: (col, row) => matchSgr(collected.join(""), col, row, "M"),
+    hasSgrRelease: (col, row) => matchSgr(collected.join(""), col, row, "m"),
+    dispose: () => {
+      try {
+        term.dispose();
+      } catch {
+        // ignore disposal noise in happy-dom
+      }
+      parent.remove();
+    },
+  };
+}
+
+/** Drive `createTouchInteractions` with deterministic timing. */
+function driveTap(
+  term: Terminal,
+  clientX: number,
+  clientY: number
+): void {
+  let nowValue = 0;
+  const handlers = createTouchInteractions({
+    getTerminal: () => term,
+    now: () => nowValue,
+    // No-op timers — tap doesn't depend on the long-press timer firing.
+    setTimer: (() => 1 as unknown as ReturnType<typeof setTimeout>) as unknown as (
+      cb: () => void,
+      ms: number
+    ) => ReturnType<typeof setTimeout>,
+    clearTimer: (() => undefined) as unknown as (
+      id: ReturnType<typeof setTimeout>
+    ) => void,
+    // Production default: real dispatch through the DOM.
+  });
+
+  const touchstart = new Event("touchstart", { bubbles: true, cancelable: true });
+  Object.defineProperty(touchstart, "touches", {
+    value: [{ clientX, clientY, identifier: 0 } as unknown as Touch],
+  });
+  handlers.handleTouchStart(touchstart as unknown as TouchEvent);
+
+  nowValue += 50; // well within TAP_MAX_MS=250
+
+  const touchend = new Event("touchend", { bubbles: true, cancelable: true });
+  Object.defineProperty(touchend, "touches", { value: [] });
+  handlers.handleTouchEnd(touchend as unknown as TouchEvent);
+
+  handlers.destroy();
+}
+
+describe("synthesizeTap against real xterm.js (integration)", () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    harness = makeRealTerminal();
+  });
+
+  afterEach(() => {
+    harness.dispose();
+  });
+
+  it("forwards a tap as SGR press + release through xterm's mouse pipeline", async () => {
+    await harness.enableSgrMouseMode();
+    // Tap at the first cell of the first row. SCREEN_LEFT + 4 lands inside
+    // col 0 (8 px wide), SCREEN_TOP + 8 inside row 0 (16 px tall). xterm
+    // reports SGR positions 1-indexed → expect col=1, row=1.
+    driveTap(harness.term, SCREEN_LEFT + 4, SCREEN_TOP + 8);
+    expect(harness.hasSgrPress(1, 1)).toBe(true);
+    expect(harness.hasSgrRelease(1, 1)).toBe(true);
+  });
+
+  it("forwards a tap at a non-origin cell with the correct (col,row) report", async () => {
+    await harness.enableSgrMouseMode();
+    // Cell (12, 3) in viewport coords: clientX = SCREEN_LEFT + 12*8 + 4,
+    // clientY = SCREEN_TOP + 3*16 + 8. SGR is 1-indexed → expect col=13, row=4.
+    driveTap(harness.term, SCREEN_LEFT + 12 * CELL_W + 4, SCREEN_TOP + 3 * CELL_H + 8);
+    expect(harness.hasSgrPress(13, 4)).toBe(true);
+    expect(harness.hasSgrRelease(13, 4)).toBe(true);
+  });
+
+  it("does NOT regress to .xterm-screen dispatch — the press still arrives even when an interceptor swallows events at .xterm-screen", async () => {
+    // Prove the fix is independent of bubbling from .xterm-screen. Install
+    // a capture-phase mousedown interceptor on the screen child that
+    // stopImmediatePropagation()s anything passing through. If we ever
+    // regress to dispatching on .xterm-screen, this would swallow the SGR
+    // report. With mousedown dispatched directly on `terminal.element`,
+    // .xterm-screen never sees the event (it's a *child*, not on the
+    // bubble path), so the SGR report still fires.
+    await harness.enableSgrMouseMode();
+    harness.screen.addEventListener(
+      "mousedown",
+      (ev) => {
+        ev.stopImmediatePropagation();
+        ev.preventDefault();
+      },
+      { capture: true }
+    );
+    driveTap(harness.term, SCREEN_LEFT + 4, SCREEN_TOP + 8);
+    expect(harness.hasSgrPress(1, 1)).toBe(true);
+  });
+});

--- a/src/components/terminal/useTouchInteractions.test.ts
+++ b/src/components/terminal/useTouchInteractions.test.ts
@@ -63,6 +63,8 @@ interface Harness {
     clientY: number;
     screenX: number;
     screenY: number;
+    detail: number;
+    composed: boolean;
     target: EventTarget | null;
   }>;
   copies: string[];
@@ -141,6 +143,8 @@ function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"]
     clientY: number;
     screenX: number;
     screenY: number;
+    detail: number;
+    composed: boolean;
     target: EventTarget | null;
   }> = [];
   const copies: string[] = [];
@@ -169,6 +173,8 @@ function makeHarness(opts: { mouseMode?: FakeXTerm["modes"]["mouseTrackingMode"]
         clientY: ev.clientY,
         screenX: ev.screenX,
         screenY: ev.screenY,
+        detail: ev.detail,
+        composed: ev.composed,
         target,
       });
     },
@@ -472,30 +478,35 @@ describe("synthesizeTap dispatch target", () => {
     document.body.innerHTML = "";
   });
 
-  it("dispatches mousedown+mouseup on the .xterm-screen element (xterm wires its mouse listeners there)", () => {
-    // We deliberately target .xterm-screen (the stable mouse-listener host
-    // in xterm v6) rather than an inner canvas. WebGL builds paint into
-    // multiple canvases and the listener isn't on any of them; the screen
-    // div is the consistent mouse-input surface.
+  it("dispatches mousedown on terminal.element (xterm's bindMouse listener host) and mouseup on the owning document", () => {
+    // xterm v6 registers its mousedown listener on `terminal.element`
+    // (`.terminal.xterm`), not `.xterm-screen`. It then registers a mouseup
+    // listener on `_document` from inside that mousedown handler so it can
+    // capture lifts outside the terminal element. We mirror that here:
+    // mousedown on the element, mouseup on the document. iOS Safari in
+    // standalone PWA mode was not reliably bubbling events from
+    // `.xterm-screen` up to the parent listener — dispatching on the actual
+    // listener host removes that dependency.
     const h = makeHarness();
     h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
     h.advanceTime(50);
     h.fireTouch("touchend", []);
     expect(h.mouseEvents).toHaveLength(2);
-    for (const e of h.mouseEvents) {
-      expect(e.target).toBe(h.screen);
-    }
+    expect(h.mouseEvents[0].type).toBe("mousedown");
+    expect(h.mouseEvents[0].target).toBe(h.xterm.element);
+    expect(h.mouseEvents[1].type).toBe("mouseup");
+    expect(h.mouseEvents[1].target).toBe(h.xterm.element.ownerDocument);
   });
 
-  it("falls back to terminal.element when .xterm-screen is missing", () => {
+  it("synthesized events carry detail=1 and composed=true so SelectionService click-count + shadow-DOM crossing work", () => {
     const h = makeHarness();
-    h.screen.remove();
     h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
     h.advanceTime(50);
     h.fireTouch("touchend", []);
     expect(h.mouseEvents).toHaveLength(2);
     for (const e of h.mouseEvents) {
-      expect(e.target).toBe(h.xterm.element);
+      expect(e.detail).toBe(1);
+      expect(e.composed).toBe(true);
     }
   });
 });

--- a/src/components/terminal/useTouchInteractions.test.ts
+++ b/src/components/terminal/useTouchInteractions.test.ts
@@ -479,14 +479,9 @@ describe("synthesizeTap dispatch target", () => {
   });
 
   it("dispatches mousedown on terminal.element (xterm's bindMouse listener host) and mouseup on the owning document", () => {
-    // xterm v6 registers its mousedown listener on `terminal.element`
-    // (`.terminal.xterm`), not `.xterm-screen`. It then registers a mouseup
-    // listener on `_document` from inside that mousedown handler so it can
-    // capture lifts outside the terminal element. We mirror that here:
-    // mousedown on the element, mouseup on the document. iOS Safari in
-    // standalone PWA mode was not reliably bubbling events from
-    // `.xterm-screen` up to the parent listener — dispatching on the actual
-    // listener host removes that dependency.
+    // See synthesizeTap() for the full rationale. The contract under test:
+    // mousedown → terminal.element, mouseup → ownerDocument. iOS PWA
+    // standalone mode broke the previous `.xterm-screen` + bubble path.
     const h = makeHarness();
     h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
     h.advanceTime(50);

--- a/src/components/terminal/useTouchInteractions.ts
+++ b/src/components/terminal/useTouchInteractions.ts
@@ -410,38 +410,37 @@ export function createTouchInteractions(
       return;
     }
 
-    // xterm v6 attaches its mousedown listener on `terminal.element`
-    // (`.terminal.xterm`) — NOT on `.xterm-screen`. See
-    // node_modules/@xterm/xterm/src/browser/CoreBrowserTerminal.ts:779. The
-    // SelectionService also binds mousedown on the same element (:544).
+    // xterm v6 binds its mousedown listener on `terminal.element`
+    // (`.terminal.xterm`), NOT on `.xterm-screen`, and registers a mouseup
+    // listener on `_document` from inside that mousedown handler so it can
+    // capture lifts outside the terminal. See CoreBrowserTerminal.ts:779/797.
+    // We mirror that path: mousedown on the host (which triggers the
+    // document-level mouseup registration), then mouseup on the owning
+    // document so the just-installed listener catches the UP edge — many TUI
+    // button handlers (Claude Code, etc.) only fire on UP.
     //
     // Previously we dispatched on `.xterm-screen` and relied on bubbling. On
-    // iOS Safari in installed-PWA (standalone) mode that bubble was not
-    // reliably reaching the parent listener — Claude Code / vim / tmux mouse-
-    // mode buttons saw nothing despite the unit tests passing. Dispatching
-    // directly on the actual listener host removes the bubbling dependency
-    // and works on every browser we've tried.
+    // iOS Safari in installed-PWA (standalone) mode the bubble was not
+    // reliably reaching the parent listener — mouse-mode TUI buttons saw
+    // nothing. Dispatching on the actual listener hosts removes that
+    // dependency and matches what a real browser does.
     const host = terminal.element;
-    // After mousedown fires, xterm registers its mouseup listener on
-    // `_document` (CoreBrowserTerminal.ts:797) so it can capture lifts that
-    // happen outside the terminal element. We mirror that here: dispatch
-    // mousedown on the host to trigger the registration, then dispatch
-    // mouseup on the owning document so xterm's just-installed listener sees
-    // it. (Dispatching mouseup on the host would still bubble in most
-    // browsers, but document-direct is the path the real browser takes.)
-    const ownerDocument = host.ownerDocument ?? (typeof document !== "undefined" ? document : null);
-    // Real browser-synthesized mouse-from-touch events include screenX /
-    // screenY. xterm itself doesn't read those for cell math (it uses
-    // clientX/Y plus its own bounding-rect origin), but other consumers in
-    // the dispatch chain might assert on them. We mirror clientX/Y here;
-    // the values aren't load-bearing for terminal coords; we just want the
-    // event shape to match what a real mouse would carry.
-    //
-    // `detail: 1` marks this as a single click so SelectionService's
-    // click-count logic works even when app mouse mode is off. `composed:
-    // true` lets the event cross shadow-DOM boundaries (defensive — xterm
-    // itself doesn't use shadow DOM, but the terminal might be embedded in
-    // a host page that does).
+    // host.ownerDocument is non-null for any mounted element, and xterm only
+    // sets `element` after `open()` on a mounted node — so this is effectively
+    // always set. The `typeof document` fallback is for headless tests that
+    // construct an element without a document. If both miss, bail rather than
+    // route mouseup through `host` (xterm's listener is on `_document`, so a
+    // host-targeted mouseup that doesn't bubble all the way to the registered
+    // document would silently drop the UP report).
+    const ownerDocument =
+      host.ownerDocument ?? (typeof document !== "undefined" ? document : null);
+    if (!ownerDocument) return;
+    // screenX/Y mirror clientX/Y so synthetic events match the shape of a
+    // real mouse-from-touch event (xterm itself uses clientX/Y, but other
+    // consumers downstream may assert on screen coords).
+    // detail: 1 makes SelectionService's click-count logic work; composed:
+    // true lets the event cross shadow-DOM boundaries if the terminal is
+    // embedded in a host page that uses them.
     const baseInit: MouseEventInit = {
       bubbles: true,
       cancelable: true,
@@ -456,12 +455,7 @@ export function createTouchInteractions(
       buttons: 1,
     };
     dispatchMouse(host, new MouseEvent("mousedown", baseInit));
-    // Route mouseup through the document so xterm's document-level listener
-    // (registered inside its mousedown handler) catches the UP report. Many
-    // TUI button handlers — including Claude Code's — only fire on the UP
-    // edge.
-    const mouseupTarget: EventTarget = ownerDocument ?? host;
-    dispatchMouse(mouseupTarget, new MouseEvent("mouseup", { ...baseInit, buttons: 0 }));
+    dispatchMouse(ownerDocument, new MouseEvent("mouseup", { ...baseInit, buttons: 0 }));
 
     // Always scroll to bottom on tap, regardless of mouse mode. Most users
     // expect tapping the terminal to "jump back to the latest output" — a

--- a/src/components/terminal/useTouchInteractions.ts
+++ b/src/components/terminal/useTouchInteractions.ts
@@ -223,9 +223,12 @@ export interface UseTouchInteractionsDeps {
   copyToClipboard?: (text: string) => Promise<void>;
   /**
    * Test seam — receives the synthesized MouseEvents. In production we
-   * dispatch them directly on the xterm element.
+   * dispatch them on the xterm element (mousedown) and the owning document
+   * (mouseup). The target type is `EventTarget` so callers can dispatch to a
+   * `Document` for the mouseup half — xterm's `bindMouse` registers its
+   * mouseup listener on `_document` after the first mousedown lands.
    */
-  dispatchMouse?: (target: HTMLElement, event: MouseEvent) => void;
+  dispatchMouse?: (target: EventTarget, event: MouseEvent) => void;
 }
 
 export interface TouchInteractionsHandlers {
@@ -258,7 +261,7 @@ export function createTouchInteractions(
         : Promise.resolve());
   const dispatchMouse =
     deps.dispatchMouse ??
-    ((target: HTMLElement, event: MouseEvent) => {
+    ((target: EventTarget, event: MouseEvent) => {
       target.dispatchEvent(event);
     });
   // The host shares one `modeRef` across this hook + touch-scroll. When
@@ -407,26 +410,43 @@ export function createTouchInteractions(
       return;
     }
 
-    // xterm v6 attaches its mouse listeners on the .xterm-screen element via
-    // `addDisposableListener`. We dispatch there — it is the stable target
-    // regardless of which renderer (WebGL canvas, DOM, multiple canvases)
-    // happens to be active. We previously aimed at the inner canvas, but
-    // that's brittle: WebGL builds paint into multiple canvases (text,
-    // selection, link, link-tooltip layers) and the listener isn't on any of
-    // them. Falling back to the host div is also fine; xterm wires a few
-    // listeners there as well.
+    // xterm v6 attaches its mousedown listener on `terminal.element`
+    // (`.terminal.xterm`) — NOT on `.xterm-screen`. See
+    // node_modules/@xterm/xterm/src/browser/CoreBrowserTerminal.ts:779. The
+    // SelectionService also binds mousedown on the same element (:544).
+    //
+    // Previously we dispatched on `.xterm-screen` and relied on bubbling. On
+    // iOS Safari in installed-PWA (standalone) mode that bubble was not
+    // reliably reaching the parent listener — Claude Code / vim / tmux mouse-
+    // mode buttons saw nothing despite the unit tests passing. Dispatching
+    // directly on the actual listener host removes the bubbling dependency
+    // and works on every browser we've tried.
     const host = terminal.element;
-    const screen = host.querySelector(".xterm-screen") as HTMLElement | null;
-    const target: HTMLElement = screen ?? host;
+    // After mousedown fires, xterm registers its mouseup listener on
+    // `_document` (CoreBrowserTerminal.ts:797) so it can capture lifts that
+    // happen outside the terminal element. We mirror that here: dispatch
+    // mousedown on the host to trigger the registration, then dispatch
+    // mouseup on the owning document so xterm's just-installed listener sees
+    // it. (Dispatching mouseup on the host would still bubble in most
+    // browsers, but document-direct is the path the real browser takes.)
+    const ownerDocument = host.ownerDocument ?? (typeof document !== "undefined" ? document : null);
     // Real browser-synthesized mouse-from-touch events include screenX /
     // screenY. xterm itself doesn't read those for cell math (it uses
     // clientX/Y plus its own bounding-rect origin), but other consumers in
     // the dispatch chain might assert on them. We mirror clientX/Y here;
     // the values aren't load-bearing for terminal coords; we just want the
     // event shape to match what a real mouse would carry.
+    //
+    // `detail: 1` marks this as a single click so SelectionService's
+    // click-count logic works even when app mouse mode is off. `composed:
+    // true` lets the event cross shadow-DOM boundaries (defensive — xterm
+    // itself doesn't use shadow DOM, but the terminal might be embedded in
+    // a host page that does).
     const baseInit: MouseEventInit = {
       bubbles: true,
       cancelable: true,
+      composed: true,
+      detail: 1,
       view: typeof window !== "undefined" ? window : undefined,
       clientX,
       clientY,
@@ -435,8 +455,13 @@ export function createTouchInteractions(
       button: 0,
       buttons: 1,
     };
-    dispatchMouse(target, new MouseEvent("mousedown", baseInit));
-    dispatchMouse(target, new MouseEvent("mouseup", { ...baseInit, buttons: 0 }));
+    dispatchMouse(host, new MouseEvent("mousedown", baseInit));
+    // Route mouseup through the document so xterm's document-level listener
+    // (registered inside its mousedown handler) catches the UP report. Many
+    // TUI button handlers — including Claude Code's — only fire on the UP
+    // edge.
+    const mouseupTarget: EventTarget = ownerDocument ?? host;
+    dispatchMouse(mouseupTarget, new MouseEvent("mouseup", { ...baseInit, buttons: 0 }));
 
     // Always scroll to bottom on tap, regardless of mouse mode. Most users
     // expect tapping the terminal to "jump back to the latest output" — a


### PR DESCRIPTION
## Summary

- Synthesized tap events were dispatched on `.xterm-screen` and relied on bubbling up to `terminal.element` where xterm v6 actually registers its mousedown listener. On installed PWAs (iOS Safari standalone) that bubble was not reliably reaching the parent listener — pinch-zoom and scroll worked (both bypass xterm's mouse pipeline), but Claude Code's clickable buttons, vim, less, lazygit, and tmux mouse-mode all silently dropped the click.
- Fix: dispatch mousedown directly on `terminal.element` (the actual listener host) and route the mouseup through the owning document, matching where xterm registers its real-mouse listeners (`CoreBrowserTerminal.ts:779,797`). Also add `detail: 1` and `composed: true` to the event init for SelectionService click-count + shadow-DOM crossing.
- Adds `useTouchInteractions.realXterm.test.ts` — an integration test that mounts a real `@xterm/xterm` Terminal in happy-dom, enables SGR mouse mode via DECSET, drives a tap, and asserts the SGR press + release sequences come out of `term.onData`. Previous unit tests only verified `dispatchMouse` was *called*; they never proved the synthesize-tap → SGR-report pipeline actually worked.

## What changed

| File | Change |
|------|--------|
| `src/components/terminal/useTouchInteractions.ts` | `synthesizeTap` now dispatches mousedown on `terminal.element` and mouseup on `terminal.element.ownerDocument`. Widened `dispatchMouse` test seam to `EventTarget`. Added `detail: 1` + `composed: true` to event init. |
| `src/components/terminal/useTouchInteractions.test.ts` | Updated dispatch-target assertions (mousedown → element, mouseup → document). Added assertion for `detail` / `composed`. |
| `src/components/terminal/useTouchInteractions.realXterm.test.ts` | NEW: 3 integration tests against a real `@xterm/xterm` Terminal verifying the full tap → SGR mouse report pipeline, including a regression guard that blocks bubbling at `.xterm-screen` to prove the fix is independent of bubbling. |
| `CHANGELOG.md` | Entry under `[Unreleased] / Fixed`. |

## Test plan

- [x] `bun run test:run -- src/components/terminal/` — 70 tests pass (5 files)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — no new errors/warnings in changed files (10 pre-existing errors elsewhere unchanged)
- [x] Full vitest suite — 1209 tests pass; one pre-existing failure in `tests/mobile/restart-agent-api-client.test.ts` (mobile package tsconfig loading error, present on master)
- [ ] Manual verification on iOS PWA: tap a Claude Code button on a real installed PWA session and confirm the button activates
- [ ] Manual verification: pinch-zoom, scroll, long-press-to-select, tap-to-deselect all still work after the change

This pull request and its description were written by Isaac.