### PR TITLE
fix(ui): align New Agent submenu with agent-list conventions

### DIFF
--- a/src/components/session/NewAgentSubmenu.tsx
+++ b/src/components/session/NewAgentSubmenu.tsx
@@ -208,8 +208,8 @@ function ProviderLine({ status }: { status: AgentCLISummary }) {
   const label = PROVIDER_DISPLAY_NAMES[status.provider] ?? status.provider;
   return (
     <div className="flex flex-col items-start gap-0.5 min-w-0">
-      <span className="text-sm font-medium truncate max-w-[220px]">{label}</span>
-      <span className="text-[11px] text-muted-foreground truncate max-w-[220px]">
+      <span className="text-xs font-medium truncate max-w-[220px]">{label}</span>
+      <span className="text-[10px] text-muted-foreground truncate max-w-[220px]">
         {status.installed
           ? `v${status.version ?? "?"} · ${status.command}`
           : "Not installed"}
@@ -261,7 +261,6 @@ export function DropdownNewAgentSubmenu({ onSelect, onManage }: SubmenuProps) {
                   key={s.provider}
                   onClick={() => onSelect(s.provider)}
                   disabled={!s.installed}
-                  className="py-2"
                 >
                   <Icon className={`w-3.5 h-3.5 mr-2 shrink-0 ${colorClass}`} />
                   <ProviderLine status={s} />
@@ -322,7 +321,6 @@ export function ContextNewAgentSubmenu({ onSelect, onManage }: SubmenuProps) {
                   key={s.provider}
                   onSelect={() => onSelect(s.provider)}
                   disabled={!s.installed}
-                  className="py-2"
                 >
                   <Icon className={`mr-2 h-4 w-4 shrink-0 ${colorClass}`} />
                   <ProviderLine status={s} />

--- a/src/components/session/NewAgentSubmenu.tsx
+++ b/src/components/session/NewAgentSubmenu.tsx
@@ -33,6 +33,23 @@ import {
 } from "@/components/ui/context-menu";
 import type { AgentProviderType } from "@/types/session";
 import { PROVIDER_DISPLAY_NAMES } from "@/types/agent";
+import { AGENT_VISUALS } from "./project-tree/agentVisuals";
+
+/**
+ * Brand-color Tailwind classes for the leading icon on each provider row.
+ * Mirrors the chip palette in `agentVisuals.ts` so the submenu matches the
+ * agent chips in `SessionMetadataBar` and the collapsed sidebar rail icons.
+ * Kept here (rather than in `agentVisuals.ts`) because the chip `classes`
+ * field bundles background/border/text together for chip rendering, whereas
+ * menu rows only need a foreground tint on the svg itself.
+ */
+const PROVIDER_ICON_COLORS: Record<Exclude<AgentProviderType, "none">, string> = {
+  claude: "text-violet-500 dark:text-violet-400",
+  codex: "text-emerald-500 dark:text-emerald-400",
+  gemini: "text-sky-500 dark:text-sky-400",
+  antigravity: "text-pink-500 dark:text-pink-400",
+  opencode: "text-amber-500 dark:text-amber-400",
+};
 
 // ---------------------------------------------------------------------------
 // Module-local cache + lazy fetch hook
@@ -236,17 +253,21 @@ export function DropdownNewAgentSubmenu({ onSelect, onManage }: SubmenuProps) {
         )}
         {!loading && !error && statuses && (
           <>
-            {statuses.map((s) => (
-              <DropdownMenuItem
-                key={s.provider}
-                onClick={() => onSelect(s.provider)}
-                disabled={!s.installed}
-                className="py-2"
-              >
-                <Sparkles className="w-3.5 h-3.5 mr-2 shrink-0" />
-                <ProviderLine status={s} />
-              </DropdownMenuItem>
-            ))}
+            {statuses.map((s) => {
+              const Icon = AGENT_VISUALS[s.provider]?.icon ?? Sparkles;
+              const colorClass = PROVIDER_ICON_COLORS[s.provider] ?? "";
+              return (
+                <DropdownMenuItem
+                  key={s.provider}
+                  onClick={() => onSelect(s.provider)}
+                  disabled={!s.installed}
+                  className="py-2"
+                >
+                  <Icon className={`w-3.5 h-3.5 mr-2 shrink-0 ${colorClass}`} />
+                  <ProviderLine status={s} />
+                </DropdownMenuItem>
+              );
+            })}
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={onManage}>
               <SettingsIcon className="w-3.5 h-3.5 mr-2" />
@@ -293,17 +314,21 @@ export function ContextNewAgentSubmenu({ onSelect, onManage }: SubmenuProps) {
         )}
         {!loading && !error && statuses && (
           <>
-            {statuses.map((s) => (
-              <ContextMenuItem
-                key={s.provider}
-                onSelect={() => onSelect(s.provider)}
-                disabled={!s.installed}
-                className="py-2"
-              >
-                <Sparkles className="mr-2 h-4 w-4 shrink-0" />
-                <ProviderLine status={s} />
-              </ContextMenuItem>
-            ))}
+            {statuses.map((s) => {
+              const Icon = AGENT_VISUALS[s.provider]?.icon ?? Sparkles;
+              const colorClass = PROVIDER_ICON_COLORS[s.provider] ?? "";
+              return (
+                <ContextMenuItem
+                  key={s.provider}
+                  onSelect={() => onSelect(s.provider)}
+                  disabled={!s.installed}
+                  className="py-2"
+                >
+                  <Icon className={`mr-2 h-4 w-4 shrink-0 ${colorClass}`} />
+                  <ProviderLine status={s} />
+                </ContextMenuItem>
+              );
+            })}
             <ContextMenuSeparator />
             <ContextMenuItem onSelect={onManage}>
               <SettingsIcon className="mr-2 h-4 w-4" />

--- a/src/components/session/__tests__/NewAgentSubmenu.test.tsx
+++ b/src/components/session/__tests__/NewAgentSubmenu.test.tsx
@@ -39,14 +39,14 @@ describe("useAgentCLIStatusLazy", () => {
     vi.unstubAllGlobals();
   });
 
-  it("fetches once on first mount and projects all four providers", async () => {
+  it("fetches once on first mount and projects all five providers", async () => {
     const { result } = renderHook(() => useAgentCLIStatusLazy());
     await waitFor(() => {
       expect(result.current.statuses).not.toBeNull();
     });
-    // Always returns rows for all four providers, even those missing from
+    // Always returns rows for all five providers, even those missing from
     // the API response (those default to installed=false).
-    expect(result.current.statuses).toHaveLength(4);
+    expect(result.current.statuses).toHaveLength(5);
     const claude = result.current.statuses!.find((s) => s.provider === "claude");
     expect(claude?.installed).toBe(true);
     expect(claude?.version).toBe("1.2.3");
@@ -63,7 +63,7 @@ describe("useAgentCLIStatusLazy", () => {
     const beforeSecondMount = fetchMock.mock.calls.length;
 
     const { result: b } = renderHook(() => useAgentCLIStatusLazy());
-    expect(b.current.statuses).toHaveLength(4);
+    expect(b.current.statuses).toHaveLength(5);
     expect(fetchMock).toHaveBeenCalledTimes(beforeSecondMount);
   });
 
@@ -99,7 +99,7 @@ describe("useAgentCLIStatusLazy", () => {
     await waitFor(() => {
       expect(result.current.error).not.toBeNull();
     });
-    expect(result.current.statuses).toHaveLength(4);
+    expect(result.current.statuses).toHaveLength(5);
     expect(result.current.statuses?.every((s) => !s.installed)).toBe(true);
     expect(result.current.error).toMatch(/HTTP 500/);
   });


### PR DESCRIPTION
## Summary

The "New Agent" / "Pick Agent" submenu (sidebar `+` dropdown + project right-click) drifted from the agent-list conventions used elsewhere in the app (chip in `SessionMetadataBar`, collapsed-rail icons in `Sidebar`). Two follow-on fixes in one branch:

**Commit 1 — per-agent icons + brand colors (closes `remote-dev-ujmp`)**
- Replaced the generic `Sparkles` on every row with `AGENT_VISUALS[provider].icon` (Sparkles for claude/gemini/antigravity, Cpu for codex, Code2 for opencode).
- Tinted with brand colors via a new local `PROVIDER_ICON_COLORS` map (violet / emerald / sky / pink / amber, matching `agentVisuals.ts`).
- Applied to both `DropdownNewAgentSubmenu` and `ContextNewAgentSubmenu`. Trigger row and "Configure agents…" row unchanged.

**Commit 2 — font sizing + test fixes**
- Primary label `text-sm font-medium` → `text-xs font-medium` so rows match the menu library's default `text-xs` and don't dominate sibling rows.
- Secondary line `text-[11px]` → `text-[10px]` to stay visibly subordinate.
- Removed `className="py-2"` from both row containers so they use the default `py-1` like every other menu item.
- Bumped 3 hardcoded `toHaveLength(4)` assertions in `NewAgentSubmenu.test.tsx` to `5` to account for `antigravity` being added to `ALL_PROVIDERS`. These had been failing on `master` for a while.

## Test plan
- [x] `bun run typecheck` — passes
- [x] `bun run test:run -- NewAgentSubmenu` — 4/4 pass (was 1/4 before)
- [x] `bun run lint` — same baseline (1 pre-existing error in `EmbeddedSessionView.test.tsx`, no new regressions)
- [ ] Visual: open sidebar `+` → Pick Agent ▸ and confirm each row shows the right colored icon at the same font size as other menu items
- [ ] Visual: right-click a project → Pick Agent ▸ shows the same

This pull request and its description were written by Isaac.