### PR TITLE
fix(deploy): report async deploy outcome to CI (close silent false-positive) [remote-dev-6pbo]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,9 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     # Skip deploy for tag pushes (handled by release.yml)
     if: "!startsWith(github.ref, 'refs/tags/')"
-    timeout-minutes: 5
+    timeout-minutes: 12
     steps:
       - name: Send deploy webhook
+        id: trigger
         env:
           DEPLOY_WEBHOOK_SECRET: ${{ secrets.DEPLOY_WEBHOOK_SECRET }}
           DEPLOY_URL: ${{ vars.DEPLOY_URL }}
@@ -35,7 +36,7 @@ jobs:
             --arg pusher "$GITHUB_ACTOR" \
             '{ref: $ref, after: $sha, pusher: {name: $pusher}}')
 
-          SIGNATURE="sha256=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$DEPLOY_WEBHOOK_SECRET" | awk '{print $NF}')"
+          SIGNATURE="sha256=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$DEPLOY_WEBHOOK_SECRET" | awk '{print $NF}')"
 
           echo "Sending deploy webhook to $DEPLOY_URL/api/deploy"
           echo "Commit: ${GITHUB_SHA:0:7}"
@@ -56,9 +57,48 @@ jobs:
 
           if [ "$HTTP_CODE" = "202" ]; then
             echo "Deploy triggered successfully"
+            echo "deploy=triggered" >> "$GITHUB_OUTPUT"
           elif [ "$HTTP_CODE" = "409" ]; then
             echo "::warning::Deploy already in progress"
+            echo "deploy=in-progress-elsewhere" >> "$GITHUB_OUTPUT"
           else
             echo "::error::Unexpected response: $HTTP_CODE"
             exit 1
           fi
+
+      - name: Wait for deploy to complete
+        if: steps.trigger.outputs.deploy == 'triggered'
+        env:
+          DEPLOY_WEBHOOK_SECRET: ${{ secrets.DEPLOY_WEBHOOK_SECRET }}
+          DEPLOY_URL: ${{ vars.DEPLOY_URL }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          SIG="sha256=$(printf '%s' "$GITHUB_SHA" | openssl dgst -sha256 -hmac "$DEPLOY_WEBHOOK_SECRET" | awk '{print $NF}')"
+          echo "Polling deploy status for ${GITHUB_SHA:0:7} ..."
+          DEADLINE=$(( $(date +%s) + 540 ))   # 9 minutes
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            BODY=$(curl -s --max-time 20 \
+              -H "X-Hub-Signature-256: $SIG" \
+              -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+              -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+              "$DEPLOY_URL/api/deploy/status?commit=$GITHUB_SHA" 2>/dev/null) || BODY=""
+            STATUS=$(printf '%s' "$BODY" | jq -r '.status // empty' 2>/dev/null)
+            RC=$(printf '%s' "$BODY" | jq -r '.requestedCommit // empty' 2>/dev/null)
+            echo "  …waiting: status='${STATUS:-none}' recorded-commit='${RC:0:7}' (want ${GITHUB_SHA:0:7})"
+            if [ "$RC" != "$GITHUB_SHA" ]; then sleep 10; continue; fi
+            case "$STATUS" in
+              success)
+                AC=$(printf '%s' "$BODY" | jq -r '.activeCommit // empty')
+                if [ "$AC" = "$GITHUB_SHA" ]; then
+                  echo "✅ Deploy succeeded — ${AC:0:7} is live"; exit 0
+                fi
+                echo "::error::Deploy reported success but active commit ($AC) != pushed ($GITHUB_SHA)"; exit 1 ;;
+              failed)
+                STAGE=$(printf '%s' "$BODY" | jq -r '.stage // "?"')
+                ERR=$(printf '%s' "$BODY" | jq -r '.error // "?"')
+                echo "::error::Deploy failed at stage '$STAGE': $ERR (see ~/.remote-dev/deploy/deploy.log)"; exit 1 ;;
+              *) sleep 10; continue ;;
+            esac
+          done
+          echo "::error::Timed out after 9m waiting for deploy of ${GITHUB_SHA:0:7} (check ~/.remote-dev/deploy/deploy.log and 'bun run deploy:status')"; exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Deploy pipeline now reports the true async deploy outcome to CI: the GH workflow polls a new HMAC-authed `GET /api/deploy/status` after triggering and fails if the deploy doesn't land, closing the silent false-positive-deploy gap where a server-side abort left CI green on the old commit (remote-dev-6pbo).
 - **Production deploy no longer aborts on a dirty/untracked working tree**
   (remote-dev-1oxx): `scripts/deploy.ts` → `buildSlot()` Step 1 previously ran
   `git merge --ff-only origin/master` in `PROJECT_ROOT`, which aborts the entire

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -148,7 +148,7 @@ SIGNATURE="sha256=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$DEPLOY_WEB
 
 | Code | Meaning |
 |------|---------|
-| `202` | Deploy triggered (CI treats this as success) |
+| `202` | Deploy triggered (CI then **polls for the outcome** — see [Deploy-outcome feedback](#deploy-outcome-feedback-ci-polling)) |
 | `409` | Deploy already in progress (CI logs a warning, non-fatal) |
 | `401` | Invalid signature |
 | `410` | Webhook deprecated because auto-update is enabled |
@@ -170,6 +170,57 @@ Run [`scripts/deploy-setup.sh`](../scripts/deploy-setup.sh) once on the producti
 host to generate the secret, initialize deploy state, and install the watchdog (see
 [§4](#4-npm-scripts)). It prints the exact `gh secret set` / `gh variable set`
 commands to register CI.
+
+### Deploy-outcome feedback (CI polling)
+
+The `202` from `POST /api/deploy` only means the deploy was **triggered** — the
+actual build/swap runs **detached** (`stdio: "ignore"`), so historically CI went
+green the instant it got the `202`, with **zero visibility** into whether the
+server-side deploy actually landed. A failed deploy (build error, failed
+migration, failed health check) calls `process.exit(1)` **without** advancing the
+live-slot pointer, leaving the old commit serving traffic while the workflow
+showed a green check (remote-dev-6pbo). The classic trap: a stray untracked file
+or dirty tracked file in `PROJECT_ROOT` aborts the deploy (see the dirty-tree
+fix above) while CI stays green — trust `bun run deploy:status`, not the workflow.
+
+To close that gap, the workflow now **polls the deploy outcome** after triggering:
+
+1. **`deploy.ts` records every attempt.** Each run writes
+   `~/.remote-dev/deploy/last-deploy.json` (atomic rename) with
+   `{ status, requestedCommit, activeCommit, stage, error?, startedAt, finishedAt? }`.
+   It is set to `in_progress` at start, `failed` (with the failing `stage` — one of
+   `build` / `migration` / `health-local` / `health-external` — and an `error`)
+   immediately before each abort, and `success` once the live-slot pointer
+   (`state.json`) advances. A failed deploy never advances `activeCommit`.
+2. **A new authenticated status endpoint exposes it.**
+   [`GET /api/deploy/status?commit=<full-sha>`](../src/app/api/deploy/status/route.ts)
+   returns that record. It is **read-only** and authenticated with the **same
+   `DEPLOY_WEBHOOK_SECRET`** as the webhook, but because a GET has no body the
+   `X-Hub-Signature-256` HMAC is computed over the `commit` query value. If no
+   attempt record matches the requested commit but `state.json`'s `activeCommit`
+   equals it, the endpoint reports `success` with `source: "state-fallback"` (this
+   covers a server bootstrapped by an older `deploy.ts` that never wrote a record);
+   otherwise it reports `in_progress` with `source: "no-record"`.
+3. **The workflow polls until terminal.** After the `202`, the
+   `Wait for deploy to complete` step polls `…/api/deploy/status` for up to **9
+   minutes**. It **fails the workflow** if the deploy reports `failed`, if it
+   reports `success` but `activeCommit` ≠ the pushed SHA, or if it times out (a
+   missing/unreachable record degrades to a timeout — the correct fail-safe
+   direction). The job `timeout-minutes` is `12` to leave headroom over the 9-minute
+   poll deadline.
+
+**Net effect: a green "Deploy to Production" run now means the pushed commit is
+actually live**, not merely that the webhook was accepted. On failure the step
+prints the failing stage/error and points at `~/.remote-dev/deploy/deploy.log`.
+
+**Known behavior — superseded pushes.** The deploy always ships `origin/master`
+HEAD (`git fetch` + `git reset --hard origin/master`), not a pinned SHA. If
+`origin/master` advances between an earlier push's webhook and that deploy's
+`git fetch`, the deploy ships the **newer** HEAD. The superseded (older) push's
+workflow run will then fail its poll with "reported success but active commit
+(`<newer>`) != pushed (`<older>`)" — because a newer commit went live — while the
+**newest** push's run goes green. This is expected: the live commit legitimately
+moved past the older push.
 
 ---
 

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -54,6 +54,7 @@ const SERVER_DIR = join(DATA_DIR, "server");
 const STATE_FILE = join(DEPLOY_DIR, "state.json");
 const LOCK_FILE = join(DEPLOY_DIR, "deploy.lock");
 const LOG_FILE = join(DEPLOY_DIR, "deploy.log");
+const RESULT_FILE = join(DEPLOY_DIR, "last-deploy.json");
 
 const NEXTJS_SOCKET = join(SOCKET_DIR, "nextjs.sock");
 const TERMINAL_SOCKET = join(SOCKET_DIR, "terminal.sock");
@@ -140,6 +141,27 @@ function writeDeployState(state: DeployState): void {
   writeFileSync(tmpFile, JSON.stringify(state, null, 2));
   // Atomic rename
   renameSync(tmpFile, STATE_FILE);
+}
+
+interface DeployResult {
+  status: "in_progress" | "success" | "failed";
+  requestedCommit: string;
+  activeCommit: string | null;
+  stage: string; // start | build | migration | health-local | health-external | done
+  error?: string;
+  startedAt: string;
+  finishedAt?: string;
+}
+
+function writeDeployResult(result: DeployResult): void {
+  try {
+    const tmpFile = RESULT_FILE + ".tmp";
+    writeFileSync(tmpFile, JSON.stringify(result, null, 2));
+    renameSync(tmpFile, RESULT_FILE);
+  } catch {
+    // Best-effort; a missing result record degrades to a poll timeout, which
+    // CI treats as a failed deploy — the correct fail-safe direction.
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -790,6 +812,11 @@ async function deploy(): Promise<void> {
   ensureDirs();
 
   if (!acquireLock()) {
+    // Lost a deploy-lock race (the POST /api/deploy lock check passed, then
+    // another deploy grabbed the lock first). Deliberately write NO result
+    // record here: the winner may be deploying this same commit, and a "failed"
+    // record would clobber its in_progress/success record (a false failure).
+    // CI degrades to a poll timeout instead — the safe direction.
     process.exit(1);
   }
 
@@ -799,12 +826,37 @@ async function deploy(): Promise<void> {
     const inactiveSlot: Slot = activeSlot === "blue" ? "green" : "blue";
     const previousCommit = state?.activeCommit || getGitCommitFull();
 
+    const requestedCommit = process.env.DEPLOY_REQUESTED_COMMIT || getGitCommitFull();
+    const startedAt = new Date().toISOString();
+
+    // Record a terminal "failed" result for a given stage before we roll back
+    // and exit. Each failure site differs only by stage + error message.
+    const writeFailure = (stage: string, error: string): void =>
+      writeDeployResult({
+        status: "failed",
+        requestedCommit,
+        activeCommit: previousCommit,
+        stage,
+        error,
+        startedAt,
+        finishedAt: new Date().toISOString(),
+      });
+
+    writeDeployResult({
+      status: "in_progress",
+      requestedCommit,
+      activeCommit: previousCommit,
+      stage: "start",
+      startedAt,
+    });
+
     logDeploy(`=== Deploy started ===`);
     logDeploy(`Active slot: ${activeSlot}, building into: ${inactiveSlot}`);
 
     // Build into inactive slot
     if (!buildSlot(inactiveSlot)) {
       logError("Build failed, aborting deploy");
+      writeFailure("build", "Build failed");
       releaseLock();
       process.exit(1);
     }
@@ -821,6 +873,7 @@ async function deploy(): Promise<void> {
     // Run database migration while servers are stopped
     if (!runMigration()) {
       logError("Migration failed, restarting via rdv.ts...");
+      writeFailure("migration", "Migration failed");
       restartViaRdvAsync();
       await Bun.sleep(5000);
       releaseLock();
@@ -834,6 +887,7 @@ async function deploy(): Promise<void> {
     const localHealthy = await healthCheckLocal();
     if (!localHealthy) {
       logError("Local health check failed, rolling back...");
+      writeFailure("health-local", "Local health check failed");
       stopCurrentServers();
       await rollbackTo(activeSlot);
       releaseLock();
@@ -844,6 +898,7 @@ async function deploy(): Promise<void> {
     const externalHealthy = await healthCheckExternal();
     if (!externalHealthy) {
       logError("External health check failed, rolling back...");
+      writeFailure("health-external", "External health check failed");
       stopCurrentServers();
       await rollbackTo(activeSlot);
       releaseLock();
@@ -857,6 +912,15 @@ async function deploy(): Promise<void> {
       deployedAt: new Date().toISOString(),
       previousSlot: activeSlot,
       previousCommit: previousCommit,
+    });
+
+    writeDeployResult({
+      status: "success",
+      requestedCommit,
+      activeCommit: newCommit,
+      stage: "done",
+      startedAt,
+      finishedAt: new Date().toISOString(),
     });
 
     logDeploy(

--- a/src/app/api/deploy/route.ts
+++ b/src/app/api/deploy/route.ts
@@ -13,12 +13,12 @@
  */
 
 import { NextResponse } from "next/server";
-import { createHmac, timingSafeEqual } from "crypto";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { spawn } from "child_process";
 import { createLogger } from "@/lib/logger";
+import { verifySignature } from "@/lib/deploy-webhook-auth";
 
 const log = createLogger("Deploy");
 
@@ -35,23 +35,6 @@ function isLockHeld(): boolean {
   } catch {
     return false; // Process dead or can't read file
   }
-}
-
-function verifySignature(
-  secret: string,
-  rawBody: Buffer,
-  signatureHeader: string
-): boolean {
-  const expected =
-    "sha256=" + createHmac("sha256", secret).update(rawBody).digest("hex");
-
-  // Always run constant-time comparison to prevent timing oracle.
-  // Pad to expected length so timingSafeEqual never throws on length mismatch.
-  const expectedBuf = Buffer.from(expected);
-  const sigBuf = Buffer.alloc(expectedBuf.length);
-  Buffer.from(signatureHeader).copy(sigBuf);
-  const match = timingSafeEqual(sigBuf, expectedBuf);
-  return match && signatureHeader.length === expected.length;
 }
 
 export async function POST(request: Request) {
@@ -154,6 +137,7 @@ export async function POST(request: Request) {
       DEPLOY_EXTERNAL_URL:
         process.env.DEPLOY_EXTERNAL_URL || "https://dev.bryanli.net",
       DEPLOY_WEBHOOK_SECRET: process.env.DEPLOY_WEBHOOK_SECRET ?? "",
+      DEPLOY_REQUESTED_COMMIT: body.after ?? "",
     };
     // Forward RDV_DATA_DIR if set
     if (process.env.RDV_DATA_DIR) {

--- a/src/app/api/deploy/status/__tests__/route.test.ts
+++ b/src/app/api/deploy/status/__tests__/route.test.ts
@@ -1,0 +1,231 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHmac } from "node:crypto";
+import { join } from "node:path";
+
+// The status route reads its data files synchronously via fs.existsSync /
+// fs.readFileSync. Mirror readyz's mocking style: mock `fs` before importing
+// the route, back it with an in-memory file map, and use vi.resetModules() +
+// dynamic import() so each test gets a fresh module that closes over the
+// current mock state. We key the in-memory FS by absolute path; the route
+// builds its paths from RDV_DATA_DIR (set per-test below).
+const fsFiles = new Map<string, string>();
+
+vi.mock("fs", () => ({
+  existsSync: (p: string) => fsFiles.has(p),
+  readFileSync: (p: string) => {
+    const v = fsFiles.get(p);
+    if (v === undefined) throw new Error(`ENOENT: ${p}`);
+    return v;
+  },
+}));
+
+const DATA_DIR = "/tmp/rdv-deploy-status-test";
+const RESULT_FILE = join(DATA_DIR, "deploy", "last-deploy.json");
+const STATE_FILE = join(DATA_DIR, "deploy", "state.json");
+const LOCK_FILE = join(DATA_DIR, "deploy", "deploy.lock");
+
+const SECRET = "test-deploy-secret";
+const COMMIT = "a".repeat(40);
+
+const ORIGINAL_SECRET = process.env.DEPLOY_WEBHOOK_SECRET;
+const ORIGINAL_DATA_DIR = process.env.RDV_DATA_DIR;
+
+/** Compute the valid HMAC-SHA256 signature header over the commit string. */
+function sign(commit: string, secret = SECRET): string {
+  return "sha256=" + createHmac("sha256", secret).update(Buffer.from(commit)).digest("hex");
+}
+
+function makeRequest(commit: string | null, signature?: string): Request {
+  const url = commit === null
+    ? "http://localhost/api/deploy/status"
+    : `http://localhost/api/deploy/status?commit=${commit}`;
+  const headers = new Headers();
+  if (signature !== undefined) headers.set("x-hub-signature-256", signature);
+  return new Request(url, { method: "GET", headers });
+}
+
+/** Import a fresh copy of the route after env + fs mock are configured. */
+async function loadRoute() {
+  vi.resetModules();
+  return import("../route");
+}
+
+beforeEach(() => {
+  fsFiles.clear();
+  process.env.DEPLOY_WEBHOOK_SECRET = SECRET;
+  process.env.RDV_DATA_DIR = DATA_DIR;
+});
+
+afterEach(() => {
+  if (ORIGINAL_SECRET === undefined) delete process.env.DEPLOY_WEBHOOK_SECRET;
+  else process.env.DEPLOY_WEBHOOK_SECRET = ORIGINAL_SECRET;
+  if (ORIGINAL_DATA_DIR === undefined) delete process.env.RDV_DATA_DIR;
+  else process.env.RDV_DATA_DIR = ORIGINAL_DATA_DIR;
+});
+
+describe("GET /api/deploy/status", () => {
+  it("returns 503 when DEPLOY_WEBHOOK_SECRET is not configured", async () => {
+    delete process.env.DEPLOY_WEBHOOK_SECRET;
+    const { GET } = await loadRoute();
+
+    const response = await GET(makeRequest(COMMIT, sign(COMMIT)));
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain("not configured");
+  });
+
+  it("returns 400 when the commit query param is missing", async () => {
+    const { GET } = await loadRoute();
+
+    const response = await GET(makeRequest(null, sign("")));
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain("Missing commit");
+  });
+
+  it("returns 401 on an invalid signature", async () => {
+    const { GET } = await loadRoute();
+
+    const response = await GET(makeRequest(COMMIT, "sha256=deadbeef"));
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain("Invalid signature");
+  });
+
+  it("returns the matching attempt record verbatim plus lockHeld", async () => {
+    fsFiles.set(
+      RESULT_FILE,
+      JSON.stringify({
+        status: "failed",
+        requestedCommit: COMMIT,
+        activeCommit: "b".repeat(40),
+        stage: "build",
+        error: "Build failed",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        finishedAt: "2026-01-01T00:05:00.000Z",
+      }),
+    );
+    // lockHeld now means "lock held by a LIVE pid" (isDeployLockAlive does
+    // process.kill(pid, 0)); use the test process's own pid so it registers
+    // as held rather than a dead/stale pid.
+    fsFiles.set(LOCK_FILE, String(process.pid));
+    const { GET } = await loadRoute();
+
+    const response = await GET(makeRequest(COMMIT, sign(COMMIT)));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      status: string;
+      requestedCommit: string;
+      activeCommit: string;
+      stage: string;
+      error: string;
+      lockHeld: boolean;
+      source?: string;
+    };
+    expect(body.status).toBe("failed");
+    expect(body.requestedCommit).toBe(COMMIT);
+    expect(body.activeCommit).toBe("b".repeat(40));
+    expect(body.stage).toBe("build");
+    expect(body.error).toBe("Build failed");
+    expect(body.lockHeld).toBe(true);
+    // A verbatim attempt record carries no `source` marker.
+    expect(body.source).toBeUndefined();
+  });
+
+  it("falls back to state.json when the live commit matches and there is no attempt record", async () => {
+    // No last-deploy.json; state.json says this commit is live → genuine success.
+    fsFiles.set(
+      STATE_FILE,
+      JSON.stringify({ activeCommit: COMMIT, deployedAt: "2026-02-02T00:00:00.000Z" }),
+    );
+    const { GET } = await loadRoute();
+
+    const response = await GET(makeRequest(COMMIT, sign(COMMIT)));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      status: string;
+      activeCommit: string;
+      stage: string;
+      source: string;
+      lockHeld: boolean;
+    };
+    expect(body.status).toBe("success");
+    expect(body.activeCommit).toBe(COMMIT);
+    expect(body.stage).toBe("done");
+    expect(body.source).toBe("state-fallback");
+    expect(body.lockHeld).toBe(false);
+  });
+
+  it("falls back to state.json when the attempt record is for a different commit", async () => {
+    // A stale record for a prior commit must not satisfy the requested one;
+    // the live-commit fallback should kick in instead.
+    fsFiles.set(
+      RESULT_FILE,
+      JSON.stringify({
+        status: "failed",
+        requestedCommit: "c".repeat(40),
+        activeCommit: COMMIT,
+        stage: "build",
+        error: "Build failed",
+        startedAt: "2026-02-02T00:00:00.000Z",
+      }),
+    );
+    fsFiles.set(
+      STATE_FILE,
+      JSON.stringify({ activeCommit: COMMIT, deployedAt: "2026-02-02T00:00:00.000Z" }),
+    );
+    const { GET } = await loadRoute();
+
+    const response = await GET(makeRequest(COMMIT, sign(COMMIT)));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { status: string; source: string };
+    expect(body.status).toBe("success");
+    expect(body.source).toBe("state-fallback");
+  });
+
+  it("does NOT short-circuit to success when the live commit matches but a deploy is in flight", async () => {
+    // Re-deploy of an already-live SHA whose in_progress record write was lost:
+    // state.json says this commit is live, but a deploy lock is held by a LIVE
+    // pid. Using the test process's own pid guarantees process.kill(pid, 0)
+    // succeeds, so the state-fallback guard must report in_progress, not success.
+    fsFiles.set(
+      STATE_FILE,
+      JSON.stringify({ activeCommit: COMMIT, deployedAt: "2026-04-04T00:00:00.000Z" }),
+    );
+    fsFiles.set(LOCK_FILE, String(process.pid));
+    const { GET } = await loadRoute();
+
+    const response = await GET(makeRequest(COMMIT, sign(COMMIT)));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      status: string;
+      source: string;
+      lockHeld: boolean;
+    };
+    expect(body.status).toBe("in_progress");
+    expect(body.lockHeld).toBe(true);
+    expect(body.source).toBe("no-record");
+  });
+
+  it("reports in_progress when there is no record and the live commit does not match", async () => {
+    fsFiles.set(
+      STATE_FILE,
+      JSON.stringify({ activeCommit: "d".repeat(40), deployedAt: "2026-03-03T00:00:00.000Z" }),
+    );
+    const { GET } = await loadRoute();
+
+    const response = await GET(makeRequest(COMMIT, sign(COMMIT)));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      status: string;
+      requestedCommit: string;
+      activeCommit: string | null;
+      source: string;
+    };
+    expect(body.status).toBe("in_progress");
+    expect(body.requestedCommit).toBe(COMMIT);
+    expect(body.activeCommit).toBe("d".repeat(40));
+    expect(body.source).toBe("no-record");
+  });
+});

--- a/src/app/api/deploy/status/route.ts
+++ b/src/app/api/deploy/status/route.ts
@@ -1,0 +1,114 @@
+/**
+ * Deploy Status Endpoint
+ *
+ * GET /api/deploy/status?commit=<full-sha>
+ * Header: X-Hub-Signature-256: sha256=<hmac of the commit string, keyed by DEPLOY_WEBHOOK_SECRET>
+ *
+ * Lets the CI workflow (and operators) observe the outcome of the async,
+ * fire-and-forget deploy triggered via POST /api/deploy, closing the gap where
+ * CI went green regardless of whether the server-side deploy actually landed
+ * (remote-dev-6pbo). Read-only; authenticated with the same HMAC secret as the
+ * deploy webhook (signature is over the `commit` query value since GET has no body).
+ */
+import { NextResponse } from "next/server";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { createLogger } from "@/lib/logger";
+import { verifySignature } from "@/lib/deploy-webhook-auth";
+
+const log = createLogger("DeployStatus");
+
+const DATA_DIR = process.env.RDV_DATA_DIR || join(homedir(), ".remote-dev");
+const RESULT_FILE = join(DATA_DIR, "deploy", "last-deploy.json");
+const STATE_FILE = join(DATA_DIR, "deploy", "state.json");
+const LOCK_FILE = join(DATA_DIR, "deploy", "deploy.lock");
+
+function readJson<T>(file: string): T | null {
+  try {
+    if (existsSync(file)) return JSON.parse(readFileSync(file, "utf-8")) as T;
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+function isDeployLockAlive(): boolean {
+  if (!existsSync(LOCK_FILE)) return false;
+  try {
+    const pid = parseInt(readFileSync(LOCK_FILE, "utf-8").trim(), 10);
+    if (Number.isNaN(pid)) return false;
+    process.kill(pid, 0);
+    return true; // process alive
+  } catch {
+    return false; // dead/stale lock or unreadable → treat as not held
+  }
+}
+
+interface DeployResultRecord {
+  status: string;
+  requestedCommit: string;
+  activeCommit: string | null;
+  stage: string;
+  error?: string;
+  startedAt: string;
+  finishedAt?: string;
+}
+interface DeployStateRecord {
+  activeCommit: string;
+  deployedAt: string;
+}
+
+export async function GET(request: Request) {
+  const secret = process.env.DEPLOY_WEBHOOK_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: "Deploy not configured" }, { status: 503 });
+  }
+
+  const commit = new URL(request.url).searchParams.get("commit") ?? "";
+  if (!commit) {
+    return NextResponse.json({ error: "Missing commit query param" }, { status: 400 });
+  }
+
+  const signature = request.headers.get("x-hub-signature-256") ?? "";
+  if (!verifySignature(secret, Buffer.from(commit), signature)) {
+    log.warn("Invalid deploy-status signature", {
+      ip: request.headers.get("x-forwarded-for") ?? "unknown",
+    });
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  const record = readJson<DeployResultRecord>(RESULT_FILE);
+  const state = readJson<DeployStateRecord>(STATE_FILE);
+  const lockHeld = isDeployLockAlive();
+
+  // Authoritative: an attempt record for exactly this commit.
+  if (record && record.requestedCommit === commit) {
+    return NextResponse.json({ ...record, lockHeld });
+  }
+  // Fallback: no attempt record for this commit. state.json only advances on
+  // success, so if this commit is live it genuinely succeeded — UNLESS a deploy
+  // is currently running (a re-deploy of an already-live SHA whose in_progress
+  // record write was lost); then we must not short-circuit to success.
+  if (state && state.activeCommit === commit && !lockHeld) {
+    return NextResponse.json({
+      status: "success",
+      requestedCommit: commit,
+      activeCommit: state.activeCommit,
+      stage: "done",
+      startedAt: state.deployedAt,
+      finishedAt: state.deployedAt,
+      source: "state-fallback",
+      lockHeld,
+    });
+  }
+  // Not live and no record yet → still starting/running (or never started).
+  return NextResponse.json({
+    status: "in_progress",
+    requestedCommit: commit,
+    activeCommit: state?.activeCommit ?? null,
+    stage: "unknown",
+    source: "no-record",
+    lockHeld,
+  });
+}

--- a/src/lib/deploy-webhook-auth.ts
+++ b/src/lib/deploy-webhook-auth.ts
@@ -1,0 +1,22 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+/**
+ * Verify an HMAC-SHA256 signature header (`sha256=<hex>`) over `data`, keyed by
+ * `secret`. Used for both the deploy webhook (signature over the raw request
+ * body) and the deploy-status endpoint (signature over the commit query value).
+ * Rejects a length mismatch up front (the expected length is a non-secret
+ * constant — "sha256=" + 64 hex) so timingSafeEqual never throws, then compares
+ * in constant time.
+ */
+export function verifySignature(
+  secret: string,
+  data: Buffer,
+  signatureHeader: string,
+): boolean {
+  const expected =
+    "sha256=" + createHmac("sha256", secret).update(data).digest("hex");
+  const expectedBuf = Buffer.from(expected);
+  const sigBuf = Buffer.from(signatureHeader);
+  if (sigBuf.length !== expectedBuf.length) return false;
+  return timingSafeEqual(sigBuf, expectedBuf);
+}


### PR DESCRIPTION
## Summary
Closes the **observability half** of the silent-failed-deploy bug (remote-dev-6pbo). The deploy webhook (`POST /api/deploy`) is fire-and-forget — it spawns `scripts/deploy.ts` detached (`stdio: ignore`) and returns **202 on *trigger***, and `state.json` only advances on success. So a server-side abort (build error, migration/health failure, or — before #311 — a dirty-tree merge abort) left the GH "Deploy to Production" workflow **green** while prod silently stayed on the old commit. (#311 already fixed the *merge-robustness* half via `git reset --hard` + ancestry guard.)

Now the deploy **outcome** is observable from CI, so the workflow result and `deploy:status` can no longer silently disagree.

## What changed
- **`scripts/deploy.ts`** — writes a per-attempt result record to `~/.remote-dev/deploy/last-deploy.json` (`in_progress` at start; `failed` with the stage — build/migration/health-local/health-external — at every failure exit; `success` at the end). A `writeFailure(stage, error)` closure de-dupes the four failure writes. `state.json` (the live-slot pointer) is untouched — it still only advances on success.
- **`src/app/api/deploy/status/route.ts`** (new) — `GET /api/deploy/status?commit=<sha>`, HMAC-authed (signature over the commit query value, same secret as the webhook). Returns the attempt record for the commit; falls back to `state.json` (a live commit genuinely succeeded) **unless a deploy lock is held by a live PID** (an in-flight re-deploy must not be reported as success from stale state).
- **`src/lib/deploy-webhook-auth.ts`** (new) — extracted the HMAC verifier (shared by both deploy routes); rewritten to the canonical constant-time idiom (reject length mismatch up front, then `timingSafeEqual`).
- **`src/app/api/deploy/route.ts`** — uses the shared verifier; passes the pushed SHA to `deploy.ts` via `DEPLOY_REQUESTED_COMMIT`.
- **`.github/workflows/deploy.yml`** — after the 202, polls `/api/deploy/status` for up to 9 min and **fails the job** if the deploy doesn't reach `success` for the pushed commit. A green workflow now means the commit is actually live. (`timeout-minutes` 5→12; trigger-step `echo -n`→`printf '%s'`; per-iteration progress log.)
- **`docs/DEPLOYMENT.md`** / **`CHANGELOG.md`** — documented the feedback loop + known behaviors.

## Key decisions
- **Self-bootstrapping rollout:** the deploy that ships *this* runs under the OLD server (no status endpoint / no result file). The `state-fallback` branch handles it — once the swap advances `state.json.activeCommit` to the pushed SHA, status returns `success` and the new workflow's poll goes green.
- **Review finding "double `releaseLock()`" — rejected (false positive):** empirically confirmed Bun does **not** run `finally` on `process.exit()`, so the explicit `releaseLock()` before each exit is required (the `finally` only covers the success path).
- **Lock-race exit writes no record — deliberate:** on a lost `acquireLock()` race the winner may be deploying the *same* commit; a `failed` record would clobber its record (worse false-failure). CI degrades to a poll timeout — the safe direction. (commented)
- **Superseded push — documented, not "fixed":** if `origin/master` advances mid-build, the deploy ships the newer HEAD and the older push's run reports a commit mismatch. Reconciling in bash would mask genuine wrong-commit deploys.

## Test plan
- 8 tests in `src/app/api/deploy/status/__tests__/route.test.ts`: missing secret→503, missing commit→400, bad sig→401, authoritative record (+`lockHeld`), state-fallback→success (no lock), in-flight re-deploy guard (live lock→`in_progress`), no-record→`in_progress`.
- `bun run typecheck` 0 errors · `bun run lint` 0 new warnings · `bun run test:run` 1351 passing · `bun run build` OK.
- Adversarial `code-reviewer` + `code-simplifier` passes applied.
- E2E verified by this PR's own merge-deploy (watched via the new feedback loop + `deploy:status`).

remote-dev-6pbo

🤖 Generated with [Claude Code](https://claude.com/claude-code)