### PR TITLE
fix(deploy): hard-reset to origin/master so a dirty/untracked tree can't abort deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Production deploy no longer aborts on a dirty/untracked working tree**
+  (remote-dev-1oxx): `scripts/deploy.ts` → `buildSlot()` Step 1 previously ran
+  `git merge --ff-only origin/master` in `PROJECT_ROOT`, which aborts the entire
+  deploy when a stray untracked file collides with an incoming tracked file
+  (a real incident: an untracked `docs/MOBILE_ARCHITECTURE.md` blocked PR #309's
+  deploy with "untracked working tree files would be overwritten by merge …
+  Aborting") or when a tracked file is dirty (e.g. `.beads/issues.jsonl`, which
+  `bd` auto-flushes). `buildSlot` now `git reset --hard origin/master` instead,
+  guarded by a `git merge-base --is-ancestor HEAD origin/master` divergence
+  check that refuses to reset (preserving the old `--ff-only` safety) if
+  `PROJECT_ROOT` has local commits not on origin. Gitignored runtime data
+  (`.env.local`, `sqlite.db`, `node_modules`, build slots) is left untouched.
+  Also fixes a stale log label that read `git merge --ff-only origin/main` —
+  the wrong branch name (remote-dev-k1jg).
 - **Watchdog now health-checks the local origin, not the CF-Access-fronted
   public URL** (remote-dev-j4wr): `scripts/watchdog.sh` previously curled
   `https://dev.bryanli.net/api/sessions` with an app Bearer token and accepted

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -441,15 +441,51 @@ function buildSlot(slot: Slot): boolean {
 
   logDeploy(`Building into ${slot} slot...`);
 
-  // Step 1: Git pull
+  // Step 1: Sync PROJECT_ROOT to origin/master, robust against a dirty/untracked
+  // working tree. A plain `git merge --ff-only` aborts the whole deploy if any
+  // untracked file collides with an incoming tracked file (e.g. a stray
+  // docs/*.md — see remote-dev-1oxx) or if a tracked file is dirty (e.g.
+  // .beads/issues.jsonl, which bd auto-flushes). We keep the fast-forward
+  // SAFETY — never silently discard divergent local commits — via an ancestry
+  // check, then `git reset --hard` to force the tree to match origin/master.
+  // reset --hard discards dirty tracked changes and deletes only untracked
+  // files in the way of incoming tracked files; gitignored runtime data
+  // (.env.local, sqlite.db, node_modules, build slots) is left untouched.
   if (!runCommand(["git", "fetch", "origin"], PROJECT_ROOT, "git fetch")) {
+    return false;
+  }
+  // Refuse to deploy if PROJECT_ROOT/HEAD has diverged from origin/master
+  // (local commits not on origin) — a hard reset would silently lose them.
+  // This preserves the protection the old `--ff-only` gave us.
+  // `git merge-base --is-ancestor` exits 0 when HEAD is an ancestor of
+  // origin/master (fast-forwardable or already equal), 1 when it is NOT
+  // (PROJECT_ROOT has diverged — local commits not on origin), and a different
+  // non-zero (typically 128) on a git error such as a missing origin/master ref
+  // after a bad fetch. Distinguish the two so the log isn't misleading.
+  const ancestry = spawnSync(
+    ["git", "merge-base", "--is-ancestor", "HEAD", "origin/master"],
+    { cwd: PROJECT_ROOT, stdout: "pipe", stderr: "pipe" }
+  );
+  if (ancestry.exitCode === 1) {
+    logError(
+      "PROJECT_ROOT HEAD has diverged from origin/master (local commits not on " +
+        "origin?). Refusing to hard-reset and risk losing them; resolve PROJECT_ROOT manually."
+    );
+    return false;
+  }
+  if (ancestry.exitCode !== 0) {
+    logError(
+      `git merge-base --is-ancestor failed (exit ${ancestry.exitCode}): ` +
+        (ancestry.stderr?.toString().trim() ||
+          "unknown git error (origin/master ref missing after a bad fetch?)")
+    );
     return false;
   }
   if (
     !runCommand(
-      ["git", "merge", "--ff-only", "origin/master"],
+      ["git", "reset", "--hard", "origin/master"],
       PROJECT_ROOT,
-      "git merge --ff-only origin/main"
+      "git reset --hard origin/master"
     )
   ) {
     return false;


### PR DESCRIPTION
## Summary

Makes the production blue-green deploy robust against a dirty/untracked working tree in `PROJECT_ROOT`. Previously `scripts/deploy.ts` → `buildSlot()` Step 1 ran `git merge --ff-only origin/master`, which **aborts the entire deploy** when:
- an untracked file collides with an incoming tracked file (real incident: a stray untracked `docs/MOBILE_ARCHITECTURE.md` blocked PR #309's deploy — `error: untracked working tree files would be overwritten by merge ... Aborting`), or
- a tracked file is dirty (e.g. `.beads/issues.jsonl`, which `bd` auto-flushes and is frequently modified in the deploy checkout).

The abort happens before the slot swap, so prod keeps running — but the deploy fails, and from the operator's view it's near-silent (the GH workflow shows the webhook accepted; only `deploy.log` records the abort). Fixes `remote-dev-1oxx`.

## Change (`scripts/deploy.ts`, `buildSlot()` Step 1 only)

`git fetch origin` → **ancestry guard** → `git reset --hard origin/master`.

- **Ancestry guard** (`git merge-base --is-ancestor HEAD origin/master`, via `spawnSync` with piped stderr) preserves the one protection `--ff-only` gave us: it refuses to proceed if `PROJECT_ROOT/HEAD` has **diverged** (local commits not on origin), so a hard reset can never silently discard them. Exit codes are disambiguated: `0` = ancestor (proceed), `1` = diverged (refuse, clear message), other non-zero (typically `128`) = git error such as a missing `origin/master` ref (refuse, surfacing git's actual stderr instead of a misleading "diverged" message).
- **`git reset --hard origin/master`** forces the tree to match origin. It discards dirty tracked changes and deletes only untracked files *in the way of* incoming tracked files (per git's documented behavior); gitignored runtime data (`.env.local`, `sqlite.db`, `node_modules`, build slots) is **not** tracked and is left untouched.
- Every error path still `return false` → deploy aborts **before** stopping servers, so prod stays up (fail-safe preserved).
- Also fixes the stale log label that read `git merge --ff-only origin/main` (wrong branch name) → `remote-dev-k1jg`.

## Key decisions

- **`reset --hard`, not `git clean`.** A reviewer suggested `git reset --hard` can't replace an untracked file colliding with an incoming tracked path and that `git clean -fd` was required. I **empirically disproved** this (git 2.54.0): for the exact #309 scenario, `git merge --ff-only` fails but `git reset --hard origin` **succeeds (exit 0)** and replaces the untracked file with the tracked content — matching the `git reset --hard` man page ("untracked files ... in the way of writing any tracked files are simply deleted"). Adding `git clean -fd` would be strictly worse: it would delete **all** untracked non-ignored files (e.g. `docs/claude/plans/*`), causing collateral data loss. So `git clean` was deliberately **not** added.
- **`.beads/issues.jsonl` stays git-tracked** (not gitignored) — it's bd's git-synced source of truth; `reset --hard` correctly discards its local churn at deploy time.

## Test plan

- **Scratch-repo verification (git 2.54.0), all confirmed:** (1) untracked-collision — `merge --ff-only` fails, `reset --hard` succeeds + replaces; (2) dirty tracked file — discarded by reset; (3) non-colliding untracked + gitignored files survive the reset; (4) divergence — `merge-base --is-ancestor` returns exit 1 (guard refuses) and a blind reset would have orphaned the local commit; (5) missing ref — `merge-base --is-ancestor` returns exit 128 (distinct from divergence), stderr surfaced.
- `bun run typecheck` → 0 errors · `bun run lint` → 0 errors · `bun run build` → success · `bun run test:run` → 1343 passed / 8 skipped (deploy.ts is a spawnSync/process.exit script not in the unit suite; the scratch repro is the behavioral proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
