### PR TITLE
fix(mobile): align Flutter list filters with PWA mobile-web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SessionsApi.list()` previously only filtered `trashed`, leaking
   `closed` (terminal-state) sessions into the picker — these belong to
   surfaces the mobile app doesn't expose.
+- **Mobile (Flutter) – Channels tab**: the tab is now project-scoped
+  to match the PWA mobile-web reference. Previously it fetched
+  `/api/channels` with no scope (the server rejects this with a 400)
+  and rendered an unrelated "No channels yet" state. The tab now
+  reads the user's pinned-or-active node via `GET /api/preferences`,
+  passes it as `?nodeId=&nodeType=` when listing channels, and shows
+  a "Pick a project to load channels" empty state with a project
+  picker button when nothing is selected. A folder-icon app-bar
+  action lets users switch projects without leaving the tab.
+  Selections persist server-side via `POST /api/preferences/active-node`.
 - **Mobile (Flutter) – Notifications Mentions filter**: the "Mentions"
   chip now actually filters. The Flutter app used to pass
   `?filter=mentions` to the API, which the server ignored — so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   eagerly from `main.dart` via a new `notificationTapHandlerProvider`, and
   restored the legacy mark-read-on-tap behavior so the web client sees the
   tap as a read event.
+- **Mobile (Flutter) – Sessions tab**: list now matches the PWA
+  mobile-web reference and shows only `active` and `suspended` sessions.
+  `SessionsApi.list()` previously only filtered `trashed`, leaking
+  `closed` (terminal-state) sessions into the picker — these belong to
+  surfaces the mobile app doesn't expose.
+- **Mobile (Flutter) – Notifications Mentions filter**: the "Mentions"
+  chip now actually filters. The Flutter app used to pass
+  `?filter=mentions` to the API, which the server ignored — so
+  "Mentions" returned the full list, identical to "All". Aligned with
+  the PWA mobile-web tab: fetch all notifications once, then filter
+  client-side using an `isMention` heuristic that respects
+  `agent_waiting` / `agent_error` / `agent_complete` / `agent_exited`
+  types and the `@<sid:UUID>` / `@name` token patterns. The
+  `AppNotification` domain model gained an optional `type` field
+  sourced from the server's `notification_event.type` column.
 - **Scripts**: `rdv` and the blue/green deploy webhook no longer leak
   server processes on stop/restart. `Bun.spawn("bun", "run", "tsx",
   "src/server/index.ts", ...)` produces a 3-deep process tree (bun

--- a/mobile/lib/application/ports/channels_port.dart
+++ b/mobile/lib/application/ports/channels_port.dart
@@ -1,9 +1,12 @@
+import '../../domain/active_node.dart';
 import '../../domain/channel.dart';
 
 abstract class ChannelsPort {
-  /// List channels visible to the current user. The implementation is
-  /// expected to flatten any server-side groupings into a single list.
-  Future<List<Channel>> list();
+  /// List channels scoped to [activeNode]. When [activeNode] is `null`
+  /// the implementation must return an empty list without hitting the
+  /// server — the `/api/channels` endpoint 400s without a scope, and
+  /// the PWA mobile-web tab models the no-project state explicitly.
+  Future<List<Channel>> list({ActiveNode? activeNode});
 
   /// Archive the channel with the given id (DELETE /api/channels/:id).
   Future<void> archive(String id);

--- a/mobile/lib/application/ports/preferences_port.dart
+++ b/mobile/lib/application/ports/preferences_port.dart
@@ -1,0 +1,23 @@
+import '../../domain/active_node.dart';
+
+/// Port for reading and mutating the user's "active node" (the project
+/// or group currently scoping tabs like Channels, Tasks, and Peers).
+/// Maps to the server's `GET /api/preferences` and
+/// `POST /api/preferences/active-node` endpoints.
+abstract class PreferencesPort {
+  /// Read the active node. Returns `null` when neither `pinnedNode*` nor
+  /// `activeNode*` is set on the server's user-settings row.
+  ///
+  /// Implementations should prefer `pinnedNode*` over `activeNode*` so
+  /// behavior matches the PWA, which treats the pinned node as the
+  /// authoritative "what is this user looking at" pointer.
+  Future<ActiveNode?> getActiveNode();
+
+  /// POST `/api/preferences/active-node` to update the active or pinned
+  /// node. Pass `nodeId: null, nodeType: null` to clear the selection.
+  Future<void> setActiveNode({
+    required String? nodeId,
+    required ActiveNodeType? nodeType,
+    bool pinned = false,
+  });
+}

--- a/mobile/lib/domain/active_node.dart
+++ b/mobile/lib/domain/active_node.dart
@@ -12,7 +12,15 @@ enum ActiveNodeType {
   @JsonValue('group')
   group,
   @JsonValue('project')
-  project,
+  project;
+
+  /// Server wire format matching the `@JsonValue` annotations above.
+  /// Used for query params and POST bodies hitting `/api/preferences` and
+  /// `/api/channels`.
+  String get wireValue => switch (this) {
+        ActiveNodeType.group => 'group',
+        ActiveNodeType.project => 'project',
+      };
 }
 
 /// Snapshot of the user's currently-active or pinned node, sourced from

--- a/mobile/lib/domain/active_node.dart
+++ b/mobile/lib/domain/active_node.dart
@@ -1,0 +1,32 @@
+// ignore_for_file: invalid_annotation_target
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'active_node.freezed.dart';
+part 'active_node.g.dart';
+
+/// Discriminator for the two kinds of node the user can pin/activate:
+/// a project group (container) or a project (leaf). Mirrors the server
+/// schema's `active_node_type` / `pinned_node_type` column.
+enum ActiveNodeType {
+  @JsonValue('group')
+  group,
+  @JsonValue('project')
+  project,
+}
+
+/// Snapshot of the user's currently-active or pinned node, sourced from
+/// `GET /api/preferences` (combining `pinnedNode*` if set, else
+/// `activeNode*`). `name` is populated from the server's `activeFolder`
+/// response field when available.
+@freezed
+class ActiveNode with _$ActiveNode {
+  const factory ActiveNode({
+    required String id,
+    required ActiveNodeType type,
+    String? name,
+  }) = _ActiveNode;
+
+  factory ActiveNode.fromJson(Map<String, dynamic> json) =>
+      _$ActiveNodeFromJson(json);
+}

--- a/mobile/lib/domain/active_node.freezed.dart
+++ b/mobile/lib/domain/active_node.freezed.dart
@@ -1,0 +1,199 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'active_node.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ActiveNode _$ActiveNodeFromJson(Map<String, dynamic> json) {
+  return _ActiveNode.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ActiveNode {
+  String get id => throw _privateConstructorUsedError;
+  ActiveNodeType get type => throw _privateConstructorUsedError;
+  String? get name => throw _privateConstructorUsedError;
+
+  /// Serializes this ActiveNode to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of ActiveNode
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ActiveNodeCopyWith<ActiveNode> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ActiveNodeCopyWith<$Res> {
+  factory $ActiveNodeCopyWith(
+          ActiveNode value, $Res Function(ActiveNode) then) =
+      _$ActiveNodeCopyWithImpl<$Res, ActiveNode>;
+  @useResult
+  $Res call({String id, ActiveNodeType type, String? name});
+}
+
+/// @nodoc
+class _$ActiveNodeCopyWithImpl<$Res, $Val extends ActiveNode>
+    implements $ActiveNodeCopyWith<$Res> {
+  _$ActiveNodeCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ActiveNode
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? type = null,
+    Object? name = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as ActiveNodeType,
+      name: freezed == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ActiveNodeImplCopyWith<$Res>
+    implements $ActiveNodeCopyWith<$Res> {
+  factory _$$ActiveNodeImplCopyWith(
+          _$ActiveNodeImpl value, $Res Function(_$ActiveNodeImpl) then) =
+      __$$ActiveNodeImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String id, ActiveNodeType type, String? name});
+}
+
+/// @nodoc
+class __$$ActiveNodeImplCopyWithImpl<$Res>
+    extends _$ActiveNodeCopyWithImpl<$Res, _$ActiveNodeImpl>
+    implements _$$ActiveNodeImplCopyWith<$Res> {
+  __$$ActiveNodeImplCopyWithImpl(
+      _$ActiveNodeImpl _value, $Res Function(_$ActiveNodeImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ActiveNode
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? type = null,
+    Object? name = freezed,
+  }) {
+    return _then(_$ActiveNodeImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as ActiveNodeType,
+      name: freezed == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ActiveNodeImpl implements _ActiveNode {
+  const _$ActiveNodeImpl({required this.id, required this.type, this.name});
+
+  factory _$ActiveNodeImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ActiveNodeImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final ActiveNodeType type;
+  @override
+  final String? name;
+
+  @override
+  String toString() {
+    return 'ActiveNode(id: $id, type: $type, name: $name)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ActiveNodeImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.name, name) || other.name == name));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, type, name);
+
+  /// Create a copy of ActiveNode
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ActiveNodeImplCopyWith<_$ActiveNodeImpl> get copyWith =>
+      __$$ActiveNodeImplCopyWithImpl<_$ActiveNodeImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ActiveNodeImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ActiveNode implements ActiveNode {
+  const factory _ActiveNode(
+      {required final String id,
+      required final ActiveNodeType type,
+      final String? name}) = _$ActiveNodeImpl;
+
+  factory _ActiveNode.fromJson(Map<String, dynamic> json) =
+      _$ActiveNodeImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  ActiveNodeType get type;
+  @override
+  String? get name;
+
+  /// Create a copy of ActiveNode
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ActiveNodeImplCopyWith<_$ActiveNodeImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/mobile/lib/domain/active_node.g.dart
+++ b/mobile/lib/domain/active_node.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'active_node.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ActiveNodeImpl _$$ActiveNodeImplFromJson(Map<String, dynamic> json) =>
+    _$ActiveNodeImpl(
+      id: json['id'] as String,
+      type: $enumDecode(_$ActiveNodeTypeEnumMap, json['type']),
+      name: json['name'] as String?,
+    );
+
+Map<String, dynamic> _$$ActiveNodeImplToJson(_$ActiveNodeImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': _$ActiveNodeTypeEnumMap[instance.type]!,
+      'name': instance.name,
+    };
+
+const _$ActiveNodeTypeEnumMap = {
+  ActiveNodeType.group: 'group',
+  ActiveNodeType.project: 'project',
+};

--- a/mobile/lib/domain/notification.dart
+++ b/mobile/lib/domain/notification.dart
@@ -14,6 +14,11 @@ class AppNotification with _$AppNotification {
     String? sessionId,
     String? channelId,
     @Default('default') String kind,
+    // Server-side notification type (e.g. `agent_waiting`, `agent_error`,
+    // `agent_complete`, `agent_exited`, `info`, …). Sourced from the
+    // `type` field on `notification_event` records. Nullable for
+    // forward-compat with payloads that omit it.
+    String? type,
   }) = _AppNotification;
 
   factory AppNotification.fromJson(Map<String, dynamic> json) =>

--- a/mobile/lib/domain/notification.freezed.dart
+++ b/mobile/lib/domain/notification.freezed.dart
@@ -27,7 +27,12 @@ mixin _$AppNotification {
   bool get read => throw _privateConstructorUsedError;
   String? get sessionId => throw _privateConstructorUsedError;
   String? get channelId => throw _privateConstructorUsedError;
-  String get kind => throw _privateConstructorUsedError;
+  String get kind =>
+      throw _privateConstructorUsedError; // Server-side notification type (e.g. `agent_waiting`, `agent_error`,
+// `agent_complete`, `agent_exited`, `info`, …). Sourced from the
+// `type` field on `notification_event` records. Nullable for
+// forward-compat with payloads that omit it.
+  String? get type => throw _privateConstructorUsedError;
 
   /// Serializes this AppNotification to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -53,7 +58,8 @@ abstract class $AppNotificationCopyWith<$Res> {
       bool read,
       String? sessionId,
       String? channelId,
-      String kind});
+      String kind,
+      String? type});
 }
 
 /// @nodoc
@@ -79,6 +85,7 @@ class _$AppNotificationCopyWithImpl<$Res, $Val extends AppNotification>
     Object? sessionId = freezed,
     Object? channelId = freezed,
     Object? kind = null,
+    Object? type = freezed,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -113,6 +120,10 @@ class _$AppNotificationCopyWithImpl<$Res, $Val extends AppNotification>
           ? _value.kind
           : kind // ignore: cast_nullable_to_non_nullable
               as String,
+      type: freezed == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
     ) as $Val);
   }
 }
@@ -133,7 +144,8 @@ abstract class _$$AppNotificationImplCopyWith<$Res>
       bool read,
       String? sessionId,
       String? channelId,
-      String kind});
+      String kind,
+      String? type});
 }
 
 /// @nodoc
@@ -157,6 +169,7 @@ class __$$AppNotificationImplCopyWithImpl<$Res>
     Object? sessionId = freezed,
     Object? channelId = freezed,
     Object? kind = null,
+    Object? type = freezed,
   }) {
     return _then(_$AppNotificationImpl(
       id: null == id
@@ -191,6 +204,10 @@ class __$$AppNotificationImplCopyWithImpl<$Res>
           ? _value.kind
           : kind // ignore: cast_nullable_to_non_nullable
               as String,
+      type: freezed == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -206,7 +223,8 @@ class _$AppNotificationImpl implements _AppNotification {
       this.read = false,
       this.sessionId,
       this.channelId,
-      this.kind = 'default'});
+      this.kind = 'default',
+      this.type});
 
   factory _$AppNotificationImpl.fromJson(Map<String, dynamic> json) =>
       _$$AppNotificationImplFromJson(json);
@@ -229,10 +247,16 @@ class _$AppNotificationImpl implements _AppNotification {
   @override
   @JsonKey()
   final String kind;
+// Server-side notification type (e.g. `agent_waiting`, `agent_error`,
+// `agent_complete`, `agent_exited`, `info`, …). Sourced from the
+// `type` field on `notification_event` records. Nullable for
+// forward-compat with payloads that omit it.
+  @override
+  final String? type;
 
   @override
   String toString() {
-    return 'AppNotification(id: $id, title: $title, body: $body, createdAt: $createdAt, read: $read, sessionId: $sessionId, channelId: $channelId, kind: $kind)';
+    return 'AppNotification(id: $id, title: $title, body: $body, createdAt: $createdAt, read: $read, sessionId: $sessionId, channelId: $channelId, kind: $kind, type: $type)';
   }
 
   @override
@@ -250,13 +274,14 @@ class _$AppNotificationImpl implements _AppNotification {
                 other.sessionId == sessionId) &&
             (identical(other.channelId, channelId) ||
                 other.channelId == channelId) &&
-            (identical(other.kind, kind) || other.kind == kind));
+            (identical(other.kind, kind) || other.kind == kind) &&
+            (identical(other.type, type) || other.type == type));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, id, title, body, createdAt, read,
-      sessionId, channelId, kind);
+      sessionId, channelId, kind, type);
 
   /// Create a copy of AppNotification
   /// with the given fields replaced by the non-null parameter values.
@@ -284,7 +309,8 @@ abstract class _AppNotification implements AppNotification {
       final bool read,
       final String? sessionId,
       final String? channelId,
-      final String kind}) = _$AppNotificationImpl;
+      final String kind,
+      final String? type}) = _$AppNotificationImpl;
 
   factory _AppNotification.fromJson(Map<String, dynamic> json) =
       _$AppNotificationImpl.fromJson;
@@ -304,7 +330,13 @@ abstract class _AppNotification implements AppNotification {
   @override
   String? get channelId;
   @override
-  String get kind;
+  String
+      get kind; // Server-side notification type (e.g. `agent_waiting`, `agent_error`,
+// `agent_complete`, `agent_exited`, `info`, …). Sourced from the
+// `type` field on `notification_event` records. Nullable for
+// forward-compat with payloads that omit it.
+  @override
+  String? get type;
 
   /// Create a copy of AppNotification
   /// with the given fields replaced by the non-null parameter values.

--- a/mobile/lib/domain/notification.g.dart
+++ b/mobile/lib/domain/notification.g.dart
@@ -17,6 +17,7 @@ _$AppNotificationImpl _$$AppNotificationImplFromJson(
       sessionId: json['sessionId'] as String?,
       channelId: json['channelId'] as String?,
       kind: json['kind'] as String? ?? 'default',
+      type: json['type'] as String?,
     );
 
 Map<String, dynamic> _$$AppNotificationImplToJson(
@@ -30,4 +31,5 @@ Map<String, dynamic> _$$AppNotificationImplToJson(
       'sessionId': instance.sessionId,
       'channelId': instance.channelId,
       'kind': instance.kind,
+      'type': instance.type,
     };

--- a/mobile/lib/infrastructure/api/channels_api.dart
+++ b/mobile/lib/infrastructure/api/channels_api.dart
@@ -19,12 +19,9 @@ class ChannelsApi implements ChannelsPort {
       return const [];
     }
 
-    final typeParam = activeNode.type == ActiveNodeType.group
-        ? 'group'
-        : 'project';
     final path =
         '/api/channels?nodeId=${Uri.encodeQueryComponent(activeNode.id)}'
-        '&nodeType=$typeParam';
+        '&nodeType=${activeNode.type.wireValue}';
     final raw = await _client.get(path);
 
     // Shape A: { channels: [...] } — flat list (anticipated future shape /

--- a/mobile/lib/infrastructure/api/channels_api.dart
+++ b/mobile/lib/infrastructure/api/channels_api.dart
@@ -1,5 +1,6 @@
 import '../../application/ports/api_client_port.dart';
 import '../../application/ports/channels_port.dart';
+import '../../domain/active_node.dart';
 import '../../domain/channel.dart';
 
 class ChannelsApi implements ChannelsPort {
@@ -8,8 +9,23 @@ class ChannelsApi implements ChannelsPort {
   final ApiClientPort _client;
 
   @override
-  Future<List<Channel>> list() async {
-    final raw = await _client.get('/api/channels');
+  Future<List<Channel>> list({ActiveNode? activeNode}) async {
+    // Skip the request entirely when no project/group is selected. The
+    // server's `/api/channels` route requires `?nodeId=&nodeType=` (or
+    // the legacy `?projectId=`) and 400s without them, so an early
+    // return is the cheap-and-correct path. Mirrors the PWA mobile-web
+    // tab, which renders a "Pick a project" empty state in this case.
+    if (activeNode == null) {
+      return const [];
+    }
+
+    final typeParam = activeNode.type == ActiveNodeType.group
+        ? 'group'
+        : 'project';
+    final path =
+        '/api/channels?nodeId=${Uri.encodeQueryComponent(activeNode.id)}'
+        '&nodeType=$typeParam';
+    final raw = await _client.get(path);
 
     // Shape A: { channels: [...] } — flat list (anticipated future shape /
     // tests).

--- a/mobile/lib/infrastructure/api/notifications_api.dart
+++ b/mobile/lib/infrastructure/api/notifications_api.dart
@@ -15,12 +15,14 @@ class NotificationsApi implements NotificationsPort {
 
   @override
   Future<List<AppNotification>> list({String? filter}) async {
-    // Server accepts `?limit=N&unreadOnly=true|false`. Translate the
-    // mobile filter enum (`all` / `unread` / `mentions`) to that shape.
-    // `mentions` has no server-side concept yet — fall back to listing
-    // all notifications so the tab isn't empty.
-    final query = (filter == 'unread') ? '?unreadOnly=true' : '';
-    final raw = await _client.get('/api/notifications$query');
+    // Match the PWA mobile-web approach (see
+    // `src/components/mobile/notifications/NotificationsTab.tsx`): always
+    // fetch the full list and let the caller apply `unread` / `mentions`
+    // filtering in memory. The `filter` parameter is accepted for
+    // interface compatibility but intentionally ignored — server-side
+    // filtering would break the Mentions tab (no server concept) and
+    // make the chip counts inconsistent.
+    final raw = await _client.get('/api/notifications');
     // Tolerate {notifications: [...]} or [...].
     if (raw is Map<String, dynamic> && raw['notifications'] is List) {
       return (raw['notifications'] as List)

--- a/mobile/lib/infrastructure/api/preferences_api.dart
+++ b/mobile/lib/infrastructure/api/preferences_api.dart
@@ -29,22 +29,10 @@ class PreferencesApi implements PreferencesPort {
     // the PWA's behavior and the server's own GET handler (see
     // `src/app/api/preferences/route.ts`), which resolves the
     // active-folder lookup with `pinnedNodeId || activeNodeId`.
-    final pinnedId = settings['pinnedNodeId'];
-    final pinnedType = settings['pinnedNodeType'];
-    final activeId = settings['activeNodeId'];
-    final activeType = settings['activeNodeType'];
-
-    final String? id =
-        (pinnedId is String && pinnedId.isNotEmpty) ? pinnedId : null;
-    final String? typeStr =
-        (pinnedType is String && pinnedType.isNotEmpty) ? pinnedType : null;
-    final String? fallbackId =
-        (activeId is String && activeId.isNotEmpty) ? activeId : null;
-    final String? fallbackTypeStr =
-        (activeType is String && activeType.isNotEmpty) ? activeType : null;
-
-    final resolvedId = id ?? fallbackId;
-    final resolvedTypeStr = typeStr ?? fallbackTypeStr;
+    final resolvedId = _nonEmptyString(settings['pinnedNodeId']) ??
+        _nonEmptyString(settings['activeNodeId']);
+    final resolvedTypeStr = _nonEmptyString(settings['pinnedNodeType']) ??
+        _nonEmptyString(settings['activeNodeType']);
     if (resolvedId == null || resolvedTypeStr == null) {
       return null;
     }
@@ -54,15 +42,11 @@ class PreferencesApi implements PreferencesPort {
       return null;
     }
 
-    String? name;
     final activeFolder = raw['activeFolder'];
-    if (activeFolder is Map<String, dynamic> &&
-        activeFolder['id'] == resolvedId) {
-      final n = activeFolder['name'];
-      if (n is String && n.isNotEmpty) {
-        name = n;
-      }
-    }
+    final name = (activeFolder is Map<String, dynamic> &&
+            activeFolder['id'] == resolvedId)
+        ? _nonEmptyString(activeFolder['name'])
+        : null;
 
     return ActiveNode(id: resolvedId, type: resolvedType, name: name);
   }
@@ -80,28 +64,18 @@ class PreferencesApi implements PreferencesPort {
       '/api/preferences/active-node',
       body: {
         'nodeId': nodeId,
-        'nodeType': nodeType == null ? null : _serializeType(nodeType),
+        'nodeType': nodeType?.wireValue,
         'pinned': pinned,
       },
     );
   }
 
-  static ActiveNodeType? _parseType(String s) {
-    switch (s) {
-      case 'group':
-        return ActiveNodeType.group;
-      case 'project':
-        return ActiveNodeType.project;
-    }
-    return null;
-  }
+  static ActiveNodeType? _parseType(String s) => switch (s) {
+        'group' => ActiveNodeType.group,
+        'project' => ActiveNodeType.project,
+        _ => null,
+      };
 
-  static String _serializeType(ActiveNodeType t) {
-    switch (t) {
-      case ActiveNodeType.group:
-        return 'group';
-      case ActiveNodeType.project:
-        return 'project';
-    }
-  }
+  static String? _nonEmptyString(Object? v) =>
+      (v is String && v.isNotEmpty) ? v : null;
 }

--- a/mobile/lib/infrastructure/api/preferences_api.dart
+++ b/mobile/lib/infrastructure/api/preferences_api.dart
@@ -1,0 +1,107 @@
+import '../../application/ports/api_client_port.dart';
+import '../../application/ports/preferences_port.dart';
+import '../../domain/active_node.dart';
+
+/// HTTP implementation of [PreferencesPort] hitting Remote Dev's
+/// `/api/preferences` and `/api/preferences/active-node` endpoints.
+class PreferencesApi implements PreferencesPort {
+  PreferencesApi(this._client);
+
+  final ApiClientPort _client;
+
+  @override
+  Future<ActiveNode?> getActiveNode() async {
+    final raw = await _client.get('/api/preferences');
+    if (raw is! Map<String, dynamic>) {
+      return null;
+    }
+
+    // Settings live under `userSettings`; `activeFolder` (when set)
+    // gives us the human-readable name to render in headers without a
+    // second round-trip. The server returns
+    // `{ userSettings: {...}, activeFolder: {id, name} | null, ... }`.
+    final settings = raw['userSettings'];
+    if (settings is! Map<String, dynamic>) {
+      return null;
+    }
+
+    // Prefer the pinned node over the live active node — this matches
+    // the PWA's behavior and the server's own GET handler (see
+    // `src/app/api/preferences/route.ts`), which resolves the
+    // active-folder lookup with `pinnedNodeId || activeNodeId`.
+    final pinnedId = settings['pinnedNodeId'];
+    final pinnedType = settings['pinnedNodeType'];
+    final activeId = settings['activeNodeId'];
+    final activeType = settings['activeNodeType'];
+
+    final String? id =
+        (pinnedId is String && pinnedId.isNotEmpty) ? pinnedId : null;
+    final String? typeStr =
+        (pinnedType is String && pinnedType.isNotEmpty) ? pinnedType : null;
+    final String? fallbackId =
+        (activeId is String && activeId.isNotEmpty) ? activeId : null;
+    final String? fallbackTypeStr =
+        (activeType is String && activeType.isNotEmpty) ? activeType : null;
+
+    final resolvedId = id ?? fallbackId;
+    final resolvedTypeStr = typeStr ?? fallbackTypeStr;
+    if (resolvedId == null || resolvedTypeStr == null) {
+      return null;
+    }
+
+    final resolvedType = _parseType(resolvedTypeStr);
+    if (resolvedType == null) {
+      return null;
+    }
+
+    String? name;
+    final activeFolder = raw['activeFolder'];
+    if (activeFolder is Map<String, dynamic> &&
+        activeFolder['id'] == resolvedId) {
+      final n = activeFolder['name'];
+      if (n is String && n.isNotEmpty) {
+        name = n;
+      }
+    }
+
+    return ActiveNode(id: resolvedId, type: resolvedType, name: name);
+  }
+
+  @override
+  Future<void> setActiveNode({
+    required String? nodeId,
+    required ActiveNodeType? nodeType,
+    bool pinned = false,
+  }) async {
+    // The server requires either both values present or both null —
+    // pass them as `null` rather than omitting so the schema's
+    // `(nodeId === null) !== (nodeType === null)` guard is satisfied.
+    await _client.post(
+      '/api/preferences/active-node',
+      body: {
+        'nodeId': nodeId,
+        'nodeType': nodeType == null ? null : _serializeType(nodeType),
+        'pinned': pinned,
+      },
+    );
+  }
+
+  static ActiveNodeType? _parseType(String s) {
+    switch (s) {
+      case 'group':
+        return ActiveNodeType.group;
+      case 'project':
+        return ActiveNodeType.project;
+    }
+    return null;
+  }
+
+  static String _serializeType(ActiveNodeType t) {
+    switch (t) {
+      case ActiveNodeType.group:
+        return 'group';
+      case ActiveNodeType.project:
+        return 'project';
+    }
+  }
+}

--- a/mobile/lib/infrastructure/api/sessions_api.dart
+++ b/mobile/lib/infrastructure/api/sessions_api.dart
@@ -12,11 +12,18 @@ class SessionsApi implements SessionsPort {
     final list = _extractSessions(raw);
     return list
         .map((m) => SessionSummary.fromJson(m))
-        // Server returns sessions in the `trashed` soft-delete state too;
-        // the web client filters them out at the rendering layer and the
-        // mobile UI has no trash-management surface. Drop them here so
-        // they never reach the picker / tabs.
-        .where((s) => s.status != SessionStatus.trashed)
+        // Mirror the PWA's mobile-web Sessions tab (see
+        // `src/components/mobile/sessions/SessionsTab.tsx`), which only
+        // shows sessions in the `active` or `suspended` states. The
+        // server also hands back `closed` sessions (terminal-but-not-
+        // trashed) and `trashed` soft-deletes; both belong to surfaces
+        // the mobile app doesn't expose, so we drop them here before
+        // they ever reach the picker / tabs.
+        .where(
+          (s) =>
+              s.status == SessionStatus.active ||
+              s.status == SessionStatus.suspended,
+        )
         .toList(growable: false);
   }
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -8,6 +8,7 @@ import 'infrastructure/api/account_api.dart';
 import 'infrastructure/api/channels_api.dart';
 import 'infrastructure/api/github_accounts_api.dart';
 import 'infrastructure/api/notifications_api.dart';
+import 'infrastructure/api/preferences_api.dart';
 import 'infrastructure/api/project_tree_api.dart';
 import 'infrastructure/api/remote_dev_client.dart';
 import 'infrastructure/api/sessions_api.dart';
@@ -21,7 +22,7 @@ import 'presentation/router/app_router.dart' show pushTokenRegistrarProvider;
 import 'presentation/screens/biometric/biometric_lock_overlay.dart'
     show biometricPortProvider, biometricSettingsStoreProvider;
 import 'presentation/screens/channels/channels_tab_screen.dart'
-    show channelsApiProvider;
+    show channelsApiProvider, preferencesApiProvider;
 import 'presentation/screens/notifications/notifications_tab_screen.dart'
     show notificationsApiProvider;
 import 'presentation/screens/profile/account_screen.dart'
@@ -86,6 +87,9 @@ List<Override> buildServerScopedOverrides({required String deviceId}) {
     ),
     channelsApiProvider.overrideWith(
       (ref) => ChannelsApi(ref.watch(_apiClientProvider)),
+    ),
+    preferencesApiProvider.overrideWith(
+      (ref) => PreferencesApi(ref.watch(_apiClientProvider)),
     ),
     notificationsApiProvider.overrideWith(
       (ref) => NotificationsApi(ref.watch(_apiClientProvider)),

--- a/mobile/lib/presentation/screens/channels/channel_screen.dart
+++ b/mobile/lib/presentation/screens/channels/channel_screen.dart
@@ -244,18 +244,12 @@ class _ChannelTitle extends ConsumerWidget {
     // generic fallback — the WebView is the source of truth for
     // content; this title is a best-effort hint.
     final node = ref.watch(activeNodeProvider).valueOrNull;
-    final asyncChannels = ref.watch(channelsListProvider(node));
-    final channels = asyncChannels.valueOrNull;
-    String? name;
-    if (channels != null) {
-      for (final c in channels) {
-        if (c.id == channelId) {
-          final trimmed = c.name.trim();
-          if (trimmed.isNotEmpty) name = trimmed;
-          break;
-        }
-      }
-    }
+    final channels = ref.watch(channelsListProvider(node)).valueOrNull;
+    final trimmed = channels
+        ?.where((c) => c.id == channelId)
+        .map((c) => c.name.trim())
+        .firstOrNull;
+    final name = (trimmed != null && trimmed.isNotEmpty) ? trimmed : null;
     return Text(
       name == null ? 'Channel' : '#$name',
       style: const TextStyle(color: Colors.white),

--- a/mobile/lib/presentation/screens/channels/channel_screen.dart
+++ b/mobile/lib/presentation/screens/channels/channel_screen.dart
@@ -12,7 +12,8 @@ import '../webview_host/session_route_host.dart'
         activeServerProvider,
         mobileCredentialsStoreProvider,
         webViewCookieSeederProvider;
-import 'channels_tab_screen.dart' show channelsListProvider;
+import 'channels_tab_screen.dart'
+    show activeNodeProvider, channelsListProvider;
 
 /// Native chrome around the embedded WebView at `/m/channel/<id>`.
 ///
@@ -238,8 +239,12 @@ class _ChannelTitle extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncChannels = ref.watch(channelsListProvider);
-    // `value` is null while loading and on error; we tolerate both.
+    // Resolve the channel name from the project-scoped list. While
+    // [activeNodeProvider] is loading or unset we just render the
+    // generic fallback — the WebView is the source of truth for
+    // content; this title is a best-effort hint.
+    final node = ref.watch(activeNodeProvider).valueOrNull;
+    final asyncChannels = ref.watch(channelsListProvider(node));
     final channels = asyncChannels.valueOrNull;
     String? name;
     if (channels != null) {

--- a/mobile/lib/presentation/screens/channels/channels_tab_screen.dart
+++ b/mobile/lib/presentation/screens/channels/channels_tab_screen.dart
@@ -39,7 +39,7 @@ final preferencesApiProvider = Provider<PreferencesApi>((ref) {
 /// needs project scoping (Channels today, Tasks/Peers later) should
 /// watch this notifier so they react to changes initiated anywhere in
 /// the UI (sessions tab, project picker, etc.).
-class ActiveNodeNotifier extends AsyncNotifier<ActiveNode?> {
+class ActiveNodeNotifier extends AutoDisposeAsyncNotifier<ActiveNode?> {
   @override
   Future<ActiveNode?> build() async {
     return ref.watch(preferencesApiProvider).getActiveNode();
@@ -65,8 +65,12 @@ class ActiveNodeNotifier extends AsyncNotifier<ActiveNode?> {
   }
 }
 
+/// `.autoDispose` is critical: when the active server changes, this
+/// provider is disposed and rebuilt against the new server's
+/// `preferencesApiProvider`. Without it, the notifier would retain a
+/// reference to the prior server's API client and operate on stale data.
 final activeNodeProvider =
-    AsyncNotifierProvider<ActiveNodeNotifier, ActiveNode?>(
+    AsyncNotifierProvider.autoDispose<ActiveNodeNotifier, ActiveNode?>(
   ActiveNodeNotifier.new,
 );
 
@@ -136,12 +140,16 @@ class _ChannelsTabScreenState extends ConsumerState<ChannelsTabScreen>
     _pollTimer = null;
   }
 
-  Future<void> _refresh(ActiveNode? node) async {
-    ref.invalidate(channelsListProvider(node));
-    await ref.read(channelsListProvider(node).future);
+  Future<void> _refresh(ActiveNode? node) {
+    return ref.refresh(channelsListProvider(node).future);
   }
 
   Future<void> _pickProject() async {
+    // Invariant: `showProjectTreeSheet` only returns project IDs. Groups
+    // render as non-tappable `ExpansionTile` headers in the sheet; only
+    // project rows pop with an id. If the sheet ever starts returning
+    // group IDs, this call site MUST be updated to pass the correct
+    // `ActiveNodeType` (group vs project).
     final projectId = await showProjectTreeSheet(context);
     if (projectId == null || !mounted) return;
     await ref.read(activeNodeProvider.notifier).select(
@@ -206,6 +214,7 @@ class _ChannelsTabScreenState extends ConsumerState<ChannelsTabScreen>
   @override
   Widget build(BuildContext context) {
     final asyncNode = ref.watch(activeNodeProvider);
+    final nodeName = asyncNode.valueOrNull?.name;
 
     return Scaffold(
       backgroundColor: const Color(0xFF1A1B26),
@@ -221,9 +230,9 @@ class _ChannelsTabScreenState extends ConsumerState<ChannelsTabScreen>
             ),
             // Active project subtitle, matching the PWA's "Channels · name"
             // header. Only render when we actually have a name to show.
-            if (asyncNode.valueOrNull?.name != null)
+            if (nodeName != null)
               Text(
-                asyncNode.value!.name!,
+                nodeName,
                 style: const TextStyle(
                   color: Colors.white54,
                   fontSize: 12,

--- a/mobile/lib/presentation/screens/channels/channels_tab_screen.dart
+++ b/mobile/lib/presentation/screens/channels/channels_tab_screen.dart
@@ -5,8 +5,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../domain/active_node.dart';
 import '../../../domain/channel.dart';
 import '../../../infrastructure/api/channels_api.dart';
+import '../../../infrastructure/api/preferences_api.dart';
+import '../sessions/project_tree_sheet.dart' show showProjectTreeSheet;
 import '../shell/home_shell.dart';
 
 /// Polling cadence for live unread refresh while the Channels tab is mounted
@@ -23,9 +26,57 @@ final channelsApiProvider = Provider<ChannelsApi>((ref) {
   );
 });
 
-final channelsListProvider =
-    FutureProvider.autoDispose<List<Channel>>((ref) async {
-  return ref.watch(channelsApiProvider).list();
+/// Provider for the preferences API. Overridden in main.dart alongside the
+/// other server-scoped APIs so it rebinds when the active server changes.
+final preferencesApiProvider = Provider<PreferencesApi>((ref) {
+  throw UnimplementedError(
+    'preferencesApiProvider must be overridden with PreferencesApi(client) in main.dart',
+  );
+});
+
+/// Holds the user's active project/group selection. Mirrors the PWA
+/// mobile-web's `usePreferencesContext().activeProject`: every tab that
+/// needs project scoping (Channels today, Tasks/Peers later) should
+/// watch this notifier so they react to changes initiated anywhere in
+/// the UI (sessions tab, project picker, etc.).
+class ActiveNodeNotifier extends AsyncNotifier<ActiveNode?> {
+  @override
+  Future<ActiveNode?> build() async {
+    return ref.watch(preferencesApiProvider).getActiveNode();
+  }
+
+  /// Select a node (project or group). Persists to the server first so
+  /// subsequent reads from any client see the same value, then refreshes
+  /// the local state so dependent providers (`channelsListProvider`)
+  /// rebuild.
+  Future<void> select({
+    required String? nodeId,
+    required ActiveNodeType? nodeType,
+  }) async {
+    final api = ref.read(preferencesApiProvider);
+    state = const AsyncValue.loading();
+    try {
+      await api.setActiveNode(nodeId: nodeId, nodeType: nodeType);
+      final fresh = await api.getActiveNode();
+      state = AsyncValue.data(fresh);
+    } catch (err, stack) {
+      state = AsyncValue.error(err, stack);
+    }
+  }
+}
+
+final activeNodeProvider =
+    AsyncNotifierProvider<ActiveNodeNotifier, ActiveNode?>(
+  ActiveNodeNotifier.new,
+);
+
+/// Family-keyed channels list. Re-fetches when the active node changes;
+/// returns an empty list when [node] is `null` (matches the API
+/// short-circuit in [ChannelsApi.list]).
+final channelsListProvider = FutureProvider.autoDispose
+    .family<List<Channel>, ActiveNode?>((ref, node) async {
+  if (node == null) return const <Channel>[];
+  return ref.watch(channelsApiProvider).list(activeNode: node);
 });
 
 class ChannelsTabScreen extends ConsumerStatefulWidget {
@@ -55,16 +106,13 @@ class _ChannelsTabScreenState extends ConsumerState<ChannelsTabScreen>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    // Pause polling while the app is backgrounded; resume when it comes back.
-    // Note: this does NOT pause polling when the user switches to another tab
-    // inside HomeShell — IndexedStack keeps this screen mounted. That's an
-    // acceptable trade-off (one cheap GET every 30s while foregrounded) and
-    // is tracked as a follow-up to wire tab-visibility-aware polling.
     if (state == AppLifecycleState.resumed) {
       if (_pollTimer == null) {
         // Refresh immediately on return-to-foreground so unread counts are
-        // current without waiting a full interval.
-        ref.invalidate(channelsListProvider);
+        // current without waiting a full interval. Use the current active
+        // node so we don't fan out a request for a stale family key.
+        final node = ref.read(activeNodeProvider).valueOrNull;
+        ref.invalidate(channelsListProvider(node));
         _startPolling();
       }
     } else if (state == AppLifecycleState.paused ||
@@ -78,7 +126,8 @@ class _ChannelsTabScreenState extends ConsumerState<ChannelsTabScreen>
     _pollTimer?.cancel();
     _pollTimer = Timer.periodic(_kChannelPollInterval, (_) {
       if (!mounted) return;
-      ref.invalidate(channelsListProvider);
+      final node = ref.read(activeNodeProvider).valueOrNull;
+      ref.invalidate(channelsListProvider(node));
     });
   }
 
@@ -87,16 +136,25 @@ class _ChannelsTabScreenState extends ConsumerState<ChannelsTabScreen>
     _pollTimer = null;
   }
 
-  Future<void> _refresh() async {
-    ref.invalidate(channelsListProvider);
-    await ref.read(channelsListProvider.future);
+  Future<void> _refresh(ActiveNode? node) async {
+    ref.invalidate(channelsListProvider(node));
+    await ref.read(channelsListProvider(node).future);
   }
 
-  Future<void> _archive(Channel channel) async {
+  Future<void> _pickProject() async {
+    final projectId = await showProjectTreeSheet(context);
+    if (projectId == null || !mounted) return;
+    await ref.read(activeNodeProvider.notifier).select(
+          nodeId: projectId,
+          nodeType: ActiveNodeType.project,
+        );
+  }
+
+  Future<void> _archive(Channel channel, ActiveNode? node) async {
     final api = ref.read(channelsApiProvider);
     try {
       await api.archive(channel.id);
-      await _refresh();
+      await _refresh(node);
       if (!mounted) return;
       _showSnack('Channel archived');
     } catch (e) {
@@ -142,63 +200,130 @@ class _ChannelsTabScreenState extends ConsumerState<ChannelsTabScreen>
   }
 
   void _onTapChannel(Channel channel) {
-    // push so the channel view has an implicit back arrow that pops
-    // to the Channels tab inside HomeShell.
     context.push('/home/channel/${channel.id}');
   }
 
   @override
   Widget build(BuildContext context) {
-    final asyncChannels = ref.watch(channelsListProvider);
+    final asyncNode = ref.watch(activeNodeProvider);
 
     return Scaffold(
       backgroundColor: const Color(0xFF1A1B26),
       appBar: AppBar(
         backgroundColor: const Color(0xFF1A1B26),
-        title: const Text('Channels', style: TextStyle(color: Colors.white)),
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text(
+              'Channels',
+              style: TextStyle(color: Colors.white),
+            ),
+            // Active project subtitle, matching the PWA's "Channels · name"
+            // header. Only render when we actually have a name to show.
+            if (asyncNode.valueOrNull?.name != null)
+              Text(
+                asyncNode.value!.name!,
+                style: const TextStyle(
+                  color: Colors.white54,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w400,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+          ],
+        ),
+        actions: [
+          IconButton(
+            tooltip: 'Pick project',
+            onPressed: _pickProject,
+            icon: const Icon(Icons.folder_open, color: Colors.white70),
+          ),
+        ],
       ),
-      body: asyncChannels.when(
+      body: asyncNode.when(
         loading: () => const Center(
           child: CupertinoActivityIndicator(color: Colors.white70),
         ),
         error: (err, _) => _ErrorView(
-          message: 'Failed to load channels',
+          message: 'Failed to load preferences',
           detail: '$err',
-          onRetry: _refresh,
+          onRetry: () async => ref.refresh(activeNodeProvider.future),
         ),
-        data: (channels) {
-          if (channels.isEmpty) {
-            return _EmptyState(onRefresh: _refresh);
+        data: (node) {
+          if (node == null) {
+            return _NoActiveProjectState(onPickProject: _pickProject);
           }
-          return RefreshIndicator(
-            onRefresh: _refresh,
-            color: const Color(0xFF7AA2F7),
-            backgroundColor: const Color(0xFF24283B),
-            child: ListView.separated(
-              physics: const AlwaysScrollableScrollPhysics(),
-              // Reserve space below the last row so it never tucks under the
-              // host shell's bottom nav bar (or the Android gesture inset).
-              padding: EdgeInsets.only(
-                bottom: tabContentBottomPadding(context),
-              ),
-              itemCount: channels.length,
-              separatorBuilder: (_, __) => const Divider(
-                color: Color(0xFF2F334D),
-                height: 1,
-              ),
-              itemBuilder: (context, i) {
-                final c = channels[i];
-                return _ChannelRow(
-                  channel: c,
-                  onTap: () => _onTapChannel(c),
-                  onArchive: () => _archive(c),
-                  confirmArchive: () => _confirmArchive(c),
-                );
-              },
-            ),
+          return _ChannelsListBody(
+            node: node,
+            onRefresh: () => _refresh(node),
+            onArchive: (c) => _archive(c, node),
+            confirmArchive: _confirmArchive,
+            onTapChannel: _onTapChannel,
           );
         },
       ),
+    );
+  }
+}
+
+class _ChannelsListBody extends ConsumerWidget {
+  const _ChannelsListBody({
+    required this.node,
+    required this.onRefresh,
+    required this.onArchive,
+    required this.confirmArchive,
+    required this.onTapChannel,
+  });
+
+  final ActiveNode node;
+  final Future<void> Function() onRefresh;
+  final void Function(Channel) onArchive;
+  final Future<bool> Function(Channel) confirmArchive;
+  final void Function(Channel) onTapChannel;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncChannels = ref.watch(channelsListProvider(node));
+    return asyncChannels.when(
+      loading: () => const Center(
+        child: CupertinoActivityIndicator(color: Colors.white70),
+      ),
+      error: (err, _) => _ErrorView(
+        message: 'Failed to load channels',
+        detail: '$err',
+        onRetry: onRefresh,
+      ),
+      data: (channels) {
+        if (channels.isEmpty) {
+          return _EmptyState(onRefresh: onRefresh);
+        }
+        return RefreshIndicator(
+          onRefresh: onRefresh,
+          color: const Color(0xFF7AA2F7),
+          backgroundColor: const Color(0xFF24283B),
+          child: ListView.separated(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: EdgeInsets.only(
+              bottom: tabContentBottomPadding(context),
+            ),
+            itemCount: channels.length,
+            separatorBuilder: (_, __) => const Divider(
+              color: Color(0xFF2F334D),
+              height: 1,
+            ),
+            itemBuilder: (context, i) {
+              final c = channels[i];
+              return _ChannelRow(
+                channel: c,
+                onTap: () => onTapChannel(c),
+                onArchive: () => onArchive(c),
+                confirmArchive: () => confirmArchive(c),
+              );
+            },
+          ),
+        );
+      },
     );
   }
 }
@@ -227,7 +352,6 @@ class _ChannelRow extends StatelessWidget {
         if (ok) {
           onArchive();
         }
-        // Always return false: the row is removed when the list refetches.
         return false;
       },
       background: const SizedBox.shrink(),
@@ -332,12 +456,68 @@ class _EmptyState extends StatelessWidget {
           SizedBox(height: 8),
           Center(
             child: Text(
-              'Channels will appear here once a project is selected.',
+              'Channels for this project will appear here.',
               style: TextStyle(color: Colors.white38, fontSize: 13),
               textAlign: TextAlign.center,
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Shown when no project (or group) is selected. Mirrors the PWA's
+/// "Pick a project from the Sessions tab to load channels" copy and
+/// gives the user a direct path to fix it without leaving the tab.
+class _NoActiveProjectState extends StatelessWidget {
+  const _NoActiveProjectState({required this.onPickProject});
+  final Future<void> Function() onPickProject;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.folder_off_outlined,
+              size: 48,
+              color: Colors.white24,
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'No project selected',
+              style: TextStyle(color: Colors.white70, fontSize: 16),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Pick a project to load channels.',
+              style: TextStyle(color: Colors.white38, fontSize: 13),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: onPickProject,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFF7AA2F7),
+                foregroundColor: const Color(0xFF1A1B26),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 12,
+                ),
+              ),
+              icon: const Icon(Icons.folder_open),
+              label: const Text(
+                'Pick a project',
+                style: TextStyle(fontWeight: FontWeight.w600),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/lib/presentation/screens/notifications/notifications_tab_screen.dart
+++ b/mobile/lib/presentation/screens/notifications/notifications_tab_screen.dart
@@ -37,25 +37,26 @@ final notificationsListProvider =
   return ref.watch(notificationsApiProvider).list();
 });
 
+/// Agent lifecycle notification types that should NEVER count as mentions,
+/// even when their text happens to contain an `@`-token.
+const _kAgentLifecycleTypes = <String>{
+  'agent_waiting',
+  'agent_error',
+  'agent_complete',
+  'agent_exited',
+};
+
+/// Matches either the peer-message `@<sid:UUID>` token or a human-readable
+/// `@name` at a word boundary.
+final _kMentionPattern = RegExp(r'@<sid:[^>]+>|(^|\s)@\w');
+
 /// Heuristic that mirrors the PWA's `isMention` (see
 /// `src/components/mobile/notifications/NotificationsTab.tsx`):
-///
-/// 1. Agent lifecycle events (`agent_waiting`, `agent_error`,
-///    `agent_complete`, `agent_exited`) are never mentions, even if
-///    their text happens to contain an `@`-token.
-/// 2. Everything else qualifies if the title or body contains either
-///    the peer-message `@<sid:UUID>` token or a human-readable `@name`
-///    word boundary.
+/// agent lifecycle events never qualify; everything else qualifies if its
+/// title or body contains a mention-shaped token.
 bool _isMention(AppNotification n) {
-  switch (n.type) {
-    case 'agent_waiting':
-    case 'agent_error':
-    case 'agent_complete':
-    case 'agent_exited':
-      return false;
-  }
-  final haystack = '${n.title} ${n.body}';
-  return RegExp(r'@<sid:[^>]+>|(^|\s)@\w').hasMatch(haystack);
+  if (_kAgentLifecycleTypes.contains(n.type)) return false;
+  return _kMentionPattern.hasMatch('${n.title} ${n.body}');
 }
 
 class NotificationsTabScreen extends ConsumerStatefulWidget {
@@ -70,9 +71,8 @@ class _NotificationsTabScreenState
     extends ConsumerState<NotificationsTabScreen> {
   NotificationFilter _filter = NotificationFilter.all;
 
-  Future<void> _refresh() async {
-    ref.invalidate(notificationsListProvider);
-    await ref.read(notificationsListProvider.future);
+  Future<void> _refresh() {
+    return ref.refresh(notificationsListProvider.future);
   }
 
   void _selectFilter(NotificationFilter filter) {

--- a/mobile/lib/presentation/screens/notifications/notifications_tab_screen.dart
+++ b/mobile/lib/presentation/screens/notifications/notifications_tab_screen.dart
@@ -26,11 +26,37 @@ enum NotificationFilter {
   final String label;
 }
 
-/// Family-keyed list provider — re-fetches when the filter changes.
-final notificationsListProvider = FutureProvider.autoDispose
-    .family<List<AppNotification>, NotificationFilter>((ref, filter) async {
-  return ref.watch(notificationsApiProvider).list(filter: filter.queryValue);
+/// Single list provider — always fetches every notification. Filtering
+/// is done client-side in the widget, mirroring the PWA mobile-web tab
+/// (`src/components/mobile/notifications/NotificationsTab.tsx`). This
+/// avoids a per-filter refetch and keeps the Mentions chip working —
+/// the server has no concept of a "mention" notification type, so we
+/// detect mentions locally with [_isMention].
+final notificationsListProvider =
+    FutureProvider.autoDispose<List<AppNotification>>((ref) async {
+  return ref.watch(notificationsApiProvider).list();
 });
+
+/// Heuristic that mirrors the PWA's `isMention` (see
+/// `src/components/mobile/notifications/NotificationsTab.tsx`):
+///
+/// 1. Agent lifecycle events (`agent_waiting`, `agent_error`,
+///    `agent_complete`, `agent_exited`) are never mentions, even if
+///    their text happens to contain an `@`-token.
+/// 2. Everything else qualifies if the title or body contains either
+///    the peer-message `@<sid:UUID>` token or a human-readable `@name`
+///    word boundary.
+bool _isMention(AppNotification n) {
+  switch (n.type) {
+    case 'agent_waiting':
+    case 'agent_error':
+    case 'agent_complete':
+    case 'agent_exited':
+      return false;
+  }
+  final haystack = '${n.title} ${n.body}';
+  return RegExp(r'@<sid:[^>]+>|(^|\s)@\w').hasMatch(haystack);
+}
 
 class NotificationsTabScreen extends ConsumerStatefulWidget {
   const NotificationsTabScreen({super.key});
@@ -45,8 +71,8 @@ class _NotificationsTabScreenState
   NotificationFilter _filter = NotificationFilter.all;
 
   Future<void> _refresh() async {
-    ref.invalidate(notificationsListProvider(_filter));
-    await ref.read(notificationsListProvider(_filter).future);
+    ref.invalidate(notificationsListProvider);
+    await ref.read(notificationsListProvider.future);
   }
 
   void _selectFilter(NotificationFilter filter) {
@@ -159,7 +185,7 @@ class _NotificationsTabScreenState
 
   @override
   Widget build(BuildContext context) {
-    final asyncList = ref.watch(notificationsListProvider(_filter));
+    final asyncList = ref.watch(notificationsListProvider);
     final hasItems = asyncList.valueOrNull?.isNotEmpty ?? false;
 
     return Scaffold(
@@ -201,7 +227,20 @@ class _NotificationsTabScreenState
                 detail: '$err',
                 onRetry: _refresh,
               ),
-              data: (items) {
+              data: (allItems) {
+                // Apply the active chip filter client-side, matching the
+                // PWA mobile-web tab. `all` passes through; `unread`
+                // drops read rows; `mentions` keeps only rows that
+                // satisfy [_isMention]. The empty-state copy below
+                // reflects the active filter so it stays accurate when
+                // the unfiltered list is non-empty.
+                final items = switch (_filter) {
+                  NotificationFilter.all => allItems,
+                  NotificationFilter.unread =>
+                    allItems.where((n) => !n.read).toList(growable: false),
+                  NotificationFilter.mentions =>
+                    allItems.where(_isMention).toList(growable: false),
+                };
                 if (items.isEmpty) {
                   return _EmptyState(filter: _filter, onRefresh: _refresh);
                 }

--- a/mobile/test/infrastructure/api/channels_api_test.dart
+++ b/mobile/test/infrastructure/api/channels_api_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:remote_dev/application/ports/api_client_port.dart';
+import 'package:remote_dev/domain/active_node.dart';
 import 'package:remote_dev/infrastructure/api/channels_api.dart';
 
 class _MockApiClient extends Mock implements ApiClientPort {}
@@ -9,14 +10,48 @@ void main() {
   late _MockApiClient client;
   late ChannelsApi api;
 
+  // The Channels tab is project-scoped — every meaningful list() call
+  // happens against an active node. These helpers keep the tests
+  // focused on response-shape parsing rather than param plumbing.
+  const projectNode = ActiveNode(id: 'proj-a', type: ActiveNodeType.project);
+  const projectPath = '/api/channels?nodeId=proj-a&nodeType=project';
+  const groupNode = ActiveNode(id: 'grp-1', type: ActiveNodeType.group);
+  const groupPath = '/api/channels?nodeId=grp-1&nodeType=group';
+
   setUp(() {
     client = _MockApiClient();
     api = ChannelsApi(client);
   });
 
   group('list()', () {
+    test('short-circuits to empty when no active node is supplied', () async {
+      // The server's /api/channels endpoint 400s without ?nodeId/?nodeType
+      // (or the legacy ?projectId). Match the PWA mobile-web tab: don't
+      // even send the request.
+      final channels = await api.list();
+      expect(channels, isEmpty);
+      verifyNever(() => client.get(any()));
+    });
+
+    test('passes nodeId + nodeType=project for a project active node',
+        () async {
+      when(() => client.get(any())).thenAnswer((_) async => const []);
+
+      await api.list(activeNode: projectNode);
+
+      verify(() => client.get(projectPath)).called(1);
+    });
+
+    test('passes nodeType=group for a group active node', () async {
+      when(() => client.get(any())).thenAnswer((_) async => const []);
+
+      await api.list(activeNode: groupNode);
+
+      verify(() => client.get(groupPath)).called(1);
+    });
+
     test('parses { channels: [...] } shape', () async {
-      when(() => client.get('/api/channels')).thenAnswer(
+      when(() => client.get(projectPath)).thenAnswer(
         (_) async => {
           'channels': [
             {
@@ -35,7 +70,7 @@ void main() {
         },
       );
 
-      final channels = await api.list();
+      final channels = await api.list(activeNode: projectNode);
 
       expect(channels, hasLength(2));
       expect(channels[0].id, 'ch-1');
@@ -46,7 +81,7 @@ void main() {
     });
 
     test('parses bare-array shape', () async {
-      when(() => client.get('/api/channels')).thenAnswer(
+      when(() => client.get(projectPath)).thenAnswer(
         (_) async => [
           {
             'id': 'ch-3',
@@ -56,7 +91,7 @@ void main() {
         ],
       );
 
-      final channels = await api.list();
+      final channels = await api.list(activeNode: projectNode);
 
       expect(channels, hasLength(1));
       expect(channels[0].id, 'ch-3');
@@ -66,7 +101,7 @@ void main() {
     });
 
     test('flattens { groups: [{ channels: [...] }] } server shape', () async {
-      when(() => client.get('/api/channels')).thenAnswer(
+      when(() => client.get(projectPath)).thenAnswer(
         (_) async => {
           'groups': [
             {
@@ -103,7 +138,7 @@ void main() {
         },
       );
 
-      final channels = await api.list();
+      final channels = await api.list(activeNode: projectNode);
 
       expect(channels, hasLength(3));
       expect(channels[0].id, 'ch-1');
@@ -114,7 +149,7 @@ void main() {
     });
 
     test('defaults unreadCount to 0 when missing', () async {
-      when(() => client.get('/api/channels')).thenAnswer(
+      when(() => client.get(projectPath)).thenAnswer(
         (_) async => {
           'channels': [
             {
@@ -125,25 +160,25 @@ void main() {
         },
       );
 
-      final channels = await api.list();
+      final channels = await api.list(activeNode: projectNode);
       expect(channels, hasLength(1));
       expect(channels[0].unreadCount, 0);
     });
 
     test('returns empty list on unrecognised shape', () async {
-      when(() => client.get('/api/channels'))
+      when(() => client.get(projectPath))
           .thenAnswer((_) async => 'unexpected');
 
-      final channels = await api.list();
+      final channels = await api.list(activeNode: projectNode);
       expect(channels, isEmpty);
     });
 
     test('returns empty list on empty groups response', () async {
-      when(() => client.get('/api/channels')).thenAnswer(
+      when(() => client.get(projectPath)).thenAnswer(
         (_) async => {'groups': <dynamic>[]},
       );
 
-      final channels = await api.list();
+      final channels = await api.list(activeNode: projectNode);
       expect(channels, isEmpty);
     });
   });

--- a/mobile/test/infrastructure/api/notifications_api_test.dart
+++ b/mobile/test/infrastructure/api/notifications_api_test.dart
@@ -96,31 +96,55 @@ void main() {
       expect(list[0].read, isFalse);
     });
 
-    test('translates filter=unread to ?unreadOnly=true', () async {
+    test('ignores the filter param and always fetches the full list',
+        () async {
+      // Match the PWA mobile-web Notifications tab: fetch every
+      // notification once and filter in memory. The `filter` arg is
+      // kept for port compatibility but must not change the request.
       when(() => client.get(any())).thenAnswer((_) async => const []);
 
       await api.list(filter: 'unread');
-      verify(() => client.get('/api/notifications?unreadOnly=true'))
-          .called(1);
-    });
-
-    test(
-      'falls back to bare path for filter=mentions (no server-side concept)',
-      () async {
-        when(() => client.get(any())).thenAnswer((_) async => const []);
-
-        await api.list(filter: 'mentions');
-        verify(() => client.get('/api/notifications')).called(1);
-      },
-    );
-
-    test('omits query string for filter=all and null', () async {
-      when(() => client.get(any())).thenAnswer((_) async => const []);
-
+      await api.list(filter: 'mentions');
       await api.list(filter: 'all');
       await api.list();
 
-      verify(() => client.get('/api/notifications')).called(2);
+      verify(() => client.get('/api/notifications')).called(4);
+      verifyNever(() => client.get('/api/notifications?filter=unread'));
+      verifyNever(() => client.get('/api/notifications?unreadOnly=true'));
+    });
+
+    test('parses the server-side notification type field', () async {
+      when(() => client.get('/api/notifications')).thenAnswer(
+        (_) async => {
+          'notifications': [
+            {
+              'id': 'n-agent',
+              'title': 'Agent waiting',
+              'body': 'Idle for 5m',
+              'createdAt': '2026-05-08T10:00:00.000Z',
+              'type': 'agent_waiting',
+            },
+            {
+              'id': 'n-info',
+              'title': '@you mentioned',
+              'body': 'see this',
+              'createdAt': '2026-05-08T10:00:00.000Z',
+              'type': 'info',
+            },
+            {
+              'id': 'n-no-type',
+              'title': 'Untyped',
+              'body': 'legacy',
+              'createdAt': '2026-05-08T10:00:00.000Z',
+            },
+          ],
+        },
+      );
+
+      final list = await api.list();
+      expect(list[0].type, 'agent_waiting');
+      expect(list[1].type, 'info');
+      expect(list[2].type, isNull);
     });
 
     test('returns empty list on unexpected response shape', () async {
@@ -131,7 +155,10 @@ void main() {
   });
 
   group('dismiss()', () {
-    test('DELETEs /api/notifications with {ids: [id]}', () async {
+    test('DELETEs /api/notifications with {ids: [id]} body', () async {
+      // The server has no `/api/notifications/:id` route — only the
+      // bulk DELETE that takes `{ids: [...]}`. Wrap the single id in an
+      // array so the dismiss button stops 404-ing on production.
       when(() => client.delete(any(), body: any(named: 'body')))
           .thenAnswer((_) async {});
 

--- a/mobile/test/infrastructure/api/preferences_api_test.dart
+++ b/mobile/test/infrastructure/api/preferences_api_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:remote_dev/application/ports/api_client_port.dart';
+import 'package:remote_dev/domain/active_node.dart';
+import 'package:remote_dev/infrastructure/api/preferences_api.dart';
+
+class _MockClient extends Mock implements ApiClientPort {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  late _MockClient client;
+  late PreferencesApi api;
+
+  setUp(() {
+    client = _MockClient();
+    api = PreferencesApi(client);
+  });
+
+  group('getActiveNode()', () {
+    test('prefers pinnedNode over activeNode when both are set', () async {
+      when(() => client.get('/api/preferences')).thenAnswer(
+        (_) async => {
+          'userSettings': {
+            'activeNodeId': 'active-id',
+            'activeNodeType': 'project',
+            'pinnedNodeId': 'pinned-id',
+            'pinnedNodeType': 'group',
+          },
+          'activeFolder': {'id': 'pinned-id', 'name': 'Pinned'},
+        },
+      );
+
+      final node = await api.getActiveNode();
+
+      expect(node, isNotNull);
+      expect(node!.id, 'pinned-id');
+      expect(node.type, ActiveNodeType.group);
+      expect(node.name, 'Pinned');
+    });
+
+    test('falls back to activeNode when pinned is empty', () async {
+      when(() => client.get('/api/preferences')).thenAnswer(
+        (_) async => {
+          'userSettings': {
+            'activeNodeId': 'active-id',
+            'activeNodeType': 'project',
+            'pinnedNodeId': null,
+            'pinnedNodeType': null,
+          },
+          'activeFolder': {'id': 'active-id', 'name': 'My project'},
+        },
+      );
+
+      final node = await api.getActiveNode();
+      expect(node!.id, 'active-id');
+      expect(node.type, ActiveNodeType.project);
+      expect(node.name, 'My project');
+    });
+
+    test('returns null when no active or pinned node is set', () async {
+      when(() => client.get('/api/preferences')).thenAnswer(
+        (_) async => {
+          'userSettings': {
+            'activeNodeId': null,
+            'activeNodeType': null,
+            'pinnedNodeId': null,
+            'pinnedNodeType': null,
+          },
+          'activeFolder': null,
+        },
+      );
+
+      expect(await api.getActiveNode(), isNull);
+    });
+
+    test('omits name when activeFolder.id does not match the resolved id',
+        () async {
+      // Defensive: server may return an activeFolder pointing at the
+      // pinned node while we resolved the active one (or vice versa).
+      // We shouldn't show a misleading name in that case.
+      when(() => client.get('/api/preferences')).thenAnswer(
+        (_) async => {
+          'userSettings': {
+            'activeNodeId': 'other-id',
+            'activeNodeType': 'project',
+            'pinnedNodeId': null,
+            'pinnedNodeType': null,
+          },
+          'activeFolder': {'id': 'mismatch', 'name': 'Wrong'},
+        },
+      );
+
+      final node = await api.getActiveNode();
+      expect(node!.id, 'other-id');
+      expect(node.name, isNull);
+    });
+
+    test('returns null when the response shape is unexpected', () async {
+      when(() => client.get('/api/preferences'))
+          .thenAnswer((_) async => 'oops');
+      expect(await api.getActiveNode(), isNull);
+    });
+
+    test('returns null when nodeType is not a known enum value', () async {
+      when(() => client.get('/api/preferences')).thenAnswer(
+        (_) async => {
+          'userSettings': {
+            'activeNodeId': 'x',
+            'activeNodeType': 'session',
+          },
+        },
+      );
+      expect(await api.getActiveNode(), isNull);
+    });
+  });
+
+  group('setActiveNode()', () {
+    test('POSTs nodeId/nodeType/pinned for a project selection', () async {
+      when(() => client.post(any(), body: any(named: 'body')))
+          .thenAnswer((_) async => null);
+
+      await api.setActiveNode(
+        nodeId: 'proj-1',
+        nodeType: ActiveNodeType.project,
+      );
+
+      verify(
+        () => client.post(
+          '/api/preferences/active-node',
+          body: {
+            'nodeId': 'proj-1',
+            'nodeType': 'project',
+            'pinned': false,
+          },
+        ),
+      ).called(1);
+    });
+
+    test('forwards pinned=true and serializes group type', () async {
+      when(() => client.post(any(), body: any(named: 'body')))
+          .thenAnswer((_) async => null);
+
+      await api.setActiveNode(
+        nodeId: 'grp-9',
+        nodeType: ActiveNodeType.group,
+        pinned: true,
+      );
+
+      verify(
+        () => client.post(
+          '/api/preferences/active-node',
+          body: {
+            'nodeId': 'grp-9',
+            'nodeType': 'group',
+            'pinned': true,
+          },
+        ),
+      ).called(1);
+    });
+
+    test('sends both fields as null when clearing the selection', () async {
+      // The server schema requires nodeId and nodeType to be present-or-
+      // absent together. Passing null for both is the documented way to
+      // clear the selection — verify we forward exactly that.
+      when(() => client.post(any(), body: any(named: 'body')))
+          .thenAnswer((_) async => null);
+
+      await api.setActiveNode(nodeId: null, nodeType: null);
+
+      verify(
+        () => client.post(
+          '/api/preferences/active-node',
+          body: {
+            'nodeId': null,
+            'nodeType': null,
+            'pinned': false,
+          },
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/mobile/test/infrastructure/api/sessions_api_test.dart
+++ b/mobile/test/infrastructure/api/sessions_api_test.dart
@@ -60,7 +60,7 @@ void main() {
             'id': 'sess-3',
             'name': 'Test',
             'tmuxSessionName': 'rdv-3',
-            'status': 'closed',
+            'status': 'active',
             'projectId': null,
           },
         ],
@@ -68,7 +68,57 @@ void main() {
 
       final sessions = await api.list();
       expect(sessions, hasLength(1));
-      expect(sessions[0].status, SessionStatus.closed);
+      expect(sessions[0].status, SessionStatus.active);
+    });
+
+    test('drops closed and trashed sessions, keeps active + suspended',
+        () async {
+      // Mirror the PWA mobile-web Sessions tab, which only displays
+      // sessions in `active` or `suspended` status. The server can hand
+      // back `closed` (terminal) and `trashed` (soft-deleted) entries
+      // too — neither belongs in the mobile picker.
+      when(() => client.get('/api/sessions')).thenAnswer(
+        (_) async => {
+          'sessions': [
+            {
+              'id': 'sess-active',
+              'name': 'A',
+              'tmuxSessionName': 'rdv-a',
+              'status': 'active',
+            },
+            {
+              'id': 'sess-suspended',
+              'name': 'S',
+              'tmuxSessionName': 'rdv-s',
+              'status': 'suspended',
+            },
+            {
+              'id': 'sess-closed',
+              'name': 'C',
+              'tmuxSessionName': 'rdv-c',
+              'status': 'closed',
+            },
+            {
+              'id': 'sess-trashed',
+              'name': 'T',
+              'tmuxSessionName': 'rdv-t',
+              'status': 'trashed',
+            },
+          ],
+        },
+      );
+
+      final sessions = await api.list();
+      final ids = sessions.map((s) => s.id).toList();
+      expect(ids, equals(['sess-active', 'sess-suspended']));
+      expect(
+        sessions.every(
+          (s) =>
+              s.status == SessionStatus.active ||
+              s.status == SessionStatus.suspended,
+        ),
+        isTrue,
+      );
     });
 
     test('throws on unexpected shape', () async {

--- a/mobile/test/presentation/screens/channels/channel_screen_test.dart
+++ b/mobile/test/presentation/screens/channels/channel_screen_test.dart
@@ -6,9 +6,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:remote_dev/application/ports/server_config_store.dart';
+import 'package:remote_dev/domain/active_node.dart';
 import 'package:remote_dev/domain/channel.dart';
 import 'package:remote_dev/domain/server_config.dart';
 import 'package:remote_dev/infrastructure/api/channels_api.dart';
+import 'package:remote_dev/infrastructure/api/preferences_api.dart';
 import 'package:remote_dev/infrastructure/auth/mobile_credentials.dart';
 import 'package:remote_dev/infrastructure/webview/bridge_controller.dart';
 import 'package:remote_dev/infrastructure/webview/navigation_policy.dart';
@@ -35,10 +37,29 @@ class _FakeChannelsApi extends Fake implements ChannelsApi {
   final List<Channel> _channels;
 
   @override
-  Future<List<Channel>> list() async => _channels;
+  Future<List<Channel>> list({ActiveNode? activeNode}) async => _channels;
 
   @override
   Future<void> archive(String id) async {}
+}
+
+/// Stub preferences API that always reports a fixed active node. The
+/// `_ChannelTitle` widget under test watches the channels-list provider
+/// keyed by the active node, so tests need *some* node present or the
+/// list short-circuits to `const []` and the title can't resolve.
+class _StaticPreferencesApi extends Fake implements PreferencesApi {
+  @override
+  Future<ActiveNode?> getActiveNode() async => const ActiveNode(
+        id: 'proj-test',
+        type: ActiveNodeType.project,
+      );
+
+  @override
+  Future<void> setActiveNode({
+    required String? nodeId,
+    required ActiveNodeType? nodeType,
+    bool pinned = false,
+  }) async {}
 }
 
 /// Returns a future the test controls so we can assert behavior while the
@@ -48,7 +69,7 @@ class _DelayedChannelsApi extends Fake implements ChannelsApi {
   final Future<List<Channel>> future;
 
   @override
-  Future<List<Channel>> list() => future;
+  Future<List<Channel>> list({ActiveNode? activeNode}) => future;
 
   @override
   Future<void> archive(String id) async {}
@@ -144,6 +165,7 @@ void main() {
         ProviderScope(
           overrides: [
             channelsApiProvider.overrideWithValue(api),
+            preferencesApiProvider.overrideWithValue(_StaticPreferencesApi()),
           ],
           child: const MaterialApp(
             home: ChannelScreen(channelId: 'c2'),
@@ -173,6 +195,7 @@ void main() {
         ProviderScope(
           overrides: [
             channelsApiProvider.overrideWithValue(api),
+            preferencesApiProvider.overrideWithValue(_StaticPreferencesApi()),
           ],
           child: const MaterialApp(
             home: ChannelScreen(channelId: 'missing-id'),
@@ -393,6 +416,7 @@ void main() {
         ProviderScope(
           overrides: [
             channelsApiProvider.overrideWithValue(api),
+            preferencesApiProvider.overrideWithValue(_StaticPreferencesApi()),
           ],
           child: const MaterialApp(
             home: ChannelScreen(channelId: 'random'),

--- a/mobile/test/presentation/screens/channels/channels_tab_screen_test.dart
+++ b/mobile/test/presentation/screens/channels/channels_tab_screen_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/domain/active_node.dart';
 import 'package:remote_dev/domain/channel.dart';
 import 'package:remote_dev/infrastructure/api/channels_api.dart';
+import 'package:remote_dev/infrastructure/api/preferences_api.dart';
 import 'package:remote_dev/presentation/screens/channels/channels_tab_screen.dart';
 
 class _FakeChannelsApi extends Fake implements ChannelsApi {
@@ -10,14 +12,16 @@ class _FakeChannelsApi extends Fake implements ChannelsApi {
   final List<Channel> _channels;
   bool _shouldThrow = false;
   int listCallCount = 0;
+  final List<ActiveNode?> calledWith = [];
 
   void setError() {
     _shouldThrow = true;
   }
 
   @override
-  Future<List<Channel>> list() async {
+  Future<List<Channel>> list({ActiveNode? activeNode}) async {
     listCallCount += 1;
+    calledWith.add(activeNode);
     if (_shouldThrow) {
       throw StateError('boom');
     }
@@ -28,141 +32,269 @@ class _FakeChannelsApi extends Fake implements ChannelsApi {
   Future<void> archive(String id) async {}
 }
 
+/// Configurable preferences fake. `node` is the initial active node; the
+/// notifier's `select` round-trips through `setActiveNode` then re-reads
+/// via `getActiveNode`, so we mutate `_current` in `setActiveNode` and
+/// return it on subsequent reads.
+class _FakePreferencesApi extends Fake implements PreferencesApi {
+  _FakePreferencesApi({ActiveNode? initial}) : _current = initial;
+  ActiveNode? _current;
+  int getCallCount = 0;
+  int setCallCount = 0;
+
+  @override
+  Future<ActiveNode?> getActiveNode() async {
+    getCallCount += 1;
+    return _current;
+  }
+
+  @override
+  Future<void> setActiveNode({
+    required String? nodeId,
+    required ActiveNodeType? nodeType,
+    bool pinned = false,
+  }) async {
+    setCallCount += 1;
+    if (nodeId == null || nodeType == null) {
+      _current = null;
+    } else {
+      _current = ActiveNode(id: nodeId, type: nodeType);
+    }
+  }
+}
+
 void main() {
-  Widget wrap(Widget child, {required _FakeChannelsApi api}) => ProviderScope(
+  Widget wrap({
+    required _FakeChannelsApi channelsApi,
+    required _FakePreferencesApi preferencesApi,
+  }) =>
+      ProviderScope(
         overrides: [
-          channelsApiProvider.overrideWithValue(api),
+          channelsApiProvider.overrideWithValue(channelsApi),
+          preferencesApiProvider.overrideWithValue(preferencesApi),
         ],
-        child: MaterialApp(home: child),
+        child: const MaterialApp(home: ChannelsTabScreen()),
       );
 
-  testWidgets('shows empty state when no channels', (tester) async {
-    final api = _FakeChannelsApi(const []);
-    await tester.pumpWidget(wrap(const ChannelsTabScreen(), api: api));
-    await tester.pumpAndSettle();
+  testWidgets(
+    'shows "No project selected" empty state when no active node',
+    (tester) async {
+      final channelsApi = _FakeChannelsApi(const []);
+      final preferencesApi = _FakePreferencesApi();
+      await tester.pumpWidget(
+        wrap(channelsApi: channelsApi, preferencesApi: preferencesApi),
+      );
+      await tester.pumpAndSettle();
 
-    expect(find.text('No channels yet'), findsOneWidget);
-    expect(find.byIcon(Icons.forum_outlined), findsOneWidget);
-  });
+      expect(find.text('No project selected'), findsOneWidget);
+      expect(find.text('Pick a project to load channels.'), findsOneWidget);
+      // Crucially: the channels API must NOT be hit when there's no node,
+      // because the server would 400 without a scope.
+      expect(channelsApi.listCallCount, 0);
+    },
+  );
 
-  testWidgets('renders rows for each channel', (tester) async {
-    final api = _FakeChannelsApi(const [
-      Channel(id: 'c1', name: 'general', unreadCount: 0),
-      Channel(id: 'c2', name: 'random', unreadCount: 0),
-      Channel(id: 'c3', name: 'announcements', unreadCount: 0),
-    ]);
+  testWidgets(
+    'fetches channels scoped to the active node when one is set',
+    (tester) async {
+      final channelsApi = _FakeChannelsApi(const [
+        Channel(id: 'c1', name: 'general'),
+      ]);
+      final preferencesApi = _FakePreferencesApi(
+        initial: const ActiveNode(
+          id: 'proj-42',
+          type: ActiveNodeType.project,
+          name: 'Demo project',
+        ),
+      );
+      await tester.pumpWidget(
+        wrap(channelsApi: channelsApi, preferencesApi: preferencesApi),
+      );
+      await tester.pumpAndSettle();
 
-    await tester.pumpWidget(wrap(const ChannelsTabScreen(), api: api));
-    await tester.pumpAndSettle();
+      // Channels rendered for the active project.
+      expect(find.text('general'), findsOneWidget);
+      // The fetch is scoped to the active node — this is the bug that
+      // motivated the work; verify the param actually reaches the API.
+      expect(channelsApi.listCallCount, greaterThanOrEqualTo(1));
+      expect(channelsApi.calledWith.first?.id, 'proj-42');
+      expect(channelsApi.calledWith.first?.type, ActiveNodeType.project);
+      // Project name surfaces in the app bar subtitle.
+      expect(find.text('Demo project'), findsOneWidget);
+    },
+  );
 
-    expect(find.text('general'), findsOneWidget);
-    expect(find.text('random'), findsOneWidget);
-    expect(find.text('announcements'), findsOneWidget);
-  });
+  testWidgets(
+    'renders unread badges and caps at 99+',
+    (tester) async {
+      final channelsApi = _FakeChannelsApi(const [
+        Channel(id: 'c1', name: 'busy', unreadCount: 7),
+        Channel(id: 'c2', name: 'huge', unreadCount: 142),
+        Channel(id: 'c3', name: 'silent', unreadCount: 0),
+      ]);
+      final preferencesApi = _FakePreferencesApi(
+        initial: const ActiveNode(id: 'p', type: ActiveNodeType.project),
+      );
+      await tester.pumpWidget(
+        wrap(channelsApi: channelsApi, preferencesApi: preferencesApi),
+      );
+      await tester.pumpAndSettle();
 
-  testWidgets('renders unread badge for channels with unread > 0',
-      (tester) async {
-    final api = _FakeChannelsApi(const [
-      Channel(id: 'c1', name: 'general', unreadCount: 0),
-      Channel(id: 'c2', name: 'busy', unreadCount: 7),
-      Channel(id: 'c3', name: 'super-busy', unreadCount: 142),
-    ]);
+      expect(find.text('7'), findsOneWidget);
+      expect(find.text('99+'), findsOneWidget);
+      expect(find.text('0'), findsNothing);
+    },
+  );
 
-    await tester.pumpWidget(wrap(const ChannelsTabScreen(), api: api));
-    await tester.pumpAndSettle();
+  testWidgets(
+    'shows error view when channel fetch fails',
+    (tester) async {
+      final channelsApi = _FakeChannelsApi(const [])..setError();
+      final preferencesApi = _FakePreferencesApi(
+        initial: const ActiveNode(id: 'p', type: ActiveNodeType.project),
+      );
+      await tester.pumpWidget(
+        wrap(channelsApi: channelsApi, preferencesApi: preferencesApi),
+      );
+      await tester.pumpAndSettle();
 
-    // Unread channels render a count.
-    expect(find.text('7'), findsOneWidget);
-    // Capped at 99+.
-    expect(find.text('99+'), findsOneWidget);
-    // The zero-unread channel must not render '0' badge text.
-    expect(find.text('0'), findsNothing);
-  });
+      expect(find.text('Failed to load channels'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    },
+  );
 
-  testWidgets('shows error view when list fails', (tester) async {
-    final api = _FakeChannelsApi(const [])..setError();
-    await tester.pumpWidget(wrap(const ChannelsTabScreen(), api: api));
-    await tester.pumpAndSettle();
+  testWidgets(
+    'polls channels list every 30s while mounted with an active node',
+    (tester) async {
+      final channelsApi = _FakeChannelsApi(const [
+        Channel(id: 'c1', name: 'general'),
+      ]);
+      final preferencesApi = _FakePreferencesApi(
+        initial: const ActiveNode(id: 'p', type: ActiveNodeType.project),
+      );
+      await tester.pumpWidget(
+        wrap(channelsApi: channelsApi, preferencesApi: preferencesApi),
+      );
+      await tester.pumpAndSettle();
+      final initial = channelsApi.listCallCount;
+      expect(initial, greaterThanOrEqualTo(1));
 
-    expect(find.text('Failed to load channels'), findsOneWidget);
-    expect(find.text('Retry'), findsOneWidget);
-  });
+      await tester.pump(const Duration(seconds: 30));
+      await tester.pumpAndSettle();
+      expect(channelsApi.listCallCount, greaterThan(initial));
+    },
+  );
 
-  testWidgets('polls channels list every 30s while mounted',
-      (tester) async {
-    final api = _FakeChannelsApi(const [
-      Channel(id: 'c1', name: 'general', unreadCount: 0),
-    ]);
-    await tester.pumpWidget(wrap(const ChannelsTabScreen(), api: api));
-    await tester.pumpAndSettle();
+  testWidgets(
+    'cancels timer on dispose so no further polls fire',
+    (tester) async {
+      final channelsApi = _FakeChannelsApi(const [
+        Channel(id: 'c1', name: 'general'),
+      ]);
+      final preferencesApi = _FakePreferencesApi(
+        initial: const ActiveNode(id: 'p', type: ActiveNodeType.project),
+      );
+      // Mount + unmount within the same ProviderScope shape (Riverpod
+      // requires identical override counts across pumpWidget calls).
+      await tester.pumpWidget(
+        wrap(channelsApi: channelsApi, preferencesApi: preferencesApi),
+      );
+      await tester.pumpAndSettle();
+      final afterMount = channelsApi.listCallCount;
 
-    // Initial load fired exactly once.
-    expect(api.listCallCount, 1);
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            channelsApiProvider.overrideWithValue(channelsApi),
+            preferencesApiProvider.overrideWithValue(preferencesApi),
+          ],
+          child: const MaterialApp(home: SizedBox.shrink()),
+        ),
+      );
+      await tester.pumpAndSettle();
 
-    // Advance the fake clock past the 30s polling interval and let the
-    // resulting future settle.
-    await tester.pump(const Duration(seconds: 30));
-    await tester.pumpAndSettle();
-    expect(api.listCallCount, greaterThan(1));
+      final afterDispose = channelsApi.listCallCount;
+      await tester.pump(const Duration(seconds: 60));
+      await tester.pumpAndSettle();
+      expect(
+        channelsApi.listCallCount,
+        afterDispose,
+        reason: 'Polling must stop once the tab is disposed',
+      );
+      // Sanity: we did poll at least the initial fetch before dispose.
+      expect(afterMount, greaterThanOrEqualTo(1));
+    },
+  );
 
-    // A second tick should fire another refresh.
-    final afterFirstTick = api.listCallCount;
-    await tester.pump(const Duration(seconds: 30));
-    await tester.pumpAndSettle();
-    expect(api.listCallCount, greaterThan(afterFirstTick));
-  });
+  testWidgets(
+    'stops polling when app is backgrounded, resumes on return',
+    (tester) async {
+      final channelsApi = _FakeChannelsApi(const [
+        Channel(id: 'c1', name: 'general'),
+      ]);
+      final preferencesApi = _FakePreferencesApi(
+        initial: const ActiveNode(id: 'p', type: ActiveNodeType.project),
+      );
+      await tester.pumpWidget(
+        wrap(channelsApi: channelsApi, preferencesApi: preferencesApi),
+      );
+      await tester.pumpAndSettle();
+      final afterMount = channelsApi.listCallCount;
 
-  testWidgets('cancels timer on dispose so no further polls fire',
-      (tester) async {
-    final api = _FakeChannelsApi(const [
-      Channel(id: 'c1', name: 'general', unreadCount: 0),
-    ]);
-    // Mount inside the same ProviderScope (single override), then swap the
-    // child to a benign widget. This unmounts ChannelsTabScreen and triggers
-    // dispose() while keeping the override list shape stable (Riverpod
-    // requires identical override counts across pumpWidget calls).
-    await tester.pumpWidget(wrap(const ChannelsTabScreen(), api: api));
-    await tester.pumpAndSettle();
-    expect(api.listCallCount, 1);
+      tester.binding
+          .handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pumpAndSettle();
+      final afterPause = channelsApi.listCallCount;
+      await tester.pump(const Duration(seconds: 60));
+      await tester.pumpAndSettle();
+      expect(
+        channelsApi.listCallCount,
+        afterPause,
+        reason: 'No polling should happen while backgrounded',
+      );
+      expect(afterMount, greaterThanOrEqualTo(1));
 
-    await tester.pumpWidget(
-      wrap(const SizedBox.shrink(), api: api),
-    );
-    await tester.pumpAndSettle();
+      tester.binding
+          .handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pumpAndSettle();
+      expect(channelsApi.listCallCount, greaterThan(afterPause));
+    },
+  );
 
-    final afterDispose = api.listCallCount;
-    await tester.pump(const Duration(seconds: 60));
-    await tester.pumpAndSettle();
-    // No additional polls should have fired after dispose.
-    expect(api.listCallCount, afterDispose);
-  });
+  testWidgets(
+    'select() persists the new node and refetches channels',
+    (tester) async {
+      // Start with no active node; programmatically select one via the
+      // notifier and assert the API call shape + ensuing channel fetch.
+      final channelsApi = _FakeChannelsApi(const [
+        Channel(id: 'c1', name: 'general'),
+      ]);
+      final preferencesApi = _FakePreferencesApi();
+      await tester.pumpWidget(
+        wrap(channelsApi: channelsApi, preferencesApi: preferencesApi),
+      );
+      await tester.pumpAndSettle();
 
-  testWidgets('stops polling when app is backgrounded and resumes on return',
-      (tester) async {
-    final api = _FakeChannelsApi(const [
-      Channel(id: 'c1', name: 'general', unreadCount: 0),
-    ]);
-    await tester.pumpWidget(wrap(const ChannelsTabScreen(), api: api));
-    await tester.pumpAndSettle();
-    expect(api.listCallCount, 1);
+      expect(find.text('No project selected'), findsOneWidget);
+      expect(channelsApi.listCallCount, 0);
 
-    // Background the app — polling should stop.
-    final binding = tester.binding;
-    binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
-    await tester.pumpAndSettle();
+      // Drive the notifier directly — this is the same code path the
+      // "Pick a project" button takes after the bottom sheet returns.
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ChannelsTabScreen)),
+      );
+      await container.read(activeNodeProvider.notifier).select(
+            nodeId: 'proj-new',
+            nodeType: ActiveNodeType.project,
+          );
+      await tester.pumpAndSettle();
 
-    final afterPause = api.listCallCount;
-    await tester.pump(const Duration(seconds: 60));
-    await tester.pumpAndSettle();
-    expect(
-      api.listCallCount,
-      afterPause,
-      reason: 'No polling should happen while backgrounded',
-    );
-
-    // Resume the app — should refresh immediately and restart the timer.
-    binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
-    await tester.pumpAndSettle();
-    expect(api.listCallCount, greaterThan(afterPause));
-  });
+      expect(preferencesApi.setCallCount, 1);
+      // After selection, the channels list provider rebuilds against the
+      // new node and renders the row.
+      expect(find.text('general'), findsOneWidget);
+      expect(channelsApi.calledWith.last?.id, 'proj-new');
+      expect(channelsApi.calledWith.last?.type, ActiveNodeType.project);
+    },
+  );
 }

--- a/mobile/test/presentation/screens/notifications/notifications_tab_screen_test.dart
+++ b/mobile/test/presentation/screens/notifications/notifications_tab_screen_test.dart
@@ -25,6 +25,7 @@ AppNotification _notif({
   String? sessionId,
   String? channelId,
   String kind = 'default',
+  String? type,
 }) {
   return AppNotification(
     id: id,
@@ -35,6 +36,7 @@ AppNotification _notif({
     sessionId: sessionId,
     channelId: channelId,
     kind: kind,
+    type: type,
   );
 }
 
@@ -79,29 +81,58 @@ void main() {
     expect(find.text('World'), findsOneWidget);
   });
 
-  testWidgets('tapping a chip refetches with the right filter',
+  testWidgets('tapping a chip filters the same fetched list in-memory',
       (tester) async {
-    final filterCalls = <String?>[];
-    when(() => api.list(filter: any(named: 'filter'))).thenAnswer(
-      (invocation) async {
-        filterCalls.add(invocation.namedArguments[#filter] as String?);
-        return const <AppNotification>[];
-      },
-    );
+    // The PWA mobile-web tab fetches all notifications once and
+    // filters client-side. The chip changes which rows are visible
+    // without firing another `list()` call. Build a payload with a
+    // mix of read/unread, agent-typed, and `@name`-bodied rows so we
+    // can verify all three chips select the right subset.
+    var listCalls = 0;
+    when(() => api.list(filter: any(named: 'filter'))).thenAnswer((_) async {
+      listCalls += 1;
+      return [
+        _notif(id: 'n-unread-plain', title: 'Plain', body: 'no mention'),
+        _notif(
+          id: 'n-read-mention',
+          title: 'Mention',
+          body: '@alice please look',
+          read: true,
+        ),
+        _notif(
+          id: 'n-agent-waiting',
+          title: '@you are pinged',
+          body: 'idle for 5m',
+          type: 'agent_waiting',
+        ),
+      ];
+    });
 
     await tester.pumpWidget(_wrap(api));
     await tester.pumpAndSettle();
-    expect(filterCalls.last, 'all');
 
-    // Tap the Unread chip.
+    // All chip: every row visible.
+    expect(find.text('Plain'), findsOneWidget);
+    expect(find.text('Mention'), findsOneWidget);
+    expect(find.text('@you are pinged'), findsOneWidget);
+
+    // Unread chip: drop the read row.
     await tester.tap(find.text('Unread'));
     await tester.pumpAndSettle();
-    expect(filterCalls.last, 'unread');
+    expect(find.text('Plain'), findsOneWidget);
+    expect(find.text('Mention'), findsNothing);
+    expect(find.text('@you are pinged'), findsOneWidget);
 
-    // Tap the Mentions chip.
+    // Mentions chip: keep only `@`-tokened rows, and exclude agent_* types
+    // even when their title contains `@`.
     await tester.tap(find.text('Mentions'));
     await tester.pumpAndSettle();
-    expect(filterCalls.last, 'mentions');
+    expect(find.text('Plain'), findsNothing);
+    expect(find.text('Mention'), findsOneWidget);
+    expect(find.text('@you are pinged'), findsNothing);
+
+    // Filtering happens in-memory — no extra fetches were issued.
+    expect(listCalls, 1);
   });
 
   testWidgets('shows error view + retry on failure', (tester) async {

--- a/mobile/test/presentation/screens/shell/home_shell_test.dart
+++ b/mobile/test/presentation/screens/shell/home_shell_test.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_dev/domain/active_node.dart';
 import 'package:remote_dev/domain/channel.dart';
 import 'package:remote_dev/domain/notification.dart';
 import 'package:remote_dev/domain/session_summary.dart';
 import 'package:remote_dev/infrastructure/api/channels_api.dart';
 import 'package:remote_dev/infrastructure/api/notifications_api.dart';
+import 'package:remote_dev/infrastructure/api/preferences_api.dart';
 import 'package:remote_dev/infrastructure/api/sessions_api.dart';
 import 'package:remote_dev/presentation/screens/channels/channels_tab_screen.dart';
 import 'package:remote_dev/presentation/screens/notifications/notifications_tab_screen.dart';
@@ -51,10 +53,29 @@ class _FakeChannelsApi extends Fake implements ChannelsApi {
   final List<Channel> _channels;
 
   @override
-  Future<List<Channel>> list() async => _channels;
+  Future<List<Channel>> list({ActiveNode? activeNode}) async => _channels;
 
   @override
   Future<void> archive(String id) async {}
+}
+
+/// Returns a fixed [ActiveNode] so the Channels tab skips the
+/// "No project selected" empty state and exercises its channel-list
+/// branch. Required after the Channels tab gained project-scoping
+/// (matching the PWA mobile-web reference).
+class _FakePreferencesApi extends Fake implements PreferencesApi {
+  _FakePreferencesApi(this._node);
+  final ActiveNode? _node;
+
+  @override
+  Future<ActiveNode?> getActiveNode() async => _node;
+
+  @override
+  Future<void> setActiveNode({
+    required String? nodeId,
+    required ActiveNodeType? nodeType,
+    bool pinned = false,
+  }) async {}
 }
 
 void main() {
@@ -71,6 +92,14 @@ void main() {
           notificationsApiProvider.overrideWithValue(_FakeNotificationsApi()),
           channelsApiProvider.overrideWithValue(
             _FakeChannelsApi(channels ?? const []),
+          ),
+          preferencesApiProvider.overrideWithValue(
+            _FakePreferencesApi(
+              const ActiveNode(
+                id: 'test-project',
+                type: ActiveNodeType.project,
+              ),
+            ),
           ),
         ],
         child: MaterialApp(home: child),
@@ -338,6 +367,17 @@ void main() {
             sessionsApiProvider.overrideWithValue(_FakeSessionsApi(const [])),
             notificationsApiProvider.overrideWithValue(_FakeNotificationsApi()),
             channelsApiProvider.overrideWithValue(_FakeChannelsApi(channels)),
+            // Channels tab is project-scoped — without an active node the
+            // tab renders the "No project selected" empty state and the
+            // ListView under test doesn't exist.
+            preferencesApiProvider.overrideWithValue(
+              _FakePreferencesApi(
+                const ActiveNode(
+                  id: 'test-project',
+                  type: ActiveNodeType.project,
+                ),
+              ),
+            ),
           ],
           child: MaterialApp(
             home: pinViewport(const HomeShell(initialTab: HomeTab.channels)),


### PR DESCRIPTION
## Summary

Fixes three list-filter bugs in the Flutter mobile app so each tab shows what the PWA mobile-web reference (`src/components/mobile/`) shows:

- **Sessions tab**: only `active` + `suspended` (was leaking `closed`). Mirrors `SessionsTab.tsx`.
- **Notifications "Mentions" filter**: actually filters now. Was a no-op (server ignored `?filter=mentions`, so it returned everything). Switched to fetch-once + client-side `isMention` heuristic mirroring `NotificationsTab.tsx`.
- **Channels tab**: scoped to the active project via `GET /api/preferences` and `?nodeId=&nodeType=`. Was unscoped, hitting a 400. Empty state with "Pick a project" picker when no active node; folder-icon app-bar action lets users switch projects from the tab.

## Key decisions

- New mobile infra: `PreferencesApi` (GET/POST `/api/preferences*`), `ActiveNode` domain + freezed model, `AutoDisposeAsyncNotifier<ActiveNode?>` provider. `AutoDispose` so the provider rebinds when the user switches servers.
- `AppNotification` gained an optional `type` field from the server's `notification_event.type`, used by the mentions heuristic to exclude `agent_*` lifecycle events.
- Branch is rebased onto current master and preserves master's concurrent bulk-dismiss feature.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` — 335 pass / 1 pre-existing skip
- [ ] Manual: open Sessions tab, confirm no closed sessions appear
- [ ] Manual: Notifications → Mentions chip shows only `@`-mention rows
- [ ] Manual: Channels tab with no active project shows "Pick a project"; tap picker → channels load; folder-icon action switches projects
- [ ] Manual: change server in profile → channels re-fetch for the new server's active project

This pull request and its description were written by Claude.