### PR TITLE
fix(watchdog): health-check local origin over unix socket, not CF-Access URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Watchdog now health-checks the local origin, not the CF-Access-fronted
+  public URL** (remote-dev-j4wr): `scripts/watchdog.sh` previously curled
+  `https://dev.bryanli.net/api/sessions` with an app Bearer token and accepted
+  200/401/403 as "alive". But Cloudflare Access intercepts at the edge and
+  returns a 302 login redirect when the request lacks a CF Access *service*
+  token, so every probe was a false FAIL — after 3 consecutive (~15 min) the
+  watchdog restarted perfectly healthy prod. The probe now hits the Next.js
+  origin directly over its unix socket (`$RDV_DATA_DIR/run/nextjs.sock`, with a
+  TCP `127.0.0.1:$PORT` fallback for dev) at `GET /api/healthz`, accepting only
+  `200`. This bypasses Cloudflare entirely and measures actual origin liveness,
+  eliminating the spurious restarts. Failure-count, threshold, deploy-lock, and
+  restart logic are unchanged — only the detection was wrong.
+
 - **Instance lock no longer deadlocks single-host restarts** (remote-dev-i85i):
   the `instance.lock` data-dir guard now engages ONLY in multi-instance mode
   (non-empty `RDV_BASE_PATH`), or when forced via `RDV_FORCE_INSTANCE_LOCK=1`.

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -1,48 +1,51 @@
 #!/usr/bin/env bash
-# Watchdog: checks if dev.bryanli.net is reachable, restarts servers after consecutive failures
+# Watchdog: checks the LOCAL origin's liveness, restarts servers after consecutive failures
+#
+# Probes the Next.js app directly over its unix socket (prod) or TCP port (dev)
+# via GET /api/healthz. This intentionally bypasses Cloudflare Access: a probe of
+# the public URL returns 302/401/403 from CF's edge whenever the request lacks a
+# CF Access service token, which proves only that CF is up — NOT that the origin
+# app is alive. Hitting the local origin is the correct liveness signal.
 #
 # Run via launchd every 5 minutes, or manually:
 #   bash scripts/watchdog.sh
 #
 # Environment:
 #   RDV_DATA_DIR       Override default data directory (~/.remote-dev)
-#   EXTERNAL_URL       Override external URL (default: https://dev.bryanli.net)
+#   PORT               TCP port for the dev fallback probe (default: 6001)
 #   MAX_FAILURES       Consecutive failures before restart (default: 3)
 #   DEPLOY_PROJECT_ROOT  Project directory for rdv restart
 
 set -euo pipefail
 
 DATA_DIR="${RDV_DATA_DIR:-$HOME/.remote-dev}"
-EXTERNAL_URL="${EXTERNAL_URL:-https://dev.bryanli.net}"
 MAX_FAILURES="${MAX_FAILURES:-3}"
 PROJECT_ROOT="${DEPLOY_PROJECT_ROOT:-$HOME/Projects/btli/remote-dev}"
 
 DEPLOY_DIR="$DATA_DIR/deploy"
 FAILURE_COUNT_FILE="$DEPLOY_DIR/watchdog-failures"
-LOCAL_KEY_FILE="$DATA_DIR/rdv/.local-key"
+NEXTJS_SOCKET="$DATA_DIR/run/nextjs.sock"
 
 mkdir -p "$DEPLOY_DIR"
 
-# Read local API key if available
-API_KEY=""
-if [ -f "$LOCAL_KEY_FILE" ]; then
-  API_KEY=$(tr -d '[:space:]' < "$LOCAL_KEY_FILE")
+# Probe the local origin's liveness endpoint. Prefer the unix socket (prod);
+# fall back to TCP for dev. The `$(...) || HTTP_CODE="000"` form keeps `set -e`
+# from aborting when curl exits non-zero (connection refused, timeout) and
+# overwrites (rather than appends) the value, so a failure yields a clean "000".
+# HTTP error codes themselves still come through because of `-s -o /dev/null -w`.
+if [ -S "$NEXTJS_SOCKET" ]; then
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    --max-time 10 \
+    --unix-socket "$NEXTJS_SOCKET" \
+    "http://localhost/api/healthz" 2>/dev/null) || HTTP_CODE="000"
+else
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    --connect-timeout 10 --max-time 15 \
+    "http://127.0.0.1:${PORT:-6001}/api/healthz" 2>/dev/null) || HTTP_CODE="000"
 fi
 
-# Build auth header
-AUTH_HEADER=""
-if [ -n "$API_KEY" ]; then
-  AUTH_HEADER="Authorization: Bearer $API_KEY"
-fi
-
-# Check external URL
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-  --connect-timeout 10 --max-time 15 \
-  ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
-  "$EXTERNAL_URL/api/sessions" 2>/dev/null || echo "000")
-
-if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "401" ] || [ "$HTTP_CODE" = "403" ]; then
-  # Server is reachable (401/403 = CF Access blocking, still alive)
+if [ "$HTTP_CODE" = "200" ]; then
+  # Local origin is alive and responsive.
   echo "$(date): OK ($HTTP_CODE)"
   echo "0" > "$FAILURE_COUNT_FILE"
   exit 0


### PR DESCRIPTION
## Summary

Stops the launchd watchdog (`scripts/watchdog.sh`) from spuriously restarting **healthy** production. This is the second of two compounding root causes behind the recurring prod outages (the first — the instance-lock deadlock — was fixed in #308).

**The bug:** the watchdog health-checked the public, Cloudflare-Access-fronted URL (`https://dev.bryanli.net/api/sessions`) with the local *app* API key and accepted only HTTP `200/401/403` as "alive". But CF Access intercepts at the edge and returns **`302`** (redirect to `cloudflareaccess.com` login: `auth_status=NONE`, `service_token_status=false`) because an app Bearer token is not a CF Access *service* token. So **every probe was a false failure** → after 3 consecutive (~15 min) the watchdog restarted perfectly healthy prod via `rdv.ts restart prod`. Pre-#308 that restart hit the instance-lock deadlock and became a dual-writer outage.

A `302/401/403` from CF Access only proves CF's edge is up — it says nothing about origin health. The correct liveness signal is the **local origin**, which bypasses CF entirely.

## Changes (`scripts/watchdog.sh`)

- **Probe the local origin** via `GET /api/healthz`: prefer the prod unix socket (`curl --unix-socket ~/.remote-dev/run/nextjs.sock`), fall back to TCP (`127.0.0.1:${PORT:-6001}`) for dev. Accept only `200` as alive. (`/api/healthz` is unauthenticated over the socket — verified returns 200.)
- **Removed the dead CF-Access path**: the `.local-key` read, the `Authorization: Bearer` header, and the `EXTERNAL_URL` probe (confirmed `EXTERNAL_URL`/`LOCAL_KEY_FILE` are unused elsewhere; the `EXTERNAL_URL` in `deploy.ts` is a separate variable).
- **Unchanged**: the consecutive-failure counter, `MAX_FAILURES` threshold, the deploy-lock guard (`deploy.lock` + `kill -0`), and the restart command. Only the *detection* was wrong; the *reaction* logic is correct.
- Robust capture: `HTTP_CODE=$(curl …) || HTTP_CODE="000"` (fallback-assignment, not `|| echo`, so `set -e` is safe and the value never doubles to `000000`).
- Updated the header/`Environment:` doc block.

## Key decisions

- **Probe the origin, not the edge.** Relying on CF Access edge response codes as a liveness proxy is fundamentally fragile (it flipped from the assumed 401/403 to 302). The local socket is what `deploy.ts` already uses for its health check.
- **Accept only `200`** (not 401/403/302). Over the local socket there is no CF Access, so a healthy origin returns 200; anything else is a real problem.

## Test plan

- `bash -n scripts/watchdog.sh` → syntax OK
- Live-socket probe → `200`; failure simulation (bogus socket) → clean `000` (no doubling), correctly treated as not-alive
- `bun run typecheck` → 0 errors (shell-only change; `lint`/`test:run`/`build` were green on the prior commit and are unaffected — neither `tsc` nor `next build` compiles shell)
- **Post-deploy validation:** re-enable the watchdog and run it manually once — it must log `OK (200)` against healthy prod and not trigger a restart.

Fixes `remote-dev-j4wr`. Unblocks safe re-enable of the `dev.remote.app.watchdog` launchd job (which has been disabled while landing #308 + this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
