### PR TITLE
fix: three pre-existing ship-it blockers (remote-dev-8v3i)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dev**: Resolved three pre-existing ship-it blockers — `packages/mobile`
+  tsconfig load failure (inlined `expo/tsconfig.base`), 10 ESLint errors
+  → 0 (`react-hooks/use-memo` + `react-hooks/refs`), and `handleTouchEnd`
+  tap-qualify axis asymmetry vs `handleTouchMove` (closes remote-dev-8v3i).
 - **Terminal**: stale glyphs during scrolling in long-running sessions
   caused by xterm.js WebGL atlas page-merge — clear atlas via
   `onRemoveTextureAtlasCanvas` on next animation frame; replaces

--- a/packages/mobile/tsconfig.json
+++ b/packages/mobile/tsconfig.json
@@ -1,6 +1,14 @@
 {
-  "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    "allowJs": true,
+    "esModuleInterop": true,
+    "jsx": "react-native",
+    "lib": ["DOM", "ESNext"],
+    "moduleResolution": "node",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "target": "ESNext",
     "strict": true,
     "paths": {
       "@/*": ["./src/*"],
@@ -14,5 +22,6 @@
     "**/*.tsx",
     ".expo/types/**/*.ts",
     "expo-env.d.ts"
-  ]
+  ],
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]
 }

--- a/src/components/mobile/sessions/SessionsTab.tsx
+++ b/src/components/mobile/sessions/SessionsTab.tsx
@@ -170,7 +170,9 @@ export function SessionsTab({ isGitHubConnected }: SessionsTabProps) {
     }
   }, [sessionCtx]);
 
-  const pull = usePullToRefresh({ onRefresh: handleRefresh });
+  const { pullDistance, isRefreshing: pullIsRefreshing, ref: pullRef } = usePullToRefresh({
+    onRefresh: handleRefresh,
+  });
 
   // Action sheet items for the long-pressed session.
   const actionSession = useMemo(
@@ -390,25 +392,25 @@ export function SessionsTab({ isGitHubConnected }: SessionsTabProps) {
         {/* Subtle pull/refresh indicator: a single line of muted text, no
             big spinner overlay. pointer-events-none so it never blocks taps
             on rows behind; z-10 so it's drawn over the list when active. */}
-        {(pull.pullDistance > 0 || pull.isRefreshing) ? (
+        {(pullDistance > 0 || pullIsRefreshing) ? (
           <div
             data-testid="mobile-sessions-refresh-indicator"
             role="status"
             aria-live="polite"
             className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-center justify-center py-2 text-xs text-muted-foreground"
             style={{
-              transform: `translateY(${Math.max(0, pull.pullDistance - 16)}px)`,
-              transitionProperty: pull.pullDistance === 0 ? "transform, opacity" : "none",
-              transitionDuration: pull.pullDistance === 0 ? "180ms" : "0ms",
-              opacity: pull.isRefreshing ? 1 : Math.min(1, pull.pullDistance / 60),
+              transform: `translateY(${Math.max(0, pullDistance - 16)}px)`,
+              transitionProperty: pullDistance === 0 ? "transform, opacity" : "none",
+              transitionDuration: pullDistance === 0 ? "180ms" : "0ms",
+              opacity: pullIsRefreshing ? 1 : Math.min(1, pullDistance / 60),
             }}
           >
-            {pull.isRefreshing ? "Refreshing…" : "Pull to refresh"}
+            {pullIsRefreshing ? "Refreshing…" : "Pull to refresh"}
           </div>
         ) : null}
 
         <div
-          ref={pull.ref}
+          ref={pullRef}
           data-testid="mobile-sessions-scroll"
           className="flex-1 overflow-y-auto overscroll-contain"
         >

--- a/src/components/mobile/sessions/SessionsTab.tsx
+++ b/src/components/mobile/sessions/SessionsTab.tsx
@@ -170,7 +170,7 @@ export function SessionsTab({ isGitHubConnected }: SessionsTabProps) {
     }
   }, [sessionCtx]);
 
-  const { pullDistance, isRefreshing: pullIsRefreshing, ref: pullRef } = usePullToRefresh({
+  const { pullDistance, isRefreshing, ref: pullRef } = usePullToRefresh({
     onRefresh: handleRefresh,
   });
 
@@ -392,7 +392,7 @@ export function SessionsTab({ isGitHubConnected }: SessionsTabProps) {
         {/* Subtle pull/refresh indicator: a single line of muted text, no
             big spinner overlay. pointer-events-none so it never blocks taps
             on rows behind; z-10 so it's drawn over the list when active. */}
-        {(pullDistance > 0 || pullIsRefreshing) ? (
+        {(pullDistance > 0 || isRefreshing) ? (
           <div
             data-testid="mobile-sessions-refresh-indicator"
             role="status"
@@ -402,10 +402,10 @@ export function SessionsTab({ isGitHubConnected }: SessionsTabProps) {
               transform: `translateY(${Math.max(0, pullDistance - 16)}px)`,
               transitionProperty: pullDistance === 0 ? "transform, opacity" : "none",
               transitionDuration: pullDistance === 0 ? "180ms" : "0ms",
-              opacity: pullIsRefreshing ? 1 : Math.min(1, pullDistance / 60),
+              opacity: isRefreshing ? 1 : Math.min(1, pullDistance / 60),
             }}
           >
-            {pullIsRefreshing ? "Refreshing…" : "Pull to refresh"}
+            {isRefreshing ? "Refreshing…" : "Pull to refresh"}
           </div>
         ) : null}
 

--- a/src/components/terminal/useTouchInteractions.test.ts
+++ b/src/components/terminal/useTouchInteractions.test.ts
@@ -841,6 +841,24 @@ describe("axis-aligned cancel threshold matches touch-scroll activation", () => 
     expect(h.getMode()).toBe("scroll");
     expect(h.xterm.select).not.toHaveBeenCalled();
   });
+
+  // Symmetric to handleTouchMove's axis-aligned cancel: handleTouchEnd's
+  // tap-qualify must use the same axis-aligned bounds. Under the old
+  // Math.hypot(dx, dy) check, a diagonal micro-swipe with dx=4, dy=4
+  // (hypot ≈ 5.66 > TAP_MAX_PX=5) was rejected as "not a tap" even though
+  // neither axis crossed the move-cancel threshold.
+  it("synthesizes a tap on touchend at dx=4, dy=4 (axis-aligned, not Euclidean)", () => {
+    const h = makeHarness();
+    h.fireTouch("touchstart", [{ x: 200, y: 100 }]);
+    // Move diagonally to dx=4, dy=4. Hypot ~= 5.66, but neither axis crosses 5.
+    h.fireTouch("touchmove", [{ x: 204, y: 104 }]);
+    h.advanceTime(50);
+    h.fireTouch("touchend", []);
+    expect(h.mouseEvents.map(({ type, clientX, clientY }) => ({ type, clientX, clientY }))).toEqual([
+      { type: "mousedown", clientX: 200, clientY: 100 },
+      { type: "mouseup", clientX: 200, clientY: 100 },
+    ]);
+  });
 });
 
 describe("synthesized MouseEvent carries screenX/screenY", () => {

--- a/src/components/terminal/useTouchInteractions.ts
+++ b/src/components/terminal/useTouchInteractions.ts
@@ -579,11 +579,10 @@ export function createTouchInteractions(
       const elapsed = now() - startT;
       const dx = lastX - startX;
       const dy = lastY - startY;
-      // Axis-aligned tap-qualify mirrors handleTouchMove's axis-aligned cancel:
-      // tap requires BOTH axes within bounds; cancel triggers if EITHER axis
-      // exceeds. A diagonal micro-swipe (dx=4, dy=4, hypot≈5.66) would have
-      // been rejected as "not a tap" under the old hypot check even though
-      // neither axis crossed the move-cancel threshold.
+      // Mirror handleTouchMove's axis-aligned cancel: tap requires BOTH axes
+      // within bounds (cancel triggers if EITHER exceeds). Hypot would reject
+      // a diagonal micro-swipe (dx=4, dy=4, hypot≈5.66) even though neither
+      // axis crossed the move-cancel threshold.
       if (elapsed <= TAP_MAX_MS && Math.abs(dx) <= TAP_MAX_PX && Math.abs(dy) <= TAP_MAX_PX) {
         synthesizeTap(startX, startY);
       }

--- a/src/components/terminal/useTouchInteractions.ts
+++ b/src/components/terminal/useTouchInteractions.ts
@@ -579,8 +579,12 @@ export function createTouchInteractions(
       const elapsed = now() - startT;
       const dx = lastX - startX;
       const dy = lastY - startY;
-      const dist = Math.hypot(dx, dy);
-      if (elapsed <= TAP_MAX_MS && dist <= TAP_MAX_PX) {
+      // Axis-aligned tap-qualify mirrors handleTouchMove's axis-aligned cancel:
+      // tap requires BOTH axes within bounds; cancel triggers if EITHER axis
+      // exceeds. A diagonal micro-swipe (dx=4, dy=4, hypot≈5.66) would have
+      // been rejected as "not a tap" under the old hypot check even though
+      // neither axis crossed the move-cancel threshold.
+      if (elapsed <= TAP_MAX_MS && Math.abs(dx) <= TAP_MAX_PX && Math.abs(dy) <= TAP_MAX_PX) {
         synthesizeTap(startX, startY);
       }
     }

--- a/src/hooks/useTerminalWsUrl.ts
+++ b/src/hooks/useTerminalWsUrl.ts
@@ -29,5 +29,5 @@ export function resolveTerminalWsUrl(): string {
 }
 
 export function useTerminalWsUrl(): string {
-  return useMemo(resolveTerminalWsUrl, []);
+  return useMemo(() => resolveTerminalWsUrl(), []);
 }


### PR DESCRIPTION
## Summary

Closes remote-dev-8v3i.

Three independent pre-existing issues surfaced during PR #296's ship-it. Combined here since they're all "pre-existing ship-it blockers."

- **Fix 1 (test suite load)** — `packages/mobile/tsconfig.json` extended `expo/tsconfig.base`, which the root workspace can't resolve (expo lives only in bun's isolated layout, not at the workspace root). Vite's oxc plugin bailed when transforming `RemoteDevApiClient.ts` from `tests/mobile/`. Inlined expo's (tiny) base options into the mobile tsconfig — keeps mobile's standalone `tsc` working and unblocks `bun run test:run`.
- **Fix 2 (10 lint errors)** — `useTerminalWsUrl.ts:32` wrapped with an inline arrow for `react-hooks/use-memo`; `SessionsTab.tsx` destructures pull-to-refresh state on the way out so `react-hooks/refs` stops treating the whole record as ref-like.
- **Fix 3 (touch-end tap asymmetry)** — `handleTouchEnd` was still using `Math.hypot(dx, dy)` while `handleTouchMove` had moved to axis-aligned thresholds in PR #231. A diagonal micro-swipe (dx=4, dy=4, hypot ≈ 5.66) was rejected as "not a tap" even though neither axis crossed the move-cancel threshold. Switched tap-qualify to axis-aligned (`Math.abs(dx) <= TAP_MAX_PX && Math.abs(dy) <= TAP_MAX_PX`) — symmetric to the move-cancel check (inverted operator: both within for tap; either exceeds for cancel). Adds a regression test.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (was 10), warnings unchanged
- [x] `bun run test:run` — 124 files / 1211 tests pass (was 1 file failing to load + 1209 passing)
- [x] Previously-failing `tests/mobile/restart-agent-api-client.test.ts` now loads and passes
- [x] New regression test in `useTouchInteractions.test.ts` covers dx=4, dy=4 tap

This pull request and its description were written by Isaac.