### PR TITLE
fix(readyz): terminal /health returns 503 when scheduler subsystem down [remote-dev-n1uv]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Terminal server `/health` now returns 503 (not a 200 with the detail buried in the body) when the scheduler subsystem isn't running, so `/api/readyz` correctly reports the pod as not-ready and pulls a wedged terminal server out of the load balancer instead of routing session-create traffic to it (remote-dev-n1uv).
 - Deploy pipeline now reports the true async deploy outcome to CI: the GH workflow polls a new HMAC-authed `GET /api/deploy/status` after triggering and fails if the deploy doesn't land, closing the silent false-positive-deploy gap where a server-side abort left CI green on the old commit (remote-dev-6pbo).
 - Deploy-status CI feedback loop: allow `/api/deploy/status` through the proxy auth boundary (it has its own HMAC auth) and make the deploy workflow's status poll tolerant of non-JSON responses, so the poll reaches the endpoint and a transient garbled response can't false-fail the job (follow-up to remote-dev-6pbo).
 - **Production deploy no longer aborts on a dirty/untracked working tree**

--- a/src/app/api/readyz/route.ts
+++ b/src/app/api/readyz/route.ts
@@ -97,7 +97,10 @@ async function healthOverPort(port: string): Promise<CheckResult> {
  * healthy — readiness would say "ready" and the LB would route session-create
  * requests that immediately fail. We hit the terminal server's `/health`
  * endpoint (see `src/server/terminal.ts`) with a 1s timeout so a wedged
- * terminal server is detected quickly.
+ * terminal server is detected quickly. That `/health` now returns 503 (not just
+ * 200-when-the-listener-is-up) when its scheduler subsystem is down, so this
+ * status-code gate reflects scheduler health too — not merely "the process is
+ * listening" (remote-dev-n1uv).
  *
  * Transport selection mirrors the rest of the codebase (scheduler-client.ts,
  * terminal-server-url.ts): prod runs on a Unix socket (`TERMINAL_SOCKET`), dev

--- a/src/server/__tests__/scheduler-health.test.ts
+++ b/src/server/__tests__/scheduler-health.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment node
+/**
+ * Tests for getSchedulerHealth — the pure helper behind the terminal server's
+ * `/health` endpoint (remote-dev-n1uv).
+ *
+ * The mapping is the whole point: when the scheduler subsystem is started the
+ * helper returns 200 (status "ok"); when it is NOT started (failed to come up,
+ * crashed, or stopped) it returns 503 (status "degraded"). `/api/readyz` gates
+ * on the status code, so the 503 is what pulls a wedged terminal server out of
+ * the load balancer.
+ *
+ * `scheduler-orchestrator.js` is mocked to a bare singleton with an
+ * `isStarted` mock — we never touch the real orchestrator (which would spin up
+ * jobs/timers on import). The relative path from this file
+ * (`src/server/__tests__/`) up to `src/services/scheduler-orchestrator.js` is
+ * `../../services/scheduler-orchestrator.js`.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../services/scheduler-orchestrator.js", () => ({
+  schedulerOrchestrator: { isStarted: vi.fn() },
+}));
+
+import { schedulerOrchestrator } from "../../services/scheduler-orchestrator.js";
+import { getSchedulerHealth } from "../scheduler-health.js";
+
+const isStartedMock = vi.mocked(schedulerOrchestrator.isStarted);
+
+beforeEach(() => {
+  isStartedMock.mockReset();
+});
+
+describe("getSchedulerHealth", () => {
+  it("returns 200 / ok when the scheduler is started", () => {
+    isStartedMock.mockReturnValue(true);
+
+    expect(getSchedulerHealth()).toEqual({
+      code: 200,
+      body: { status: "ok", scheduler: true },
+    });
+  });
+
+  it("returns 503 / degraded when the scheduler is not started", () => {
+    isStartedMock.mockReturnValue(false);
+
+    expect(getSchedulerHealth()).toEqual({
+      code: 503,
+      body: { status: "degraded", scheduler: false },
+    });
+  });
+});

--- a/src/server/scheduler-health.ts
+++ b/src/server/scheduler-health.ts
@@ -1,0 +1,20 @@
+import { schedulerOrchestrator } from "../services/scheduler-orchestrator.js";
+
+export interface SchedulerHealth {
+  code: 200 | 503;
+  body: { status: "ok" | "degraded"; scheduler: boolean };
+}
+
+/**
+ * Health of the terminal server's scheduler subsystem, shaped for the `/health`
+ * endpoint. Returns 503 when the scheduler is not started (failed/crashed/not-
+ * yet-up) so `/api/readyz` — which gates on the status code — correctly pulls a
+ * wedged terminal server out of the load balancer instead of routing
+ * session-create traffic to it (remote-dev-n1uv). 200 only when fully started.
+ */
+export function getSchedulerHealth(): SchedulerHealth {
+  const ready = schedulerOrchestrator.isStarted();
+  return ready
+    ? { code: 200, body: { status: "ok", scheduler: true } }
+    : { code: 503, body: { status: "degraded", scheduler: false } };
+}

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { resolve as pathResolve } from "node:path";
 import { promisify } from "node:util";
 import { schedulerOrchestrator } from "../services/scheduler-orchestrator.js";
+import { getSchedulerHealth } from "./scheduler-health.js";
 import { validateWsToken, getAuthSecret } from "../lib/ws-token.js";
 import { createLogger } from "../lib/logger.js";
 import { WS_PATH_PREFIX } from "../lib/base-path.js";
@@ -630,7 +631,8 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
   const query = Object.fromEntries(parsedUrl.searchParams);
 
   if (pathname === "/health" && req.method === "GET") {
-    sendJson(res, 200, { status: "ok", scheduler: schedulerOrchestrator.isStarted() });
+    const health = getSchedulerHealth();
+    sendJson(res, health.code, health.body);
     return true;
   }
 


### PR DESCRIPTION
## Summary
Closes remote-dev-n1uv (P2). The terminal server's `/health` always returned **200** when the HTTP listener was up, burying `scheduler: <bool>` in the body — but `/api/readyz` only gates on the status **code**. So a terminal server whose scheduler subsystem failed to start (or crashed) still reported ready, and the LB would route session-create traffic to a wedged server. This became live once PR #308 made prod's (unix-socket) readyz path actually probe `/health`.

## Fix (issue's option b)
`/health` now returns **503** when `schedulerOrchestrator.isStarted()` is false (`{status:"degraded",scheduler:false}`), else 200 (`{status:"ok",scheduler:true}`). `readyz`'s existing 2xx contract already honors this, so **readyz logic is unchanged** (only its doc comment updated). `isStarted()` is `isRunning && startupComplete` — false only before startup, after graceful stop, or if start() threw, so no steady-state false-negative.

Logic lives in a small pure helper `src/server/scheduler-health.ts` (`getSchedulerHealth()`) so it's unit-testable without importing the side-effectful terminal server.

## Scope
Scoped to the scheduler gate. The issue also mentions PTY/tmux: tmux is already probed directly by readyz (`tmux -V`); a deeper PTY-spawn synthetic probe is a larger, separate change and isn't needed to satisfy this issue.

## Test plan
- New `src/server/__tests__/scheduler-health.test.ts`: started→200/ok, not-started→503/degraded (mocks the orchestrator singleton).
- `bun run typecheck` 0 errors · `lint` 0 new warnings · `test:run` 1353 passing (+2) · `build` OK.
- readyz handler/`checkTerminalServer`/`healthOverSocket`/`healthOverPort` byte-unchanged.

remote-dev-n1uv

🤖 Generated with [Claude Code](https://claude.com/claude-code)