### PR TITLE
fix(beads): preserve sidebar localStorage on late userSettings load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defaults so SSR and first client render agree, and `localStorage` is
   read in a mount-only `useEffect` with plain setters (not `setStoredX`,
   which dispatch a `CustomEvent` the component subscribes to).
+- **Web**: BeadsSidebar no longer clobbers the user's `localStorage`
+  sidebar preferences when `userSettings` finishes loading after mount.
+  The previous DB-sync `useEffect`s used `collapsedSyncMounted` /
+  `widthSyncMounted` refs that only skipped the very first render, so
+  when `userSettings` arrived asynchronously and `dbCollapsed` /
+  `dbWidth` flipped from the hardcoded defaults to real DB values, the
+  sync effect fired and wrote the DB value into `localStorage` (plus
+  broadcast a cross-tab `CustomEvent` other tabs reacted to). A new
+  `userSettingsLoaded` boolean is plumbed through `BeadsContext` and the
+  sync effects gate on it, skipping the first run AFTER load (the load
+  transition itself) and propagating every subsequent change — so the
+  Settings-page-edit flow still works (closes remote-dev-8y2n).
 - **Mobile/Terminal**: PWA tap-to-click now reliably reaches xterm.js
   mouse-mode TUIs (Claude Code clickable buttons, vim, less, lazygit,
   tmux mouse). The previous implementation dispatched synthesized

--- a/src/components/beads/BeadsSidebar.tsx
+++ b/src/components/beads/BeadsSidebar.tsx
@@ -238,6 +238,7 @@ export function BeadsSidebar({
     beadsSidebarCollapsed: dbCollapsed,
     beadsSidebarWidth: dbWidth,
     beadsSectionExpanded: dbSectionExpanded,
+    userSettingsLoaded,
   } = useBeadsContext();
   const { updateUserSettings } = usePreferencesContext();
   const { schedules } = useScheduleContext();
@@ -269,22 +270,32 @@ export function BeadsSidebar({
     }
   }, []);
 
-  // Sync DB settings → local state when changed via Settings page.
-  // Skip the initial mount to avoid overwriting localStorage values that the
-  // hydration effect above applied (the user may have toggled before prefs loaded).
-  const collapsedSyncMounted = useRef(false);
+  // Sync DB settings → local state for changes that happen AFTER the initial
+  // userSettings load (e.g. the user editing the value on the Settings page).
+  // The initial load transition itself is skipped: at that moment dbCollapsed
+  // flips from the hardcoded default to the real DB value, and propagating
+  // that would clobber any localStorage value the hydration effect applied.
+  const collapsedSyncReady = useRef(false);
   useEffect(() => {
-    if (!collapsedSyncMounted.current) { collapsedSyncMounted.current = true; return; }
+    if (!userSettingsLoaded) return;
+    if (!collapsedSyncReady.current) {
+      collapsedSyncReady.current = true;
+      return;
+    }
     setCollapsed(dbCollapsed);
     setStoredCollapsed(dbCollapsed);
-  }, [dbCollapsed]);
+  }, [userSettingsLoaded, dbCollapsed]);
 
-  const widthSyncMounted = useRef(false);
+  const widthSyncReady = useRef(false);
   useEffect(() => {
-    if (!widthSyncMounted.current) { widthSyncMounted.current = true; return; }
+    if (!userSettingsLoaded) return;
+    if (!widthSyncReady.current) {
+      widthSyncReady.current = true;
+      return;
+    }
     setWidth(dbWidth);
     setStoredWidth(dbWidth);
-  }, [dbWidth]);
+  }, [userSettingsLoaded, dbWidth]);
 
   const switchTab = useCallback((tab: SidebarTab) => {
     setActiveTab(tab);

--- a/src/components/beads/BeadsSidebar.tsx
+++ b/src/components/beads/BeadsSidebar.tsx
@@ -270,11 +270,10 @@ export function BeadsSidebar({
     }
   }, []);
 
-  // Sync DB settings → local state for changes that happen AFTER the initial
-  // userSettings load (e.g. the user editing the value on the Settings page).
-  // The initial load transition itself is skipped: at that moment dbCollapsed
-  // flips from the hardcoded default to the real DB value, and propagating
-  // that would clobber any localStorage value the hydration effect applied.
+  // Propagate DB → local state for edits that arrive AFTER the initial
+  // userSettings load (e.g. Settings-page edits). The load transition itself
+  // is skipped — that first dbCollapsed change is just the default → real-DB
+  // flip and would clobber the localStorage value the hydration effect applied.
   const collapsedSyncReady = useRef(false);
   useEffect(() => {
     if (!userSettingsLoaded) return;

--- a/src/contexts/BeadsContext.tsx
+++ b/src/contexts/BeadsContext.tsx
@@ -58,6 +58,14 @@ interface BeadsContextValue {
   beadsSidebarWidth: number;
   beadsClosedRetentionDays: number;
   beadsSectionExpanded: BeadsSectionExpandDefaults;
+  /**
+   * True once `userSettings` has been fetched from the server. Until then,
+   * the sidebar-related fields above expose hardcoded defaults that consumers
+   * must not treat as authoritative (e.g. don't write them back to
+   * localStorage on first paint — that would clobber the user's stored
+   * preference from a prior session).
+   */
+  userSettingsLoaded: boolean;
 }
 
 const BeadsContext = createContext<BeadsContextValue | null>(null);
@@ -89,6 +97,7 @@ export function BeadsProvider({ children }: BeadsProviderProps) {
 
   const { currentPreferences, userSettings } = usePreferencesContext();
   const projectPath = currentPreferences.defaultWorkingDirectory || null;
+  const userSettingsLoaded = userSettings !== null;
 
   // Beads display settings from user preferences
   const beadsSidebarCollapsed = userSettings?.beadsSidebarCollapsed ?? true;
@@ -218,9 +227,10 @@ export function BeadsProvider({ children }: BeadsProviderProps) {
       beadsSidebarWidth,
       beadsClosedRetentionDays,
       beadsSectionExpanded,
+      userSettingsLoaded,
     }),
     [issues, computedStats, loading, error, initialized, projectPath, refreshIssues, debouncedRefresh,
-     beadsSidebarCollapsed, beadsSidebarWidth, beadsClosedRetentionDays, beadsSectionExpanded]
+     beadsSidebarCollapsed, beadsSidebarWidth, beadsClosedRetentionDays, beadsSectionExpanded, userSettingsLoaded]
   );
 
   return (


### PR DESCRIPTION
## Summary

Two related bugs in `BeadsSidebar.tsx` and one cross-context plumbing change in `BeadsContext`.

### Bug 1 — `remote-dev-ge5h` (hydration mismatch from localStorage in useState initializers)

Already fixed in 696437b on master. The current `BeadsSidebar.tsx` seeds `useState` for `collapsed`, `width`, and `activeTab` from DB defaults so SSR and the first client render agree, then hydrates from localStorage in a mount-only `useEffect` using plain setters (so we don't echo cross-tab CustomEvents). That matches the prescribed pattern exactly — no further changes needed beyond what already shipped.

### Bug 2 — `remote-dev-8y2n` (late `userSettings` load clobbers localStorage)

The DB-sync effects used `collapsedSyncMounted` / `widthSyncMounted` refs that only skipped the first render. When `userSettings` arrived asynchronously from `PreferencesContext`, `dbCollapsed` / `dbWidth` flipped from hardcoded defaults (`?? true` / `?? 320`) to the real DB values, the sync effects fired, and `setStoredCollapsed` / `setStoredWidth` wrote the DB value over the user's stored localStorage preference (plus dispatched cross-tab CustomEvents that other open tabs reacted to).

**Fix:** plumb a `userSettingsLoaded` boolean through `BeadsContext` (derived from `userSettings !== null` already exposed by `PreferencesContext`). The sync effects now (1) bail while `userSettingsLoaded` is false, (2) skip the first run after load (that run carries the load transition itself, not a user-initiated edit), and (3) propagate every subsequent change. The legitimate Settings-page-edit propagation flow still works.

### Files

- `src/contexts/BeadsContext.tsx` — new `userSettingsLoaded: boolean` on the context value, derived from `usePreferencesContext().userSettings !== null`.
- `src/components/beads/BeadsSidebar.tsx` — sync effects re-gated on `userSettingsLoaded`; renamed the mount refs to `collapsedSyncReady` / `widthSyncReady` to reflect the new "ready to propagate" semantics.

Cross-tab CustomEvent dispatch behavior is preserved for actual user-initiated changes.

## Test plan

- [ ] Open the app with `localStorage["beads-sidebar-collapsed"] = "false"` set (collapsed = false stored locally). Reload — sidebar should expand without flipping back to collapsed when `userSettings` arrives, and the localStorage value should remain `"false"`.
- [ ] Same as above for `beads-sidebar-width` — local value should not be overwritten by the DB value on the initial load.
- [ ] In Settings page, toggle the beads sidebar collapsed default — the change should still propagate to the live sidebar and to localStorage (Settings-page-edit flow).
- [ ] Open two tabs. Change the value via Settings in tab A — tab B should still react via the cross-tab `beads-sidebar-collapsed-change` event.
- [ ] No React hydration error in the browser console on first load with a populated localStorage.

Closes remote-dev-ge5h
Closes remote-dev-8y2n

This pull request and its description were written by Isaac.