### PR TITLE
fix(deploy): make prod restart resilient + observable (capture logs, consolidate+bound shutdown, clear stale lock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Production deploy/restart resilience** (remote-dev-i85i): auto-deploy
+  restarts could wedge with "Terminal socket not ready" and were
+  undiagnosable because all child stdio was discarded. Three fixes: (1)
+  `rdv.ts` now redirects the prod terminal + Next.js child stdout/stderr to
+  append-only `~/.remote-dev/logs/{terminal,nextjs}.log` (with a per-restart
+  banner; falls back to inherited stdio if the log can't be opened, and dev
+  mode is unchanged); (2) the terminal server's graceful shutdown is now
+  bounded (7s) and consolidated into a single authority in
+  `src/server/index.ts` — `terminal.ts` no longer self-exits or traps signals
+  — so SIGTERM always exits cleanly within the deploy's 10s window, releasing
+  the instance lock instead of being SIGKILLed; (3) `deploy.ts`'s stop phase
+  now clears a stale instance lock (ownership-checked: only same-host,
+  dead-holder locks are removed; a live owner is preserved).
 - **Mobile release CI**: Android `:app:signReleaseBundle` no longer crashes
   with `Tag number over 30 is not supported`. The Gradle signing config
   now sets `storeType = "PKCS12"` by default (matching `keytool`'s modern

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -38,7 +38,7 @@ import {
   renameSync,
 } from "fs";
 import { join } from "path";
-import { homedir } from "os";
+import { homedir, hostname as osHostname } from "os";
 import http from "http";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -225,6 +225,22 @@ function isProcessRunning(pid: number): boolean {
   }
 }
 
+// Liveness probe for the instance-lock holder. Unlike isProcessRunning above
+// (which treats EPERM as "dead"), this mirrors instance-lock.ts's isPidAlive:
+// EPERM means the process EXISTS but is owned by another user, so it is alive.
+// We MUST err toward "alive" here so the deploy never deletes a live lock it
+// merely can't signal — wrongly removing a held lock is the failure this
+// ownership check exists to prevent.
+function isLockHolderAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    return code === "EPERM";
+  }
+}
+
 // Kill an entire process group by negative PID. Servers are spawned
 // `detached: true` so each is its own session/pgid leader — signalling
 // `-pid` reaches every descendant (tsx wrapper + actual node server)
@@ -300,6 +316,47 @@ function stopCurrentServers(): void {
     } catch {
       // Ignore
     }
+  }
+
+  // Clear a STALE instance lock (src/lib/instance-lock.ts). A SIGKILLed
+  // terminal server can't release its own lock on the way out, and a leftover
+  // lock would block the restart we're about to trigger via rdv.ts. The deploy
+  // lock already serializes deploys, but a manual out-of-band `rdv:prod` could
+  // hold a live lock — so we mirror releaseInstanceLock()'s defensiveness and
+  // only remove the lock when it's same-host AND its holder PID is dead. A
+  // live-owner lock is preserved (we warn instead). Only deploy.ts clears the
+  // lock; rdv.ts manual start must NOT, so it preserves the double-start guard.
+  const instanceLock = join(DATA_DIR, "instance.lock");
+  try {
+    if (existsSync(instanceLock)) {
+      let lockPid: number | null = null;
+      let lockHost: string | null = null;
+      try {
+        const parsed = JSON.parse(readFileSync(instanceLock, "utf-8"));
+        if (parsed && typeof parsed === "object") {
+          if (typeof parsed.pid === "number") lockPid = parsed.pid;
+          if (typeof parsed.hostname === "string") lockHost = parsed.hostname;
+        }
+      } catch {
+        // Unreadable/malformed lock → treat as stale and remove below.
+      }
+
+      const sameHost = lockHost === null || lockHost === osHostname();
+      const holderAlive = lockPid !== null && isLockHolderAlive(lockPid);
+
+      if (sameHost && !holderAlive) {
+        unlinkSync(instanceLock);
+        logDeploy(
+          `Removed stale instance lock (pid=${lockPid ?? "?"}, host=${lockHost ?? "?"})`,
+        );
+      } else {
+        logError(
+          `Instance lock held by a live process (pid=${lockPid ?? "?"}, host=${lockHost ?? "?"}) — leaving it in place`,
+        );
+      }
+    }
+  } catch {
+    // Ignore
   }
 
   logDeploy("Servers stopped");

--- a/scripts/rdv.ts
+++ b/scripts/rdv.ts
@@ -17,7 +17,7 @@
  */
 
 import { spawn, spawnSync } from "bun";
-import { existsSync, mkdirSync, readFileSync, symlinkSync, unlinkSync, writeFileSync } from "fs";
+import { appendFileSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, symlinkSync, unlinkSync, writeFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { ensureLocalApiKey } from "../src/lib/local-api-key";
@@ -30,6 +30,9 @@ const TERMINAL_PID_FILE = join(PID_DIR, "terminal.pid");
 const MODE_FILE = join(PID_DIR, "mode");
 const STANDALONE_DIR = join(PROJECT_ROOT, ".next", "standalone");
 const SOCKET_DIR = join(DATA_DIR, "run");
+const LOGS_DIR = join(DATA_DIR, "logs");
+const TERMINAL_LOG_FILE = join(LOGS_DIR, "terminal.log");
+const NEXT_LOG_FILE = join(LOGS_DIR, "nextjs.log");
 
 // Ports come from env vars so two pods on the same host can run concurrently
 // for multi-instance smoke tests (`PORT=6101 TERMINAL_PORT=6102 ...`).
@@ -290,13 +293,62 @@ function stopProcess(pidFile: string, name: string): boolean {
   return false;
 }
 
+// Resolve the short git commit for the startup banner. Cheap and best-effort:
+// a failed/absent git just yields "unknown" and never blocks startup.
+function getShortCommit(): string {
+  try {
+    const result = spawnSync(["git", "rev-parse", "--short", "HEAD"], { cwd: PROJECT_ROOT });
+    const out = result.stdout?.toString().trim();
+    return out || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+// Open a per-server log file (append mode) and write a one-line banner that
+// delimits this restart. Returns the fd to be handed to bun's spawn as
+// stdout/stderr. The data-dir logs/ directory is created if missing.
+//
+// This is the key diagnosis enabler: in prod the child's stdout/stderr would
+// otherwise chain up to a deploy.ts that /api/deploy spawned with
+// stdio:"ignore", so a terminal-server crash before the structured logger
+// flushes went to /dev/null. Redirecting to a real file makes failed-deploy
+// crash output recoverable.
+function openServerLog(name: string, logFile: string): number {
+  if (!existsSync(LOGS_DIR)) {
+    mkdirSync(LOGS_DIR, { recursive: true });
+  }
+  const fd = openSync(logFile, "a");
+  const banner = `\n===== ${name} starting ${new Date().toISOString()} (commit ${getShortCommit()}) =====\n`;
+  appendFileSync(fd, banner);
+  return fd;
+}
+
 async function startServer(
   name: string,
   cmd: string[],
   env: Record<string, string>,
-  pidFile: string
+  pidFile: string,
+  logFile?: string
 ): Promise<SpawnedProcess | null> {
   console.log(`Starting ${name}...`);
+
+  // In prod mode (logFile provided) redirect the child's stdout+stderr to an
+  // append-only log file. In dev mode (no logFile) keep "inherit" so
+  // `bun run dev` shows server output in the terminal. If the log file can't
+  // be opened (e.g. unwritable logs dir), fall back to "inherit" rather than
+  // aborting an otherwise-healthy start — losing the captured log is far less
+  // harmful than failing the deploy restart.
+  let stdio: number | "inherit" = "inherit";
+  if (logFile) {
+    try {
+      stdio = openServerLog(name, logFile);
+      console.log(`  ${name} stdout/stderr → ${logFile}`);
+    } catch (err) {
+      console.error(`  ${name}: could not open log file ${logFile}, falling back to inherit:`, err);
+      stdio = "inherit";
+    }
+  }
 
   // detached: true makes the child the leader of a new session/process
   // group (POSIX setsid). This lets stop() target the whole tree via
@@ -307,10 +359,21 @@ async function startServer(
     cmd,
     cwd: PROJECT_ROOT,
     env: { ...process.env, ...env },
-    stdout: "inherit",
-    stderr: "inherit",
+    stdout: stdio,
+    stderr: stdio,
     detached: true,
   });
+
+  // The child dup'd the log fd during spawn, so close our copy in the parent
+  // to avoid leaking it. Only close an fd we actually opened (a number) — not
+  // the "inherit" sentinel.
+  if (typeof stdio === "number") {
+    try {
+      closeSync(stdio);
+    } catch {
+      // ignore — fd may already be closed
+    }
+  }
 
   if (proc.pid) {
     writePid(pidFile, proc.pid);
@@ -399,7 +462,8 @@ async function start(mode: Mode): Promise<void> {
         TERMINAL_SOCKET: config.terminalSocket,
         DATABASE_URL: prodDatabaseUrl,
       },
-      TERMINAL_PID_FILE
+      TERMINAL_PID_FILE,
+      TERMINAL_LOG_FILE
     );
 
     console.log("Waiting for terminal server to initialize...");
@@ -416,7 +480,8 @@ async function start(mode: Mode): Promise<void> {
         NEXTAUTH_URL: config.nextAuthUrl,
         AUTH_URL: config.nextAuthUrl, // NextAuth v5 also checks AUTH_URL
       },
-      NEXT_PID_FILE
+      NEXT_PID_FILE,
+      NEXT_LOG_FILE
     );
 
     await waitForExit(mode, terminalProc, nextProc);

--- a/src/lib/__tests__/with-timeout.test.ts
+++ b/src/lib/__tests__/with-timeout.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for `src/lib/with-timeout.ts`.
+ *
+ * `withTimeout` bounds the terminal server's async shutdown cleanup so the
+ * process always reaches its explicit `releaseInstanceLock()` + `exit(0)`
+ * before the deploy's 10s SIGKILL. These tests pin the three behaviours the
+ * shutdown path depends on: fast resolution passes through, a hung promise
+ * times out, and a rejection is swallowed (never re-thrown).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { withTimeout } from "../with-timeout";
+
+describe("withTimeout", () => {
+  it("resolves with the value when the promise settles before the timeout", async () => {
+    const result = await withTimeout(Promise.resolve("done"), 1000);
+    expect(result.timedOut).toBe(false);
+    expect(result.value).toBe("done");
+  });
+
+  it("reports timedOut when the promise outlives the timeout", async () => {
+    // A promise that never settles within the window.
+    const never = new Promise<string>(() => {});
+    const result = await withTimeout(never, 10);
+    expect(result.timedOut).toBe(true);
+    expect(result.value).toBeUndefined();
+  });
+
+  it("swallows a rejection into a non-timed-out result (never throws)", async () => {
+    const rejecting = Promise.reject(new Error("cleanup blew up"));
+    // Must not throw — shutdown callers only care that the work is no longer
+    // pending, not why it failed.
+    const result = await withTimeout(rejecting, 1000);
+    expect(result.timedOut).toBe(false);
+    expect(result.value).toBeUndefined();
+  });
+
+  it("clears the internal timer when the promise wins (no dangling timer)", async () => {
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    try {
+      await withTimeout(Promise.resolve(42), 5000);
+      expect(clearSpy).toHaveBeenCalled();
+    } finally {
+      clearSpy.mockRestore();
+    }
+  });
+
+  it("settles only once even if both the timer and promise are eligible", async () => {
+    // Promise resolves at ~5ms, timeout at 5ms — whichever wins, the result
+    // must be a single, well-formed object (the internal `settled` guard).
+    const slow = new Promise<string>((resolve) => setTimeout(() => resolve("late"), 5));
+    const result = await withTimeout(slow, 5);
+    expect(typeof result.timedOut).toBe("boolean");
+    // Whichever branch won, the shape is valid.
+    if (!result.timedOut) {
+      expect(result.value).toBe("late");
+    }
+  });
+});

--- a/src/lib/with-timeout.ts
+++ b/src/lib/with-timeout.ts
@@ -1,0 +1,51 @@
+/**
+ * Race a promise against a wall-clock timeout.
+ *
+ * Used by the terminal server's shutdown path (`src/server/index.ts`) to
+ * bound async cleanup so the process always exits well within the deploy
+ * stop window (`PROCESS_STOP_TIMEOUT_MS` in `scripts/deploy.ts`). If cleanup
+ * exceeds the deadline the process would otherwise be SIGKILLed — which can't
+ * be trapped, so `releaseInstanceLock()` never runs and the instance lock /
+ * sockets are orphaned.
+ *
+ * Semantics:
+ *   - Resolves `{ timedOut: false, value }` if `promise` settles first.
+ *   - Resolves `{ timedOut: true }` if the timer fires first.
+ *   - Never rejects: a rejection from `promise` is swallowed into
+ *     `{ timedOut: false, value: undefined }` (callers in a shutdown path
+ *     don't care *why* cleanup failed — only that they should stop waiting).
+ *   - The internal timer is `unref()`-ed and always cleared, so it never
+ *     keeps the event loop alive on its own.
+ */
+export interface TimeoutResult<T> {
+  timedOut: boolean;
+  value?: T;
+}
+
+export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<TimeoutResult<T>> {
+  return new Promise<TimeoutResult<T>>((resolve) => {
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve({ timedOut: true });
+    }, ms);
+    // Don't let the pending timer hold the event loop open by itself.
+    timer.unref?.();
+
+    const finish = (result: TimeoutResult<T>): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    promise.then(
+      (value) => finish({ timedOut: false, value }),
+      // Swallow the rejection reason — shutdown callers only need to know
+      // the awaited work is no longer pending.
+      () => finish({ timedOut: false, value: undefined }),
+    );
+  });
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,7 +12,7 @@ if (!process.env.LC_CTYPE) process.env.LC_CTYPE = "en_US.UTF-8";
 if (!process.env.TERM) process.env.TERM = "xterm-256color";
 
 import { config } from "dotenv";
-import { createTerminalServer } from "./terminal.js";
+import { createTerminalServer, shutdownTerminalConnections } from "./terminal.js";
 import { schedulerOrchestrator } from "../services/scheduler-orchestrator.js";
 import { updateScheduler } from "../services/update-scheduler.js";
 import { autoUpdateOrchestrator } from "../infrastructure/container.js";
@@ -22,6 +22,7 @@ import { fileURLToPath } from "node:url";
 import { createLogger } from "../lib/logger.js";
 import { closeLogDatabase } from "../infrastructure/logging/LogDatabase.js";
 import { acquireInstanceLock, releaseInstanceLock } from "../lib/instance-lock.js";
+import { withTimeout } from "../lib/with-timeout.js";
 
 const log = createLogger("Server");
 
@@ -39,6 +40,21 @@ try {
 
 const TERMINAL_SOCKET = process.env.TERMINAL_SOCKET;
 const TERMINAL_PORT = parseInt(process.env.TERMINAL_PORT || "6002");
+
+/**
+ * Guards against a second signal racing the shutdown already in flight. The
+ * first SIGTERM/SIGINT/SIGHUP runs the (bounded) cleanup; a second one short-
+ * circuits straight to exit so we can't double-run cleanup or hang.
+ */
+let shuttingDown = false;
+
+/**
+ * Hard ceiling on async cleanup during shutdown. The deploy stop phase
+ * (`scripts/deploy.ts` `PROCESS_STOP_TIMEOUT_MS`) SIGKILLs us at 10s; a
+ * SIGKILL can't release the instance lock or sockets. Cap cleanup well under
+ * that so we always reach the explicit `releaseInstanceLock()` + `exit(0)`.
+ */
+const SHUTDOWN_CLEANUP_TIMEOUT_MS = 7_000;
 
 /**
  * Check if the rdv CLI is installed and accessible.
@@ -107,30 +123,73 @@ async function startServer(): Promise<void> {
     .catch((error) => log.error("Failed to auto-start LiteLLM", { error: String(error) }));
 
   async function shutdown(signal: string): Promise<void> {
+    // A second signal while we're already tearing down must not re-run
+    // cleanup or wedge — force an immediate exit instead.
+    if (shuttingDown) {
+      log.warn("Second shutdown signal received during teardown — exiting now", { signal });
+      process.exit(0);
+    }
+    shuttingDown = true;
     log.info("Shutdown signal received", { signal });
 
-    updateScheduler.stop();
-    autoUpdateOrchestrator.stop();
-
+    // Synchronous stops — cheap, no awaits. Guarded so a synchronous throw
+    // here can't escape as an unhandledRejection (shutdown is async, invoked
+    // fire-and-forget from the signal handler) and skip the graceful tail
+    // below (terminal teardown + lock release + exit).
     try {
-      await schedulerOrchestrator.stop();
-      log.info("Scheduler stopped");
-    } catch (error) {
-      log.error("Error stopping scheduler", { error: String(error) });
+      updateScheduler.stop();
+      autoUpdateOrchestrator.stop();
+    } catch (err) {
+      log.error("Error during synchronous shutdown stops", { error: String(err) });
     }
 
-    try {
-      const { litellmProcessManager } = await import("../services/litellm-process-manager.js");
-      await litellmProcessManager.stop();
-    } catch (error) {
-      log.error("Error stopping LiteLLM", { error: String(error) });
+    // Bound the async cleanup so we ALWAYS reach the lock release + exit
+    // below within the deploy's 10s stop window. If a hung scheduler / proxy
+    // teardown blows past SHUTDOWN_CLEANUP_TIMEOUT_MS we stop waiting and
+    // proceed to exit anyway. A timeout here is far less harmful than being
+    // SIGKILLed (which orphans the instance lock + sockets).
+    const cleanup = (async () => {
+      try {
+        await schedulerOrchestrator.stop();
+        log.info("Scheduler stopped");
+      } catch (error) {
+        log.error("Error stopping scheduler", { error: String(error) });
+      }
+
+      try {
+        const { litellmProcessManager } = await import("../services/litellm-process-manager.js");
+        await litellmProcessManager.stop();
+      } catch (error) {
+        log.error("Error stopping LiteLLM", { error: String(error) });
+      }
+
+      try {
+        const { closeAnalyticsDatabase } = await import("../infrastructure/analytics/AnalyticsDatabase.js");
+        closeAnalyticsDatabase();
+      } catch { /* ignore */ }
+    })();
+
+    const { timedOut } = await withTimeout(cleanup, SHUTDOWN_CLEANUP_TIMEOUT_MS);
+    if (timedOut) {
+      log.warn("Shutdown cleanup exceeded timeout — exiting without finishing cleanup", {
+        timeoutMs: SHUTDOWN_CLEANUP_TIMEOUT_MS,
+      });
     }
 
+    // Tear down terminal connections (destroy PTYs, close WebSockets; tmux
+    // sessions are preserved). Synchronous + fast, so it runs OUTSIDE the
+    // bounded async race — this guarantees PTY teardown even if the async
+    // cleanup above timed out. terminal.ts no longer self-exits or traps
+    // signals; index.ts is the single shutdown authority (remote-dev-i85i).
     try {
-      const { closeAnalyticsDatabase } = await import("../infrastructure/analytics/AnalyticsDatabase.js");
-      closeAnalyticsDatabase();
-    } catch { /* ignore */ }
+      shutdownTerminalConnections();
+    } catch (e) {
+      log.error("Error during terminal connection cleanup", { error: String(e) });
+    }
 
+    // Always run these, even if cleanup timed out. `instance-lock.ts` also
+    // releases on `process.on("exit")`, so exit(0) is a backstop — but call
+    // it explicitly so a hung exit listener can't leave the lock orphaned.
     closeLogDatabase();
     releaseInstanceLock();
     process.exit(0);

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -2359,8 +2359,17 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
   return wss;
 }
 
-// Graceful shutdown: destroy PTY wrappers but preserve tmux sessions for reconnection
-function cleanup() {
+// Graceful shutdown of terminal connections: destroy PTY wrappers but preserve
+// tmux sessions for reconnection. Synchronous and fast.
+//
+// IMPORTANT: this MUST NOT call process.exit() and MUST NOT register its own
+// signal handlers. The terminal server's single shutdown authority is
+// `shutdown()` in src/server/index.ts (the sole entry point that imports this
+// module); it calls this function as part of its bounded teardown, then
+// releases the instance lock and exits. If this function exited the process
+// or trapped SIGTERM itself, it would run before index.ts's shutdown and skip
+// the lock release + bounded cleanup. See remote-dev-i85i.
+export function shutdownTerminalConnections(): void {
   log.info("Shutting down terminal server (tmux sessions preserved)...");
   for (const [id, conn] of connections) {
     cleanupVoiceFifo(conn);
@@ -2372,8 +2381,4 @@ function cleanup() {
   sessionConnections.clear();
   sessionPrimaryConnection.clear();
   sessionLastPromotionAt.clear();
-  process.exit(0);
 }
-
-process.on("SIGINT", cleanup);
-process.on("SIGTERM", cleanup);


### PR DESCRIPTION
Fixes **remote-dev-i85i** — production auto-deploy intermittently wedged (terminal socket never ready, rollback also failed, prod down; recovered only by a manual fresh `rdv:prod`). Recurring (also 05‑21).

## Root-cause findings
- **Blind by construction:** every layer discarded child stdio (`rdv.ts` `inherit` → login shell → `/api/deploy` spawns `deploy.ts` with `stdio:"ignore"`), and `logs.db` had zero entries in the failure window — so the terminal server's startup crash output went to `/dev/null`. We could not see *why* it failed.
- **Shutdown was unbounded *and* the wrong handler ran:** code review caught that `terminal.ts` registered a top-level `process.on("SIGTERM", cleanup)` that `process.exit(0)`s before `index.ts`'s handler — so any bounded-shutdown logic in `index.ts` was dead code on the deploy's SIGTERM.
- **Stale lock + sockets:** a SIGKILLed predecessor (force-killed at the 10s stop timeout) could orphan the new `instance.lock`; `deploy.ts` cleared stale sockets/PID files but not the lock.

## What this changes
- **Capture startup logs (the key enabler):** `rdv.ts` prod redirects terminal + Next.js stdout/stderr to append-only `~/.remote-dev/logs/{terminal,nextjs}.log` with a per-restart banner; **falls back to `inherit`** if the log file can't be opened (never aborts a healthy start); closes the parent fd after spawn. Dev keeps `inherit`.
- **Single, bounded shutdown authority:** `terminal.ts`'s self-registered SIGINT/SIGTERM handlers are removed; its teardown is exported as `shutdownTerminalConnections()`. `index.ts`'s `shutdown()` is now the only handler — guards re-entry, bounds async orchestrator cleanup to 7s via `withTimeout`, then always tears down PTYs, closes DBs, releases the instance lock, and exits 0 within the deploy's 10s window.
- **Ownership-checked lock cleanup:** `deploy.ts` stop phase unlinks `instance.lock` only when it's same-host **and** the holder PID is dead (EPERM-as-alive, mirroring `instance-lock.ts`); a live owner is preserved. Neutralizes the orphaned-lock hazard regardless of why the old server died.

## Key decisions
- `deploy.ts` lock cleanup uses `isLockHolderAlive` (EPERM ⇒ alive), deliberately **not** `isProcessRunning` (EPERM ⇒ dead), so it never deletes a live lock held by another user.
- The bounded shutdown is defense-in-depth; the lock cleanup is what actually removes the hazard, so this is robust even if the still-unknown forward-start transient recurs — which the new log capture will finally make diagnosable.

## Test plan
- Local scratch-`RDV_DATA_DIR` validation: **empirically confirmed** index.ts `shutdown()` now runs on SIGTERM (its log line + lock removal fire; terminal.ts cleanup never did either), clean exit ~178ms; child stdio captured to the log files; stale dead-pid lock reclaimed on start; `deploy.ts` unlink removes a dead-owner lock but **preserves** a live-owner lock (incl. EPERM case).
- `bun run typecheck` ✓ 0 errors · `bun run lint` ✓ 0 errors · `bun run test:run` ✓ 1334 passed / 8 skipped.

## Note on rollout
Production currently runs `5279e46` (manually restarted). Deploying this exercises the same stop→start path that failed; the residual pre-existing forward-start risk remains, but this deploy is the first one that will **capture** the cause if it recurs, and the lock cleanup keeps the restart clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)