### PR TITLE
fix(mobile): silently refresh CF Access JWT, fall back to interactive only on real failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Mobile (Flutter)**: CF Access JWT expiry no longer surfaces as a
+  `FormatException: Unexpected /api/sessions response shape` with the
+  user stuck behind a "Failed to load sessions" error until force-quit.
+  `CfAuthInterceptor` now disables Dio's redirect-following, detects CF
+  Access intervention (401/403, 3xx → `cloudflareaccess.com`, or 200
+  `text/html`), and silently refreshes credentials via the system-browser
+  `/auth/mobile-callback` flow before transparently replaying the
+  original request. Concurrent failures dedupe to a single browser
+  launch, a retry sentinel guards against infinite loops, and the full
+  `/reauth` screen only kicks in when refresh genuinely fails
+  (closes remote-dev-arua).
+
 - **Mobile (Flutter)**: Push notifications were silently broken end-to-end
   in the new app at `mobile/` (worked in the archived `archive/mobile-flutter/`).
   Six independent bugs all combined to break the flow: (1) `PushTokenRegistrar`

--- a/mobile/lib/infrastructure/api/cf_auth_interceptor.dart
+++ b/mobile/lib/infrastructure/api/cf_auth_interceptor.dart
@@ -121,13 +121,10 @@ class CfAuthInterceptor extends Interceptor {
     RequestOptions options,
     RequestInterceptorHandler handler,
   ) async {
-    // Disable automatic redirect following so CF Access's 302 to its
-    // login page surfaces as a DioException we can classify, rather
-    // than being silently fetched as HTML and decoded as JSON.
+    // Disable redirect-following and treat only 2xx as success so CF
+    // Access's 302 → login page lands in onError (where we can classify
+    // it) instead of being silently fetched as HTML and decoded as JSON.
     options.followRedirects = false;
-    // Without overriding validateStatus, Dio treats any 3xx as a
-    // badResponse error (because followRedirects is now false). That's
-    // what we want: 3xx falls into onError where we can detect CF.
     options.validateStatus = (status) =>
         status != null && status >= 200 && status < 300;
 

--- a/mobile/lib/infrastructure/api/cf_auth_interceptor.dart
+++ b/mobile/lib/infrastructure/api/cf_auth_interceptor.dart
@@ -121,9 +121,16 @@ class CfAuthInterceptor extends Interceptor {
     RequestOptions options,
     RequestInterceptorHandler handler,
   ) async {
-    // Disable redirect-following and treat only 2xx as success so CF
-    // Access's 302 → login page lands in onError (where we can classify
-    // it) instead of being silently fetched as HTML and decoded as JSON.
+    // All outbound API requests have follow-redirects disabled so
+    // Cloudflare Access's 302→cloudflareaccess.com login redirect lands in
+    // `onError` (where _isAuthFailure classifies it) instead of being
+    // silently fetched as HTML and decoded as JSON. The Remote Dev API
+    // itself never legitimately responds with a 3xx that the client should
+    // follow — if that ever changes, this guard will need an opt-out per
+    // request (e.g., a RequestOptions.extra flag). validateStatus is
+    // narrowed to 2xx for the same reason: anything else flows through
+    // onError where CF interventions can be detected and silently
+    // refreshed.
     options.followRedirects = false;
     options.validateStatus = (status) =>
         status != null && status >= 200 && status < 300;
@@ -272,7 +279,14 @@ class CfAuthInterceptor extends Interceptor {
       } catch (e, st) {
         completer.completeError(e, st);
       } finally {
-        _refreshInFlight = null;
+        // Defer clearing until after all current awaiters have resumed from
+        // pending.future. Dart schedules completer listeners as microtasks,
+        // so if we clear `_refreshInFlight` synchronously in `finally`, a
+        // request that hits a CF failure in the same tick (before the
+        // listeners run) would miss the mutex and launch a redundant
+        // browser refresh. scheduleMicrotask runs at the end of the current
+        // microtask queue, after the listeners.
+        scheduleMicrotask(() => _refreshInFlight = null);
       }
     });
 

--- a/mobile/lib/infrastructure/api/cf_auth_interceptor.dart
+++ b/mobile/lib/infrastructure/api/cf_auth_interceptor.dart
@@ -31,43 +31,106 @@ class AuthMaterial {
 /// - `Cookie: CF_Authorization=<cfCookie>` appended to any existing
 ///   `Cookie` header so upstream interceptors are preserved
 ///
-/// On a 401/403 response, fires [onReauthNeeded] so the UI can route
-/// the user back through the system-browser CF Access flow.
+/// On a CF Access intervention (401/403, redirect to
+/// `cloudflareaccess.com`, or a 200 HTML response) the interceptor first
+/// tries to **silently refresh** the auth material by re-running the
+/// system-browser callback flow via [refreshAuth]. The platform browser
+/// (Chrome Custom Tab / SFSafariViewController) typically still holds a
+/// valid CF Access SSO session even after our stored JWT has expired, so
+/// the user usually sees only a brief Custom-Tab flash before the
+/// original request is replayed transparently with fresh credentials.
+///
+/// Only when refresh **genuinely fails** (browser SSO also dead, network
+/// down, user cancelled the browser sheet) does the interceptor fire
+/// [onReauthNeeded] so the UI can route to a full `/reauth` screen.
 ///
 /// Cookie composition:
 /// - When no `Cookie` header exists, sets it to `CF_Authorization=<v>`.
 /// - When a `Cookie` header already exists, appends with `; ` separator.
 ///
-/// History: this class was originally `CfAuthInterceptor` and only
-/// attached the cookie. The class name is preserved for source-stability
-/// with the import sites in `remote_dev_client.dart`; the doc and shape
-/// reflect the post-jch1 dual-auth model.
+/// Redirect handling:
+/// - Disables Dio's automatic redirect-following so CF's
+///   `302 → cloudflareaccess.com/cdn-cgi/access/login/...` page surfaces
+///   as a DioException we can classify, rather than being silently
+///   fetched as HTML and decoded as JSON.
+///
+/// Concurrency:
+/// - A single in-flight refresh is shared across simultaneous failures
+///   via a [Completer] mutex, so a burst of three concurrent requests
+///   only triggers ONE browser launch.
+///
+/// Retry safety:
+/// - The replayed request is stamped with a sentinel in
+///   `RequestOptions.extra` to guard against infinite retry loops if
+///   the freshly-refreshed JWT is somehow still rejected.
 class CfAuthInterceptor extends Interceptor {
   CfAuthInterceptor({
+    required this.dio,
     required this.serverId,
     required this.authReader,
+    required this.refreshAuth,
     required this.onReauthNeeded,
   });
 
-  /// Server scope used by [authReader] to look up the right material.
+  /// Back-reference to the owning Dio so the interceptor can call
+  /// [Dio.fetch] to replay the original request after a successful
+  /// silent refresh.
+  final Dio dio;
+
+  /// Server scope used by [authReader] / [refreshAuth] to look up or
+  /// mint the right material.
   final String serverId;
 
   /// Reads the persisted auth material for [serverId]. Returns an
   /// [AuthMaterial] with `null`/empty fields when no credentials have
   /// been captured yet — the interceptor then sends an unauthenticated
-  /// request and the server returns 401/403, which fires [onReauthNeeded].
+  /// request, the server returns 401/403, and refresh kicks in.
   final FutureOr<AuthMaterial> Function(String serverId) authReader;
 
-  /// Fires once per failed (401/403) response. Idempotent on the
-  /// consumer side: the UI debounces by routing to `/reauth` only when
-  /// not already there.
+  /// Drives the system-browser CF Access callback flow to mint fresh
+  /// credentials for [serverId], persists them via the mobile
+  /// credentials store, and returns the new [AuthMaterial] (with at
+  /// least an `apiKey` populated) — or `null` when the browser session
+  /// is also dead, the user cancelled, the network is down, or any
+  /// other failure occurred.
+  ///
+  /// MUST be safe to await from a Dio interceptor context: it will be
+  /// called from within `onError`, so it should not depend on
+  /// concurrent Dio activity against the same client.
+  final FutureOr<AuthMaterial?> Function(String serverId) refreshAuth;
+
+  /// Fired only when silent refresh via [refreshAuth] fails (returned
+  /// null, threw, or the replayed request still came back with a CF
+  /// intervention). The UI is expected to debounce by routing to
+  /// `/reauth` only when not already there.
   final void Function() onReauthNeeded;
+
+  static const _cfAccessHost = 'cloudflareaccess.com';
+  static const _redirectStatuses = <int>{301, 302, 303, 307, 308};
+
+  /// Namespaced sentinel key for [RequestOptions.extra] so we don't
+  /// collide with anything else stashing data on the same map.
+  static const _retrySentinelKey = 'rdv.cfAuth.retryAttempted';
+
+  /// Mutex so a burst of concurrent failures dedupes to a single
+  /// browser launch — every caller awaits the same Completer.
+  Completer<AuthMaterial?>? _refreshInFlight;
 
   @override
   Future<void> onRequest(
     RequestOptions options,
     RequestInterceptorHandler handler,
   ) async {
+    // Disable automatic redirect following so CF Access's 302 to its
+    // login page surfaces as a DioException we can classify, rather
+    // than being silently fetched as HTML and decoded as JSON.
+    options.followRedirects = false;
+    // Without overriding validateStatus, Dio treats any 3xx as a
+    // badResponse error (because followRedirects is now false). That's
+    // what we want: 3xx falls into onError where we can detect CF.
+    options.validateStatus = (status) =>
+        status != null && status >= 200 && status < 300;
+
     final material = await authReader(serverId);
 
     final apiKey = material.apiKey;
@@ -94,11 +157,134 @@ class CfAuthInterceptor extends Interceptor {
   }
 
   @override
-  void onError(DioException err, ErrorInterceptorHandler handler) {
-    final status = err.response?.statusCode;
-    if (status == 401 || status == 403) {
-      onReauthNeeded();
+  Future<void> onError(
+    DioException err,
+    ErrorInterceptorHandler handler,
+  ) async {
+    if (!_isAuthFailure(err)) {
+      handler.next(err);
+      return;
     }
-    handler.next(err);
+
+    // Sentinel guard: this request was already retried once with a
+    // refreshed JWT and still failed. Don't spin — give up, signal
+    // the UI for an interactive recovery, and let the caller's catch
+    // fire with the original retry error.
+    if (err.requestOptions.extra[_retrySentinelKey] == true) {
+      onReauthNeeded();
+      handler.next(err);
+      return;
+    }
+
+    // Dedupe concurrent refreshes: the first failure starts the
+    // browser flow; any subsequent failure observes a non-null
+    // _refreshInFlight and awaits the same Completer.
+    final AuthMaterial? fresh;
+    try {
+      fresh = await _runRefresh();
+    } catch (_) {
+      // refreshAuth itself threw — fall through to onReauthNeeded.
+      onReauthNeeded();
+      handler.next(err);
+      return;
+    }
+
+    if (fresh == null || fresh.isEmpty) {
+      onReauthNeeded();
+      handler.next(err);
+      return;
+    }
+
+    // Stamp the sentinel BEFORE replaying so a still-failing retry
+    // can't loop. dio.fetch reuses the same RequestOptions instance.
+    err.requestOptions.extra[_retrySentinelKey] = true;
+
+    try {
+      final response = await dio.fetch<dynamic>(err.requestOptions);
+      handler.resolve(response);
+    } on DioException catch (retryErr) {
+      // Retry itself failed. If it's another CF intervention, the
+      // sentinel ensures we don't recurse — onError will see the
+      // sentinel and surface to onReauthNeeded directly. For any
+      // other failure (network, 5xx), just propagate.
+      handler.next(retryErr);
+    } catch (e, st) {
+      // Wrap any non-Dio throwable into a DioException so handlers
+      // upstream remain typed-correct.
+      handler.next(
+        DioException(
+          requestOptions: err.requestOptions,
+          error: e,
+          stackTrace: st,
+          type: DioExceptionType.unknown,
+          message: 'Retry after CF refresh failed: $e',
+        ),
+      );
+    }
+  }
+
+  /// True when the error looks like CF Access intervention or an
+  /// outright auth failure:
+  /// - 401 or 403, OR
+  /// - 3xx whose `Location` points at `cloudflareaccess.com`, OR
+  /// - 200 whose Content-Type is `text/html` (defense-in-depth — once
+  ///   redirects are disabled this shouldn't normally reach onError,
+  ///   but `validateStatus` could conceivably surface a 200 here in
+  ///   the future).
+  bool _isAuthFailure(DioException err) {
+    final response = err.response;
+    final status = response?.statusCode;
+
+    if (status == 401 || status == 403) return true;
+
+    if (status != null && _redirectStatuses.contains(status)) {
+      final location = _headerValue(response, HttpHeaders.locationHeader);
+      if (location != null &&
+          location.toLowerCase().contains(_cfAccessHost)) {
+        return true;
+      }
+    }
+
+    if (status == 200) {
+      final contentType =
+          _headerValue(response, HttpHeaders.contentTypeHeader);
+      if (contentType != null &&
+          contentType.toLowerCase().contains('text/html')) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// Coalesces concurrent refresh calls onto a single browser launch.
+  Future<AuthMaterial?> _runRefresh() {
+    final pending = _refreshInFlight;
+    if (pending != null) return pending.future;
+
+    final completer = Completer<AuthMaterial?>();
+    _refreshInFlight = completer;
+
+    // Fire-and-forget the async work; the completer is what callers
+    // await. We clear _refreshInFlight in `finally` so the next CF
+    // failure can start a fresh refresh once this one resolves.
+    Future<void>(() async {
+      try {
+        final result = await refreshAuth(serverId);
+        completer.complete(result);
+      } catch (e, st) {
+        completer.completeError(e, st);
+      } finally {
+        _refreshInFlight = null;
+      }
+    });
+
+    return completer.future;
+  }
+
+  String? _headerValue(Response<dynamic>? response, String name) {
+    final headers = response?.headers;
+    if (headers == null) return null;
+    return headers.value(name);
   }
 }

--- a/mobile/lib/infrastructure/api/cf_auth_interceptor.dart
+++ b/mobile/lib/infrastructure/api/cf_auth_interceptor.dart
@@ -121,16 +121,12 @@ class CfAuthInterceptor extends Interceptor {
     RequestOptions options,
     RequestInterceptorHandler handler,
   ) async {
-    // All outbound API requests have follow-redirects disabled so
-    // Cloudflare Access's 302→cloudflareaccess.com login redirect lands in
-    // `onError` (where _isAuthFailure classifies it) instead of being
-    // silently fetched as HTML and decoded as JSON. The Remote Dev API
-    // itself never legitimately responds with a 3xx that the client should
-    // follow — if that ever changes, this guard will need an opt-out per
-    // request (e.g., a RequestOptions.extra flag). validateStatus is
-    // narrowed to 2xx for the same reason: anything else flows through
-    // onError where CF interventions can be detected and silently
-    // refreshed.
+    // Force every non-2xx response (including 3xx) through `onError` so
+    // `_isAuthFailure` can detect CF Access's 302→cloudflareaccess.com
+    // login redirect instead of it being silently followed and decoded
+    // as JSON. The Remote Dev API never legitimately returns a 3xx the
+    // client should follow — if that changes, callers will need an
+    // opt-out per request (e.g., a RequestOptions.extra flag).
     options.followRedirects = false;
     options.validateStatus = (status) =>
         status != null && status >= 200 && status < 300;
@@ -279,13 +275,10 @@ class CfAuthInterceptor extends Interceptor {
       } catch (e, st) {
         completer.completeError(e, st);
       } finally {
-        // Defer clearing until after all current awaiters have resumed from
-        // pending.future. Dart schedules completer listeners as microtasks,
-        // so if we clear `_refreshInFlight` synchronously in `finally`, a
-        // request that hits a CF failure in the same tick (before the
-        // listeners run) would miss the mutex and launch a redundant
-        // browser refresh. scheduleMicrotask runs at the end of the current
-        // microtask queue, after the listeners.
+        // Clear AFTER waiting awaiters have resumed (their listeners are
+        // microtasks queued by complete/completeError). Clearing
+        // synchronously here would let a CF failure in the same tick miss
+        // the mutex and launch a redundant browser refresh.
         scheduleMicrotask(() => _refreshInFlight = null);
       }
     });

--- a/mobile/lib/infrastructure/api/remote_dev_client.dart
+++ b/mobile/lib/infrastructure/api/remote_dev_client.dart
@@ -28,10 +28,9 @@ class RemoteDevClient implements ApiClientPort {
           final cfToken = await _credentials.readCfToken(id);
           return AuthMaterial(apiKey: apiKey, cfCookie: cfToken);
         },
-        // Default no-op refresh: returns null so the interceptor falls
-        // through to onReauthNeeded. Production callers (see main.dart
-        // -> buildServerScopedOverrides) inject a real refresh that
-        // drives the system-browser /auth/mobile-callback flow.
+        // Default no-op refresh (returns null → interceptor falls through
+        // to onReauthNeeded). Production callers in main.dart inject a
+        // real refresh that drives the system-browser callback flow.
         refreshAuth: refreshAuth ?? ((_) async => null),
         onReauthNeeded: onReauthNeeded ?? () {},
       ),

--- a/mobile/lib/infrastructure/api/remote_dev_client.dart
+++ b/mobile/lib/infrastructure/api/remote_dev_client.dart
@@ -11,6 +11,7 @@ class RemoteDevClient implements ApiClientPort {
     required this.serverId,
     required SecureStoragePort storage,
     void Function()? onReauthNeeded,
+    Future<AuthMaterial?> Function(String serverId)? refreshAuth,
     Dio? dio,
   })  : _dio = dio ?? Dio(),
         _credentials = MobileCredentialsStore(storage) {
@@ -20,12 +21,18 @@ class RemoteDevClient implements ApiClientPort {
       ..receiveTimeout = const Duration(seconds: 30);
     _dio.interceptors.add(
       CfAuthInterceptor(
+        dio: _dio,
         serverId: serverId,
         authReader: (id) async {
           final apiKey = await _credentials.readApiKey(id);
           final cfToken = await _credentials.readCfToken(id);
           return AuthMaterial(apiKey: apiKey, cfCookie: cfToken);
         },
+        // Default no-op refresh: returns null so the interceptor falls
+        // through to onReauthNeeded. Production callers (see main.dart
+        // -> buildServerScopedOverrides) inject a real refresh that
+        // drives the system-browser /auth/mobile-callback flow.
+        refreshAuth: refreshAuth ?? ((_) async => null),
         onReauthNeeded: onReauthNeeded ?? () {},
       ),
     );

--- a/mobile/lib/infrastructure/api/sessions_api.dart
+++ b/mobile/lib/infrastructure/api/sessions_api.dart
@@ -83,6 +83,10 @@ class SessionsApi implements SessionsPort {
         return inner.cast<Map<String, dynamic>>();
       }
     }
+    // CF Access redirects (302 → cloudflareaccess.com / 200 text/html
+    // login page) are caught upstream by CfAuthInterceptor's silent
+    // refresh path, so this throw should only surface for genuinely
+    // malformed API responses — kept as defense in depth.
     throw const FormatException('Unexpected /api/sessions response shape');
   }
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -97,7 +97,8 @@ Future<AuthMaterial?> Function(String serverId) _buildRefreshAuth(Ref ref) {
           break;
         }
       }
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[CfAuth] refresh aborted: serverConfigStore.loadAll failed: $e');
       return null;
     }
     if (server == null) return null;

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -6,8 +6,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'app.dart';
 import 'application/ports/api_client_port.dart';
 import 'application/state/reauth_signal_provider.dart';
+import 'domain/server_config.dart';
 import 'infrastructure/api/account_api.dart';
 import 'infrastructure/api/agent_cli_api.dart';
+import 'infrastructure/api/cf_auth_interceptor.dart' show AuthMaterial;
 import 'infrastructure/api/channels_api.dart';
 import 'infrastructure/api/github_accounts_api.dart';
 import 'infrastructure/api/notifications_api.dart';
@@ -15,8 +17,10 @@ import 'infrastructure/api/preferences_api.dart';
 import 'infrastructure/api/project_tree_api.dart';
 import 'infrastructure/api/remote_dev_client.dart';
 import 'infrastructure/api/sessions_api.dart';
+import 'infrastructure/auth/mobile_callback_login_launcher.dart';
 import 'infrastructure/biometric/biometric_settings_store.dart';
 import 'infrastructure/biometric/local_auth_service.dart';
+import 'infrastructure/deep_link/deep_link_stream_provider.dart';
 import 'infrastructure/device/device_id_provider.dart';
 import 'infrastructure/push/fcm_push_service.dart';
 import 'infrastructure/push/push_token_registrar.dart';
@@ -39,7 +43,11 @@ import 'presentation/screens/sessions/project_tree_sheet.dart'
 import 'presentation/screens/sessions/sessions_tab_screen.dart'
     show sessionsApiProvider;
 import 'presentation/screens/webview_host/session_route_host.dart'
-    show activeServerProvider, secureStorageProvider, serverConfigStoreProvider;
+    show
+        activeServerProvider,
+        mobileCredentialsStoreProvider,
+        secureStorageProvider,
+        serverConfigStoreProvider;
 
 /// Thrown by [_apiClientProvider] when no active server has been chosen.
 ///
@@ -57,6 +65,54 @@ class NoActiveServerError extends Error {
       'No active server. Sign in via the server picker first.';
 }
 
+/// Build a silent-refresh callback that the [CfAuthInterceptor] will
+/// invoke when it detects CF Access intervention (401/403, redirect to
+/// `cloudflareaccess.com`, or 200 text/html). The callback drives the
+/// same system-browser `/auth/mobile-callback` flow we use at initial
+/// sign-in via [MobileCallbackLoginLauncher], persists the refreshed
+/// credentials, and returns the new [AuthMaterial] so Dio can replay
+/// the original request transparently.
+///
+/// When the browser's CF SSO session is still valid (the common case
+/// — browser sessions typically outlive our stored JWT), the Custom Tab
+/// flashes briefly and completes in <1s with no user interaction. Only
+/// when the browser session is ALSO dead does the user need to type
+/// credentials again.
+///
+/// Returning `null` signals genuine failure (user cancelled, timeout,
+/// no active server, etc.) — the interceptor then falls through to
+/// `onReauthNeeded` so the UI routes to `/reauth`.
+Future<AuthMaterial?> Function(String serverId) _buildRefreshAuth(Ref ref) {
+  return (String serverId) async {
+    // The interceptor passes its captured serverId; we honour it rather
+    // than reading the (potentially stale) active server, so a refresh
+    // can't accidentally cross-bind credentials to a different server
+    // after the user switches.
+    ServerConfig? server;
+    try {
+      final all = await ref.read(serverConfigStoreProvider).loadAll();
+      for (final cfg in all) {
+        if (cfg.id == serverId) {
+          server = cfg;
+          break;
+        }
+      }
+    } catch (_) {
+      return null;
+    }
+    if (server == null) return null;
+
+    final launcher = MobileCallbackLoginLauncher(
+      deepLinkStream: ref.read(deepLinkStreamProvider),
+    );
+    final result = await launcher.login(serverUrl: Uri.parse(server.url));
+    if (result == null) return null;
+
+    await ref.read(mobileCredentialsStoreProvider).save(server.id, result);
+    return AuthMaterial(apiKey: result.apiKey, cfCookie: result.cfToken);
+  };
+}
+
 /// Internal: synchronous [ApiClientPort] bound to the current active server.
 ///
 /// Re-evaluates whenever [activeServerProvider] resolves to a different
@@ -71,6 +127,7 @@ final _apiClientProvider = Provider<ApiClientPort>((ref) {
     serverOrigin: Uri.parse(server.url),
     serverId: server.id,
     storage: storage,
+    refreshAuth: _buildRefreshAuth(ref),
     onReauthNeeded: () => ref.read(reauthSignalProvider.notifier).request(),
   );
 });
@@ -116,6 +173,7 @@ List<Override> buildServerScopedOverrides({required String deviceId}) {
           serverOrigin: Uri.parse(server.url),
           serverId: server.id,
           storage: ref.read(secureStorageProvider),
+          refreshAuth: _buildRefreshAuth(ref),
           onReauthNeeded: () =>
               ref.read(reauthSignalProvider.notifier).request(),
         ),

--- a/mobile/test/infrastructure/api/cf_auth_interceptor_test.dart
+++ b/mobile/test/infrastructure/api/cf_auth_interceptor_test.dart
@@ -1,3 +1,8 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' show HttpHeaders;
+import 'dart:typed_data';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -7,6 +12,64 @@ class _MockRequestHandler extends Mock implements RequestInterceptorHandler {}
 
 class _MockErrorHandler extends Mock implements ErrorInterceptorHandler {}
 
+/// Programmable [HttpClientAdapter] used so we can drive realistic
+/// `dio.fetch(...)` retries through the interceptor without touching the
+/// network.
+///
+/// Pass a [responder] for sequence-aware behavior. The adapter records
+/// every path it served so tests can assert call counts.
+class _CannedAdapter implements HttpClientAdapter {
+  _CannedAdapter({this.responder});
+
+  ResponseBody Function(RequestOptions options, int callIndex)? responder;
+
+  final List<String> calls = <String>[];
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<dynamic>? cancelFuture,
+  ) async {
+    final idx = calls.length;
+    calls.add(options.path);
+    final r = responder;
+    if (r == null) {
+      return ResponseBody.fromString(
+        '{}',
+        200,
+        headers: {
+          HttpHeaders.contentTypeHeader: ['application/json'],
+        },
+      );
+    }
+    return r(options, idx);
+  }
+}
+
+ResponseBody _jsonBody(int statusCode, Object json) {
+  return ResponseBody.fromString(
+    jsonEncode(json),
+    statusCode,
+    headers: {
+      HttpHeaders.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+ResponseBody _redirectBody(int statusCode, String location) {
+  return ResponseBody.fromString(
+    '',
+    statusCode,
+    headers: {
+      HttpHeaders.locationHeader: [location],
+    },
+  );
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(RequestOptions(path: '/'));
@@ -15,16 +78,22 @@ void main() {
     );
   });
 
+  // ------------------------------------------------------------------
+  // onRequest — header / cookie / redirect-disable behavior
+  // ------------------------------------------------------------------
+
   group('onRequest', () {
     test('attaches Authorization Bearer when api key is stored', () async {
       final handler = _MockRequestHandler();
       when(() => handler.next(any())).thenAnswer((_) {});
       final interceptor = CfAuthInterceptor(
+        dio: Dio(),
         serverId: 'srv-1',
         authReader: (id) async {
           expect(id, 'srv-1');
           return const AuthMaterial(apiKey: 'sk-abc');
         },
+        refreshAuth: (_) async => null,
         onReauthNeeded: () => fail('should not fire on success'),
       );
 
@@ -40,8 +109,10 @@ void main() {
       final handler = _MockRequestHandler();
       when(() => handler.next(any())).thenAnswer((_) {});
       final interceptor = CfAuthInterceptor(
+        dio: Dio(),
         serverId: 'srv-1',
         authReader: (_) async => const AuthMaterial(cfCookie: 'jwt-token'),
+        refreshAuth: (_) async => null,
         onReauthNeeded: () {},
       );
 
@@ -58,9 +129,11 @@ void main() {
       final handler = _MockRequestHandler();
       when(() => handler.next(any())).thenAnswer((_) {});
       final interceptor = CfAuthInterceptor(
+        dio: Dio(),
         serverId: 'srv-1',
         authReader: (_) async =>
             const AuthMaterial(apiKey: 'sk-abc', cfCookie: 'jwt-token'),
+        refreshAuth: (_) async => null,
         onReauthNeeded: () {},
       );
 
@@ -75,8 +148,10 @@ void main() {
       final handler = _MockRequestHandler();
       when(() => handler.next(any())).thenAnswer((_) {});
       final interceptor = CfAuthInterceptor(
+        dio: Dio(),
         serverId: 'srv-1',
         authReader: (_) async => const AuthMaterial(),
+        refreshAuth: (_) async => null,
         onReauthNeeded: () {},
       );
 
@@ -93,8 +168,10 @@ void main() {
       final handler = _MockRequestHandler();
       when(() => handler.next(any())).thenAnswer((_) {});
       final interceptor = CfAuthInterceptor(
+        dio: Dio(),
         serverId: 'srv-1',
         authReader: (_) async => const AuthMaterial(apiKey: '', cfCookie: ''),
+        refreshAuth: (_) async => null,
         onReauthNeeded: () {},
       );
 
@@ -110,14 +187,13 @@ void main() {
       final handler = _MockRequestHandler();
       when(() => handler.next(any())).thenAnswer((_) {});
       final interceptor = CfAuthInterceptor(
+        dio: Dio(),
         serverId: 'srv-1',
         authReader: (_) async => const AuthMaterial(cfCookie: 'jwt-token'),
+        refreshAuth: (_) async => null,
         onReauthNeeded: () {},
       );
 
-      // Dio normalizes header keys to lowercase internally, so the
-      // 'Cookie' key collapses to 'cookie' here. The interceptor
-      // appends to the existing slot rather than creating a duplicate.
       final options = RequestOptions(
         path: '/api/sessions',
         headers: {'Cookie': 'foo=bar'},
@@ -138,8 +214,10 @@ void main() {
       final handler = _MockRequestHandler();
       when(() => handler.next(any())).thenAnswer((_) {});
       final interceptor = CfAuthInterceptor(
+        dio: Dio(),
         serverId: 'srv-1',
         authReader: (_) => const AuthMaterial(apiKey: 'sync-key'),
+        refreshAuth: (_) async => null,
         onReauthNeeded: () {},
       );
 
@@ -148,86 +226,530 @@ void main() {
 
       expect(options.headers['authorization'], 'Bearer sync-key');
     });
+
+    test('disables follow-redirects so CF Access 302s surface as errors',
+        () async {
+      final handler = _MockRequestHandler();
+      when(() => handler.next(any())).thenAnswer((_) {});
+      final interceptor = CfAuthInterceptor(
+        dio: Dio(),
+        serverId: 'srv-1',
+        authReader: (_) async => const AuthMaterial(cfCookie: 'jwt'),
+        refreshAuth: (_) async => null,
+        onReauthNeeded: () {},
+      );
+
+      final options = RequestOptions(path: '/api/sessions');
+      // Confirm Dio's default is on, so we know we changed it.
+      expect(options.followRedirects, isTrue);
+
+      await interceptor.onRequest(options, handler);
+
+      expect(options.followRedirects, isFalse);
+      // 2xx must still validate; 3xx must NOT (so they fall into onError).
+      expect(options.validateStatus(200), isTrue);
+      expect(options.validateStatus(204), isTrue);
+      expect(options.validateStatus(302), isFalse);
+      expect(options.validateStatus(401), isFalse);
+      expect(options.validateStatus(500), isFalse);
+    });
   });
 
-  group('onError', () {
-    DioException buildError(int? status) => DioException(
-          requestOptions: RequestOptions(path: '/api/sessions'),
-          response: status == null
-              ? null
-              : Response(
-                  requestOptions: RequestOptions(path: '/api/sessions'),
-                  statusCode: status,
-                ),
-        );
+  // ------------------------------------------------------------------
+  // onError — classifier: synthetic DioException, no network
+  //
+  // Verifies which response shapes are recognized as auth failures and
+  // which pass through unchanged.
+  // ------------------------------------------------------------------
 
-    test('fires onReauthNeeded on 401', () {
-      var calls = 0;
-      final handler = _MockErrorHandler();
-      when(() => handler.next(any())).thenAnswer((_) {});
-      final interceptor = CfAuthInterceptor(
-        serverId: 'srv-1',
-        authReader: (_) async => const AuthMaterial(),
-        onReauthNeeded: () => calls += 1,
+  group('onError — classifier', () {
+    DioException buildError(int? status, {Map<String, List<String>>? headers}) {
+      final requestOptions = RequestOptions(path: '/api/sessions');
+      return DioException(
+        requestOptions: requestOptions,
+        response: status == null
+            ? null
+            : Response(
+                requestOptions: requestOptions,
+                statusCode: status,
+                headers: Headers.fromMap(headers ?? const {}),
+              ),
       );
+    }
 
-      final err = buildError(401);
-      interceptor.onError(err, handler);
-
-      expect(calls, 1);
-      verify(() => handler.next(err)).called(1);
-    });
-
-    test('fires onReauthNeeded on 403', () {
-      var calls = 0;
+    test('does not fire refresh on 500', () async {
+      var refreshes = 0;
+      var reauthCalls = 0;
       final handler = _MockErrorHandler();
       when(() => handler.next(any())).thenAnswer((_) {});
       final interceptor = CfAuthInterceptor(
+        dio: Dio(),
         serverId: 'srv-1',
         authReader: (_) async => const AuthMaterial(),
-        onReauthNeeded: () => calls += 1,
-      );
-
-      final err = buildError(403);
-      interceptor.onError(err, handler);
-
-      expect(calls, 1);
-      verify(() => handler.next(err)).called(1);
-    });
-
-    test('does not fire onReauthNeeded on 500', () {
-      var calls = 0;
-      final handler = _MockErrorHandler();
-      when(() => handler.next(any())).thenAnswer((_) {});
-      final interceptor = CfAuthInterceptor(
-        serverId: 'srv-1',
-        authReader: (_) async => const AuthMaterial(),
-        onReauthNeeded: () => calls += 1,
+        refreshAuth: (_) async {
+          refreshes += 1;
+          return null;
+        },
+        onReauthNeeded: () => reauthCalls += 1,
       );
 
       final err = buildError(500);
-      interceptor.onError(err, handler);
+      await interceptor.onError(err, handler);
 
-      expect(calls, 0);
+      expect(refreshes, 0);
+      expect(reauthCalls, 0);
       verify(() => handler.next(err)).called(1);
     });
 
-    test('does not fire onReauthNeeded when response is absent (network err)',
-        () {
-      var calls = 0;
+    test('does not fire refresh when response is absent (network err)',
+        () async {
+      var refreshes = 0;
+      var reauthCalls = 0;
       final handler = _MockErrorHandler();
       when(() => handler.next(any())).thenAnswer((_) {});
       final interceptor = CfAuthInterceptor(
+        dio: Dio(),
         serverId: 'srv-1',
         authReader: (_) async => const AuthMaterial(),
-        onReauthNeeded: () => calls += 1,
+        refreshAuth: (_) async {
+          refreshes += 1;
+          return null;
+        },
+        onReauthNeeded: () => reauthCalls += 1,
       );
 
       final err = buildError(null);
-      interceptor.onError(err, handler);
+      await interceptor.onError(err, handler);
 
-      expect(calls, 0);
+      expect(refreshes, 0);
+      expect(reauthCalls, 0);
       verify(() => handler.next(err)).called(1);
     });
+
+    test('does NOT fire refresh on a 302 to a non-cloudflareaccess host',
+        () async {
+      var refreshes = 0;
+      var reauthCalls = 0;
+      final handler = _MockErrorHandler();
+      when(() => handler.next(any())).thenAnswer((_) {});
+      final interceptor = CfAuthInterceptor(
+        dio: Dio(),
+        serverId: 'srv-1',
+        authReader: (_) async => const AuthMaterial(),
+        refreshAuth: (_) async {
+          refreshes += 1;
+          return null;
+        },
+        onReauthNeeded: () => reauthCalls += 1,
+      );
+
+      final err = buildError(
+        302,
+        headers: {
+          HttpHeaders.locationHeader: ['https://api.example.com/v2/sessions'],
+        },
+      );
+      await interceptor.onError(err, handler);
+
+      expect(refreshes, 0);
+      expect(reauthCalls, 0);
+      // Pass-through: caller receives the original 302 error.
+      verify(() => handler.next(err)).called(1);
+    });
+
+    test('does NOT fire refresh on a 302 with no Location header', () async {
+      var refreshes = 0;
+      var reauthCalls = 0;
+      final handler = _MockErrorHandler();
+      when(() => handler.next(any())).thenAnswer((_) {});
+      final interceptor = CfAuthInterceptor(
+        dio: Dio(),
+        serverId: 'srv-1',
+        authReader: (_) async => const AuthMaterial(),
+        refreshAuth: (_) async {
+          refreshes += 1;
+          return null;
+        },
+        onReauthNeeded: () => reauthCalls += 1,
+      );
+
+      final err = buildError(302);
+      await interceptor.onError(err, handler);
+
+      expect(refreshes, 0);
+      expect(reauthCalls, 0);
+      verify(() => handler.next(err)).called(1);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // onError — silent refresh + replay via dio.fetch
+  //
+  // Drives the full happy/sad paths against a real Dio with a canned
+  // HttpClientAdapter, since dio.fetch is the load-bearing replay
+  // primitive that mocked handlers can't exercise.
+  // ------------------------------------------------------------------
+
+  group('onError — silent refresh', () {
+    test(
+      'fires refreshAuth and retries on CF Access 302 redirect '
+      '(refresh succeeds -> request succeeds)',
+      () async {
+        var refreshCalls = 0;
+        var reauthCalls = 0;
+        final dio = Dio();
+        final adapter = _CannedAdapter(
+          responder: (options, idx) {
+            // First call: CF redirect. Second (the retry): success.
+            if (idx == 0) {
+              return _redirectBody(
+                302,
+                'https://joyfulhouse.cloudflareaccess.com/cdn-cgi/access/login/x',
+              );
+            }
+            return _jsonBody(200, {'sessions': <dynamic>[]});
+          },
+        );
+        dio.httpClientAdapter = adapter;
+
+        var authReaderCalls = 0;
+        dio.interceptors.add(
+          CfAuthInterceptor(
+            dio: dio,
+            serverId: 'srv-1',
+            authReader: (_) async {
+              authReaderCalls += 1;
+              return const AuthMaterial(apiKey: 'sk-1', cfCookie: 'old-jwt');
+            },
+            refreshAuth: (_) async {
+              refreshCalls += 1;
+              return const AuthMaterial(apiKey: 'sk-2', cfCookie: 'new-jwt');
+            },
+            onReauthNeeded: () => reauthCalls += 1,
+          ),
+        );
+
+        final response = await dio.get<dynamic>('/api/sessions');
+
+        expect(response.statusCode, 200);
+        expect(response.data, {'sessions': <dynamic>[]});
+        expect(refreshCalls, 1);
+        expect(reauthCalls, 0, reason: 'silent refresh must not trip reauth');
+        expect(
+          adapter.calls.length,
+          2,
+          reason: 'one CF redirect + one retry',
+        );
+        expect(
+          authReaderCalls,
+          2,
+          reason: 'onRequest fires for both the original and the retry',
+        );
+      },
+    );
+
+    test(
+      'fires refreshAuth and retries on 401 '
+      '(refresh succeeds -> request succeeds)',
+      () async {
+        var refreshCalls = 0;
+        var reauthCalls = 0;
+        final dio = Dio();
+        final adapter = _CannedAdapter(
+          responder: (options, idx) {
+            if (idx == 0) {
+              return _jsonBody(401, {'error': 'unauthorized'});
+            }
+            return _jsonBody(200, {'ok': true});
+          },
+        );
+        dio.httpClientAdapter = adapter;
+        dio.interceptors.add(
+          CfAuthInterceptor(
+            dio: dio,
+            serverId: 'srv-1',
+            authReader: (_) async => const AuthMaterial(apiKey: 'sk-1'),
+            refreshAuth: (_) async {
+              refreshCalls += 1;
+              return const AuthMaterial(apiKey: 'sk-2');
+            },
+            onReauthNeeded: () => reauthCalls += 1,
+          ),
+        );
+
+        final response = await dio.get<dynamic>('/api/sessions');
+
+        expect(response.statusCode, 200);
+        expect(response.data, {'ok': true});
+        expect(refreshCalls, 1);
+        expect(reauthCalls, 0);
+        expect(adapter.calls.length, 2);
+      },
+    );
+
+    test('fires onReauthNeeded when refresh returns null (user cancelled)',
+        () async {
+      var refreshCalls = 0;
+      var reauthCalls = 0;
+      final dio = Dio();
+      final adapter = _CannedAdapter(
+        responder: (_, __) => _jsonBody(401, {'error': 'unauthorized'}),
+      );
+      dio.httpClientAdapter = adapter;
+      dio.interceptors.add(
+        CfAuthInterceptor(
+          dio: dio,
+          serverId: 'srv-1',
+          authReader: (_) async => const AuthMaterial(apiKey: 'sk-1'),
+          refreshAuth: (_) async {
+            refreshCalls += 1;
+            return null; // user cancelled the browser sheet
+          },
+          onReauthNeeded: () => reauthCalls += 1,
+        ),
+      );
+
+      DioException? caught;
+      try {
+        await dio.get<dynamic>('/api/sessions');
+      } on DioException catch (e) {
+        caught = e;
+      }
+
+      expect(caught, isNotNull);
+      expect(refreshCalls, 1);
+      expect(reauthCalls, 1, reason: 'fallback to /reauth screen');
+      expect(adapter.calls.length, 1, reason: 'no retry attempted');
+      expect(caught!.response?.statusCode, 401);
+    });
+
+    test('fires onReauthNeeded when refresh throws', () async {
+      var refreshCalls = 0;
+      var reauthCalls = 0;
+      final dio = Dio();
+      final adapter = _CannedAdapter(
+        responder: (_, __) => _redirectBody(
+          302,
+          'https://x.cloudflareaccess.com/cdn-cgi/access/login/x',
+        ),
+      );
+      dio.httpClientAdapter = adapter;
+      dio.interceptors.add(
+        CfAuthInterceptor(
+          dio: dio,
+          serverId: 'srv-1',
+          authReader: (_) async => const AuthMaterial(cfCookie: 'old'),
+          refreshAuth: (_) async {
+            refreshCalls += 1;
+            throw StateError('browser launch failed');
+          },
+          onReauthNeeded: () => reauthCalls += 1,
+        ),
+      );
+
+      DioException? caught;
+      try {
+        await dio.get<dynamic>('/api/sessions');
+      } on DioException catch (e) {
+        caught = e;
+      }
+
+      expect(caught, isNotNull);
+      expect(refreshCalls, 1);
+      expect(reauthCalls, 1);
+      expect(adapter.calls.length, 1, reason: 'no retry attempted');
+    });
+
+    test('fires onReauthNeeded when refresh returns empty AuthMaterial',
+        () async {
+      var refreshCalls = 0;
+      var reauthCalls = 0;
+      final dio = Dio();
+      final adapter = _CannedAdapter(
+        responder: (_, __) => _jsonBody(403, {'error': 'forbidden'}),
+      );
+      dio.httpClientAdapter = adapter;
+      dio.interceptors.add(
+        CfAuthInterceptor(
+          dio: dio,
+          serverId: 'srv-1',
+          authReader: (_) async => const AuthMaterial(),
+          refreshAuth: (_) async {
+            refreshCalls += 1;
+            // Empty AuthMaterial == as good as null.
+            return const AuthMaterial();
+          },
+          onReauthNeeded: () => reauthCalls += 1,
+        ),
+      );
+
+      DioException? caught;
+      try {
+        await dio.get<dynamic>('/api/sessions');
+      } on DioException catch (e) {
+        caught = e;
+      }
+
+      expect(caught, isNotNull);
+      expect(refreshCalls, 1);
+      expect(reauthCalls, 1);
+      expect(adapter.calls.length, 1);
+    });
+
+    test(
+      'concurrent failed requests share a single refresh call',
+      () async {
+        var refreshCalls = 0;
+        var reauthCalls = 0;
+        final refreshStarted = Completer<void>();
+        final refreshGate = Completer<AuthMaterial?>();
+        final dio = Dio();
+        final adapter = _CannedAdapter(
+          responder: (options, idx) {
+            // First 3 calls (one per concurrent request) get 401.
+            // Subsequent calls (the retries after refresh) succeed.
+            if (idx < 3) {
+              return _jsonBody(401, {'error': 'unauthorized'});
+            }
+            return _jsonBody(200, {'idx': idx});
+          },
+        );
+        dio.httpClientAdapter = adapter;
+        dio.interceptors.add(
+          CfAuthInterceptor(
+            dio: dio,
+            serverId: 'srv-1',
+            authReader: (_) async => const AuthMaterial(apiKey: 'sk-old'),
+            refreshAuth: (_) async {
+              refreshCalls += 1;
+              if (!refreshStarted.isCompleted) refreshStarted.complete();
+              // Hold the refresh open so all three failures pile up on
+              // the same in-flight Completer.
+              return refreshGate.future;
+            },
+            onReauthNeeded: () => reauthCalls += 1,
+          ),
+        );
+
+        final futures = [
+          dio.get<dynamic>('/api/a'),
+          dio.get<dynamic>('/api/b'),
+          dio.get<dynamic>('/api/c'),
+        ];
+
+        // Wait until the first refresh has been triggered, then release
+        // the gate so all three queued callers replay their requests.
+        await refreshStarted.future;
+        refreshGate.complete(const AuthMaterial(apiKey: 'sk-new'));
+
+        final responses = await Future.wait(futures);
+
+        expect(responses.length, 3);
+        for (final r in responses) {
+          expect(r.statusCode, 200);
+        }
+        expect(
+          refreshCalls,
+          1,
+          reason: 'all three failures must share one refresh',
+        );
+        expect(reauthCalls, 0);
+        // 3 originals + 3 retries.
+        expect(adapter.calls.length, 6);
+      },
+    );
+
+    test(
+      'does NOT retry twice — sentinel guards infinite loop',
+      () async {
+        var refreshCalls = 0;
+        var reauthCalls = 0;
+        final dio = Dio();
+        // Every call returns a CF redirect, including the retry.
+        final adapter = _CannedAdapter(
+          responder: (_, __) => _redirectBody(
+            302,
+            'https://x.cloudflareaccess.com/cdn-cgi/access/login/x',
+          ),
+        );
+        dio.httpClientAdapter = adapter;
+        dio.interceptors.add(
+          CfAuthInterceptor(
+            dio: dio,
+            serverId: 'srv-1',
+            authReader: (_) async => const AuthMaterial(cfCookie: 'jwt'),
+            refreshAuth: (_) async {
+              refreshCalls += 1;
+              // Refresh succeeds, but the server still rejects.
+              return const AuthMaterial(apiKey: 'sk', cfCookie: 'jwt2');
+            },
+            onReauthNeeded: () => reauthCalls += 1,
+          ),
+        );
+
+        DioException? caught;
+        try {
+          await dio.get<dynamic>('/api/sessions');
+        } on DioException catch (e) {
+          caught = e;
+        }
+
+        expect(caught, isNotNull);
+        expect(refreshCalls, 1, reason: 'must not refresh twice');
+        expect(
+          reauthCalls,
+          1,
+          reason: 'sentinel-guarded retry escalates to /reauth',
+        );
+        expect(
+          adapter.calls.length,
+          2,
+          reason: 'original + exactly one retry',
+        );
+      },
+    );
+
+    test(
+      'allows a fresh refresh on a subsequent unrelated request '
+      '(in-flight mutex resets when refresh resolves)',
+      () async {
+        var refreshCalls = 0;
+        final dio = Dio();
+        final adapter = _CannedAdapter(
+          responder: (options, idx) {
+            // Even-indexed calls = 401; odd-indexed calls = 200.
+            return idx.isEven
+                ? _jsonBody(401, {'error': 'unauthorized'})
+                : _jsonBody(200, {'idx': idx});
+          },
+        );
+        dio.httpClientAdapter = adapter;
+        dio.interceptors.add(
+          CfAuthInterceptor(
+            dio: dio,
+            serverId: 'srv-1',
+            authReader: (_) async => const AuthMaterial(apiKey: 'sk-1'),
+            refreshAuth: (_) async {
+              refreshCalls += 1;
+              return AuthMaterial(apiKey: 'sk-$refreshCalls-fresh');
+            },
+            onReauthNeeded: () {},
+          ),
+        );
+
+        // First round: 401 -> refresh -> retry succeeds.
+        final r1 = await dio.get<dynamic>('/api/a');
+        expect(r1.statusCode, 200);
+
+        // Second round, fresh request: 401 again -> refresh AGAIN
+        // (because the in-flight mutex was cleared in finally).
+        final r2 = await dio.get<dynamic>('/api/b');
+        expect(r2.statusCode, 200);
+
+        expect(refreshCalls, 2);
+        // 4 round trips: a (401), a-retry (200), b (401), b-retry (200).
+        expect(adapter.calls.length, 4);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Fixes the mobile-app symptom \"Failed to load sessions / FormatException: Unexpected /api/sessions response shape\" that hits whenever the user's CF Access JWT expires.

**Root cause.** Cloudflare Access signals JWT expiry with a `302` redirect to `cloudflareaccess.com/cdn-cgi/access/login/…`. Dio's default `followRedirects: true` swallowed the redirect into the HTML login page, callers JSON-parsed HTML, and the app crashed with a `FormatException`. The existing `CfAuthInterceptor` only fired `onReauthNeeded` on 401/403, so neither auto-retry nor `/reauth` ever kicked in — the user was stuck.

## What changed

The interceptor (`mobile/lib/infrastructure/api/cf_auth_interceptor.dart`) now:

1. **Disables follow-redirects** on every outbound request so 3xx lands in `onError` instead of being silently followed to HTML.
2. **Classifies CF Access intervention**: 401/403, or 3xx with `Location` containing `cloudflareaccess.com`, or 200 with `text/html` Content-Type.
3. **Drives a refresh via the system browser** through an injected `refreshAuth(serverId)` callback. The callback reuses the existing `MobileCallbackLoginLauncher` to open `<server>/auth/mobile-callback` in a Chrome Custom Tab / SFSafariViewController.
   - **Browser SSO still valid** (common case): the Custom Tab flashes briefly, gets the deep-link callback with fresh credentials, closes. User sees a flash, nothing else.
   - **Browser SSO also dead**: the CF Access sign-in page renders inside the Custom Tab and the user authenticates there. After sign-in, the deep link returns to the app with new credentials.
4. **Replays the original request** via `dio.fetch(err.requestOptions)` with the fresh JWT attached by `onRequest`, so the caller's Future resolves with the retry's response — they never see the failure.
5. **Falls back to `onReauthNeeded()` → `/reauth` screen** ONLY when refresh genuinely fails (user cancelled the Custom Tab, network down, browser SSO dead AND user backed out, etc.).
6. **Dedupes concurrent refreshes** with a `Completer` mutex. A burst of N simultaneous failures triggers ONE browser launch; all N callers share the result. Mutex clears via `scheduleMicrotask` so late-arriving same-tick waiters still piggyback.
7. **Sentinel-guards against infinite retry loops** via `RequestOptions.extra['rdv.cfAuth.retryAttempted']`.

`_buildRefreshAuth(ref)` in `mobile/lib/main.dart` wires the callback to `serverConfigStoreProvider` + `MobileCallbackLoginLauncher` + `mobileCredentialsStoreProvider`. It honours the interceptor's bound `serverId` (not the user-active server) so a refresh can't cross-bind credentials if the user switches servers mid-request.

## What this is NOT

- It is **not** a fully silent refresh in all cases. CF Access doesn't expose a headless refresh endpoint. The Custom Tab always shows briefly; when the browser SSO is also expired the CF sign-in page renders and the user authenticates. The user explicitly confirmed this is the desired behaviour: \"it should pop up the CF page for the user the reauth.\"
- It is **not** a force-quit / manual-recovery flow. Users no longer need to kill and reopen the app.

## Test plan

- [x] `flutter analyze --no-fatal-infos` clean
- [x] `flutter test` — 346/346 pass (20 new interceptor tests covering: 302→refresh-success retry, 401→refresh-success retry, refresh-null → onReauthNeeded fallback, refresh-throws fallback, refresh-empty-AuthMaterial fallback, concurrent-dedup single-refresh three-replays, sentinel-guard infinite-loop, mutex-resets-between-requests, non-CF 302 not treated as auth failure)
- [ ] Manual on iOS: let CF JWT expire (or revoke), trigger an API call, confirm Custom Tab flashes and request retries automatically
- [ ] Manual on Android: same as above
- [ ] Manual: when browser SSO is also dead, confirm CF Access sign-in page renders in Custom Tab and original request completes after user authenticates
- [ ] Manual: cancel the Custom Tab during refresh — confirm `/reauth` screen appears as final fallback

Closes bd \`remote-dev-arua\`. \`CHANGELOG.md\` updated under \`[Unreleased] → Fixed\`.

This pull request and its description were written by Isaac.