### PR TITLE
fix(prod): instance lock no-ops single-host + readyz checks terminal over unix socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Instance lock no longer deadlocks single-host restarts** (remote-dev-i85i):
+  the `instance.lock` data-dir guard now engages ONLY in multi-instance mode
+  (non-empty `RDV_BASE_PATH`), or when forced via `RDV_FORCE_INSTANCE_LOCK=1`.
+  On single-host (dev, Electron, self-hosted single-tenant prod) it is a no-op
+  and never touches the lock file. Previously a watchdog/`rdv.ts`/`deploy.ts`
+  restart — which spawns the new terminal server while the old one is briefly
+  still alive — hit `acquireInstanceLock()`, saw the live holder, and refused
+  to start, crash-looping until the 5-minute age-reclaim (which then left two
+  live writers on one data dir). Process management is the real single-writer
+  guard on single-host, so the lock was pure harm there.
+- **Readiness probe checks the terminal server over its Unix socket in prod**
+  (remote-dev-i85i): `GET /api/readyz` previously always probed
+  `http://127.0.0.1:$TERMINAL_PORT/health`, but production runs the terminal
+  server on a Unix socket (`TERMINAL_SOCKET`), so the check always failed and
+  `/readyz` falsely returned 503 even when the terminal server was healthy. It
+  now reaches `/health` over the Unix socket when `TERMINAL_SOCKET` is set
+  (via `node:http`, matching `scheduler-client.ts`), falling back to the TCP
+  port in dev. Same 1s timeout and `{ ok, error }` result shape.
 - **Production deploy/restart resilience** (remote-dev-i85i): auto-deploy
   restarts could wedge with "Terminal socket not ready" and were
   undiagnosable because all child stdio was discarded. Three fixes: (1)

--- a/docs/MULTI_INSTANCE.md
+++ b/docs/MULTI_INSTANCE.md
@@ -379,6 +379,16 @@ body in the 503 response identifies which check failed.
   live PID holds it. This catches accidental misconfiguration (two pods
   sharing a PVC via a non-RWO mount) but is not kernel-enforced. ReadWriteOnce
   PVCs are the real isolation guarantee.
+
+  The lock engages **only in multi-instance mode** — i.e. when `RDV_BASE_PATH`
+  is non-empty (as in every manifest above). In single-host mode (empty
+  `RDV_BASE_PATH`: dev, Electron, self-hosted single-tenant prod) it is a no-op:
+  there, the launchd/systemd watchdog and the deploy/restart scripts are the
+  single-writer guard, and an engaged lock would deadlock a restart (the new
+  server sees the old one's still-live lock and crash-loops). Set
+  `RDV_FORCE_INSTANCE_LOCK=1` to force the lock on even with an empty
+  `RDV_BASE_PATH` — for the unusual single-host setup that genuinely runs
+  multiple writers against one `RDV_DATA_DIR`.
 - **No horizontal scale per instance.** SQLite is single-writer. Use
   more instances under different prefixes if you need to spread load.
 - **tmux sockets on PVC.** `entrypoint.sh` sets `TMUX_TMPDIR` under

--- a/src/app/api/readyz/__tests__/route.test.ts
+++ b/src/app/api/readyz/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
 
 // Mock the DB and exec helpers before importing the route handler so the
 // handler closes over the mocks. `db.run` returns a libsql ResultSet; we
@@ -10,6 +11,16 @@ vi.mock("@/db", () => ({
 }));
 vi.mock("@/lib/exec", () => ({
   execFile: vi.fn(),
+}));
+
+// The route picks its transport (Unix socket vs TCP) from env at call time:
+// `TERMINAL_SOCKET` → `node:http` request; else `TERMINAL_PORT` → fetch. We
+// mock `http.request` so the socket-mode tests are hermetic, and stub `fetch`
+// for the TCP-mode tests. Mock `node:http` before importing the route.
+const httpRequestMock = vi.fn();
+vi.mock("node:http", () => ({
+  default: { request: (...args: unknown[]) => httpRequestMock(...args) },
+  request: (...args: unknown[]) => httpRequestMock(...args),
 }));
 
 import { db } from "@/db";
@@ -26,6 +37,9 @@ const mockedExecFile = vi.mocked(execFile);
 const fetchMock = vi.fn();
 vi.stubGlobal("fetch", fetchMock);
 
+const ORIGINAL_TERMINAL_SOCKET = process.env.TERMINAL_SOCKET;
+const ORIGINAL_TERMINAL_PORT = process.env.TERMINAL_PORT;
+
 function mockTerminalHealthy(): void {
   fetchMock.mockResolvedValue(new Response(JSON.stringify({ status: "ok" }), { status: 200 }));
 }
@@ -38,17 +52,74 @@ function mockTerminalUnhealthyStatus(status: number): void {
   fetchMock.mockResolvedValue(new Response("", { status }));
 }
 
-describe("GET /api/readyz", () => {
-  beforeEach(() => {
-    mockedDbRun.mockReset();
-    mockedExecFile.mockReset();
-    fetchMock.mockReset();
+/**
+ * Build a fake `http.ClientRequest` whose response emits `statusCode` then
+ * ends. `httpRequestMock` invokes the route's response callback with it.
+ *
+ * Behaviors (mutually exclusive):
+ *   - `error`: the request emits `error` instead of responding.
+ *   - `fireTimeout`: simulate a wedged server. `req.setTimeout(ms, cb)` captures
+ *     `cb` and invokes it synchronously on `req.end()` (the idle timeout firing);
+ *     no response is ever produced, so `"end"` never emits.
+ *   - otherwise: the response emits `statusCode` then ends.
+ */
+function stubHttpRequest(opts: { statusCode?: number; error?: Error; fireTimeout?: boolean }): void {
+  httpRequestMock.mockImplementation((_options: unknown, cb?: (res: EventEmitter) => void) => {
+    let timeoutCb: (() => void) | undefined;
+    const req = new EventEmitter() as EventEmitter & {
+      setTimeout: (ms: number, fn: () => void) => void;
+      destroy: () => void;
+      end: () => void;
+    };
+    req.setTimeout = (_ms: number, fn: () => void) => {
+      // Capture so a wedged-server test can fire the production timeout branch.
+      timeoutCb = fn;
+    };
+    req.destroy = () => {};
+    req.end = () => {
+      if (opts.fireTimeout) {
+        // Wedged server: the idle timeout fires and no response ever arrives.
+        timeoutCb?.();
+        return;
+      }
+      queueMicrotask(() => {
+        if (opts.error) {
+          req.emit("error", opts.error);
+          return;
+        }
+        const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+        res.statusCode = opts.statusCode ?? 200;
+        cb?.(res);
+        // Emit a chunk before "end" so the production drain handler
+        // (`res.on("data", ...)`) is exercised. Valid for every status; only
+        // the 2xx path's outcome is asserted, so this is purely coverage.
+        res.emit("data", Buffer.from("{}"));
+        res.emit("end");
+      });
+    };
+    return req;
   });
+}
 
-  afterEach(() => {
-    // No-op for now; stubGlobal persists across this describe block, which
-    // is the intent (every test mocks fetch). If a later suite needs the
-    // real fetch back, add `vi.unstubAllGlobals()` here.
+beforeEach(() => {
+  mockedDbRun.mockReset();
+  mockedExecFile.mockReset();
+  fetchMock.mockReset();
+  httpRequestMock.mockReset();
+});
+
+afterEach(() => {
+  if (ORIGINAL_TERMINAL_SOCKET === undefined) delete process.env.TERMINAL_SOCKET;
+  else process.env.TERMINAL_SOCKET = ORIGINAL_TERMINAL_SOCKET;
+  if (ORIGINAL_TERMINAL_PORT === undefined) delete process.env.TERMINAL_PORT;
+  else process.env.TERMINAL_PORT = ORIGINAL_TERMINAL_PORT;
+});
+
+describe("GET /api/readyz — TCP/port mode (dev)", () => {
+  beforeEach(() => {
+    // Force the fetch/TCP path: no socket, explicit port.
+    delete process.env.TERMINAL_SOCKET;
+    process.env.TERMINAL_PORT = "6002";
   });
 
   it("returns 200 with checks=true when DB, tmux, and terminal are healthy", async () => {
@@ -63,6 +134,8 @@ describe("GET /api/readyz", () => {
     expect(body.checks.db.ok).toBe(true);
     expect(body.checks.tmux.ok).toBe(true);
     expect(body.checks.terminal.ok).toBe(true);
+    // Confirm we used the TCP path, not the socket path.
+    expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:6002/health", expect.anything());
   });
 
   it("returns 503 when the DB probe fails", async () => {
@@ -131,5 +204,74 @@ describe("GET /api/readyz", () => {
     expect(response.status).toBe(503);
     const body = (await response.json()) as { ready: boolean };
     expect(body.ready).toBe(false);
+  });
+});
+
+describe("GET /api/readyz — Unix socket mode (prod)", () => {
+  beforeEach(() => {
+    // Force the socket path: TERMINAL_SOCKET set takes precedence.
+    process.env.TERMINAL_SOCKET = "/tmp/rdv-test/terminal.sock";
+    delete process.env.TERMINAL_PORT;
+  });
+
+  it("checks /health over the unix socket and returns 200 when healthy", async () => {
+    mockedDbRun.mockResolvedValue(undefined as never);
+    mockedExecFile.mockResolvedValue({ stdout: "tmux 3.4", stderr: "", exitCode: 0 });
+    stubHttpRequest({ statusCode: 200 });
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { ready: boolean; checks: Record<string, { ok: boolean }> };
+    expect(body.ready).toBe(true);
+    expect(body.checks.terminal.ok).toBe(true);
+    // fetch must NOT be used in socket mode; http.request must be, with the
+    // socketPath + /health.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(httpRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({ socketPath: "/tmp/rdv-test/terminal.sock", path: "/health" }),
+      expect.any(Function),
+    );
+  });
+
+  it("returns 503 when the terminal socket connection errors", async () => {
+    mockedDbRun.mockResolvedValue(undefined as never);
+    mockedExecFile.mockResolvedValue({ stdout: "tmux 3.4", stderr: "", exitCode: 0 });
+    stubHttpRequest({ error: new Error("ENOENT: socket missing") });
+
+    const response = await GET();
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as { ready: boolean; checks: Record<string, { ok: boolean; error?: string }> };
+    expect(body.ready).toBe(false);
+    expect(body.checks.terminal.ok).toBe(false);
+    expect(body.checks.terminal.error).toContain("ENOENT");
+  });
+
+  it("socket mode: a wedged terminal server (timeout) reports not-ready", async () => {
+    mockedDbRun.mockResolvedValue(undefined as never);
+    mockedExecFile.mockResolvedValue({ stdout: "tmux 3.4", stderr: "", exitCode: 0 });
+    // Wedged server: connection opens but no response ever arrives, so the
+    // 1s idle timeout fires. `fireTimeout` invokes the captured `setTimeout`
+    // callback synchronously; the fake response never emits "end".
+    stubHttpRequest({ fireTimeout: true });
+
+    const response = await GET();
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as { ready: boolean; checks: Record<string, { ok: boolean; error?: string }> };
+    expect(body.ready).toBe(false);
+    expect(body.checks.terminal.ok).toBe(false);
+    expect(body.checks.terminal.error).toContain("timed out");
+  });
+
+  it("returns 503 when the terminal server returns a non-200 over the socket", async () => {
+    mockedDbRun.mockResolvedValue(undefined as never);
+    mockedExecFile.mockResolvedValue({ stdout: "tmux 3.4", stderr: "", exitCode: 0 });
+    stubHttpRequest({ statusCode: 503 });
+
+    const response = await GET();
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as { ready: boolean; checks: Record<string, { ok: boolean; error?: string }> };
+    expect(body.ready).toBe(false);
+    expect(body.checks.terminal.ok).toBe(false);
+    expect(body.checks.terminal.error).toContain("HTTP 503");
   });
 });

--- a/src/app/api/readyz/route.ts
+++ b/src/app/api/readyz/route.ts
@@ -16,6 +16,7 @@
  */
 
 import { NextResponse } from "next/server";
+import http from "node:http";
 import { sql } from "drizzle-orm";
 import { db } from "@/db";
 import { execFile } from "@/lib/exec";
@@ -23,26 +24,60 @@ import { execFile } from "@/lib/exec";
 // Disable static optimization — probes must run fresh per request.
 export const dynamic = "force-dynamic";
 
+const TERMINAL_CHECK_TIMEOUT_MS = 1000;
+
 interface CheckResult {
   ok: boolean;
   error?: string;
 }
 
 /**
- * Probe the terminal server on loopback. Without this, the terminal server
- * can be dead (crashed, OOM-killed, mid-restart) while the Next.js process
- * is still healthy — readiness would say "ready" and the LB would route
- * session-create requests that immediately fail. We hit the terminal
- * server's `/health` endpoint (see `src/server/terminal.ts:632`) with a
- * 1s timeout so a wedged terminal server is detected quickly.
- *
- * Uses `127.0.0.1` rather than `localhost` to avoid IPv6/IPv4 resolution
- * surprises in container DNS (some images don't have IPv6 enabled).
+ * GET `/health` over a Unix socket. Production runs the terminal server on a
+ * Unix socket (`TERMINAL_SOCKET`), not a TCP port — `fetch()` can't address a
+ * Unix socket cleanly, so we use `node:http` with `socketPath` (same approach
+ * as `src/lib/scheduler-client.ts`). A non-2xx response or any transport
+ * error resolves to `{ ok: false }`; a 1s timeout guards a wedged server.
  */
-async function checkTerminalServer(): Promise<CheckResult> {
-  const port = process.env.TERMINAL_PORT ?? "6002";
+function healthOverSocket(socketPath: string): Promise<CheckResult> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (result: CheckResult): void => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    const req = http.request({ socketPath, path: "/health", method: "GET" }, (res) => {
+      // Drain so the socket can close cleanly.
+      res.on("data", () => {});
+      res.on("end", () => {
+        const status = res.statusCode ?? 0;
+        if (status >= 200 && status < 300) {
+          settle({ ok: true });
+        } else {
+          settle({ ok: false, error: `terminal server returned HTTP ${status}` });
+        }
+      });
+    });
+    req.setTimeout(TERMINAL_CHECK_TIMEOUT_MS, () => {
+      req.destroy();
+      settle({ ok: false, error: "terminal server health check timed out" });
+    });
+    req.on("error", (err) => {
+      req.destroy();
+      settle({ ok: false, error: String(err) });
+    });
+    req.end();
+  });
+}
+
+/**
+ * GET `/health` over a TCP loopback port (development mode). Uses `127.0.0.1`
+ * rather than `localhost` to avoid IPv6/IPv4 resolution surprises in container
+ * DNS (some images don't have IPv6 enabled).
+ */
+async function healthOverPort(port: string): Promise<CheckResult> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 1000);
+  const timeout = setTimeout(() => controller.abort(), TERMINAL_CHECK_TIMEOUT_MS);
   try {
     const res = await fetch(`http://127.0.0.1:${port}/health`, { signal: controller.signal });
     if (!res.ok) {
@@ -54,6 +89,28 @@ async function checkTerminalServer(): Promise<CheckResult> {
   } finally {
     clearTimeout(timeout);
   }
+}
+
+/**
+ * Probe the terminal server. Without this, the terminal server can be dead
+ * (crashed, OOM-killed, mid-restart) while the Next.js process is still
+ * healthy — readiness would say "ready" and the LB would route session-create
+ * requests that immediately fail. We hit the terminal server's `/health`
+ * endpoint (see `src/server/terminal.ts`) with a 1s timeout so a wedged
+ * terminal server is detected quickly.
+ *
+ * Transport selection mirrors the rest of the codebase (scheduler-client.ts,
+ * terminal-server-url.ts): prod runs on a Unix socket (`TERMINAL_SOCKET`), dev
+ * on a TCP port (`TERMINAL_PORT`). Previously this always used the TCP port,
+ * so prod readiness falsely reported 503 even when the terminal server was up.
+ */
+async function checkTerminalServer(): Promise<CheckResult> {
+  const socketPath = process.env.TERMINAL_SOCKET;
+  if (socketPath) {
+    return healthOverSocket(socketPath);
+  }
+  const port = process.env.TERMINAL_PORT ?? "6002";
+  return healthOverPort(port);
 }
 
 export async function GET(): Promise<NextResponse> {

--- a/src/lib/__tests__/instance-lock.test.ts
+++ b/src/lib/__tests__/instance-lock.test.ts
@@ -1,27 +1,28 @@
 /**
  * Tests for `src/lib/instance-lock.ts`.
  *
- * The module reads `getDataDir()` lazily inside `acquireInstanceLock()`,
- * so we can swap `RDV_DATA_DIR` to a per-test tmpdir without `vi.resetModules`.
+ * The lock only engages in multi-instance mode (non-empty `RDV_BASE_PATH`) or
+ * when `RDV_FORCE_INSTANCE_LOCK=1`. `BASE_PATH` is read once at
+ * `src/lib/base-path.ts` load, so to exercise both modes we set
+ * `RDV_BASE_PATH` BEFORE a fresh dynamic import via `vi.resetModules()` (same
+ * approach as `base-path.test.ts`). `loadLock()` returns a fresh
+ * `instance-lock` module bound to the requested env.
  *
- * We hand-craft lock files in the expected JSON format to simulate
- * cross-pod / cross-host scenarios that can't be reproduced by simply
- * running `acquireInstanceLock()` twice.
+ * `RDV_DATA_DIR` is still swapped to a per-test tmpdir. We hand-craft lock
+ * files in the expected JSON format to simulate cross-pod / cross-host
+ * scenarios that can't be reproduced by simply running `acquireInstanceLock()`
+ * twice.
  */
 
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { hostname as osHostname } from "node:os";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-
-import {
-  __resetInstanceLockForTests,
-  acquireInstanceLock,
-  releaseInstanceLock,
-} from "../instance-lock";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ORIGINAL_DATA_DIR = process.env.RDV_DATA_DIR;
+const ORIGINAL_BASE_PATH = process.env.RDV_BASE_PATH;
+const ORIGINAL_FORCE_LOCK = process.env.RDV_FORCE_INSTANCE_LOCK;
 
 let testDir: string;
 let lockPath: string;
@@ -33,6 +34,8 @@ interface LockRecord {
   writerNonce: string;
 }
 
+type InstanceLockModule = typeof import("../instance-lock");
+
 function writeLock(record: LockRecord): void {
   writeFileSync(lockPath, JSON.stringify(record), { mode: 0o600 });
 }
@@ -41,22 +44,64 @@ function readLock(): LockRecord {
   return JSON.parse(readFileSync(lockPath, "utf-8")) as LockRecord;
 }
 
+function restoreEnv(key: string, original: string | undefined): void {
+  if (original === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = original;
+  }
+}
+
+/**
+ * Load a fresh `instance-lock` module after setting the lock-mode env vars.
+ * `basePath` controls multi-instance vs single-host; `forceLock` toggles the
+ * `RDV_FORCE_INSTANCE_LOCK` escape hatch. Both are read at module load.
+ */
+async function loadLock(opts: {
+  basePath?: string;
+  forceLock?: boolean;
+}): Promise<InstanceLockModule> {
+  vi.resetModules();
+  if (opts.basePath === undefined) delete process.env.RDV_BASE_PATH;
+  else process.env.RDV_BASE_PATH = opts.basePath;
+  if (opts.forceLock) process.env.RDV_FORCE_INSTANCE_LOCK = "1";
+  else delete process.env.RDV_FORCE_INSTANCE_LOCK;
+  const mod = await import("../instance-lock");
+  mod.__resetInstanceLockForTests();
+  return mod;
+}
+
+// Each fresh `instance-lock` module (one per `loadLock()`) registers its own
+// process `exit` / `uncaughtException` listeners on first successful acquire.
+// Across many cases these would accumulate and trip Node's
+// MaxListenersExceededWarning, so we snapshot the baseline and prune anything
+// the module-under-test added after each case.
+const baselineListeners = {
+  exit: process.listeners("exit"),
+  uncaughtException: process.listeners("uncaughtException"),
+};
+
+function pruneAddedProcessListeners(): void {
+  for (const l of process.listeners("exit")) {
+    if (!baselineListeners.exit.includes(l)) process.off("exit", l);
+  }
+  for (const l of process.listeners("uncaughtException")) {
+    if (!baselineListeners.uncaughtException.includes(l)) process.off("uncaughtException", l);
+  }
+}
+
 beforeEach(() => {
   testDir = mkdtempSync(join(tmpdir(), "rdv-lock-test-"));
   lockPath = join(testDir, "instance.lock");
   process.env.RDV_DATA_DIR = testDir;
-  // Make sure no prior test leaked a lock into this module instance.
-  __resetInstanceLockForTests();
 });
 
 afterEach(() => {
-  releaseInstanceLock();
-  __resetInstanceLockForTests();
-  if (ORIGINAL_DATA_DIR === undefined) {
-    delete process.env.RDV_DATA_DIR;
-  } else {
-    process.env.RDV_DATA_DIR = ORIGINAL_DATA_DIR;
-  }
+  restoreEnv("RDV_DATA_DIR", ORIGINAL_DATA_DIR);
+  restoreEnv("RDV_BASE_PATH", ORIGINAL_BASE_PATH);
+  restoreEnv("RDV_FORCE_INSTANCE_LOCK", ORIGINAL_FORCE_LOCK);
+  pruneAddedProcessListeners();
+  vi.resetModules();
   try {
     rmSync(testDir, { recursive: true, force: true });
   } catch {
@@ -64,8 +109,62 @@ afterEach(() => {
   }
 });
 
-describe("instance-lock — basic acquire/release", () => {
-  it("creates the lock file with our PID + hostname on acquire", () => {
+describe("instance-lock — single-host mode (empty RDV_BASE_PATH)", () => {
+  it("acquire is a no-op: writes no lock file", async () => {
+    const { acquireInstanceLock } = await loadLock({ basePath: "" });
+    acquireInstanceLock();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("does NOT throw even when a live-looking lock file already exists (no deadlock)", async () => {
+    // This is the prod deadlock scenario: the watchdog restart spawns a new
+    // server while the old one's lock is still present with a live PID. In
+    // single-host mode this MUST NOT refuse to start.
+    writeLock({
+      pid: process.pid === 1 ? 2 : 1, // PID 1 (init) is guaranteed alive
+      hostname: osHostname(),
+      startedAt: new Date().toISOString(), // fresh — would block in multi-instance
+      writerNonce: "live-but-single-host",
+    });
+    const { acquireInstanceLock } = await loadLock({ basePath: "" });
+    expect(() => acquireInstanceLock()).not.toThrow();
+    // The pre-existing file is left untouched — we never read or write it.
+    expect(readLock().writerNonce).toBe("live-but-single-host");
+  });
+
+  it("release is a harmless no-op when nothing was acquired", async () => {
+    const { acquireInstanceLock, releaseInstanceLock } = await loadLock({ basePath: "" });
+    acquireInstanceLock();
+    expect(() => releaseInstanceLock()).not.toThrow();
+  });
+
+  it("engages when RDV_FORCE_INSTANCE_LOCK=1 even with no basePath", async () => {
+    const { acquireInstanceLock } = await loadLock({ basePath: "", forceLock: true });
+    acquireInstanceLock();
+    expect(existsSync(lockPath)).toBe(true);
+    const record = readLock();
+    expect(record.pid).toBe(process.pid);
+    expect(record.hostname).toBe(osHostname());
+  });
+
+  it("forced lock still refuses a live same-host conflict", async () => {
+    const otherPid = process.pid === 1 ? 2 : 1;
+    const fresh: LockRecord = {
+      pid: otherPid,
+      hostname: osHostname(),
+      startedAt: new Date().toISOString(),
+      writerNonce: "forced-live-conflict",
+    };
+    writeLock(fresh);
+    const { acquireInstanceLock } = await loadLock({ basePath: "", forceLock: true });
+    expect(() => acquireInstanceLock()).toThrow(/Instance lock/);
+    expect(readLock()).toEqual(fresh);
+  });
+});
+
+describe("instance-lock — multi-instance basic acquire/release (RDV_BASE_PATH set)", () => {
+  it("creates the lock file with our PID + hostname on acquire", async () => {
+    const { acquireInstanceLock } = await loadLock({ basePath: "/alpha" });
     acquireInstanceLock();
     expect(existsSync(lockPath)).toBe(true);
     const record = readLock();
@@ -76,7 +175,8 @@ describe("instance-lock — basic acquire/release", () => {
     expect(record.writerNonce.length).toBeGreaterThan(0);
   });
 
-  it("is idempotent within the same process", () => {
+  it("is idempotent within the same process", async () => {
+    const { acquireInstanceLock } = await loadLock({ basePath: "/alpha" });
     acquireInstanceLock();
     const firstNonce = readLock().writerNonce;
     // Second call must not throw or rewrite a different record.
@@ -84,7 +184,8 @@ describe("instance-lock — basic acquire/release", () => {
     expect(readLock().writerNonce).toBe(firstNonce);
   });
 
-  it("releases the lock cleanly, allowing re-acquisition", () => {
+  it("releases the lock cleanly, allowing re-acquisition", async () => {
+    const { acquireInstanceLock, releaseInstanceLock } = await loadLock({ basePath: "/alpha" });
     acquireInstanceLock();
     expect(existsSync(lockPath)).toBe(true);
     releaseInstanceLock();
@@ -93,15 +194,16 @@ describe("instance-lock — basic acquire/release", () => {
     expect(existsSync(lockPath)).toBe(true);
   });
 
-  it("release is safe to call multiple times", () => {
+  it("release is safe to call multiple times", async () => {
+    const { acquireInstanceLock, releaseInstanceLock } = await loadLock({ basePath: "/alpha" });
     acquireInstanceLock();
     releaseInstanceLock();
     expect(() => releaseInstanceLock()).not.toThrow();
   });
 });
 
-describe("instance-lock — stale lock detection", () => {
-  it("reclaims a stale lock left behind by a dead PID on the same host", () => {
+describe("instance-lock — multi-instance stale lock detection (RDV_BASE_PATH set)", () => {
+  it("reclaims a stale lock left behind by a dead PID on the same host", async () => {
     // PID 99999999 almost certainly isn't running.
     writeLock({
       pid: 99999999,
@@ -109,35 +211,38 @@ describe("instance-lock — stale lock detection", () => {
       startedAt: new Date().toISOString(),
       writerNonce: "stale-dead-pid",
     });
+    const { acquireInstanceLock } = await loadLock({ basePath: "/alpha" });
     expect(() => acquireInstanceLock()).not.toThrow();
     const record = readLock();
     expect(record.pid).toBe(process.pid);
     expect(record.hostname).toBe(osHostname());
   });
 
-  it("reclaims a lock with malformed/unreadable JSON", () => {
+  it("reclaims a lock with malformed/unreadable JSON", async () => {
     writeFileSync(lockPath, "not-valid-json{{{");
+    const { acquireInstanceLock } = await loadLock({ basePath: "/alpha" });
     expect(() => acquireInstanceLock()).not.toThrow();
     const record = readLock();
     expect(record.pid).toBe(process.pid);
   });
 
-  it("reclaims a same-host lock that has aged out (>5 min)", () => {
-    // Use our own PID — which IS alive — but with an old startedAt. The
-    // aged-out branch should let us take over because real container
-    // restarts on the same node can present this exact pattern (tini-as-1
-    // is always alive in a fresh PID namespace).
+  it("reclaims a same-host lock that has aged out (>5 min)", async () => {
+    // Use a live PID (init) but with an old startedAt. The aged-out branch
+    // should let us take over because real container restarts on the same
+    // node can present this exact pattern (tini-as-1 is always alive in a
+    // fresh PID namespace).
     writeLock({
       pid: process.pid === 1 ? 2 : 1, // PID 1 (init/tini) is always alive
       hostname: osHostname(),
       startedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(), // 1h ago
       writerNonce: "stale-by-age",
     });
+    const { acquireInstanceLock } = await loadLock({ basePath: "/alpha" });
     expect(() => acquireInstanceLock()).not.toThrow();
     expect(readLock().pid).toBe(process.pid);
   });
 
-  it("reclaims a lock from a different hostname (cross-pod restart)", () => {
+  it("reclaims a lock from a different hostname (cross-pod restart)", async () => {
     // K8s scenario: previous pod's terminal server (PID 7 in its PID
     // namespace) crashed without cleanup. New pod starts with a fresh PID
     // namespace; PID 7 may or may not be alive in the new namespace. The
@@ -148,13 +253,14 @@ describe("instance-lock — stale lock detection", () => {
       startedAt: new Date().toISOString(), // fresh — would block on same host
       writerNonce: "stale-by-host",
     });
+    const { acquireInstanceLock } = await loadLock({ basePath: "/alpha" });
     expect(() => acquireInstanceLock()).not.toThrow();
     const record = readLock();
     expect(record.pid).toBe(process.pid);
     expect(record.hostname).toBe(osHostname());
   });
 
-  it("refuses to start when a same-host PID is alive and recent", () => {
+  it("refuses to start when a same-host PID is alive and recent", async () => {
     // Use a PID guaranteed to be alive (PID 1 = init) and a fresh startedAt.
     // This is the genuine "another rdv is running" case and we must refuse.
     const otherPid = process.pid === 1 ? 2 : 1;
@@ -165,14 +271,16 @@ describe("instance-lock — stale lock detection", () => {
       writerNonce: "live-conflict",
     };
     writeLock(fresh);
+    const { acquireInstanceLock } = await loadLock({ basePath: "/alpha" });
     expect(() => acquireInstanceLock()).toThrow(/Instance lock/);
     // The existing record must not have been overwritten.
     expect(readLock()).toEqual(fresh);
   });
 });
 
-describe("instance-lock — defensive release", () => {
-  it("release does not delete the lock file if its nonce is no longer ours", () => {
+describe("instance-lock — defensive release (RDV_BASE_PATH set)", () => {
+  it("release does not delete the lock file if its nonce is no longer ours", async () => {
+    const { acquireInstanceLock, releaseInstanceLock } = await loadLock({ basePath: "/alpha" });
     acquireInstanceLock();
     // Simulate another writer winning a TOCTOU race by hand-overwriting
     // the file with a fresh record. `releaseInstanceLock` should NOT

--- a/src/lib/instance-lock.ts
+++ b/src/lib/instance-lock.ts
@@ -7,6 +7,28 @@
  * pods from mounting concurrently — this is a belt-and-suspenders sentinel
  * for non-K8s deployments and for the brief overlap during pod restarts.
  *
+ * ## When the lock engages
+ *
+ * The lock ONLY engages in **multi-instance mode** — i.e. when `RDV_BASE_PATH`
+ * is non-empty (the env var that gives each co-hosted instance its own URL
+ * prefix). In **single-host mode** (empty `RDV_BASE_PATH`: dev, Electron, and
+ * self-hosted single-tenant prod) `acquireInstanceLock()` is a no-op and never
+ * touches the lock file.
+ *
+ * Why: on single-host the lock is pure harm. The launchd/systemd watchdog and
+ * the deploy/restart scripts (`rdv.ts`, `deploy.ts`) are the real single-writer
+ * guard there — and they restart by killing the old server and re-spawning. A
+ * restart momentarily has the old terminal server still alive while the new one
+ * starts; with the lock engaged the new server's `acquireInstanceLock()` saw
+ * the still-live holder and refused to start, crash-looping until the 5-min
+ * age-reclaim — which then left TWO live writers on one data dir. The
+ * `BASE_PATH === ""` gate disables the lock in exactly the deployments where it
+ * caused this deadlock and adds no value. See remote-dev-i85i.
+ *
+ * Escape hatch: set `RDV_FORCE_INSTANCE_LOCK=1` to engage the lock even with an
+ * empty `RDV_BASE_PATH` (tests, or unusual single-host setups that genuinely
+ * run multiple writers against one data dir).
+ *
  * ## Lock-file format
  *
  * The lock file at `${RDV_DATA_DIR}/instance.lock` is a JSON record:
@@ -58,6 +80,7 @@ import { hostname as osHostname } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 
+import { BASE_PATH } from "@/lib/base-path";
 import { createLogger } from "@/lib/logger";
 import { getDataDir } from "@/lib/paths";
 
@@ -171,6 +194,18 @@ function registerProcessHandlers(): void {
  * no-op.
  */
 export function acquireInstanceLock(): void {
+  // Single-host mode (empty RDV_BASE_PATH): the lock is pure harm — process
+  // management is the real single-writer guard, and the lock would deadlock
+  // watchdog/deploy restarts. No-op without reading or writing the lock file.
+  // RDV_FORCE_INSTANCE_LOCK=1 forces it on (tests / unusual setups).
+  // BASE_PATH is resolved once at module load (see base-path.ts), so multi-instance
+  // deployments must set RDV_BASE_PATH in the real process env (k8s/Docker/entrypoint),
+  // not .env.local — same requirement as every other BASE_PATH consumer.
+  if (BASE_PATH === "" && process.env.RDV_FORCE_INSTANCE_LOCK !== "1") {
+    log.info("Instance lock skipped (single-host mode; set RDV_FORCE_INSTANCE_LOCK=1 to force)");
+    return;
+  }
+
   if (heldRecord !== null) {
     return; // already held in this process
   }


### PR DESCRIPTION
## Summary

Real root-cause fix for the recurring multi-minute production outages on the self-hosted single-host deployment (`dev.bryanli.net`). Two independent bugs, both surfaced by the deploy-observability work in #307:

1. **`instance.lock` deadlocked single-host restarts.** The lock (`src/lib/instance-lock.ts`, a k8s multi-pod single-writer guard acquired at the top of `src/server/index.ts`) has no place on a single host. On restart, the watchdog/deploy kills the old server and spawns a new one; the new server's `acquireInstanceLock()` saw the **still-alive prior holder** and refused to start → `tsx exited 1` → watchdog retried → crash-loop. It only self-healed after the 5-minute `STALE_LOCK_THRESHOLD_MS` age-reclaim — which then left **two live writers** on one data dir (exactly the corruption the lock was meant to prevent).

2. **`/api/readyz` falsely reported 503 in prod.** `checkTerminalServer()` probed the terminal server over TCP (`127.0.0.1:$TERMINAL_PORT`), but prod runs it on a **Unix socket** (`TERMINAL_SOCKET`). So readiness reported the terminal server down even when it was healthy.

## Changes

- **`src/lib/instance-lock.ts`** — `acquireInstanceLock()` early-returns a no-op when `BASE_PATH === "" && process.env.RDV_FORCE_INSTANCE_LOCK !== "1"` (single-host mode: dev, Electron, self-hosted single-tenant prod). `BASE_PATH` is read through `@/lib/base-path` (single source of truth). The lock still engages in **multi-instance mode** (non-empty `RDV_BASE_PATH`, e.g. k3s `/alpha`), preserving the dual-writer guard it was built for. Escape hatch: `RDV_FORCE_INSTANCE_LOCK=1`.
- **`src/app/api/readyz/route.ts`** — `checkTerminalServer()` now branches on `TERMINAL_SOCKET`: `healthOverSocket()` uses `node:http` `request({socketPath, path:"/health"})` (mirrors `scheduler-client.ts`); `healthOverPort()` keeps the dev TCP `fetch` path. Same 1s timeout and `{ok,error}` shape. A one-shot `settled` guard ensures the Promise resolves exactly once (timeout/error/end races) and the request is destroyed on error.
- **Tests** — `instance-lock.test.ts` rebuilt around `vi.resetModules()` + dynamic import to vary `RDV_BASE_PATH`; new cases for single-host no-op (no lock file written, no deadlock with a live-looking lock present), `RDV_FORCE_INSTANCE_LOCK=1`, and the preserved multi-instance acquire/refuse/stale-reclaim path. `readyz/route.test.ts` split into TCP-mode and Unix-socket-mode blocks (also fixes a latent breakage where the test env's `TERMINAL_SOCKET` hit the real prod socket).
- **`CHANGELOG.md`** — two `[Unreleased] → Fixed` entries.

## Key decisions

- **No-op single-host rather than tune the reclaim threshold.** The lock provides zero value on a single host (process management — `rdv.ts`/`deploy.ts`/watchdog — is the real single-writer guard there) and only causes harm. Gating on `BASE_PATH` disables it precisely where it deadlocks and nowhere it's needed.
- **Did not read `process.env.RDV_BASE_PATH` directly** in `instance-lock.ts` (a reviewer suggestion) — that violates the documented single-source-of-truth rule in `base-path.ts`. Multi-instance deploys set `RDV_BASE_PATH` in the real process env (entrypoint/k8s), so `BASE_PATH` is correctly populated at module load; documented inline.

## Test plan

- `bun run typecheck` → 0 errors
- `bun run lint` → 0 errors (changed files clean)
- `bun run test:run` → 1342 passed / 8 skipped (instance-lock + readyz suites green)
- `bun run build` → succeeds
- **Behavioral (scratch data dir, real `~/.remote-dev` untouched):** single-host — two servers against the same data dir both start, no lock file written, skip logged once; multi-instance (`RDV_BASE_PATH=/alpha`) — server #1 acquires, server #2 **refuses**, no socket. readyz socket branch returns `ok` against a live terminal socket.

Fixes the deadlock tracked in `remote-dev-i85i`. After merge + deploy, the launchd watchdog (`dev.remote.app.watchdog`) can be safely re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
