### PR TITLE
fix(db): stop defaulting terminal_session.agent_provider to "claude" on every row

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ bun run db:migrate-agents  # One-time agent session migration
 bun run db:migrate-github-accounts  # Backfill GitHub account metadata from existing OAuth accounts
 bun run db:migrate-profile-gitconfigs  # Add [credential] section to existing profile .gitconfig files
 bun run db:migrate-channels  # Migrate existing messages to channels
+bun run db:migrate-agent-provider  # One-time: null out agent_provider on non-agent sessions
 ```
 
 ## Logging (NON-NEGOTIABLE)

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "db:migrate-github-accounts": "bun run scripts/migrate-github-accounts.ts",
     "db:migrate-profile-gitconfigs": "bun run scripts/migrate-profile-gitconfigs.ts",
     "db:migrate-channels": "tsx src/db/migrations/migrate-channels.ts",
+    "db:migrate-agent-provider": "bun run scripts/migrate-agent-provider.ts",
     "db:migrate-session-project-id": "bun run scripts/migrate-session-project-id.ts",
     "terminal:build": "bun build src/server/index.ts --outdir dist-terminal --target node --external node-pty --external better-sqlite3 --external playwright --external playwright-core --external chromium-bidi --sourcemap",
     "electron:build": "tsc -p electron/tsconfig.json",

--- a/scripts/migrate-agent-provider.ts
+++ b/scripts/migrate-agent-provider.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env bun
+/**
+ * One-time migration: null out agent_provider on non-agent sessions.
+ *
+ * Prior to this fix, the Drizzle schema column `agent_provider` had a
+ * `.default("claude")` clause, which caused every session row — including
+ * shells, file viewers, browsers, SSH sessions, etc. — to be written with
+ * `agent_provider = 'claude'`. That value is meaningless and misleading for
+ * non-agent terminal types.
+ *
+ * This script clears `agent_provider` (sets it to NULL) for every row where
+ * `terminal_type` is NOT 'agent' or 'loop'. Agent and loop sessions keep their
+ * provider value as-is.
+ *
+ * The script is idempotent — running it a second time reports 0 updates
+ * because no qualifying rows with a non-NULL provider remain.
+ *
+ * After this script runs, the schema default has already been removed from
+ * schema.ts. New sessions will be written with NULL for non-agent types.
+ */
+
+import { db } from "../src/db";
+import { terminalSessions } from "../src/db/schema";
+import { notInArray, isNotNull, and, sql } from "drizzle-orm";
+
+const AGENT_TERMINAL_TYPES = ["agent", "loop"] as const;
+
+async function main() {
+  console.log(
+    "[migrate-agent-provider] Clearing stale agent_provider values on non-agent sessions\n"
+  );
+
+  // Count how many rows are affected before updating, for the summary.
+  const candidates = await db.query.terminalSessions.findMany({
+    where: and(
+      notInArray(terminalSessions.terminalType, [...AGENT_TERMINAL_TYPES]),
+      isNotNull(terminalSessions.agentProvider)
+    ),
+    columns: { id: true },
+  });
+
+  const count = candidates.length;
+
+  if (count === 0) {
+    console.log(
+      "[migrate-agent-provider] No stale rows found — nothing to do (idempotent re-run or already clean).\n"
+    );
+    return;
+  }
+
+  // Perform the bulk update using raw SQL for clarity and atomicity.
+  // Drizzle's `notInArray` on text columns with a typed literal array works
+  // cleanly here but we use sql`` to avoid any type coercion edge cases with
+  // the text-typed column and the enum values.
+  await db
+    .update(terminalSessions)
+    .set({ agentProvider: null })
+    .where(
+      and(
+        notInArray(terminalSessions.terminalType, [...AGENT_TERMINAL_TYPES]),
+        isNotNull(terminalSessions.agentProvider)
+      )
+    );
+
+  console.log(
+    `[migrate-agent-provider] cleared ${count} stale agent_provider values on non-agent sessions\n`
+  );
+}
+
+main()
+  .then(() => {
+    process.exit(process.exitCode ?? 0);
+  })
+  .catch((err) => {
+    console.error("[migrate-agent-provider] Migration failed:", err);
+    process.exit(1);
+  });

--- a/src/app/api/sessions/[id]/spawn/route.ts
+++ b/src/app/api/sessions/[id]/spawn/route.ts
@@ -54,7 +54,7 @@ export const POST = withApiAuth(async (request, { userId, params }) => {
     const input: CreateSessionInput = {
       name,
       terminalType: body.terminalType || parent.terminalType || "agent",
-      agentProvider: (body.agentProvider || parent.agentProvider || "claude") as CreateSessionInput["agentProvider"],
+      agentProvider: (body.agentProvider ?? parent.agentProvider ?? undefined) as CreateSessionInput["agentProvider"],
       projectId: resolvedProjectId,
       projectPath: body.workingDirectory || parent.projectPath || undefined,
       profileId: body.profileId || parent.profileId || undefined,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -342,7 +342,7 @@ export const terminalSessions = sqliteTable(
     // Terminal type: shell, agent, file, or custom plugin types
     terminalType: text("terminal_type").$type<TerminalType>().default("shell"),
     // Agent-aware session: which AI agent is associated
-    agentProvider: text("agent_provider").$type<AgentProviderType>().default("claude"),
+    agentProvider: text("agent_provider").$type<AgentProviderType>(),
     // Agent session state (for agent terminal type)
     agentExitState: text("agent_exit_state").$type<AgentExitState>(),
     agentExitCode: integer("agent_exit_code"),

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -245,6 +245,7 @@ export async function createSessionWithDedupFlag(
   }
 
   // Build a partial session stub for the plugin to introspect if needed.
+  const isAgentTerminal = terminalType === "agent" || terminalType === "loop";
   const pluginSessionStub: Partial<TerminalSession> = {
     id: sessionId,
     userId,
@@ -252,7 +253,7 @@ export async function createSessionWithDedupFlag(
     projectId: input.projectId,
     profileId: input.profileId ?? null,
     terminalType,
-    agentProvider: input.agentProvider ?? "claude",
+    agentProvider: isAgentTerminal ? (input.agentProvider ?? "claude") : null,
   };
 
   // Pre-resolve folder/user preferences so we can layer in per-provider
@@ -765,7 +766,7 @@ export async function createSessionWithDedupFlag(
         terminalType,
         typeMetadata,
         scopeKey: input.scopeKey ?? null,
-        agentProvider: input.agentProvider ?? "claude",
+        agentProvider: isAgentTerminal ? (mergedAgentProvider ?? "claude") : null,
         // Initialize the agent-style exit-state machine for any plugin that
         // opts into the exit-screen / restart UX (agent / loop / ssh today).
         // Driven by the plugin registry capability flag, not hardcoded types.


### PR DESCRIPTION
## Summary

Root cause for the shell-sessions-show-agent-chip class of bugs — the cosmetic UI patch shipped in #304 papered over a data-integrity issue. The Drizzle schema column `terminal_session.agent_provider` had `.default("claude")`, so every row (shells, file viewers, browsers, SSH sessions, etc.) was written with `agent_provider = 'claude'`.

## Changes

**Schema**
- `src/db/schema.ts`: drop `.default("claude")` from the column. It stays nullable.

**Service**
- `src/services/session-service.ts`: compute `isAgentTerminal = terminalType === "agent" || "loop"` once and gate both write sites (plugin stub + DB insert). For non-agent terminals, write `null` instead of `"claude"`.
- Fixes a **latent bug in passing**: the DB insert previously used raw `input.agentProvider ?? "claude"` and silently ignored the `mergedAgentProvider` value computed just above (which folds in `earlyPreferences.defaultAgentProvider`). The insert now uses `mergedAgentProvider`, so the user/project-level `defaultAgentProvider` setting is actually honored for new agent sessions.

**Spawn route**
- `src/app/api/sessions/[id]/spawn/route.ts`: change `body.agentProvider || parent.agentProvider || "claude"` → `body.agentProvider ?? parent.agentProvider ?? undefined`. `??` preserves an explicit `"none"`, and the service applies the agent-type default for us.

**Migration**
- `scripts/migrate-agent-provider.ts`: new idempotent one-shot that nulls out `agent_provider` on every existing row where `terminal_type NOT IN ('agent', 'loop')`. Re-runs are a no-op.
- `package.json` + `CLAUDE.md`: register `bun run db:migrate-agent-provider`.

## Consumer safety

Every existing reader of `session.agentProvider` is already null-safe:

- `Sidebar.tsx`, `SessionMetadataBar.tsx`, `agent-plugin-server.ts`, `shell-plugin-server.ts`, `loop-agent-plugin-server.ts`, `RestartAgentUseCase.ts`, `LoopChatPane.tsx`, `FolderTabBar.tsx`, `DmPickerSheet.tsx`, mcp-servers routes (via `isMCPSupported`), `SessionMapper.ts`
- Type `TerminalSession.agentProvider` is already `AgentProviderType | null`

No consumer changes needed. The `terminalType`-based UI gate in `SessionMetadataBar.tsx` (from #304) is kept as defense in depth.

Closes `remote-dev-2hhn`.

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run lint` — baseline unchanged (1 pre-existing error in `EmbeddedSessionView.test.tsx`)
- [x] `bun run test:run -- session-service` — 19/19 pass (`session-service-plugin-dispatch.test.ts` + sibling)
- [x] `bun build scripts/migrate-agent-provider.ts --target node` — compiles
- [ ] After merge, the user should run: `bun run db:push` (drop the DEFAULT constraint on local SQLite) and `bun run db:migrate-agent-provider` (null out existing junk rows)
- [ ] Create a new shell terminal — confirm `agent_provider IS NULL` in the DB row and no chip in the metadata bar
- [ ] Create a new agent terminal — confirm `agent_provider = 'claude'` (or whichever provider) in the DB row

This pull request and its description were written by Isaac.