### PR TITLE
fix(ui): scope agent chip to actual agent terminals + match branch chip styling

### DIFF
--- a/src/components/session/SessionMetadataBar.tsx
+++ b/src/components/session/SessionMetadataBar.tsx
@@ -30,31 +30,20 @@ export function SessionMetadataBar({
     ? allocations.filter((p) => p.folderId === session.projectId)
     : [];
 
-  const hasAgent = session.agentProvider && session.agentProvider !== "none" && AGENT_VISUALS[session.agentProvider];
+  const isAgentTerminal =
+    session.terminalType === "agent" || session.terminalType === "loop";
+
+  const hasAgent =
+    isAgentTerminal &&
+    session.agentProvider &&
+    session.agentProvider !== "none" &&
+    AGENT_VISUALS[session.agentProvider];
 
   if (isCollapsed) return null;
   if (!gitStatus && sessionPorts.length === 0 && !hasAgent) return null;
 
   return (
     <div className="flex flex-wrap gap-1 mt-0.5 px-1">
-      {/* Active Agent Chip */}
-      {session.agentProvider && AGENT_VISUALS[session.agentProvider] && (
-        (() => {
-          const config = AGENT_VISUALS[session.agentProvider]!;
-          const AgentIcon = config.icon;
-          return (
-            <span
-              className={cn(
-                "inline-flex items-center gap-0.5 text-[9px] font-semibold border rounded-md px-1.5 py-0.5 shrink-0 uppercase tracking-wider",
-                config.classes
-              )}
-            >
-              <AgentIcon className="w-2.5 h-2.5 shrink-0" />
-              <span>{config.label}</span>
-            </span>
-          );
-        })()
-      )}
       {/* Branch chip with ahead/behind */}
       {gitStatus?.branch && (
         <span className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground/70 bg-muted/30 rounded px-1 py-0.5 max-w-[120px] truncate">
@@ -87,6 +76,25 @@ export function SessionMetadataBar({
         >
           <GitPullRequest className="w-2.5 h-2.5" />#{gitStatus.pr.number}
         </span>
+      )}
+
+      {/* Active Agent Chip */}
+      {isAgentTerminal && session.agentProvider && AGENT_VISUALS[session.agentProvider] && (
+        (() => {
+          const config = AGENT_VISUALS[session.agentProvider]!;
+          const AgentIcon = config.icon;
+          return (
+            <span
+              className={cn(
+                "inline-flex items-center gap-0.5 text-[10px] border rounded px-1 py-0.5 shrink-0",
+                config.classes
+              )}
+            >
+              <AgentIcon className="w-2.5 h-2.5 shrink-0" />
+              <span>{config.label}</span>
+            </span>
+          );
+        })()
       )}
 
       {/* Port chips */}


### PR DESCRIPTION
## Summary

Three problems in the session metadata bar (`src/components/session/SessionMetadataBar.tsx`):

1. **Shell terminals were showing a "claude" badge.** Root cause: `db/schema.ts:345` defaults `agentProvider` to `"claude"` for every new `terminal_session` row, regardless of `terminalType`. The chip render only gated on `agentProvider`, not `terminalType`, so every non-agent terminal got tagged. Fixed by adding an `isAgentTerminal = terminalType === "agent" || "loop"` guard on both the chip render and the `hasAgent` early-return.
2. **Chip styling was too loud next to the branch chip.** Was `text-[9px] font-semibold uppercase tracking-wider`, `rounded-md`, `px-1.5`. Dropped to `text-[10px]`, removed `font-semibold`/`uppercase`/`tracking-wider`, `rounded-md` → `rounded`, `px-1.5` → `px-1`. Brand-color `config.classes` from `AGENT_VISUALS` retained so the chip stays distinct.
3. **Chip ordering.** Was agent → branch → PR → ports. Now branch → PR → agent → ports, putting git-state info first.

Closes `remote-dev-8mw5`.

Note: I intentionally did not touch the DB default. The downstream agent-creation paths read `session.agentProvider` and expect a non-null fallback, and rewiring that is outside the scope of this UI fix.

## Test plan
- [x] `bun run typecheck` — passes
- [x] `bun run lint` — same baseline (1 pre-existing error in `EmbeddedSessionView.test.tsx`, no new)
- [ ] Visual: create a new shell terminal — no agent chip in the row metadata
- [ ] Visual: create a new agent terminal — chip renders with brand color, sized like the branch chip
- [ ] Visual: confirm chip order is branch → PR → agent → ports in an agent session inside a git worktree with an open PR

This pull request and its description were written by Isaac.