### PR TITLE
fix(deploy): unblock /api/deploy/status at proxy + harden workflow poll (6pbo follow-up)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,20 +83,20 @@ jobs:
               -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
               -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
               "$DEPLOY_URL/api/deploy/status?commit=$GITHUB_SHA" 2>/dev/null) || BODY=""
-            STATUS=$(printf '%s' "$BODY" | jq -r '.status // empty' 2>/dev/null)
-            RC=$(printf '%s' "$BODY" | jq -r '.requestedCommit // empty' 2>/dev/null)
+            STATUS=$(printf '%s' "$BODY" | jq -r '.status // empty' 2>/dev/null || true)
+            RC=$(printf '%s' "$BODY" | jq -r '.requestedCommit // empty' 2>/dev/null || true)
             echo "  …waiting: status='${STATUS:-none}' recorded-commit='${RC:0:7}' (want ${GITHUB_SHA:0:7})"
             if [ "$RC" != "$GITHUB_SHA" ]; then sleep 10; continue; fi
             case "$STATUS" in
               success)
-                AC=$(printf '%s' "$BODY" | jq -r '.activeCommit // empty')
+                AC=$(printf '%s' "$BODY" | jq -r '.activeCommit // empty' 2>/dev/null || true)
                 if [ "$AC" = "$GITHUB_SHA" ]; then
                   echo "✅ Deploy succeeded — ${AC:0:7} is live"; exit 0
                 fi
                 echo "::error::Deploy reported success but active commit ($AC) != pushed ($GITHUB_SHA)"; exit 1 ;;
               failed)
-                STAGE=$(printf '%s' "$BODY" | jq -r '.stage // "?"')
-                ERR=$(printf '%s' "$BODY" | jq -r '.error // "?"')
+                STAGE=$(printf '%s' "$BODY" | jq -r '.stage // "?"' 2>/dev/null || true)
+                ERR=$(printf '%s' "$BODY" | jq -r '.error // "?"' 2>/dev/null || true)
                 echo "::error::Deploy failed at stage '$STAGE': $ERR (see ~/.remote-dev/deploy/deploy.log)"; exit 1 ;;
               *) sleep 10; continue ;;
             esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Deploy pipeline now reports the true async deploy outcome to CI: the GH workflow polls a new HMAC-authed `GET /api/deploy/status` after triggering and fails if the deploy doesn't land, closing the silent false-positive-deploy gap where a server-side abort left CI green on the old commit (remote-dev-6pbo).
+- Deploy-status CI feedback loop: allow `/api/deploy/status` through the proxy auth boundary (it has its own HMAC auth) and make the deploy workflow's status poll tolerant of non-JSON responses, so the poll reaches the endpoint and a transient garbled response can't false-fail the job (follow-up to remote-dev-6pbo).
 - **Production deploy no longer aborts on a dirty/untracked working tree**
   (remote-dev-1oxx): `scripts/deploy.ts` → `buildSlot()` Step 1 previously ran
   `git merge --ff-only origin/master` in `PROJECT_ROOT`, which aborts the entire

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -56,8 +56,11 @@ export async function proxy(request: NextRequest) {
     return tagInstance(NextResponse.next());
   }
 
-  // Allow deploy webhook (uses its own HMAC-SHA256 auth)
-  if (pathname === "/api/deploy") {
+  // Allow deploy webhook + its status endpoint (both use their own
+  // HMAC-SHA256 auth; the status poll is read-only). The bare unprefixed
+  // pathname is what Next.js exposes after stripping basePath, so this matches
+  // both `/api/deploy/status` and `/<prefix>/api/deploy/status`.
+  if (pathname === "/api/deploy" || pathname === "/api/deploy/status") {
     return tagInstance(NextResponse.next());
   }
 


### PR DESCRIPTION
## Summary
Fast-follow to #312. Dogfooding the first deploy under the new feedback loop surfaced **two defects** that prevented the CI poll from working (the deploy itself succeeded — prod is healthy on `26a87650` — but the workflow went red):

1. **`/api/deploy/status` was blocked by the proxy auth gate.** `src/proxy.ts` only bypassed the *exact* path `/api/deploy` for HMAC auth; the new `/api/deploy/status` fell through to the CF-Access/NextAuth gate and returned `{"error":"Unauthorized"}` (401) before its own HMAC check ran. Verified directly over the unix socket. Fix: add `/api/deploy/status` to the same bypass (it does its own HMAC auth; read-only; CF edge still applies).
2. **The workflow poll step errexit-died on a non-JSON body.** GitHub runs `run:` under `bash -e`; `STATUS=$(… | jq …)` propagated jq's exit 5 (parse error on the old server's 404 HTML pre-swap) through the assignment, killing the step (observed: `Process completed with exit code 5`). Fix: `|| true` inside each jq substitution so a garbled/non-JSON body yields an empty string and the loop keeps polling instead of false-failing.

## Why unit tests didn't catch #1
The status-route tests (and healthz's) import the handler and call `GET()` directly — they don't exercise `src/proxy.ts`'s bypass list. Caught by an over-socket end-to-end check post-deploy. No proxy test harness exists in the repo; not adding one from scratch here (the proxy is impractical to unit-test in isolation).

## Validation
This PR's own merge-deploy is the end-to-end test: the poll sees 401-JSON (treated as "still waiting") until the swap, then — once the proxy fix is live and the new `deploy.ts` writes `last-deploy.json` — resolves to `success` and the workflow goes **green**, with `deploy:status` agreeing. `bun run typecheck`/`lint`/`test:run` (1351)/`build` all green.

remote-dev-6pbo

🤖 Generated with [Claude Code](https://claude.com/claude-code)