### PR TITLE
feat(supervisor): scaffold apps/supervisor control-plane service (Phase 1) [remote-dev-jvcx.3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Scaffolded the k3s Supervisor control-plane service (apps/supervisor): Next.js + Drizzle schema, role-based auth (admin/operator/viewer, owner-scoped instances), @kubernetes/client-node wrapper, and a controller-process skeleton — foundation for Phase 1 of the k3s supervisor epic (remote-dev-jvcx.3).
 - **Documentation overhaul — new docs**: added `docs/README.md` (docs index /
   landing page), `docs/DEPLOYMENT.md` (blue/green + HMAC auto-deploy webhook),
   `docs/AGENTS.md` (the 5 agent CLIs + profile isolation), and

--- a/apps/supervisor/.env.example
+++ b/apps/supervisor/.env.example
@@ -1,0 +1,40 @@
+# --- @remote-dev/supervisor environment ---
+# Copy to .env.local for local development.
+
+# Next.js UI + REST API port (dev:supervisor runs on this).
+PORT=6003
+
+# Where the Supervisor stores its own SQLite database.
+# Empty -> ~/.remote-dev-supervisor (default). Set to ./.data for a repo-local DB.
+SUPERVISOR_DATA_DIR=
+
+# First admin user. On startup the auth layer seeds a supervisor_user row with
+# role=admin for this email if none exists. In local dev (no CF Access), this
+# email is also the authenticated identity.
+SUPERVISOR_ADMIN_EMAIL=
+
+# Cloudflare Access for the Supervisor's OWN application (distinct AUD from any
+# instance). Required in production; leave blank for local dev (auth falls back
+# to SUPERVISOR_ADMIN_EMAIL).
+SUPERVISOR_CF_ACCESS_TEAM=
+SUPERVISOR_CF_ACCESS_AUD=
+
+# Escape hatch: when "1", bypasses the production requirement that CF Access be
+# configured (otherwise the server refuses to start in prod, and the auth layer
+# refuses the SUPERVISOR_ADMIN_EMAIL fallback). FOR EXPLICIT TESTING ONLY —
+# never set in a real production deployment.
+SUPERVISOR_ALLOW_INSECURE_AUTH=
+
+# Shared secret the Supervisor router presents (header
+# x-supervisor-internal-secret) to read the ready-instance allowlist at
+# GET /api/internal/routes. Required in production; if unset there, that
+# endpoint returns 503. In dev it may be left blank (endpoint is open).
+SUPERVISOR_INTERNAL_SECRET=
+
+# Kubeconfig for local development against a k3d/kind cluster. Optional —
+# the k8s client uses loadFromDefault() which already honours KUBECONFIG and
+# the in-cluster ServiceAccount token in production.
+KUBECONFIG=
+
+# Minimum log level: error | warn | info | debug | trace
+LOG_LEVEL=info

--- a/apps/supervisor/.gitignore
+++ b/apps/supervisor/.gitignore
@@ -1,0 +1,27 @@
+# Dependencies (bun's isolated layout creates a local node_modules with
+# symlinks into the repo-root store — never commit it).
+node_modules/
+.vite/
+
+# Next.js
+/.next/
+/out/
+next-env.d.ts
+
+# Build output
+/dist/
+
+# Local data (SQLite) + drizzle generated migrations
+/.data/
+/drizzle/
+
+# Env
+.env
+.env.local
+.env*.local
+# Re-include the documented template (the repo-root .gitignore's broad `.env*`
+# rule would otherwise swallow it).
+!.env.example
+
+# Misc
+*.tsbuildinfo

--- a/apps/supervisor/README.md
+++ b/apps/supervisor/README.md
@@ -1,0 +1,74 @@
+# @remote-dev/supervisor
+
+The **k3s Supervisor** — a standalone control-plane service that provisions and
+lifecycle-manages Remote Dev **instances** on a Kubernetes (k3s) cluster.
+
+Each instance is an independent, single-tenant `remote-dev` deployment living in
+its own namespace (`rdv-<slug>`) behind a supervisor-owned router. The Supervisor
+offers an operator dashboard to spin up instances, choose where their persistent
+data lives (storage targets), and manage their lifecycle. It talks to the
+Kubernetes API directly via `@kubernetes/client-node`.
+
+> **Status: scaffold — Phase 1 in progress (remote-dev-jvcx.3).**
+> This workspace currently contains the foundation only: DB schema, role-based
+> auth, the k8s client wrapper, slug validation, a dashboard shell, a health
+> route, auth-wrapped API route **stubs**, and a controller-process skeleton.
+> Provisioning (jvcx.4), storage discovery (jvcx.5), the router (jvcx.6), and
+> RBAC/Deployments (jvcx.7) are not implemented yet — those endpoints return
+> `501 { code: "PHASE1_PENDING" }`.
+
+## Architecture
+
+Mirrors the main app's two-process model:
+
+1. **Next.js** (`PORT`, default **6003**) — operator UI + REST API.
+2. **Controller** (`dev:controller`) — a long-running reconciler/capacity loop
+   that drives instances toward their desired state from live cluster state.
+
+The Supervisor runs on its **own hostname** (e.g. `sup.example.com`) with its own
+Cloudflare Access application — it is not slug-pathed (`basePath` is always `""`).
+
+## Roles & ownership
+
+Three roles gate the API (`src/lib/roles.ts`):
+
+| Role | Capabilities |
+|------|--------------|
+| `viewer` | read instances / nodes / storage |
+| `operator` | create, suspend, resume instances |
+| `admin` | delete instances, register storage targets, manage users |
+
+**Instances are owner-scoped:** operators see and manage only the instances they
+created; admins see all.
+
+## Development
+
+From the **repo root**:
+
+```bash
+bun install            # resolves this workspace
+bun run dev:supervisor # next dev on :6003 (this package's `dev` script)
+```
+
+Or from `apps/supervisor`:
+
+```bash
+bun run dev            # Next.js UI + API (:6003)
+bun run dev:controller # reconciler loop (separate process)
+bun run typecheck
+bun run lint
+bun run test
+bun run build
+bun run db:push        # push the Drizzle schema to the Supervisor SQLite db
+```
+
+## Environment
+
+See [`.env.example`](./.env.example). Key variables:
+
+- `PORT` — UI/API port (default 6003)
+- `SUPERVISOR_DATA_DIR` — SQLite location (default `~/.remote-dev-supervisor`)
+- `SUPERVISOR_ADMIN_EMAIL` — seeded first admin; local-dev identity when no CF Access
+- `SUPERVISOR_CF_ACCESS_TEAM` / `SUPERVISOR_CF_ACCESS_AUD` — the Supervisor's own CF Access app
+- `KUBECONFIG` — optional, for local dev against k3d/kind (the client uses `loadFromDefault()`)
+- `LOG_LEVEL` — `error|warn|info|debug|trace`

--- a/apps/supervisor/components.json
+++ b/apps/supervisor/components.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "registries": {}
+}

--- a/apps/supervisor/drizzle.config.ts
+++ b/apps/supervisor/drizzle.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "drizzle-kit";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// The Supervisor keeps its own SQLite database, independent of any instance.
+// Path resolution mirrors src/db/index.ts:
+//   DATABASE_URL > SUPERVISOR_DATA_DIR/supervisor.db > ~/.remote-dev-supervisor/supervisor.db
+function getDatabasePath(): string {
+  const dbUrl = process.env.DATABASE_URL;
+  if (dbUrl) {
+    return dbUrl.startsWith("file:") ? dbUrl.slice(5) : dbUrl;
+  }
+  const dataDir =
+    process.env.SUPERVISOR_DATA_DIR || join(homedir(), ".remote-dev-supervisor");
+  return join(dataDir, "supervisor.db");
+}
+
+export default defineConfig({
+  schema: "./src/db/schema.ts",
+  out: "./drizzle",
+  dialect: "sqlite",
+  dbCredentials: {
+    url: getDatabasePath(),
+  },
+});

--- a/apps/supervisor/eslint.config.mjs
+++ b/apps/supervisor/eslint.config.mjs
@@ -1,0 +1,34 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
+
+// Standalone flat config for the @remote-dev/supervisor workspace. Mirrors the
+// root app's rules but is scoped to apps/supervisor so the root `eslint` run
+// (which globally-ignores `apps/**`) never lints this tree, and vice-versa.
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  {
+    rules: {
+      // Allow intentionally unused args/vars when prefixed with `_`.
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+  globalIgnores([
+    ".next/**",
+    "out/**",
+    "build/**",
+    "next-env.d.ts",
+    "coverage/**",
+    "drizzle/**",
+  ]),
+]);
+
+export default eslintConfig;

--- a/apps/supervisor/next.config.ts
+++ b/apps/supervisor/next.config.ts
@@ -1,0 +1,30 @@
+import type { NextConfig } from "next";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// The Supervisor UI runs on its OWN hostname (e.g. sup.example.com) per the
+// k3s supervisor spec §15 M3 — it is NOT slug-pathed like provisioned
+// instances. basePath is therefore always "" (root). Do not wire RDV_BASE_PATH
+// here; that is an instance (data-plane) concern, not a control-plane one.
+
+// Turbopack root = the monorepo root. In this bun workspace the app's deps
+// (incl. `next`) are symlinks into the repo-root `node_modules/.bun` store, so
+// Turbopack must be allowed to resolve from the monorepo root — pointing it at
+// the app dir makes Next fail to locate `next` and re-infer the root. Because
+// the root is shared with the main app, this app provides its OWN convention
+// files (`src/proxy.ts`, `src/instrumentation.ts`) so Turbopack uses them
+// rather than walking up to the sibling root app's `src/`.
+const monorepoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const nextConfig: NextConfig = {
+  // `output: "standalone"` produces a self-contained server bundle suitable
+  // for the Supervisor's own container image (built in a later task).
+  output: "standalone",
+  // libsql ships native bindings that must not be bundled by the Next compiler.
+  serverExternalPackages: ["@libsql/client"],
+  turbopack: {
+    root: monorepoRoot,
+  },
+};
+
+export default nextConfig;

--- a/apps/supervisor/package.json
+++ b/apps/supervisor/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@remote-dev/supervisor",
+  "version": "0.1.0",
+  "description": "k3s Supervisor control-plane service for Remote Dev — provisions and lifecycle-manages instances on a Kubernetes cluster",
+  "private": true,
+  "scripts": {
+    "dev": "dotenv -e .env.local -- sh -c 'next dev -p ${PORT:-6003}'",
+    "build": "next build",
+    "start": "dotenv -e .env.local -- sh -c 'next start -p ${PORT:-6003}'",
+    "dev:controller": "dotenv -e .env.local -- tsx src/controller/index.ts",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "db:push": "drizzle-kit push"
+  },
+  "dependencies": {
+    "@kubernetes/client-node": "^1.4.0",
+    "@libsql/client": "^0.15.15",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "drizzle-orm": "^0.45.1",
+    "jose": "^6.1.3",
+    "lucide-react": "^0.562.0",
+    "next": "16.1.0",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
+    "tailwind-merge": "^3.4.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^5.1.2",
+    "dotenv-cli": "^11.0.0",
+    "drizzle-kit": "^0.31.8",
+    "eslint": "^9",
+    "eslint-config-next": "16.1.0",
+    "happy-dom": "^20.0.11",
+    "tailwindcss": "^4",
+    "tsx": "^4.21.0",
+    "tw-animate-css": "^1.4.0",
+    "typescript": "^5",
+    "vitest": "^4.0.16"
+  }
+}

--- a/apps/supervisor/postcss.config.mjs
+++ b/apps/supervisor/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/apps/supervisor/src/__tests__/proxy.test.ts
+++ b/apps/supervisor/src/__tests__/proxy.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+import { proxy } from "@/proxy";
+
+// Build a minimal NextRequest-like object: proxy() only reads
+// `nextUrl.pathname` and `headers.get(...)`.
+function makeReq(pathname: string, headers: Record<string, string> = {}): NextRequest {
+  return {
+    nextUrl: { pathname },
+    headers: new Headers(headers),
+  } as unknown as NextRequest;
+}
+
+const ORIGINAL = {
+  aud: process.env.SUPERVISOR_CF_ACCESS_AUD,
+  team: process.env.SUPERVISOR_CF_ACCESS_TEAM,
+};
+
+beforeEach(() => {
+  process.env.SUPERVISOR_CF_ACCESS_AUD = ORIGINAL.aud;
+  process.env.SUPERVISOR_CF_ACCESS_TEAM = ORIGINAL.team;
+});
+
+const PLAUSIBLE_JWT = "aaa.bbb.ccc";
+
+describe("supervisor proxy edge gate (I1)", () => {
+  beforeEach(() => {
+    process.env.SUPERVISOR_CF_ACCESS_AUD = "aud-123";
+    process.env.SUPERVISOR_CF_ACCESS_TEAM = "team-x";
+  });
+
+  it("passes static/health/api regardless of token", () => {
+    for (const p of ["/_next/static/x.js", "/favicon.ico", "/api/health", "/api/instances"]) {
+      expect(proxy(makeReq(p)).status).toBe(200);
+    }
+  });
+
+  it("401s a page route in prod-config when no token is present", () => {
+    const res = proxy(makeReq("/"));
+    expect(res.status).toBe(401);
+  });
+
+  it("401s when the token is present but NOT structurally a JWT", () => {
+    // garbage cookie value (not 3 dot-separated non-empty parts)
+    const res = proxy(makeReq("/", { cookie: "CF_Authorization=not-a-jwt" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("allows a structurally-plausible JWT in the cookie", () => {
+    const res = proxy(
+      makeReq("/", { cookie: `CF_Authorization=${PLAUSIBLE_JWT}` }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("allows a structurally-plausible JWT in the assertion header", () => {
+    const res = proxy(makeReq("/", { "cf-access-jwt-assertion": PLAUSIBLE_JWT }));
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects an assertion header with empty segments", () => {
+    const res = proxy(makeReq("/", { "cf-access-jwt-assertion": "a..c" }));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("supervisor proxy edge gate — CF not configured (dev)", () => {
+  beforeEach(() => {
+    delete process.env.SUPERVISOR_CF_ACCESS_AUD;
+    delete process.env.SUPERVISOR_CF_ACCESS_TEAM;
+  });
+
+  it("allows page routes through (auth handled server-side / local dev)", () => {
+    expect(proxy(makeReq("/")).status).toBe(200);
+  });
+});

--- a/apps/supervisor/src/app/api/health/route.ts
+++ b/apps/supervisor/src/app/api/health/route.ts
@@ -1,0 +1,11 @@
+/**
+ * GET /api/health — liveness. Unauthenticated by design (spec §6.7).
+ * Returns 200 as long as the Node process can serve HTTP.
+ */
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET(): NextResponse {
+  return NextResponse.json({ status: "ok" });
+}

--- a/apps/supervisor/src/app/api/instances/[id]/route.ts
+++ b/apps/supervisor/src/app/api/instances/[id]/route.ts
@@ -1,0 +1,45 @@
+/**
+ * /api/instances/:id
+ *   GET    (viewer) — detail from DB, owner-checked.
+ *   DELETE (admin)  — terminate; 501 PHASE1_PENDING (teardown is jvcx.4).
+ */
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { instance } from "@/db/schema";
+import { withSupervisorAuth, phase1Pending } from "@/lib/auth";
+import { canManageInstance } from "@/lib/roles";
+
+/** GET /api/instances/:id — owner-checked detail. */
+export const GET = withSupervisorAuth("viewer", async (_request, { user, params }) => {
+  const id = params?.id;
+  if (!id) {
+    return NextResponse.json(
+      { error: "Missing instance id", code: "INVALID_BODY" },
+      { status: 400 },
+    );
+  }
+
+  const row = await db.query.instance.findFirst({
+    where: eq(instance.id, id),
+  });
+
+  // 404 both when missing AND when the caller may not see it — don't leak
+  // existence of other owners' instances to non-admins.
+  if (!row || !canManageInstance(user, row)) {
+    return NextResponse.json(
+      { error: "Instance not found", code: "NOT_FOUND" },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({ instance: row });
+});
+
+/**
+ * DELETE /api/instances/:id — terminate the instance.
+ * Teardown (delete namespace → confirm gone → mark deleted) is jvcx.4.
+ */
+export const DELETE = withSupervisorAuth("admin", async () => {
+  return phase1Pending();
+});

--- a/apps/supervisor/src/app/api/instances/route.ts
+++ b/apps/supervisor/src/app/api/instances/route.ts
@@ -1,0 +1,97 @@
+/**
+ * /api/instances
+ *   GET  (viewer)   — owner-scoped list (admins see all).
+ *   POST (operator) — validate slug + body, then 501 PHASE1_PENDING for the
+ *                     actual k8s provisioning (provisioner is jvcx.4).
+ */
+import { NextResponse } from "next/server";
+import { eq, desc } from "drizzle-orm";
+import { db } from "@/db";
+import { instance } from "@/db/schema";
+import { withSupervisorAuth } from "@/lib/auth";
+import { validateSlug, namespaceForSlug } from "@/lib/slug";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("api/instances");
+
+/** GET /api/instances — owner-scoped list. */
+export const GET = withSupervisorAuth("viewer", async (_request, { user }) => {
+  const rows =
+    user.role === "admin"
+      ? await db.select().from(instance).orderBy(desc(instance.createdAt))
+      : await db
+          .select()
+          .from(instance)
+          .where(eq(instance.ownerId, user.id))
+          .orderBy(desc(instance.createdAt));
+
+  return NextResponse.json({ instances: rows });
+});
+
+interface CreateInstanceBody {
+  slug?: unknown;
+  displayName?: unknown;
+  storageTargetId?: unknown;
+}
+
+/**
+ * POST /api/instances — create an instance.
+ *
+ * Phase 1: we validate the slug + body and the namespace mapping, but the k8s
+ * provisioning (Namespace/Secret/Service/StatefulSet, readyz poll, rollback) is
+ * jvcx.4. We therefore do NOT persist a row or touch the cluster — we return
+ * 501 PHASE1_PENDING after validation so the contract (and validation errors)
+ * are exercisable now without leaving orphaned `requested` rows behind.
+ */
+export const POST = withSupervisorAuth("operator", async (request, { user }) => {
+  let body: CreateInstanceBody;
+  try {
+    body = (await request.json()) as CreateInstanceBody;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON in request body", code: "INVALID_JSON" },
+      { status: 400 },
+    );
+  }
+
+  const slugResult = validateSlug(body.slug);
+  if (!slugResult.valid) {
+    return NextResponse.json(
+      { error: slugResult.message, code: "INVALID_SLUG" },
+      { status: 400 },
+    );
+  }
+  const slug = body.slug as string;
+
+  if (typeof body.displayName !== "string" || body.displayName.trim() === "") {
+    return NextResponse.json(
+      { error: "displayName is required", code: "INVALID_BODY" },
+      { status: 400 },
+    );
+  }
+
+  // Uniqueness pre-check (the unique index is the source of truth once we
+  // actually insert in jvcx.4).
+  const existing = await db.query.instance.findFirst({
+    where: eq(instance.slug, slug),
+  });
+  if (existing) {
+    return NextResponse.json(
+      { error: `Slug "${slug}" is already in use`, code: "SLUG_TAKEN" },
+      { status: 409 },
+    );
+  }
+
+  log.info("Instance create requested (provisioning deferred to jvcx.4)", {
+    slug,
+    namespace: namespaceForSlug(slug),
+    ownerId: user.id,
+  });
+
+  // TODO(jvcx.4): generate AUTH_SECRET, insert `requested` row (+ optional seed
+  // row), and hand off to the provisioner/reconciler. Until then:
+  return NextResponse.json(
+    { error: "not implemented", code: "PHASE1_PENDING" },
+    { status: 501 },
+  );
+});

--- a/apps/supervisor/src/app/api/internal/routes/__tests__/route.test.ts
+++ b/apps/supervisor/src/app/api/internal/routes/__tests__/route.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The route module imports @/db at top level; stub it so importing the route
+// never initialises the real libsql client. We only test the auth gate here.
+vi.mock("@/db", () => ({ db: {} }));
+
+import { authorizeInternalRequest } from "@/app/api/internal/routes/route";
+
+function reqWith(secretHeader?: string): Request {
+  const headers = new Headers();
+  if (secretHeader !== undefined) {
+    headers.set("x-supervisor-internal-secret", secretHeader);
+  }
+  return new Request("https://sup.example.com/api/internal/routes", { headers });
+}
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+function setNodeEnv(value: string | undefined): void {
+  (process.env as Record<string, string | undefined>).NODE_ENV = value;
+}
+
+beforeEach(() => {
+  delete process.env.SUPERVISOR_INTERNAL_SECRET;
+  setNodeEnv(ORIGINAL_NODE_ENV);
+});
+
+describe("authorizeInternalRequest (I2)", () => {
+  it("allows when the provided secret matches", () => {
+    process.env.SUPERVISOR_INTERNAL_SECRET = "s3cret";
+    expect(authorizeInternalRequest(reqWith("s3cret"))).toBeNull();
+  });
+
+  it("401 when a secret is set but the header is wrong/missing", async () => {
+    process.env.SUPERVISOR_INTERNAL_SECRET = "s3cret";
+
+    const wrong = authorizeInternalRequest(reqWith("nope"));
+    expect(wrong?.status).toBe(401);
+    expect((await wrong!.json()).code).toBe("UNAUTHORIZED");
+
+    const missing = authorizeInternalRequest(reqWith());
+    expect(missing?.status).toBe(401);
+  });
+
+  it("503 MISCONFIGURED in production when no secret is set", async () => {
+    setNodeEnv("production");
+    const res = authorizeInternalRequest(reqWith());
+    expect(res?.status).toBe(503);
+    expect((await res!.json()).code).toBe("MISCONFIGURED");
+  });
+
+  it("allows in dev when no secret is set (open endpoint)", () => {
+    setNodeEnv("development");
+    expect(authorizeInternalRequest(reqWith())).toBeNull();
+  });
+});

--- a/apps/supervisor/src/app/api/internal/routes/route.ts
+++ b/apps/supervisor/src/app/api/internal/routes/route.ts
@@ -1,0 +1,106 @@
+/**
+ * GET /api/internal/routes — the router allowlist endpoint (spec §6.7, §15 B2).
+ *
+ * Consumed by the Supervisor router (jvcx.6), NOT the UI — there is no user
+ * session here. It is gated by a shared secret the router presents:
+ *   - SUPERVISOR_INTERNAL_SECRET set → require header
+ *     `x-supervisor-internal-secret` to match (else 401).
+ *   - unset in production → refuse to serve (503 MISCONFIGURED) — never expose
+ *     the allowlist unauthenticated in prod.
+ *   - unset in dev → allow, but warn once that it's unauthenticated.
+ *
+ * Namespace model (§15 B2): ONE namespace per instance (`rdv-<slug>`) with a
+ * Service named `rdv` inside it. Each entry is therefore:
+ *   slug -> { namespace, service, httpPort, wsPort, ready }
+ *
+ * Phase 1: no instances reach `ready` yet (provisioning is jvcx.4), so this is
+ * effectively empty — but it reads live from the DB so it lights up
+ * automatically once provisioning lands.
+ */
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { instance } from "@/db/schema";
+import { createLogger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const log = createLogger("api/internal/routes");
+
+/** Convention ports for the instance data plane (matches the instance image). */
+const HTTP_PORT = 6001;
+const WS_PORT = 6002;
+/** Service name inside each `rdv-<slug>` namespace (§15 B2). */
+const SERVICE_NAME = "rdv";
+
+let warnedUnauthenticated = false;
+
+export interface RouteEntry {
+  namespace: string;
+  service: string;
+  httpPort: number;
+  wsPort: number;
+  ready: boolean;
+}
+
+/**
+ * Authorize an internal-routes request. Returns null when allowed, or a
+ * NextResponse to short-circuit. Exported for unit testing.
+ */
+export function authorizeInternalRequest(request: Request): NextResponse | null {
+  const secret = process.env.SUPERVISOR_INTERNAL_SECRET;
+  const provided = request.headers.get("x-supervisor-internal-secret");
+
+  if (secret) {
+    if (provided !== secret) {
+      return NextResponse.json(
+        { error: "Unauthorized", code: "UNAUTHORIZED" },
+        { status: 401 },
+      );
+    }
+    return null;
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    log.error(
+      "SUPERVISOR_INTERNAL_SECRET not set; refusing to serve internal routes in production",
+      {},
+    );
+    return NextResponse.json(
+      { error: "internal endpoint not configured", code: "MISCONFIGURED" },
+      { status: 503 },
+    );
+  }
+
+  // Dev with no secret: allow, but warn once.
+  if (!warnedUnauthenticated) {
+    warnedUnauthenticated = true;
+    log.warn(
+      "SUPERVISOR_INTERNAL_SECRET not set; /api/internal/routes is unauthenticated (dev only)",
+    );
+  }
+  return null;
+}
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const denied = authorizeInternalRequest(request);
+  if (denied) return denied;
+
+  const ready = await db
+    .select()
+    .from(instance)
+    .where(eq(instance.status, "ready"));
+
+  const routes: Record<string, RouteEntry> = {};
+  for (const inst of ready) {
+    routes[inst.slug] = {
+      namespace: inst.namespace,
+      service: SERVICE_NAME,
+      httpPort: HTTP_PORT,
+      wsPort: WS_PORT,
+      ready: true,
+    };
+  }
+
+  return NextResponse.json({ routes });
+}

--- a/apps/supervisor/src/app/api/nodes/route.ts
+++ b/apps/supervisor/src/app/api/nodes/route.ts
@@ -1,0 +1,11 @@
+/**
+ * GET /api/nodes (viewer) — nodes + capacity summary.
+ *
+ * 501 PHASE1_PENDING: node listing / capacity summary is part of the
+ * storage + capacity work (jvcx.5 / Phase 3). Auth-wrapped.
+ */
+import { withSupervisorAuth, phase1Pending } from "@/lib/auth";
+
+export const GET = withSupervisorAuth("viewer", async () => {
+  return phase1Pending();
+});

--- a/apps/supervisor/src/app/api/storage-targets/route.ts
+++ b/apps/supervisor/src/app/api/storage-targets/route.ts
@@ -1,0 +1,11 @@
+/**
+ * GET /api/storage-targets (viewer) — live storage discovery.
+ *
+ * 501 PHASE1_PENDING: StorageClass/node discovery + registered-target merge +
+ * resiliencyNote is jvcx.5. Auth-wrapped so the contract is exercisable now.
+ */
+import { withSupervisorAuth, phase1Pending } from "@/lib/auth";
+
+export const GET = withSupervisorAuth("viewer", async () => {
+  return phase1Pending();
+});

--- a/apps/supervisor/src/app/globals.css
+++ b/apps/supervisor/src/app/globals.css
@@ -1,0 +1,87 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+
+/* Design tokens mirror the root app (src/app/globals.css) so the Supervisor UI
+   shares the new-york shadcn look. Trimmed to the tokens used by the control
+   plane's chrome. */
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/apps/supervisor/src/app/layout.tsx
+++ b/apps/supervisor/src/app/layout.tsx
@@ -1,0 +1,38 @@
+import type { Metadata, Viewport } from "next";
+import { Geist, Geist_Mono } from "next/font/google";
+import "./globals.css";
+
+const geistSans = Geist({
+  variable: "--font-geist-sans",
+  subsets: ["latin"],
+});
+
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+export const metadata: Metadata = {
+  title: "Remote Dev Supervisor",
+  description: "Control plane for Remote Dev instances on k3s",
+};
+
+export const viewport: Viewport = {
+  themeColor: "#1a1b26",
+  width: "device-width",
+  initialScale: 1,
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en" className="dark" suppressHydrationWarning>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+      >
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/apps/supervisor/src/app/page.tsx
+++ b/apps/supervisor/src/app/page.tsx
@@ -1,0 +1,175 @@
+export const dynamic = "force-dynamic";
+
+import { headers } from "next/headers";
+import { eq, desc } from "drizzle-orm";
+import { db } from "@/db";
+import { instance, type InstanceRow } from "@/db/schema";
+import {
+  validateAccessJWT,
+  isCfAccessConfigured,
+} from "@/lib/cf-access";
+import { resolveSupervisorUser } from "@/lib/auth";
+import { type Role } from "@/lib/roles";
+import { cn } from "@/lib/utils";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("Dashboard");
+
+interface CurrentUser {
+  id: string;
+  email: string;
+  role: Role;
+}
+
+/**
+ * Resolve the current operator for a server-rendered page. Same precedence as
+ * `withSupervisorAuth` (CF Access in prod, SUPERVISOR_ADMIN_EMAIL in local dev),
+ * but reads headers via next/headers instead of a Request.
+ */
+async function getCurrentUser(): Promise<CurrentUser | null> {
+  let email: string | null = null;
+
+  if (isCfAccessConfigured()) {
+    const hdrs = await headers();
+    const headerToken = hdrs.get("cf-access-jwt-assertion");
+    const cookie = hdrs.get("cookie");
+    const cookieToken = cookie?.match(/CF_Authorization=([^;]+)/)?.[1] ?? null;
+    const cfUser = await validateAccessJWT(headerToken ?? cookieToken);
+    email = cfUser?.email ?? null;
+  } else {
+    const adminEmail = process.env.SUPERVISOR_ADMIN_EMAIL;
+    email = adminEmail && adminEmail.length > 0 ? adminEmail : null;
+  }
+
+  if (!email) return null;
+
+  try {
+    const user = await resolveSupervisorUser(email);
+    return { id: user.id, email: user.email, role: user.role };
+  } catch (error) {
+    log.error("Failed to resolve current user", { error: String(error) });
+    return null;
+  }
+}
+
+/** Owner-scoped instance list: admins see all; others see only their own. */
+async function listVisibleInstances(user: CurrentUser): Promise<InstanceRow[]> {
+  if (user.role === "admin") {
+    return db.select().from(instance).orderBy(desc(instance.createdAt));
+  }
+  return db
+    .select()
+    .from(instance)
+    .where(eq(instance.ownerId, user.id))
+    .orderBy(desc(instance.createdAt));
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  ready: "bg-emerald-500/15 text-emerald-400",
+  provisioning: "bg-amber-500/15 text-amber-400",
+  requested: "bg-sky-500/15 text-sky-400",
+  suspended: "bg-zinc-500/15 text-zinc-400",
+  terminating: "bg-orange-500/15 text-orange-400",
+  deleted: "bg-zinc-500/15 text-zinc-500",
+  error: "bg-red-500/15 text-red-400",
+};
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+        STATUS_STYLES[status] ?? "bg-muted text-muted-foreground",
+      )}
+    >
+      {status}
+    </span>
+  );
+}
+
+export default async function DashboardPage() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return (
+      <main className="mx-auto flex min-h-svh max-w-2xl flex-col items-center justify-center px-6 text-center">
+        <h1 className="text-2xl font-semibold">Remote Dev Supervisor</h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Not authenticated. In production this UI is gated by Cloudflare Access;
+          for local development set{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+            SUPERVISOR_ADMIN_EMAIL
+          </code>{" "}
+          in <code className="font-mono text-xs">.env.local</code>.
+        </p>
+      </main>
+    );
+  }
+
+  const instances = await listVisibleInstances(user);
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-10">
+      <header className="flex items-end justify-between border-b border-border pb-6">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Remote Dev Supervisor
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {user.role === "admin"
+              ? "All instances across the cluster."
+              : "Instances you own."}
+          </p>
+        </div>
+        <div className="text-right text-xs text-muted-foreground">
+          <div className="font-medium text-foreground">{user.email}</div>
+          <div className="uppercase tracking-wide">{user.role}</div>
+        </div>
+      </header>
+
+      <section className="mt-8">
+        {instances.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border px-6 py-16 text-center">
+            <h2 className="text-base font-medium">No instances yet</h2>
+            <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
+              Provisioning lands in a later Phase&nbsp;1 task (jvcx.4). Once
+              available, operators will create instances here and reach them at{" "}
+              <code className="font-mono text-xs">/&lt;slug&gt;</code> through the
+              router.
+            </p>
+          </div>
+        ) : (
+          <ul className="divide-y divide-border overflow-hidden rounded-lg border border-border">
+            {instances.map((inst) => (
+              <li
+                key={inst.id}
+                className="flex items-center justify-between gap-4 px-5 py-4"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate font-medium">
+                      {inst.displayName}
+                    </span>
+                    <StatusBadge status={inst.status} />
+                  </div>
+                  <div className="mt-1 truncate font-mono text-xs text-muted-foreground">
+                    /{inst.slug} · {inst.namespace}
+                  </div>
+                </div>
+                {inst.baseUrl ? (
+                  <span className="shrink-0 truncate font-mono text-xs text-muted-foreground">
+                    {inst.baseUrl}
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <footer className="mt-10 text-xs text-muted-foreground">
+        Scaffold — Phase 1 in progress (remote-dev-jvcx.3).
+      </footer>
+    </main>
+  );
+}

--- a/apps/supervisor/src/controller/index.ts
+++ b/apps/supervisor/src/controller/index.ts
@@ -1,0 +1,83 @@
+/**
+ * Supervisor controller process (the second process in the two-process model,
+ * spec §6.1). Long-running reconciler + capacity loop.
+ *
+ * SCAFFOLD ONLY: this is a no-op reconcile loop that ticks every
+ * RECONCILE_INTERVAL_MS and logs. The real reconciler — advancing instances
+ * through the state machine from live k8s state (§6.3), transactional
+ * provisioning + rollback (§6.4), and the capacity loop (Phase 3) — lands in
+ * jvcx.4+. It plugs in at `reconcileTick()` below.
+ *
+ * Run via: `bun run dev:controller` (tsx).
+ */
+
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("Controller");
+
+/** Reconcile cadence — 30s poll (§6.3: no Watch streams; restart-safe). */
+const RECONCILE_INTERVAL_MS = 30_000;
+
+let ticking = false;
+let timer: ReturnType<typeof setInterval> | null = null;
+let shuttingDown = false;
+
+/**
+ * One reconcile pass. No-op until jvcx.4.
+ *
+ * When implemented this will: load instances from the DB, query live k8s state,
+ * and drive each instance's state machine (requested→provisioning→ready, etc.),
+ * recording transitions in the audit log.
+ */
+async function reconcileTick(): Promise<void> {
+  // Guard against overlapping ticks if a future implementation runs long.
+  if (ticking) {
+    log.debug("Reconcile tick skipped (previous still running)");
+    return;
+  }
+  ticking = true;
+  try {
+    log.info("reconcile tick", { intervalMs: RECONCILE_INTERVAL_MS });
+    // TODO(jvcx.4): reconcile instances against live cluster state.
+  } catch (error) {
+    log.error("reconcile tick failed", { error: String(error) });
+  } finally {
+    ticking = false;
+  }
+}
+
+function start(): void {
+  log.info("Supervisor controller starting", {
+    intervalMs: RECONCILE_INTERVAL_MS,
+  });
+  // Kick an immediate tick, then poll on the interval.
+  void reconcileTick();
+  timer = setInterval(() => void reconcileTick(), RECONCILE_INTERVAL_MS);
+}
+
+async function shutdown(signal: string): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  log.info("Supervisor controller shutting down", { signal });
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+  // Wait (up to 5s) for any in-flight reconcile tick to settle before exit.
+  // Matters once jvcx.4 adds real work that shouldn't be torn out mid-flight.
+  const deadline = Date.now() + 5_000;
+  while (ticking && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  if (ticking) log.warn("Exiting with a reconcile tick still in flight");
+  process.exit(0);
+}
+
+process.on("SIGTERM", () => {
+  void shutdown("SIGTERM");
+});
+process.on("SIGINT", () => {
+  void shutdown("SIGINT");
+});
+
+start();

--- a/apps/supervisor/src/db/__tests__/schema.test.ts
+++ b/apps/supervisor/src/db/__tests__/schema.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import * as schema from "@/db/schema";
+
+/**
+ * Smoke test: the schema module imports cleanly and exposes the Phase-1 tables
+ * (and NOT the Phase-3 machine tables). Guards against accidental breakage of
+ * the Drizzle table definitions during refactors.
+ */
+describe("supervisor schema", () => {
+  it("exports the Phase-1 tables", () => {
+    expect(schema.supervisorUser).toBeDefined();
+    expect(schema.instance).toBeDefined();
+    expect(schema.registeredStorageTarget).toBeDefined();
+    expect(schema.instanceAuditLog).toBeDefined();
+    expect(schema.instanceSeed).toBeDefined();
+  });
+
+  it("does NOT define Phase-3 machine tables yet", () => {
+    expect((schema as Record<string, unknown>).machine).toBeUndefined();
+    expect((schema as Record<string, unknown>).capacityEvent).toBeUndefined();
+  });
+
+  it("instance table carries the owner-scoping + namespace columns", () => {
+    // Drizzle exposes columns on the table object; assert the load-bearing ones.
+    const cols = schema.instance as unknown as Record<string, unknown>;
+    expect(cols.ownerId).toBeDefined();
+    expect(cols.namespace).toBeDefined();
+    expect(cols.slug).toBeDefined();
+    expect(cols.status).toBeDefined();
+  });
+});

--- a/apps/supervisor/src/db/index.ts
+++ b/apps/supervisor/src/db/index.ts
@@ -1,0 +1,43 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { existsSync, mkdirSync } from "node:fs";
+import { createClient } from "@libsql/client/node";
+import { drizzle } from "drizzle-orm/libsql";
+import * as schema from "./schema";
+
+/**
+ * Supervisor SQLite client. Independent of any instance database.
+ *
+ * Path resolution (mirrors the root app's src/db + src/lib/paths.ts):
+ *   DATABASE_URL > SUPERVISOR_DATA_DIR/supervisor.db > ~/.remote-dev-supervisor/supervisor.db
+ */
+function getDataDir(): string {
+  return (
+    process.env.SUPERVISOR_DATA_DIR || join(homedir(), ".remote-dev-supervisor")
+  );
+}
+
+function getDatabaseUrl(): string {
+  const dbUrl = process.env.DATABASE_URL;
+  if (dbUrl) {
+    return dbUrl.startsWith("file:") ? dbUrl : `file:${dbUrl}`;
+  }
+  return `file:${join(getDataDir(), "supervisor.db")}`;
+}
+
+// Ensure the data directory exists before connecting (no-op when DATABASE_URL
+// points elsewhere and the dir already exists).
+const dataDir = getDataDir();
+if (!existsSync(dataDir)) {
+  mkdirSync(dataDir, { recursive: true });
+}
+
+export const client = createClient({ url: getDatabaseUrl() });
+
+// WAL + busy_timeout to avoid SQLITE_BUSY under concurrent writes (the Next.js
+// API process and the controller process both write).
+client.execute("PRAGMA journal_mode = WAL").catch(() => {});
+client.execute("PRAGMA synchronous = NORMAL").catch(() => {});
+client.execute("PRAGMA busy_timeout = 5000").catch(() => {});
+
+export const db = drizzle(client, { schema });

--- a/apps/supervisor/src/db/schema.ts
+++ b/apps/supervisor/src/db/schema.ts
@@ -1,0 +1,194 @@
+/**
+ * Supervisor Drizzle schema (sqlite / libsql).
+ *
+ * Phase-1 tables only — see the k3s supervisor spec §6.2. The `machine` and
+ * `capacity_event` tables (machine autoscaling, §8.7) are Phase 3 and are
+ * intentionally OMITTED here; add them when Phase 3 lands.
+ *
+ * Instances are OWNER-SCOPED: `instance.ownerId` references the creating
+ * supervisor_user. Operators manage only their own instances; admins see all.
+ * Owner-scope enforcement lives in `src/lib/roles.ts` (`canManageInstance`).
+ */
+
+import {
+  sqliteTable,
+  text,
+  integer,
+  index,
+} from "drizzle-orm/sqlite-core";
+
+/** Supervisor RBAC role. Mirrors the union in src/lib/roles.ts. */
+export type SupervisorRole = "admin" | "operator" | "viewer";
+
+/**
+ * Instance lifecycle status (§6.3 state machine):
+ *   requested → provisioning → ready ↔ suspended → terminating → deleted
+ *   (+ error from any state)
+ */
+export type InstanceStatus =
+  | "requested"
+  | "provisioning"
+  | "ready"
+  | "suspended"
+  | "terminating"
+  | "deleted"
+  | "error";
+
+/** Storage target backend kind (§7). */
+export type StorageTargetKind =
+  | "local-path"
+  | "storage-class"
+  | "nfs"
+  | "cloud-csi";
+
+const now = () => new Date();
+
+/**
+ * Operators/admins/viewers of the Supervisor. The role concept the main app
+ * lacks. First admin is seeded from SUPERVISOR_ADMIN_EMAIL (see src/lib/auth.ts).
+ */
+export const supervisorUser = sqliteTable("supervisor_user", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  email: text("email").notNull().unique(),
+  role: text("role").$type<SupervisorRole>().notNull().default("viewer"),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(now),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(now)
+    .$onUpdateFn(now),
+});
+
+/**
+ * A provisioned (or to-be-provisioned) Remote Dev instance.
+ *
+ * Namespace model (§15 B2): ONE namespace per instance, `rdv-<slug>`, with a
+ * Service named `rdv` inside it. The `namespace` column stores `rdv-<slug>`.
+ */
+export const instance = sqliteTable(
+  "instance",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    slug: text("slug").notNull().unique(),
+    displayName: text("display_name").notNull(),
+    // Owner-scoping: the supervisor_user who created this instance.
+    // Explicit RESTRICT (no cascade): deleting a user must NOT nuke their
+    // running instances — reassign or delete the instances first.
+    ownerId: text("owner_id")
+      .notNull()
+      .references(() => supervisorUser.id, { onDelete: "restrict" }),
+    status: text("status").$type<InstanceStatus>().notNull().default("requested"),
+    errorMessage: text("error_message"),
+    // One namespace per instance: "rdv-<slug>" (§15 B2). notNull() with NO
+    // insert-time default: jvcx.4's create path MUST set
+    // `namespace: namespaceForSlug(slug)` (== `rdv-<slug>`); omitting it fails
+    // at insert.
+    namespace: text("namespace").notNull(),
+    imageTag: text("image_tag"),
+    baseUrl: text("base_url"),
+    // FK is soft (no .references) so deleting a storage target cannot cascade
+    // into live instances; the chosen config is snapshotted below.
+    storageTargetId: text("storage_target_id"),
+    // Snapshot of the chosen storage target's config at provision time so later
+    // edits/deletes of the target don't corrupt existing instances (§7). JSON text.
+    storageConfigSnapshot: text("storage_config_snapshot"),
+    cpuRequest: text("cpu_request"),
+    cpuLimit: text("cpu_limit"),
+    memRequest: text("mem_request"),
+    memLimit: text("mem_limit"),
+    storageRequest: text("storage_request"),
+    lastReconciledAt: integer("last_reconciled_at", { mode: "timestamp_ms" }),
+    provisionedAt: integer("provisioned_at", { mode: "timestamp_ms" }),
+    suspendedAt: integer("suspended_at", { mode: "timestamp_ms" }),
+    deletedAt: integer("deleted_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(now),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(now)
+      .$onUpdateFn(now),
+  },
+  (t) => [
+    index("instance_owner_idx").on(t.ownerId),
+    index("instance_status_idx").on(t.status),
+  ],
+);
+
+/**
+ * Storage targets that are NOT live-discoverable (NFS / custom). StorageClasses
+ * and nodes are discovered from the cluster at request time, not stored here.
+ */
+export const registeredStorageTarget = sqliteTable("registered_storage_target", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  name: text("name").notNull().unique(),
+  kind: text("kind").$type<StorageTargetKind>().notNull(),
+  config: text("config").notNull(), // JSON text
+  resiliencyNote: text("resiliency_note"),
+  isDefault: integer("is_default", { mode: "boolean" }).notNull().default(false),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .notNull()
+    .$defaultFn(now),
+});
+
+/** Append-only audit trail of instance lifecycle actions. */
+export const instanceAuditLog = sqliteTable(
+  "instance_audit_log",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    instanceId: text("instance_id")
+      .notNull()
+      .references(() => instance.id, { onDelete: "cascade" }),
+    actorId: text("actor_id"),
+    actorEmail: text("actor_email"),
+    action: text("action").notNull(),
+    previousStatus: text("previous_status").$type<InstanceStatus>(),
+    newStatus: text("new_status").$type<InstanceStatus>(),
+    metadata: text("metadata"), // JSON text
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(now),
+  },
+  (t) => [index("instance_audit_log_instance_idx").on(t.instanceId)],
+);
+
+/** First-boot seed bookkeeping for an instance (authorized users → seed Job). */
+export const instanceSeed = sqliteTable("instance_seed", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  instanceId: text("instance_id")
+    .notNull()
+    .unique()
+    .references(() => instance.id, { onDelete: "cascade" }),
+  authorizedEmails: text("authorized_emails"), // JSON text (array of emails)
+  jobDispatched: integer("job_dispatched", { mode: "boolean" })
+    .notNull()
+    .default(false),
+  jobName: text("job_name"),
+  completedAt: integer("completed_at", { mode: "timestamp_ms" }),
+});
+
+// --- Phase 3 (NOT in this scaffold) -----------------------------------------
+// `machine(machineId, providerId, providerType, displayName, nodeName, arch,
+//   instanceType, phase, provisionedAt, readyAt, errorMessage, labels,
+//   pinnedPvcCount, timestamps)` and
+// `capacity_event(id, eventType, machineId, pendingPods, workerCount, detail,
+//   createdAt)` are added when machine autoscaling lands (spec §8.7).
+
+// Inferred row types for convenience in services / route handlers.
+export type SupervisorUserRow = typeof supervisorUser.$inferSelect;
+export type InstanceRow = typeof instance.$inferSelect;
+export type RegisteredStorageTargetRow =
+  typeof registeredStorageTarget.$inferSelect;
+export type InstanceAuditLogRow = typeof instanceAuditLog.$inferSelect;
+export type InstanceSeedRow = typeof instanceSeed.$inferSelect;

--- a/apps/supervisor/src/instrumentation.ts
+++ b/apps/supervisor/src/instrumentation.ts
@@ -1,0 +1,79 @@
+/**
+ * Next.js instrumentation — runs once when the Supervisor server starts.
+ * @see https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+ *
+ * Two jobs, both guarded to the Node runtime (the Edge runtime cannot import
+ * the libsql client):
+ *   1. FAIL-CLOSED in production if Cloudflare Access is not configured —
+ *      otherwise `resolveAuthenticatedEmail` would trust SUPERVISOR_ADMIN_EMAIL
+ *      and every request would be admin. Refuse to start unless the explicit
+ *      escape hatch SUPERVISOR_ALLOW_INSECURE_AUTH=1 is set (testing only).
+ *   2. Seed the first admin user from SUPERVISOR_ADMIN_EMAIL (spec §6.2) so the
+ *      dashboard is reachable on a fresh database.
+ *
+ * NOTE: `register()` runs at server START, not at `next build` — so the prod
+ * guard never trips a CI build (vitest/`next build` don't call it).
+ */
+
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  const { createLogger } = await import("@/lib/logger");
+  const log = createLogger("Startup");
+
+  // (1) Production fail-closed guard. Mirror cf-access.isCfAccessConfigured():
+  // both AUD and TEAM must be present. Without it, the auth fallback would make
+  // everyone admin in prod.
+  const cfConfigured = Boolean(
+    process.env.SUPERVISOR_CF_ACCESS_AUD &&
+      process.env.SUPERVISOR_CF_ACCESS_TEAM,
+  );
+  if (
+    process.env.NODE_ENV === "production" &&
+    !cfConfigured &&
+    process.env.SUPERVISOR_ALLOW_INSECURE_AUTH !== "1"
+  ) {
+    log.error(
+      "FATAL: production without CF Access configured; refusing to start",
+      {},
+    );
+    process.exit(1);
+  }
+
+  const adminEmail = process.env.SUPERVISOR_ADMIN_EMAIL;
+  if (!adminEmail) {
+    log.warn(
+      "SUPERVISOR_ADMIN_EMAIL is not set — no admin seeded. The dashboard will be inaccessible until an admin exists.",
+    );
+    return;
+  }
+
+  try {
+    const { db } = await import("@/db");
+    const { supervisorUser } = await import("@/db/schema");
+    const { eq } = await import("drizzle-orm");
+
+    const existing = await db.query.supervisorUser.findFirst({
+      where: eq(supervisorUser.email, adminEmail),
+    });
+    if (existing) {
+      // Ensure the configured admin email keeps admin rights even if its role
+      // was lowered, so an operator can't lock the configured admin out.
+      if (existing.role !== "admin") {
+        await db
+          .update(supervisorUser)
+          .set({ role: "admin", updatedAt: new Date() })
+          .where(eq(supervisorUser.id, existing.id));
+        log.info("Restored admin role for configured admin", {
+          email: adminEmail,
+        });
+      }
+      return;
+    }
+
+    await db.insert(supervisorUser).values({ email: adminEmail, role: "admin" });
+    log.info("Seeded first admin user", { email: adminEmail });
+  } catch (error) {
+    log.error("Admin seed failed", { error: String(error) });
+  }
+}

--- a/apps/supervisor/src/lib/__tests__/auth.test.ts
+++ b/apps/supervisor/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Role } from "@/lib/roles";
+
+// --- Mocks -----------------------------------------------------------------
+// Control the CF Access layer and the DB user resolution so the auth wrapper
+// can be exercised without a cluster or a database.
+
+const cfState: { configured: boolean; email: string | null } = {
+  configured: false,
+  email: null,
+};
+
+vi.mock("@/lib/cf-access", () => ({
+  isCfAccessConfigured: () => cfState.configured,
+  getAccessToken: () => "test-token",
+  validateAccessJWT: async () =>
+    cfState.email ? { email: cfState.email, sub: "sub-1" } : null,
+}));
+
+// DB seam: `existingUser` models a row already present in the table.
+//   - findFirst returns it (or undefined for first-sight).
+//   - the upsert (insert ... onConflictDoUpdate) is modelled faithfully: if a
+//     row already exists for the email, RETURNING yields the EXISTING row
+//     (role preserved — the C2 invariant), otherwise the freshly-inserted row.
+//   - `inserted` captures the VALUES the insert was called with, so tests can
+//     assert what role the insert *attempted* and that no clobber occurred.
+//   - `returningEmpty` forces RETURNING to come back empty so the defensive
+//     re-query path is exercised.
+type UserRow = { id: string; email: string; role: Role };
+const dbState: {
+  existingUser: UserRow | undefined;
+  inserted: UserRow | null;
+  returningEmpty: boolean;
+} = {
+  existingUser: undefined,
+  inserted: null,
+  returningEmpty: false,
+};
+
+vi.mock("@/db", () => ({
+  db: {
+    query: {
+      supervisorUser: {
+        findFirst: async () => dbState.existingUser,
+      },
+    },
+    insert: () => ({
+      values: (vals: { email: string; role: Role }) => {
+        const attempted: UserRow = {
+          id: `id-${vals.email}`,
+          email: vals.email,
+          role: vals.role,
+        };
+        dbState.inserted = attempted;
+        const resolveRow = () => {
+          if (dbState.returningEmpty) return [] as UserRow[];
+          // Conflict: preserve the existing row (role NOT clobbered).
+          if (dbState.existingUser) return [dbState.existingUser];
+          return [attempted];
+        };
+        return {
+          returning: async () => resolveRow(),
+          onConflictDoUpdate: () => ({
+            returning: async () => resolveRow(),
+          }),
+        };
+      },
+    }),
+  },
+}));
+
+// Import AFTER mocks are registered.
+import {
+  withSupervisorAuth,
+  resolveAuthenticatedEmail,
+  resolveSupervisorUser,
+} from "@/lib/auth";
+
+function req(): Request {
+  return new Request("https://sup.example.com/api/test");
+}
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+function setNodeEnv(value: string | undefined): void {
+  // NODE_ENV is readonly in the Node typings; assign through a cast.
+  (process.env as Record<string, string | undefined>).NODE_ENV = value;
+}
+
+beforeEach(() => {
+  cfState.configured = false;
+  cfState.email = null;
+  dbState.existingUser = undefined;
+  dbState.inserted = null;
+  dbState.returningEmpty = false;
+  delete process.env.SUPERVISOR_ADMIN_EMAIL;
+  delete process.env.SUPERVISOR_ALLOW_INSECURE_AUTH;
+  setNodeEnv(ORIGINAL_NODE_ENV);
+});
+
+describe("withSupervisorAuth — unauthenticated (401)", () => {
+  it("401 when no CF Access and no SUPERVISOR_ADMIN_EMAIL", async () => {
+    const handler = withSupervisorAuth(
+      "viewer",
+      async () => Response.json({ ok: true }) as never,
+    );
+    const res = await handler(req());
+    expect(res.status).toBe(401);
+    expect((await res.json()).code).toBe("UNAUTHORIZED");
+  });
+
+  it("401 in prod when CF token does not validate", async () => {
+    cfState.configured = true;
+    cfState.email = null; // token invalid
+    const handler = withSupervisorAuth(
+      "viewer",
+      async () => Response.json({ ok: true }) as never,
+    );
+    const res = await handler(req());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("withSupervisorAuth — local dev admin seeding", () => {
+  it("seeds SUPERVISOR_ADMIN_EMAIL as admin and allows admin-gated routes", async () => {
+    process.env.SUPERVISOR_ADMIN_EMAIL = "boss@example.com";
+    dbState.existingUser = undefined; // first sight → insert
+
+    const handler = withSupervisorAuth(
+      "admin",
+      async (_r, { user }) =>
+        Response.json({ email: user.email, role: user.role }) as never,
+    );
+    const res = await handler(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.email).toBe("boss@example.com");
+    expect(body.role).toBe("admin");
+    expect(dbState.inserted?.role).toBe("admin");
+  });
+
+  it("a non-admin email seen for the first time is seeded as viewer", async () => {
+    process.env.SUPERVISOR_ADMIN_EMAIL = "boss@example.com";
+    cfState.configured = true;
+    cfState.email = "newcomer@example.com";
+    dbState.existingUser = undefined;
+
+    const handler = withSupervisorAuth(
+      "viewer",
+      async (_r, { user }) => Response.json({ role: user.role }) as never,
+    );
+    const res = await handler(req());
+    expect(res.status).toBe(200);
+    expect(dbState.inserted?.role).toBe("viewer");
+  });
+});
+
+describe("withSupervisorAuth — role gate (403)", () => {
+  it("403 when a viewer hits an operator-gated route", async () => {
+    cfState.configured = true;
+    cfState.email = "viewer@example.com";
+    dbState.existingUser = {
+      id: "id-viewer",
+      email: "viewer@example.com",
+      role: "viewer",
+    };
+
+    const handler = withSupervisorAuth(
+      "operator",
+      async () => Response.json({ ok: true }) as never,
+    );
+    const res = await handler(req());
+    expect(res.status).toBe(403);
+    expect((await res.json()).code).toBe("FORBIDDEN");
+  });
+
+  it("allows when the user meets the required role", async () => {
+    cfState.configured = true;
+    cfState.email = "op@example.com";
+    dbState.existingUser = {
+      id: "id-op",
+      email: "op@example.com",
+      role: "operator",
+    };
+
+    const handler = withSupervisorAuth(
+      "viewer",
+      async (_r, { user }) => Response.json({ id: user.id }) as never,
+    );
+    const res = await handler(req());
+    expect(res.status).toBe(200);
+    expect((await res.json()).id).toBe("id-op");
+  });
+});
+
+describe("resolveAuthenticatedEmail — production fail-closed (C1)", () => {
+  it("returns null in production when CF Access is NOT configured (no admin-email fallback)", async () => {
+    setNodeEnv("production");
+    cfState.configured = false;
+    process.env.SUPERVISOR_ADMIN_EMAIL = "boss@example.com";
+
+    expect(await resolveAuthenticatedEmail(req())).toBeNull();
+  });
+
+  it("the SUPERVISOR_ALLOW_INSECURE_AUTH=1 escape hatch re-enables the fallback in prod", async () => {
+    setNodeEnv("production");
+    cfState.configured = false;
+    process.env.SUPERVISOR_ADMIN_EMAIL = "boss@example.com";
+    process.env.SUPERVISOR_ALLOW_INSECURE_AUTH = "1";
+
+    expect(await resolveAuthenticatedEmail(req())).toBe("boss@example.com");
+  });
+
+  it("still trusts the admin-email fallback in non-production (dev)", async () => {
+    setNodeEnv("development");
+    cfState.configured = false;
+    process.env.SUPERVISOR_ADMIN_EMAIL = "dev@example.com";
+
+    expect(await resolveAuthenticatedEmail(req())).toBe("dev@example.com");
+  });
+
+  it("uses the validated CF email in production when CF Access IS configured", async () => {
+    setNodeEnv("production");
+    cfState.configured = true;
+    cfState.email = "cf@example.com";
+
+    expect(await resolveAuthenticatedEmail(req())).toBe("cf@example.com");
+  });
+});
+
+describe("resolveSupervisorUser — idempotent upsert (C2)", () => {
+  it("a racing insert does NOT downgrade an existing admin (role preserved)", async () => {
+    // The email is the configured admin, but a concurrent request already
+    // created the row as admin. Our insert would compute role=admin here, but
+    // the invariant is: even if it computed viewer, the existing role wins.
+    process.env.SUPERVISOR_ADMIN_EMAIL = "other@example.com"; // so computed role = viewer
+    dbState.existingUser = {
+      id: "id-admin",
+      email: "admin@example.com",
+      role: "admin",
+    };
+    // Force the first-sight path (findFirst miss) then conflict on insert.
+    const findFirstSpy = vi
+      .spyOn(
+        (await import("@/db")).db.query.supervisorUser,
+        "findFirst",
+      )
+      .mockResolvedValueOnce(undefined as never);
+
+    const resolved = await resolveSupervisorUser("admin@example.com");
+    expect(resolved.role).toBe("admin"); // NOT downgraded to viewer
+    // The insert attempted role=viewer (computed), proving the preserve came
+    // from the conflict path, not the computed value.
+    expect(dbState.inserted?.role).toBe("viewer");
+    findFirstSpy.mockRestore();
+  });
+
+  it("returns the existing row on the no-RETURNING defensive path", async () => {
+    dbState.existingUser = {
+      id: "id-x",
+      email: "x@example.com",
+      role: "operator",
+    };
+    dbState.returningEmpty = true; // force empty RETURNING → re-query
+    const db = (await import("@/db")).db;
+    const findFirstSpy = vi
+      .spyOn(db.query.supervisorUser, "findFirst")
+      // first call (initial findFirst) misses; re-query returns the row.
+      .mockResolvedValueOnce(undefined as never)
+      .mockResolvedValueOnce(dbState.existingUser as never);
+
+    const resolved = await resolveSupervisorUser("x@example.com");
+    expect(resolved.role).toBe("operator");
+    findFirstSpy.mockRestore();
+  });
+
+  it("returns the existing row immediately when findFirst hits (no insert)", async () => {
+    dbState.existingUser = {
+      id: "id-hit",
+      email: "hit@example.com",
+      role: "viewer",
+    };
+    const resolved = await resolveSupervisorUser("hit@example.com");
+    expect(resolved.id).toBe("id-hit");
+    expect(dbState.inserted).toBeNull(); // never attempted an insert
+  });
+});

--- a/apps/supervisor/src/lib/__tests__/roles.test.ts
+++ b/apps/supervisor/src/lib/__tests__/roles.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  hasRole,
+  canManageInstance,
+  isRole,
+  ROLES,
+  type Role,
+} from "@/lib/roles";
+
+describe("roles hierarchy", () => {
+  it("admin satisfies every required role", () => {
+    const admin = { id: "u1", role: "admin" as Role };
+    expect(hasRole(admin, "viewer")).toBe(true);
+    expect(hasRole(admin, "operator")).toBe(true);
+    expect(hasRole(admin, "admin")).toBe(true);
+  });
+
+  it("operator satisfies viewer + operator but not admin", () => {
+    const op = { role: "operator" as Role };
+    expect(hasRole(op, "viewer")).toBe(true);
+    expect(hasRole(op, "operator")).toBe(true);
+    expect(hasRole(op, "admin")).toBe(false);
+  });
+
+  it("viewer satisfies only viewer", () => {
+    const viewer = { role: "viewer" as Role };
+    expect(hasRole(viewer, "viewer")).toBe(true);
+    expect(hasRole(viewer, "operator")).toBe(false);
+    expect(hasRole(viewer, "admin")).toBe(false);
+  });
+
+  it("null/undefined user never has a role", () => {
+    expect(hasRole(null, "viewer")).toBe(false);
+    expect(hasRole(undefined, "viewer")).toBe(false);
+  });
+});
+
+describe("isRole", () => {
+  it("accepts known roles", () => {
+    for (const r of ROLES) expect(isRole(r)).toBe(true);
+  });
+  it("rejects unknown values", () => {
+    expect(isRole("superadmin")).toBe(false);
+    expect(isRole("")).toBe(false);
+    expect(isRole(undefined)).toBe(false);
+    expect(isRole(42)).toBe(false);
+  });
+});
+
+describe("canManageInstance owner-scoping", () => {
+  const owner = { id: "owner-1", role: "operator" as Role };
+  const otherOperator = { id: "owner-2", role: "operator" as Role };
+  const admin = { id: "admin-1", role: "admin" as Role };
+  const viewer = { id: "owner-1", role: "viewer" as Role };
+  const inst = { ownerId: "owner-1" };
+
+  it("owner can manage their own instance", () => {
+    expect(canManageInstance(owner, inst)).toBe(true);
+  });
+
+  it("a different operator cannot manage someone else's instance", () => {
+    expect(canManageInstance(otherOperator, inst)).toBe(false);
+  });
+
+  it("admin can manage any instance regardless of owner", () => {
+    expect(canManageInstance(admin, inst)).toBe(true);
+    expect(canManageInstance(admin, { ownerId: "owner-2" })).toBe(true);
+  });
+
+  it("ownership is checked by id, even for a viewer who owns it", () => {
+    // (role gating for the action is separate; this only checks ownership.)
+    expect(canManageInstance(viewer, inst)).toBe(true);
+  });
+
+  it("null user or null instance is never manageable", () => {
+    expect(canManageInstance(null, inst)).toBe(false);
+    expect(canManageInstance(owner, null)).toBe(false);
+    expect(canManageInstance(admin, null)).toBe(false);
+  });
+});

--- a/apps/supervisor/src/lib/__tests__/slug.test.ts
+++ b/apps/supervisor/src/lib/__tests__/slug.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateSlug,
+  isValidSlug,
+  isReserved,
+  namespaceForSlug,
+  RESERVED_SLUGS,
+} from "@/lib/slug";
+
+describe("validateSlug — format", () => {
+  it("accepts valid slugs", () => {
+    for (const s of ["a", "alpha", "alpha-1", "a1", "my-instance", "abcdefghijklmno"]) {
+      expect(validateSlug(s).valid, s).toBe(true);
+    }
+  });
+
+  it("rejects empty / non-string", () => {
+    expect(validateSlug("").error).toBe("empty");
+    expect(validateSlug(undefined).error).toBe("empty");
+    expect(validateSlug(123).error).toBe("empty");
+  });
+
+  it("rejects bad formats", () => {
+    expect(validateSlug("1abc").error).toBe("format"); // must start with a letter
+    expect(validateSlug("-abc").error).toBe("format"); // cannot start with hyphen
+    expect(validateSlug("Alpha").error).toBe("format"); // no uppercase
+    expect(validateSlug("a_b").error).toBe("format"); // no underscore
+    expect(validateSlug("a".repeat(16)).error).toBe("format"); // max 15 chars
+    expect(validateSlug("al pha").error).toBe("format"); // no spaces
+  });
+
+  it("exactly 15 chars is allowed, 16 is not", () => {
+    expect(validateSlug("a".repeat(15)).valid).toBe(true);
+    expect(validateSlug("a".repeat(16)).valid).toBe(false);
+  });
+});
+
+describe("reserved slugs", () => {
+  it("flags every reserved name", () => {
+    for (const r of RESERVED_SLUGS) expect(isReserved(r)).toBe(true);
+  });
+
+  it("includes the required root paths and supervisor prefix", () => {
+    for (const r of [
+      "api",
+      "ws",
+      "_next",
+      "login",
+      "healthz",
+      "readyz",
+      "manifest.json",
+      "sw.js",
+      "favicon.svg",
+      "favicon.ico",
+      "icons",
+      "supervisor",
+    ]) {
+      expect(isReserved(r), r).toBe(true);
+    }
+  });
+
+  it("validateSlug rejects reserved names that are otherwise well-formed", () => {
+    // "api" is format-valid but reserved.
+    expect(validateSlug("api").error).toBe("reserved");
+    expect(validateSlug("login").error).toBe("reserved");
+  });
+
+  it("reserved check is case-insensitive", () => {
+    expect(isReserved("API")).toBe(true);
+  });
+
+  it("non-reserved well-formed slug passes", () => {
+    expect(isValidSlug("alpha")).toBe(true);
+    expect(isReserved("alpha")).toBe(false);
+  });
+});
+
+describe("namespaceForSlug", () => {
+  it("maps slug -> rdv-<slug> (one namespace per instance, §15 B2)", () => {
+    expect(namespaceForSlug("alpha")).toBe("rdv-alpha");
+    expect(namespaceForSlug("my-instance")).toBe("rdv-my-instance");
+  });
+});

--- a/apps/supervisor/src/lib/auth.ts
+++ b/apps/supervisor/src/lib/auth.ts
@@ -1,0 +1,185 @@
+/**
+ * withSupervisorAuth — role-gated auth wrapper for Supervisor API routes.
+ *
+ * Mirrors the root app's `withApiAuth` (src/lib/api.ts) and adds a role gate
+ * (spec §6.6). Resolution order:
+ *   1. Production: validate the Supervisor's own CF Access JWT (src/lib/cf-access.ts).
+ *   2. Local dev (no CF Access AUD configured): fall back to SUPERVISOR_ADMIN_EMAIL,
+ *      mirroring the main app's localhost credentials path.
+ * The authenticated email is resolved to (or created as) a `supervisor_user`
+ * row; the first admin is seeded from SUPERVISOR_ADMIN_EMAIL. The handler then
+ * runs only if the user holds at least `requiredRole`.
+ *
+ * On failure: 401 (no/!valid identity) or 403 (authenticated but under-privileged),
+ * both as JSON.
+ */
+
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { supervisorUser } from "@/db/schema";
+import type { SupervisorUserRow } from "@/db/schema";
+import { hasRole, isRole, type Role } from "@/lib/roles";
+import {
+  validateAccessJWT,
+  getAccessToken,
+  isCfAccessConfigured,
+} from "@/lib/cf-access";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("api/auth");
+
+/** Route context for dynamic routes — params are a Promise in Next.js 16. */
+export interface RouteContext {
+  params?: Promise<Record<string, string>>;
+}
+
+/** Context passed to a wrapped handler. */
+export interface SupervisorAuthContext {
+  user: SupervisorUserRow;
+  params?: Record<string, string>;
+}
+
+type Handler = (
+  request: Request,
+  context: SupervisorAuthContext,
+) => Promise<NextResponse> | NextResponse;
+
+/**
+ * Resolve the authenticated email for this request, or null.
+ * Exported for unit testing the precedence rules.
+ */
+export async function resolveAuthenticatedEmail(
+  request: Request,
+): Promise<string | null> {
+  // Production path: a valid CF Access JWT for the Supervisor's own app.
+  if (isCfAccessConfigured()) {
+    const token = getAccessToken(request);
+    const cfUser = await validateAccessJWT(token);
+    return cfUser?.email ?? null;
+  }
+
+  // Belt-and-suspenders: NEVER trust the admin-email fallback in production.
+  // The startup guard in src/instrumentation.ts already refuses to boot prod
+  // without CF Access, but defend here too in case that guard is bypassed (or
+  // a future entry point skips instrumentation). The explicit escape hatch
+  // SUPERVISOR_ALLOW_INSECURE_AUTH=1 re-enables the fallback for testing only.
+  if (
+    process.env.NODE_ENV === "production" &&
+    process.env.SUPERVISOR_ALLOW_INSECURE_AUTH !== "1"
+  ) {
+    return null;
+  }
+
+  // Local-dev path: no CF Access configured → trust SUPERVISOR_ADMIN_EMAIL as
+  // the operator identity (mirrors the main app's localhost credentials path).
+  const adminEmail = process.env.SUPERVISOR_ADMIN_EMAIL;
+  return adminEmail && adminEmail.length > 0 ? adminEmail : null;
+}
+
+/**
+ * Get the supervisor_user for `email`, creating it on first sight. The very
+ * first user matching SUPERVISOR_ADMIN_EMAIL is seeded as `admin`; everyone
+ * else defaults to `viewer` until an admin promotes them.
+ */
+export async function resolveSupervisorUser(
+  email: string,
+): Promise<SupervisorUserRow> {
+  const existing = await db.query.supervisorUser.findFirst({
+    where: eq(supervisorUser.email, email),
+  });
+  if (existing) return existing;
+
+  const adminEmail = process.env.SUPERVISOR_ADMIN_EMAIL;
+  const role: Role = adminEmail && email === adminEmail ? "admin" : "viewer";
+
+  // Idempotent insert: concurrent first-sight requests can both miss findFirst
+  // and race to insert the same email. onConflictDoUpdate makes the loser a
+  // benign no-op (touch updatedAt) that PRESERVES the existing role — a racing
+  // insert must never downgrade an already-seeded admin to viewer.
+  const [created] = await db
+    .insert(supervisorUser)
+    .values({ email, role })
+    .onConflictDoUpdate({
+      target: supervisorUser.email,
+      set: { updatedAt: new Date() },
+    })
+    .returning();
+  if (created) {
+    log.info("Resolved supervisor user", { email, role: created.role });
+    return created;
+  }
+
+  // Extremely defensive: some drivers can return an empty RETURNING set on a
+  // conflict no-op — re-query to be safe.
+  return (await db.query.supervisorUser.findFirst({
+    where: eq(supervisorUser.email, email),
+  }))!;
+}
+
+function unauthorized(): NextResponse {
+  return NextResponse.json(
+    { error: "Unauthorized", code: "UNAUTHORIZED" },
+    { status: 401 },
+  );
+}
+
+function forbidden(required: Role): NextResponse {
+  return NextResponse.json(
+    {
+      error: `Forbidden: requires role "${required}"`,
+      code: "FORBIDDEN",
+    },
+    { status: 403 },
+  );
+}
+
+/**
+ * Wrap a Supervisor API route handler with auth + a minimum role gate.
+ *
+ * @example
+ * export const GET = withSupervisorAuth("viewer", async (_req, { user }) => {
+ *   return NextResponse.json({ email: user.email });
+ * });
+ */
+export function withSupervisorAuth(
+  requiredRole: Role,
+  handler: Handler,
+): (request: Request, context?: RouteContext) => Promise<NextResponse> {
+  return async (request: Request, context?: RouteContext) => {
+    try {
+      const email = await resolveAuthenticatedEmail(request);
+      if (!email) return unauthorized();
+
+      const user = await resolveSupervisorUser(email);
+
+      if (!isRole(user.role) || !hasRole(user, requiredRole)) {
+        log.warn("Role gate denied", {
+          email,
+          role: user.role,
+          requiredRole,
+        });
+        return forbidden(requiredRole);
+      }
+
+      const params = context?.params ? await context.params : undefined;
+      return await handler(request, { user, params });
+    } catch (error) {
+      log.error("Unhandled error in supervisor API route", {
+        error: String(error),
+      });
+      return NextResponse.json(
+        { error: "Internal server error", code: "INTERNAL_ERROR" },
+        { status: 500 },
+      );
+    }
+  };
+}
+
+/** Standard "not implemented in Phase 1" response for stubbed endpoints. */
+export function phase1Pending(): NextResponse {
+  return NextResponse.json(
+    { error: "not implemented", code: "PHASE1_PENDING" },
+    { status: 501 },
+  );
+}

--- a/apps/supervisor/src/lib/cf-access.ts
+++ b/apps/supervisor/src/lib/cf-access.ts
@@ -1,0 +1,97 @@
+/**
+ * Cloudflare Access JWT validation for the Supervisor's OWN application.
+ *
+ * Mirrors the root app's src/lib/cloudflare-access.ts (jose + remote JWKS), but
+ * scoped to the Supervisor's distinct team/AUD env vars so access to the
+ * Supervisor UI never implies access to an instance, and vice-versa.
+ *
+ * Duplicated here for workspace isolation. NOTE: promote to a shared package
+ * once both the Supervisor and the instance app can depend on it.
+ */
+
+import { jwtVerify, createRemoteJWKSet } from "jose";
+
+// Must NOT default to a real team — a wrong default fetches a foreign team's
+// JWKS and breaks verification silently. Deployers set these explicitly.
+const CF_ACCESS_TEAM = process.env.SUPERVISOR_CF_ACCESS_TEAM;
+const CF_ACCESS_AUD = process.env.SUPERVISOR_CF_ACCESS_AUD;
+
+let jwksCache: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+function getJWKS() {
+  if (!jwksCache) {
+    if (!CF_ACCESS_TEAM) {
+      throw new Error(
+        "SUPERVISOR_CF_ACCESS_TEAM is not configured; cannot build Cloudflare Access JWKS URL",
+      );
+    }
+    jwksCache = createRemoteJWKSet(
+      new URL(
+        `https://${CF_ACCESS_TEAM}.cloudflareaccess.com/cdn-cgi/access/certs`,
+      ),
+    );
+  }
+  return jwksCache;
+}
+
+export interface CloudflareAccessUser {
+  email: string;
+  /** Cloudflare user id (JWT `sub`). */
+  sub: string;
+  country?: string;
+}
+
+/** True when CF Access is configured (production). False in local dev. */
+export function isCfAccessConfigured(): boolean {
+  return Boolean(CF_ACCESS_AUD && CF_ACCESS_TEAM);
+}
+
+/**
+ * Validate a Supervisor CF Access JWT and extract the user. Returns null when
+ * the token is absent or invalid.
+ *
+ * When CF_ACCESS_AUD is unset (local dev), this returns null — callers fall
+ * back to the SUPERVISOR_ADMIN_EMAIL local-dev path (see src/lib/auth.ts).
+ */
+export async function validateAccessJWT(
+  token: string | null,
+): Promise<CloudflareAccessUser | null> {
+  if (!token) return null;
+
+  // Without an AUD configured we are in local dev — do not trust unverified
+  // tokens; let the caller use the explicit local-dev admin path instead.
+  if (!CF_ACCESS_AUD || !CF_ACCESS_TEAM) return null;
+
+  try {
+    const { payload } = await jwtVerify(token, getJWKS(), {
+      audience: CF_ACCESS_AUD,
+      issuer: `https://${CF_ACCESS_TEAM}.cloudflareaccess.com`,
+    });
+    if (typeof payload.email !== "string" || typeof payload.sub !== "string") {
+      return null;
+    }
+    return {
+      email: payload.email,
+      sub: payload.sub,
+      country: payload.country as string | undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the CF Access JWT from a request: the `Cf-Access-Jwt-Assertion`
+ * header (preferred) or the `CF_Authorization` cookie.
+ */
+export function getAccessToken(request: Request): string | null {
+  const headerToken = request.headers.get("Cf-Access-Jwt-Assertion");
+  if (headerToken) return headerToken;
+
+  const cookies = request.headers.get("cookie");
+  if (cookies) {
+    const match = cookies.match(/CF_Authorization=([^;]+)/);
+    if (match) return match[1];
+  }
+  return null;
+}

--- a/apps/supervisor/src/lib/k8s.ts
+++ b/apps/supervisor/src/lib/k8s.ts
@@ -1,0 +1,86 @@
+/**
+ * Kubernetes client wrapper.
+ *
+ * Lazy singleton over `@kubernetes/client-node`. Config is loaded via
+ * `kc.loadFromDefault()` (spec §6.1): the in-cluster ServiceAccount token in
+ * production, `~/.kube/config` (honouring `KUBECONFIG`) for local dev. No
+ * runtime switching.
+ *
+ * Missing/invalid kubeconfig is handled GRACEFULLY: importing this module never
+ * touches the cluster. The config is loaded — and any error thrown — only on
+ * the first `getKubeConfig()` / typed-getter call, so the Next.js app and tests
+ * can import freely without a cluster present.
+ *
+ * This module is intentionally JUST a client accessor. Provisioning logic
+ * (object builders, reconcile, storage translation) is jvcx.4+ and lives
+ * elsewhere.
+ */
+
+import {
+  KubeConfig,
+  CoreV1Api,
+  AppsV1Api,
+  StorageV1Api,
+  BatchV1Api,
+} from "@kubernetes/client-node";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("K8s");
+
+let kubeConfig: KubeConfig | null = null;
+
+/**
+ * Get the lazily-initialised KubeConfig. Throws a clear error if no kubeconfig
+ * / in-cluster credentials are available.
+ */
+export function getKubeConfig(): KubeConfig {
+  if (kubeConfig) return kubeConfig;
+
+  const kc = new KubeConfig();
+  try {
+    kc.loadFromDefault();
+  } catch (error) {
+    log.error("Failed to load Kubernetes config", { error: String(error) });
+    throw new Error(
+      "Kubernetes config unavailable: loadFromDefault() failed. " +
+        "Set KUBECONFIG (local dev) or run in-cluster with a ServiceAccount.",
+    );
+  }
+
+  // loadFromDefault() can succeed with no usable context (e.g. empty kubeconfig).
+  // Fail loudly here rather than letting a later API call throw opaquely.
+  if (!kc.getCurrentCluster()) {
+    throw new Error(
+      "Kubernetes config has no current cluster/context. " +
+        "Set KUBECONFIG (local dev) or run in-cluster with a ServiceAccount.",
+    );
+  }
+
+  kubeConfig = kc;
+  return kubeConfig;
+}
+
+/** Core API (namespaces, services, secrets, pods, PVCs, nodes, events). */
+export function getCoreV1Api(): CoreV1Api {
+  return getKubeConfig().makeApiClient(CoreV1Api);
+}
+
+/** Apps API (StatefulSets / Deployments). */
+export function getAppsV1Api(): AppsV1Api {
+  return getKubeConfig().makeApiClient(AppsV1Api);
+}
+
+/** Storage API (StorageClasses — storage discovery, jvcx.5). */
+export function getStorageV1Api(): StorageV1Api {
+  return getKubeConfig().makeApiClient(StorageV1Api);
+}
+
+/** Batch API (Jobs — first-boot seed Job, jvcx.4). */
+export function getBatchV1Api(): BatchV1Api {
+  return getKubeConfig().makeApiClient(BatchV1Api);
+}
+
+/** Reset the cached config. Test-only seam. */
+export function resetKubeConfigForTesting(): void {
+  kubeConfig = null;
+}

--- a/apps/supervisor/src/lib/logger.ts
+++ b/apps/supervisor/src/lib/logger.ts
@@ -1,0 +1,95 @@
+/**
+ * Structured logger for the Supervisor service.
+ *
+ * Mirrors the root app's `createLogger(namespace)` INTERFACE
+ * (see src/infrastructure/logging/AppLogger.ts) so server-side code uses the
+ * same ergonomics and NEVER calls `console.*` directly. This is a minimal
+ * console-backed implementation — there is no separate logs database yet.
+ *
+ * @example
+ * ```ts
+ * import { createLogger } from "@/lib/logger";
+ * const log = createLogger("Supervisor");
+ * log.info("Started", { port: 6003 });
+ * log.error("Failed", { error: String(err) });
+ * ```
+ */
+
+const LEVEL_RANK = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+  trace: 4,
+} as const;
+
+type LogLevel = keyof typeof LEVEL_RANK;
+
+export interface Logger {
+  error(message: string, data?: Record<string, unknown>): void;
+  warn(message: string, data?: Record<string, unknown>): void;
+  info(message: string, data?: Record<string, unknown>): void;
+  debug(message: string, data?: Record<string, unknown>): void;
+  trace(message: string, data?: Record<string, unknown>): void;
+}
+
+let configuredLevel: LogLevel | null = null;
+
+function getConfiguredLevel(): LogLevel {
+  if (configuredLevel) return configuredLevel;
+  const env = process.env.LOG_LEVEL?.toLowerCase();
+  if (env && env in LEVEL_RANK) {
+    configuredLevel = env as LogLevel;
+  } else {
+    configuredLevel = process.env.NODE_ENV === "production" ? "warn" : "info";
+  }
+  return configuredLevel;
+}
+
+function shouldLog(level: LogLevel): boolean {
+  return LEVEL_RANK[level] <= LEVEL_RANK[getConfiguredLevel()];
+}
+
+function write(
+  level: LogLevel,
+  namespace: string,
+  message: string,
+  data?: Record<string, unknown>,
+): void {
+  if (!shouldLog(level)) return;
+  const prefix = `[${namespace}]`;
+  const args: unknown[] = [prefix, message];
+  if (data) args.push(data);
+
+  // This module IS the logging boundary; console.* is intentional here, exactly
+  // as the root app's AppLogger uses console internally.
+  switch (level) {
+    case "error":
+      console.error(...args);
+      break;
+    case "warn":
+      console.warn(...args);
+      break;
+    case "debug":
+    case "trace":
+      console.debug(...args);
+      break;
+    default:
+      console.log(...args);
+      break;
+  }
+}
+
+/**
+ * Create a namespaced logger. Use a PascalCase service/module name for the
+ * namespace (e.g. "Supervisor", "Controller", "api/instances").
+ */
+export function createLogger(namespace: string): Logger {
+  return {
+    error: (msg, data) => write("error", namespace, msg, data),
+    warn: (msg, data) => write("warn", namespace, msg, data),
+    info: (msg, data) => write("info", namespace, msg, data),
+    debug: (msg, data) => write("debug", namespace, msg, data),
+    trace: (msg, data) => write("trace", namespace, msg, data),
+  };
+}

--- a/apps/supervisor/src/lib/roles.ts
+++ b/apps/supervisor/src/lib/roles.ts
@@ -1,0 +1,65 @@
+/**
+ * Supervisor RBAC roles + owner-scoping helpers.
+ *
+ * Role matrix (spec §6.6):
+ *   - viewer   : read instances / nodes / storage
+ *   - operator : create / suspend / resume instances
+ *   - admin    : delete instances, register storage targets, manage users
+ *
+ * Roles are hierarchical: admin ⊇ operator ⊇ viewer.
+ *
+ * Ownership (LOCKED product decision): instances are owner-scoped. Operators
+ * may manage only the instances they created; admins may manage all.
+ */
+
+export const ROLES = ["viewer", "operator", "admin"] as const;
+export type Role = (typeof ROLES)[number];
+
+/** Higher rank = more privilege. */
+const RANK: Record<Role, number> = {
+  viewer: 0,
+  operator: 1,
+  admin: 2,
+};
+
+export function isRole(value: unknown): value is Role {
+  return typeof value === "string" && (ROLES as readonly string[]).includes(value);
+}
+
+/** Minimal shape needed for authorization decisions. */
+export interface RoleUser {
+  id: string;
+  role: Role;
+}
+
+/** Minimal shape of an instance needed for owner-scoping decisions. */
+export interface OwnedInstance {
+  ownerId: string;
+}
+
+/**
+ * True if `user` holds at least the `required` role (hierarchical).
+ *
+ * @example hasRole({ id, role: "admin" }, "operator") === true
+ */
+export function hasRole(
+  user: Pick<RoleUser, "role"> | null | undefined,
+  required: Role,
+): boolean {
+  if (!user) return false;
+  return RANK[user.role] >= RANK[required];
+}
+
+/**
+ * True if `user` may manage `instance`: admins manage everything; everyone else
+ * manages only instances they own. This is the single owner-scoping gate —
+ * the API list/detail/mutation handlers all funnel through it.
+ */
+export function canManageInstance(
+  user: Pick<RoleUser, "id" | "role"> | null | undefined,
+  instance: OwnedInstance | null | undefined,
+): boolean {
+  if (!user || !instance) return false;
+  if (user.role === "admin") return true;
+  return instance.ownerId === user.id;
+}

--- a/apps/supervisor/src/lib/slug.ts
+++ b/apps/supervisor/src/lib/slug.ts
@@ -1,0 +1,90 @@
+/**
+ * Instance slug validation + reserved names.
+ *
+ * The slug is the first path segment a request is routed by (`/<slug>/…`) and
+ * also names the instance's namespace (`rdv-<slug>`) and in-namespace Service.
+ *
+ * Grammar (spec §6.4): `^[a-z][a-z0-9-]{0,14}$`
+ *   - starts with a lowercase letter
+ *   - lowercase alphanumerics + hyphen, max 15 chars total
+ *   - kept short so `rdv-<slug>` stays a valid DNS-1123 label (≤63 chars)
+ *
+ * NOTE: when the router (jvcx.6) and instance-env generation also need this,
+ * promote this module to a shared package so Supervisor + router + instance
+ * agree on one validator. For now it lives here.
+ */
+
+export const SLUG_PATTERN = /^[a-z][a-z0-9-]{0,14}$/;
+
+/**
+ * Slugs that would collide with the root public paths an instance serves, the
+ * Supervisor UI prefix, or k8s/router internals (spec §15 m2). Disallowed as
+ * instance slugs.
+ */
+export const RESERVED_SLUGS: ReadonlySet<string> = new Set([
+  "api",
+  "ws",
+  "_next",
+  "login",
+  "healthz",
+  "readyz",
+  "manifest.json",
+  "sw.js",
+  "favicon.svg",
+  "favicon.ico",
+  "icons",
+  // Supervisor UI prefix — reserved so an instance can never shadow it.
+  "supervisor",
+]);
+
+/** True if `slug` is reserved (case-insensitive). */
+export function isReserved(slug: string): boolean {
+  return RESERVED_SLUGS.has(slug.toLowerCase());
+}
+
+export type SlugValidationError =
+  | "empty"
+  | "format"
+  | "reserved";
+
+export interface SlugValidationResult {
+  valid: boolean;
+  error?: SlugValidationError;
+  message?: string;
+}
+
+/**
+ * Validate an instance slug. Returns a structured result rather than throwing
+ * so callers (API handlers) can map it to a 400 with a clear message.
+ */
+export function validateSlug(input: unknown): SlugValidationResult {
+  if (typeof input !== "string" || input.length === 0) {
+    return { valid: false, error: "empty", message: "Slug is required." };
+  }
+  if (!SLUG_PATTERN.test(input)) {
+    return {
+      valid: false,
+      error: "format",
+      message:
+        "Slug must be 1–15 chars, start with a lowercase letter, and contain only lowercase letters, digits, and hyphens.",
+    };
+  }
+  if (isReserved(input)) {
+    return {
+      valid: false,
+      error: "reserved",
+      message: `"${input}" is a reserved slug and cannot be used.`,
+    };
+  }
+  return { valid: true };
+}
+
+/** Convenience boolean form of {@link validateSlug}. */
+export function isValidSlug(input: unknown): input is string {
+  return validateSlug(input).valid;
+}
+
+/** The namespace an instance with this slug lives in (§15 B2). */
+export function namespaceForSlug(slug: string): string {
+  return `rdv-${slug}`;
+}

--- a/apps/supervisor/src/lib/utils.ts
+++ b/apps/supervisor/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/supervisor/src/proxy.ts
+++ b/apps/supervisor/src/proxy.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+/**
+ * Edge auth boundary for the Supervisor UI (mirrors the root app's
+ * `src/proxy.ts`; renamed from `middleware` per Next.js 16 conventions).
+ *
+ * SCOPE: this is coarse, Edge-safe, defense-in-depth ONLY. It is NOT the
+ * authoritative verifier and is NOT a substitute for server-side auth. The
+ * route/page layer MUST verify the CF Access JWT signature/claims via
+ * `validateAccessJWT` + `resolveSupervisorUser` (API routes do this through
+ * `withSupervisorAuth`; the dashboard page resolves the user server-side).
+ * It MUST NOT import the DB (`@libsql/client` is not Edge-compatible) or the
+ * role layer. Here we only:
+ *   - always allow static assets, the health route, and the favicon;
+ *   - in production (CF Access configured) require a *structurally-plausible*
+ *     CF Access JWT to be PRESENT (header or cookie) for page routes — this
+ *     just rejects obviously-missing/garbage tokens early; the real signature
+ *     check happens server-side;
+ *   - in local dev (no CF Access), allow through — `withSupervisorAuth` uses
+ *     SUPERVISOR_ADMIN_EMAIL as the identity.
+ *
+ * API routes are intentionally NOT redirected here; they self-gate and return
+ * JSON 401/403, which is the correct behavior for programmatic callers.
+ */
+
+/** A token is structurally JWT-plausible: three non-empty dot-separated parts. */
+function looksLikeJwt(token: string | null | undefined): boolean {
+  if (!token) return false;
+  const parts = token.split(".");
+  return parts.length === 3 && parts.every((p) => p.length > 0);
+}
+
+function hasCfAssertion(request: NextRequest): boolean {
+  if (looksLikeJwt(request.headers.get("cf-access-jwt-assertion"))) return true;
+  const cookie = request.headers.get("cookie");
+  const match = cookie?.match(/CF_Authorization=([^;]+)/);
+  return looksLikeJwt(match?.[1]);
+}
+
+export function proxy(request: NextRequest): NextResponse {
+  const { pathname } = request.nextUrl;
+
+  // Static assets + favicon + health probe always pass.
+  if (
+    pathname.startsWith("/_next/") ||
+    pathname === "/favicon.ico" ||
+    pathname === "/favicon.svg" ||
+    pathname === "/api/health"
+  ) {
+    return NextResponse.next();
+  }
+
+  // API routes self-gate via withSupervisorAuth (JSON 401/403). Don't redirect.
+  if (pathname.startsWith("/api/")) {
+    return NextResponse.next();
+  }
+
+  // Production: a CF Access app gates this hostname. Require the assertion to be
+  // present for page routes; the actual signature check happens server-side.
+  const cfConfigured = Boolean(
+    process.env.SUPERVISOR_CF_ACCESS_AUD &&
+      process.env.SUPERVISOR_CF_ACCESS_TEAM,
+  );
+  if (cfConfigured && !hasCfAssertion(request)) {
+    return NextResponse.json(
+      { error: "Unauthorized", code: "UNAUTHORIZED" },
+      { status: 401 },
+    );
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image).*)"],
+};

--- a/apps/supervisor/tsconfig.json
+++ b/apps/supervisor/tsconfig.json
@@ -25,12 +25,6 @@
     "paths": {
       "@/*": [
         "./src/*"
-      ],
-      "@remote-dev/domain": [
-        "./packages/domain/src"
-      ],
-      "@remote-dev/domain/*": [
-        "./packages/domain/src/*"
       ]
     }
   },
@@ -39,14 +33,9 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts",
-    "**/*.mts"
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules",
-    ".trash",
-    "packages",
-    "apps",
-    "scripts"
+    "node_modules"
   ]
 }

--- a/apps/supervisor/vitest.config.ts
+++ b/apps/supervisor/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "happy-dom",
+    globals: true,
+    // Scoped to this workspace's src only — never reaches into the root app's
+    // src/** or tests/** (and the root vitest config never reaches in here).
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    exclude: ["node_modules", ".next", "dist"],
+    testTimeout: 10000,
+    hookTimeout: 10000,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -109,6 +109,40 @@
         "vitest": "^4.0.16",
       },
     },
+    "apps/supervisor": {
+      "name": "@remote-dev/supervisor",
+      "version": "0.1.0",
+      "dependencies": {
+        "@kubernetes/client-node": "^1.4.0",
+        "@libsql/client": "^0.15.15",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "drizzle-orm": "^0.45.1",
+        "jose": "^6.1.3",
+        "lucide-react": "^0.562.0",
+        "next": "16.1.0",
+        "react": "19.2.3",
+        "react-dom": "19.2.3",
+        "tailwind-merge": "^3.4.0",
+      },
+      "devDependencies": {
+        "@tailwindcss/postcss": "^4",
+        "@types/node": "^20",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "@vitejs/plugin-react": "^5.1.2",
+        "dotenv-cli": "^11.0.0",
+        "drizzle-kit": "^0.31.8",
+        "eslint": "^9",
+        "eslint-config-next": "16.1.0",
+        "happy-dom": "^20.0.11",
+        "tailwindcss": "^4",
+        "tsx": "^4.21.0",
+        "tw-animate-css": "^1.4.0",
+        "typescript": "^5",
+        "vitest": "^4.0.16",
+      },
+    },
     "packages/domain": {
       "name": "@remote-dev/domain",
       "version": "0.1.0",
@@ -731,6 +765,12 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@jsep-plugin/assignment": ["@jsep-plugin/assignment@1.3.0", "", { "peerDependencies": { "jsep": "^0.4.0||^1.0.0" } }, "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ=="],
+
+    "@jsep-plugin/regex": ["@jsep-plugin/regex@1.0.4", "", { "peerDependencies": { "jsep": "^0.4.0||^1.0.0" } }, "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg=="],
+
+    "@kubernetes/client-node": ["@kubernetes/client-node@1.4.0", "", { "dependencies": { "@types/js-yaml": "^4.0.1", "@types/node": "^24.0.0", "@types/node-fetch": "^2.6.13", "@types/stream-buffers": "^3.0.3", "form-data": "^4.0.0", "hpagent": "^1.2.0", "isomorphic-ws": "^5.0.0", "js-yaml": "^4.1.0", "jsonpath-plus": "^10.3.0", "node-fetch": "^2.7.0", "openid-client": "^6.1.3", "rfc4648": "^1.3.0", "socks-proxy-agent": "^8.0.4", "stream-buffers": "^3.0.2", "tar-fs": "^3.0.9", "ws": "^8.18.2" } }, "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA=="],
+
     "@lezer/common": ["@lezer/common@1.5.1", "", {}, "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw=="],
 
     "@lezer/css": ["@lezer/css@1.3.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg=="],
@@ -973,6 +1013,8 @@
 
     "@remote-dev/mobile": ["@remote-dev/mobile@workspace:packages/mobile"],
 
+    "@remote-dev/supervisor": ["@remote-dev/supervisor@workspace:apps/supervisor"],
+
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.12", "", { "os": "android", "cpu": "arm64" }, "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg=="],
@@ -1107,6 +1149,8 @@
 
     "@types/istanbul-reports": ["@types/istanbul-reports@3.0.4", "", { "dependencies": { "@types/istanbul-lib-report": "*" } }, "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ=="],
 
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
+
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
@@ -1118,6 +1162,8 @@
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
+
+    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
     "@types/node-forge": ["@types/node-forge@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw=="],
 
@@ -1132,6 +1178,8 @@
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
 
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
+
+    "@types/stream-buffers": ["@types/stream-buffers@3.0.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -1353,6 +1401,8 @@
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
+    "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
+
     "babel-core": ["babel-core@7.0.0-bridge.0", "", { "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="],
 
     "babel-jest": ["babel-jest@29.7.0", "", { "dependencies": { "@jest/transform": "^29.7.0", "@types/babel__core": "^7.1.14", "babel-plugin-istanbul": "^6.1.1", "babel-preset-jest": "^29.6.3", "chalk": "^4.0.0", "graceful-fs": "^4.2.9", "slash": "^3.0.0" }, "peerDependencies": { "@babel/core": "^7.8.0" } }, "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg=="],
@@ -1386,6 +1436,18 @@
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "bare-events": ["bare-events@2.8.3", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw=="],
+
+    "bare-fs": ["bare-fs@4.7.1", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw=="],
+
+    "bare-os": ["bare-os@3.9.1", "", {}, "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ=="],
+
+    "bare-path": ["bare-path@3.0.0", "", { "dependencies": { "bare-os": "^3.0.1" } }, "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw=="],
+
+    "bare-stream": ["bare-stream@2.13.1", "", { "dependencies": { "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer", "bare-events"] }, "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow=="],
+
+    "bare-url": ["bare-url@2.4.3", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
@@ -1785,6 +1847,8 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
@@ -1844,6 +1908,8 @@
     "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
     "fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
 
@@ -1905,7 +1971,7 @@
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
-    "form-data": ["form-data@3.0.4", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35" } }, "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ=="],
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
@@ -2018,6 +2084,8 @@
     "hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
 
     "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
+
+    "hpagent": ["hpagent@1.2.0", "", {}, "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
@@ -2175,6 +2243,8 @@
 
     "isobject": ["isobject@3.0.1", "", {}, "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="],
 
+    "isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
+
     "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
 
     "istanbul-lib-instrument": ["istanbul-lib-instrument@5.2.1", "", { "dependencies": { "@babel/core": "^7.12.3", "@babel/parser": "^7.14.7", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.2.0", "semver": "^6.3.0" } }, "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg=="],
@@ -2227,6 +2297,8 @@
 
     "jscodeshift": ["jscodeshift@0.14.0", "", { "dependencies": { "@babel/core": "^7.13.16", "@babel/parser": "^7.13.16", "@babel/plugin-proposal-class-properties": "^7.13.0", "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8", "@babel/plugin-proposal-optional-chaining": "^7.13.12", "@babel/plugin-transform-modules-commonjs": "^7.13.8", "@babel/preset-flow": "^7.13.13", "@babel/preset-typescript": "^7.13.0", "@babel/register": "^7.13.16", "babel-core": "^7.0.0-bridge.0", "chalk": "^4.1.2", "flow-parser": "0.*", "graceful-fs": "^4.2.4", "micromatch": "^4.0.4", "neo-async": "^2.5.0", "node-dir": "^0.1.17", "recast": "^0.21.0", "temp": "^0.8.4", "write-file-atomic": "^2.3.0" }, "peerDependencies": { "@babel/preset-env": "^7.1.6" }, "bin": { "jscodeshift": "bin/jscodeshift.js" } }, "sha512-7eCC1knD7bLUPuSCwXsMZUH51O8jIcoVyKtI6P0XM0IVzlGjckPy3FIwQlorzbN0Sg79oK+RlohN32Mqf/lrYA=="],
 
+    "jsep": ["jsep@1.4.0", "", {}, "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw=="],
+
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
@@ -2248,6 +2320,8 @@
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
+
+    "jsonpath-plus": ["jsonpath-plus@10.4.0", "", { "dependencies": { "@jsep-plugin/assignment": "^1.3.0", "@jsep-plugin/regex": "^1.0.4", "jsep": "^1.4.0" }, "bin": { "jsonpath": "bin/jsonpath-cli.js", "jsonpath-plus": "bin/jsonpath-cli.js" } }, "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA=="],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
@@ -2565,7 +2639,7 @@
 
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
 
-    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-forge": ["node-forge@1.4.0", "", {}, "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="],
 
@@ -2622,6 +2696,8 @@
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
+
+    "openid-client": ["openid-client@6.8.4", "", { "dependencies": { "jose": "^6.2.2", "oauth4webapi": "^3.8.5" } }, "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -2871,6 +2947,8 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "rfc4648": ["rfc4648@1.5.4", "", {}, "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg=="],
+
     "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
@@ -3013,7 +3091,9 @@
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
-    "stream-buffers": ["stream-buffers@2.2.0", "", {}, "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg=="],
+    "stream-buffers": ["stream-buffers@3.0.3", "", {}, "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw=="],
+
+    "streamx": ["streamx@2.26.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A=="],
 
     "strict-uri-encode": ["strict-uri-encode@2.0.0", "", {}, "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="],
 
@@ -3079,9 +3159,11 @@
 
     "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
 
-    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+    "tar-fs": ["tar-fs@3.1.2", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw=="],
 
-    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+    "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
+
+    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
 
     "temp": ["temp@0.8.4", "", { "dependencies": { "rimraf": "~2.6.2" } }, "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg=="],
 
@@ -3096,6 +3178,8 @@
     "terser": ["terser@5.46.1", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ=="],
 
     "test-exclude": ["test-exclude@6.0.0", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^7.1.4", "minimatch": "^3.0.4" } }, "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w=="],
+
+    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -3387,6 +3471,8 @@
 
     "@expo/cli/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
+    "@expo/cli/form-data": ["form-data@3.0.4", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35" } }, "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ=="],
+
     "@expo/cli/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
     "@expo/cli/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
@@ -3437,8 +3523,6 @@
 
     "@expo/prebuild-config/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
-    "@expo/rudder-sdk-node/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
-
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
@@ -3458,6 +3542,10 @@
     "@jest/transform/write-file-atomic": ["write-file-atomic@4.0.2", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^3.0.7" } }, "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg=="],
 
     "@jest/types/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "@kubernetes/client-node/@types/node": ["@types/node@24.12.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA=="],
+
+    "@libsql/hrana-client/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
@@ -3496,8 +3584,6 @@
     "@react-native/codegen/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "@react-native/codegen/hermes-parser": ["hermes-parser@0.23.1", "", { "dependencies": { "hermes-estree": "0.23.1" } }, "sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA=="],
-
-    "@react-native/community-cli-plugin/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "@react-native/dev-middleware/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -3539,11 +3625,15 @@
 
     "@types/keyv/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
+    "@types/node-fetch/@types/node": ["@types/node@24.12.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA=="],
+
     "@types/node-forge/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
     "@types/plist/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
     "@types/responselike/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "@types/stream-buffers/@types/node": ["@types/node@24.12.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA=="],
 
     "@types/yauzl/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
@@ -3583,6 +3673,8 @@
 
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
+    "bplist-creator/stream-buffers": ["stream-buffers@2.2.0", "", {}, "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg=="],
+
     "bun-types/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
     "cacache/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
@@ -3619,8 +3711,6 @@
 
     "cosmiconfig/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
-    "cross-fetch/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
-
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "default-gateway/execa": ["execa@1.0.0", "", { "dependencies": { "cross-spawn": "^6.0.0", "get-stream": "^4.0.0", "is-stream": "^1.1.0", "npm-run-path": "^2.0.0", "p-finally": "^1.0.0", "signal-exit": "^3.0.0", "strip-eof": "^1.0.0" } }, "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA=="],
@@ -3630,8 +3720,6 @@
     "dotenv-expand/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "electron/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
-
-    "electron-publish/form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "electron-squirrel-startup/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -3684,6 +3772,8 @@
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "glob/minimatch": ["minimatch@8.0.7", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg=="],
 
@@ -3781,6 +3871,8 @@
 
     "prebuild-install/node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
 
+    "prebuild-install/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
@@ -3834,8 +3926,6 @@
     "sucrase/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "supports-hyperlinks/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
-
-    "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "temp/rimraf": ["rimraf@2.6.3", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "./bin.js" } }, "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA=="],
 
@@ -3923,6 +4013,8 @@
 
     "@expo/cli/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "@expo/cli/form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "@expo/cli/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "@expo/cli/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
@@ -4007,6 +4099,8 @@
 
     "@istanbuljs/load-nyc-config/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
+    "@kubernetes/client-node/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@react-native/codegen/hermes-parser/hermes-estree": ["hermes-estree@0.23.1", "", {}, "sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg=="],
@@ -4020,6 +4114,10 @@
     "@testing-library/dom/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "@types/node-fetch/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/stream-buffers/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
@@ -4072,8 +4170,6 @@
     "default-gateway/execa/is-stream": ["is-stream@1.1.0", "", {}, "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="],
 
     "default-gateway/execa/npm-run-path": ["npm-run-path@2.0.2", "", { "dependencies": { "path-key": "^2.0.0" } }, "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw=="],
-
-    "electron-publish/form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "electron-squirrel-startup/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -4135,7 +4231,13 @@
 
     "pkg-up/find-up/locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
 
+    "prebuild-install/tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+
+    "prebuild-install/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
     "schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "simple-plist/bplist-creator/stream-buffers": ["stream-buffers@2.2.0", "", {}, "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg=="],
 
     "sucrase/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
@@ -4198,6 +4300,8 @@
     "@babel/highlight/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
     "@expo/cli/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "@expo/cli/form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "@expo/cli/glob/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
 
@@ -4266,8 +4370,6 @@
     "default-gateway/execa/cross-spawn/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "which": "./bin/which" } }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
 
     "default-gateway/execa/npm-run-path/path-key": ["path-key@2.0.1", "", {}, "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="],
-
-    "electron-publish/form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "electron-winstaller/temp/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 

--- a/docs/plans/2026-05-30-k3s-supervisor-platform.md
+++ b/docs/plans/2026-05-30-k3s-supervisor-platform.md
@@ -496,6 +496,14 @@ bd create --title "Phase 4: cloud-VM + Proxmox MachineProviders, auto scale-up/d
 
 ## 14. Open questions (resolve before/with Phase 1)
 
+> **Phase 1 status:** being built task-by-task against this section. `jvcx.3`
+> (the `apps/supervisor` scaffold) has landed: bun workspace, Drizzle schema
+> (owner-scoped instances), role-based `withSupervisorAuth`, `@kubernetes/client-node`
+> wrapper, slug validation + reserved names, dashboard shell, health route,
+> auth-wrapped API route stubs, and a controller-process skeleton. Provisioning
+> (`jvcx.4`), storage discovery (`jvcx.5`), the router (`jvcx.6`), and
+> RBAC/Deployments (`jvcx.7`) are the remaining Phase-1 tasks.
+
 1. **Host + tunnel:** confirm the single external host (e.g. `dev.example.com`) and that the
    existing Cloudflare tunnel can be pointed at the router Service.
 2. **Cloudflare Access:** one app covering `dev.example.com/*` for instances + a separate app for
@@ -503,8 +511,11 @@ bd create --title "Phase 4: cloud-VM + Proxmox MachineProviders, auto scale-up/d
 3. **GitHub OAuth at scale:** one GitHub App with callback `https://dev.example.com/<slug>/api/auth/callback/github`
    per instance, vs a shared wildcard-capable GitHub App. Decide before enabling GitHub features
    on provisioned instances.
-4. **Instance ownership / multi-user:** are instances per-operator (owner-scoped lists) or a shared
-   fleet all operators manage? Affects `instance.ownerId` enforcement in the API.
+4. **Instance ownership / multi-user:** **RESOLVED — instances are owner-scoped** (operators
+   manage only their own; admins see all). `instance.ownerId` enforcement is baked into the
+   schema and the `canManageInstance(user, instance)` auth helper from Phase 1 (`jvcx.3`):
+   non-admin list/detail/mutation paths funnel through it, and detail returns 404 (not 403) for
+   instances the caller doesn't own so existence isn't leaked.
 5. **Default storage target:** which backend is the default in the dropdown for this cluster
    (local-path vs Longhorn)? Drives the resiliency default.
 6. **Router vs Supervisor co-location:** ship the router as a separate Deployment (recommended,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,6 +81,8 @@ const eslintConfig = defineConfig([
     "scripts/**",
     // Mobile app (separate React Native project)
     "packages/**",
+    // Supervisor & other apps workspaces (each has its own eslint config)
+    "apps/**",
     // Git worktrees (separate checkouts with their own lint)
     ".worktrees/**",
     // Agent worktrees (stale isolated checkouts inside .claude/)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Remote Dev Team",
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "apps/*"
   ],
   "main": "dist-electron/main/index.js",
   "scripts": {
@@ -15,6 +16,8 @@
     "build": "next build --experimental-build-mode compile",
     "start": "dotenv -e .env.local -- sh -c 'next start -p $PORT'",
     "start:terminal": "dotenv -e .env.local -- tsx src/server/index.ts",
+    "dev:supervisor": "cd apps/supervisor && bun run dev",
+    "build:supervisor": "cd apps/supervisor && bun run build",
     "rdv": "bun run scripts/rdv.ts",
     "rdv:dev": "bun run scripts/rdv.ts start dev",
     "rdv:prod": "bun run scripts/rdv.ts start prod",


### PR DESCRIPTION
## Summary
First task of Phase 1 of the k3s Supervisor epic (remote-dev-jvcx.3): scaffolds a new `apps/supervisor` bun workspace — the control-plane service that will provision/lifecycle-manage remote-dev instances on k3s. Spec: `docs/plans/2026-05-30-k3s-supervisor-platform.md` §6.

This is the **scaffold/foundation** only. Provisioner object-builders (jvcx.4), storage discovery (jvcx.5), the router (jvcx.6), and RBAC manifests/Deployments (jvcx.7) are deliberately deferred — those endpoints return `501 PHASE1_PENDING`.

## What's included
- **Workspace** `apps/supervisor`: Next.js 16 + Drizzle + libsql + `@kubernetes/client-node@^1.4.0`, isolated as a bun workspace.
- **DB schema** (§6.2): `supervisor_user` (admin/operator/viewer), `instance` (**owner-scoped**), `registered_storage_target`, `instance_audit_log`, `instance_seed`. (`machine`/`capacity_event` are Phase 3.)
- **Auth**: `withSupervisorAuth(role)` mirroring the main app's `withApiAuth` + a role gate; CF Access JWT validation scoped to the Supervisor's own AUD/team (§15 M3 — separate hostname); **owner-scoped** access (operators manage only their own instances; admins see all). Locked decision per §14.4.
- **k8s client**: lazy `loadFromDefault()` wrapper (in-cluster SA token in prod, `~/.kube/config` in dev).
- **Controller skeleton**: the two-process model's reconciler loop (no-op for Phase 1) with graceful shutdown.
- **Slug validation + reserved names** (§15 m2), dashboard shell, `/api/health`, auth-wrapped API route stubs, and `/api/internal/routes` (router allowlist, §15 B2 shape).

## Isolation (keeps the main app's build + prod deploy green)
Root `workspaces` += `apps/*`; root `tsconfig` excludes `apps`; root `eslint` ignores `apps/**`; root vitest stays scoped to `src/**`. `bun.lock` updated + committed so the prod deploy's `bun install --frozen-lockfile` passes. The supervisor has its own next/tsconfig/eslint/vitest/proxy/instrumentation — verified no cross-workspace imports leak into either build.

## Hardening (from adversarial review)
- **Fail-closed in production** if CF Access is unconfigured (startup guard `process.exit(1)` + auth-layer null-return; escape hatch `SUPERVISOR_ALLOW_INSECURE_AUTH=1` for testing) — prevents a misconfigured prod from trusting `SUPERVISOR_ADMIN_EMAIL` as admin.
- First-sight user creation is an idempotent upsert that **preserves an existing role** (no admin-downgrade race).
- `/api/internal/routes` shared-secret gate (`SUPERVISOR_INTERNAL_SECRET`); 503 in prod if unset.
- Edge gate requires a structurally-plausible JWT (defense-in-depth; route/page layer is authoritative).
- `updatedAt` auto-updates (`$onUpdateFn`); explicit `ownerId` FK `onDelete: restrict`.

## Test plan
- 48 supervisor unit tests (roles/owner-scoping, slug+reserved, `withSupervisorAuth` 401/403 + prod fail-closed + escape hatch, race-preserves-role, internal-routes secret gate, edge JWT gate, schema smoke).
- ROOT gates green: typecheck 0, lint 0-new, **test:run 1353 passing**, **build OK** (main app unaffected). SUPERVISOR gates green: typecheck/lint/test(48)/build.
- This PR's merge-deploy verifies the main-app prod deploy stays green with the workspace added (watched via the deploy feedback loop).

remote-dev-jvcx.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)