### PR TITLE
feat(supervisor): storage-target discovery + 4-backend translation + dropdown UI [remote-dev-jvcx.5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Supervisor storage targets (apps/supervisor): live discovery of StorageClasses + schedulable nodes (local-path) + registered NFS/custom targets, the 4-backend PVC translation with per-backend resiliency notes, a register/delete API, and a create-instance form with a storage-target dropdown; instance creation snapshots the chosen target so later edits don't affect existing instances (remote-dev-jvcx.5).
 - Supervisor provisioner-service (apps/supervisor): k8s object builders (namespace/secret/service/statefulset/seed-job), transactional create with namespace-delete rollback, instance state machine, and a 30s reconciler that drives create→ready and terminate→delete; POST/DELETE /api/instances now provision/terminate via the reconciler (remote-dev-jvcx.4).
 - Scaffolded the k3s Supervisor control-plane service (apps/supervisor): Next.js + Drizzle schema, role-based auth (admin/operator/viewer, owner-scoped instances), @kubernetes/client-node wrapper, and a controller-process skeleton — foundation for Phase 1 of the k3s supervisor epic (remote-dev-jvcx.3).
 - **Documentation overhaul — new docs**: added `docs/README.md` (docs index /

--- a/apps/supervisor/README.md
+++ b/apps/supervisor/README.md
@@ -11,10 +11,11 @@ Kubernetes API directly via `@kubernetes/client-node`.
 
 > **Status: Phase 1 in progress.** Provisioning has landed (remote-dev-jvcx.4):
 > `POST`/`DELETE /api/instances` now create/terminate real instances via the
-> reconciler. Still pending: storage discovery + dropdown (jvcx.5), the router
-> (jvcx.6), and RBAC/Deployments (jvcx.7). Suspend/resume
-> (`POST /api/instances/:id/{suspend,resume}`) are defined in the state machine
-> but return `501 { code: "PHASE1_PENDING" }` until Phase 2 (jvcx.8).
+> reconciler. Storage targets have landed (remote-dev-jvcx.5): live discovery +
+> the 4-backend PVC translation + a create-instance form with a storage-target
+> dropdown. Still pending: the router (jvcx.6) and RBAC/Deployments (jvcx.7).
+> Suspend/resume (`POST /api/instances/:id/{suspend,resume}`) are defined in the
+> state machine but return `501 { code: "PHASE1_PENDING" }` until Phase 2 (jvcx.8).
 
 ## Architecture
 
@@ -71,9 +72,54 @@ cluster state:
 If no cluster is reachable (local dev without `KUBECONFIG`), the reconcile tick
 logs a warning and returns without erroring any instance.
 
-> Storage targets are the cluster **default** for now
-> (`SUPERVISOR_DEFAULT_STORAGE_CLASS`/`_SIZE`); live discovery + the per-instance
-> dropdown (4 backends) land in jvcx.5.
+## Storage targets
+
+Each instance picks **where its persistent data lives** at create time. Targets
+are surfaced in the create-instance dropdown, each with a **resiliency note** so
+the operator sees the trade-off. Options come from three sources:
+
+| Source | Option id | Discovered from | Kind |
+|--------|-----------|-----------------|------|
+| Cluster default | `default` | `SUPERVISOR_DEFAULT_STORAGE_CLASS`/`_SIZE` (env) | storage-class |
+| StorageClass | `sc:<name>` | live `listStorageClass()` | storage-class, or **cloud-csi** for a known cloud CSI provisioner |
+| Node (local-path) | `node:<host>` | live `listNode()` (control-plane nodes skipped) | local-path (node-pinned) |
+| Registered NFS/custom | `reg:<uuid>` | `registered_storage_target` table | nfs / custom |
+
+Provisioner detection:
+
+- `driver.longhorn.io` → *"Replicated (Longhorn); survives node loss."*
+- `ebs.csi.aws.com` / `pd.csi.storage.gke.io` / `disk.csi.azure.com` →
+  cloud-csi, *"Cloud volume; reattaches on node loss within its AZ."*
+- local-path → *"Node-pinned (local-path); NO replication — data is lost if the
+  node is lost."*
+
+The chosen target's config is **snapshotted** into `instance.storageConfigSnapshot`
+at create time. The reconciler builds the PVC `volumeClaimTemplate` from that
+snapshot (never by re-resolving the target live), so editing or deleting a target
+later **never changes an existing instance's volume** — it only affects future
+dropdowns.
+
+### API
+
+```
+GET    /api/storage-targets        viewer   live discovery (default + SCs + nodes + registered)
+POST   /api/storage-targets        admin    register an NFS/custom target
+DELETE /api/storage-targets/:id    admin    delete a registered (reg:<uuid>) target
+```
+
+`POST` body: `{ name, kind, config, resiliencyNote?, isDefault? }`. For **NFS**,
+prefer the dynamic `nfs-subdir-external-provisioner` StorageClass over a static
+PV (§15 B3) — put its name in `config.storageClassName`, e.g.
+`{ "name": "office-nfs", "kind": "nfs", "config": { "storageClassName": "nfs-client" } }`.
+Only `reg:<uuid>` targets are deletable; `sc:`/`node:`/`default` are discovered
+(not stored) and return `400`. Deleting a target does **not** affect existing
+instances (their config is snapshotted).
+
+Resilience: if no cluster is reachable (local dev without `KUBECONFIG`), discovery
+degrades to the `default` option + any registered rows rather than failing.
+
+If no `storageTargetId` is supplied to `POST /api/instances`, the cluster default
+is used.
 
 ## Development
 

--- a/apps/supervisor/src/app/api/instances/__tests__/route.test.ts
+++ b/apps/supervisor/src/app/api/instances/__tests__/route.test.ts
@@ -108,6 +108,48 @@ describe("POST /api/instances — validation", () => {
   });
 });
 
+describe("POST /api/instances — storage target (jvcx.5)", () => {
+  it("default (no storageTargetId) snapshots the cluster-default config onto the row", async () => {
+    const res = await POST(postReq({ slug: "alpha", displayName: "Alpha" }));
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    const snap = JSON.parse(body.instance.storageConfigSnapshot);
+    expect(snap).toMatchObject({ kind: "storage-class", isDefault: true });
+    expect(body.instance.storageTargetId).toBeNull();
+  });
+
+  it("a chosen node:<host> id is resolved + snapshotted (local-path, pinned)", async () => {
+    const res = await POST(
+      postReq({
+        slug: "beta",
+        displayName: "Beta",
+        storageTargetId: "node:worker-1",
+      }),
+    );
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.instance.storageTargetId).toBe("node:worker-1");
+    const snap = JSON.parse(body.instance.storageConfigSnapshot);
+    expect(snap).toMatchObject({
+      kind: "local-path",
+      storageClassName: "local-path",
+      nodeHostname: "worker-1",
+    });
+  });
+
+  it("a bad/unknown storageTargetId → 400 INVALID_STORAGE_TARGET", async () => {
+    const res = await POST(
+      postReq({
+        slug: "gamma",
+        displayName: "Gamma",
+        storageTargetId: "bogus:x",
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("INVALID_STORAGE_TARGET");
+  });
+});
+
 describe("POST /api/instances — insert error handling (Fix 4)", () => {
   it("409 SLUG_TAKEN when the insert hits a UNIQUE violation", async () => {
     dbState.insertError = new Error(

--- a/apps/supervisor/src/app/api/instances/route.ts
+++ b/apps/supervisor/src/app/api/instances/route.ts
@@ -16,7 +16,10 @@ import { db } from "@/db";
 import { instance, instanceSeed, instanceAuditLog } from "@/db/schema";
 import { withSupervisorAuth } from "@/lib/auth";
 import { validateSlug, namespaceForSlug } from "@/lib/slug";
-import { resolveDefaultStorageTarget } from "@/lib/storage";
+import {
+  resolveStorageTarget,
+  StorageTargetResolutionError,
+} from "@/lib/storage";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("api/instances");
@@ -120,9 +123,25 @@ export const POST = withSupervisorAuth("operator", async (request, { user }) => 
     );
   }
 
-  // Resolve storage now so the chosen config is snapshotted onto the row (jvcx.5
-  // will resolve by storageTargetId; Phase 1 always uses the cluster default).
-  const storage = resolveDefaultStorageTarget();
+  // Resolve the chosen storage target NOW so its config is snapshotted onto the
+  // row. The snapshot is authoritative (§7): the reconciler builds the PVC
+  // template from `storageConfigSnapshot`, never by re-resolving the target —
+  // so a later edit/delete of the target can't change this instance's volume.
+  // A bad/unknown id → 400 (404 for a missing registered row).
+  const storageTargetId =
+    typeof body.storageTargetId === "string" ? body.storageTargetId : null;
+  let storage;
+  try {
+    storage = await resolveStorageTarget(storageTargetId);
+  } catch (err) {
+    if (err instanceof StorageTargetResolutionError) {
+      return NextResponse.json(
+        { error: err.message, code: "INVALID_STORAGE_TARGET" },
+        { status: err.code === "NOT_FOUND" ? 404 : 400 },
+      );
+    }
+    throw err;
+  }
 
   let created;
   try {

--- a/apps/supervisor/src/app/api/storage-targets/[id]/route.ts
+++ b/apps/supervisor/src/app/api/storage-targets/[id]/route.ts
@@ -1,0 +1,63 @@
+/**
+ * DELETE /api/storage-targets/:id (admin) — delete a REGISTERED storage target.
+ *
+ * Only registered (`reg:<uuid>`) targets are deletable. The `sc:` / `node:` /
+ * `default` options are DISCOVERED live (not stored), so they can't be deleted
+ * here → 400.
+ *
+ * IMPORTANT: deleting a registered target does NOT affect existing instances —
+ * each instance snapshots its chosen storage config into
+ * `instance.storageConfigSnapshot` at provision time (§7), and the reconciler
+ * rebuilds the PVC template from that snapshot, never by re-resolving the target.
+ * So a delete here only removes the option from future dropdowns.
+ */
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { registeredStorageTarget } from "@/db/schema";
+import { withSupervisorAuth } from "@/lib/auth";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("api/storage-targets/[id]");
+
+export const DELETE = withSupervisorAuth("admin", async (_request, { params }) => {
+  const id = params?.id;
+  if (!id) {
+    return NextResponse.json(
+      { error: "Missing storage target id", code: "INVALID_BODY" },
+      { status: 400 },
+    );
+  }
+
+  // Reject discovered ids — only `reg:<uuid>` rows are deletable.
+  if (id === "default" || id.startsWith("sc:") || id.startsWith("node:")) {
+    return NextResponse.json(
+      {
+        error:
+          "Only registered (reg:<id>) storage targets can be deleted; StorageClasses and nodes are discovered, not stored.",
+        code: "NOT_DELETABLE",
+      },
+      { status: 400 },
+    );
+  }
+
+  // Accept either the bare uuid or the `reg:<uuid>` option-id form.
+  const uuid = id.startsWith("reg:") ? id.slice("reg:".length) : id;
+
+  const row = await db.query.registeredStorageTarget.findFirst({
+    where: eq(registeredStorageTarget.id, uuid),
+  });
+  if (!row) {
+    return NextResponse.json(
+      { error: "Storage target not found", code: "NOT_FOUND" },
+      { status: 404 },
+    );
+  }
+
+  await db
+    .delete(registeredStorageTarget)
+    .where(eq(registeredStorageTarget.id, uuid));
+
+  log.info("deleted registered storage target", { id: uuid, name: row.name });
+  return NextResponse.json({ deleted: { id: uuid, name: row.name } });
+});

--- a/apps/supervisor/src/app/api/storage-targets/__tests__/route.test.ts
+++ b/apps/supervisor/src/app/api/storage-targets/__tests__/route.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Role } from "@/lib/roles";
+
+/**
+ * Tests for /api/storage-targets:
+ *   GET    (viewer) → returns discovered options.
+ *   POST   (admin)  → registers a target; operator forbidden; dup name → 409.
+ *   DELETE (admin)  → rejects non-`reg:` ids (400); deletes a reg row.
+ *
+ * Auth is mocked to a faithful role gate over a configurable user (mirrors the
+ * instances route tests).
+ */
+
+const authState: { user: { id: string; email: string; role: Role } } = {
+  user: { id: "admin-1", email: "admin@example.com", role: "admin" },
+};
+const RANK: Record<Role, number> = { viewer: 0, operator: 1, admin: 2 };
+
+vi.mock("@/lib/auth", () => ({
+  withSupervisorAuth:
+    (required: Role, handler: (req: Request, ctx: unknown) => unknown) =>
+    async (req: Request, ctx?: { params?: Promise<Record<string, string>> }) => {
+      if (RANK[authState.user.role] < RANK[required]) {
+        return Response.json({ code: "FORBIDDEN" }, { status: 403 });
+      }
+      try {
+        const params = ctx?.params ? await ctx.params : undefined;
+        return await handler(req, { user: authState.user, params });
+      } catch {
+        return Response.json({ code: "INTERNAL_ERROR" }, { status: 500 });
+      }
+    },
+  phase1Pending: () => Response.json({ code: "PHASE1_PENDING" }, { status: 501 }),
+}));
+
+// discoverStorageTargets is mocked so GET doesn't touch a cluster/db.
+vi.mock("@/lib/storage", () => ({
+  discoverStorageTargets: vi.fn(async () => [
+    { id: "default", name: "Cluster default", kind: "storage-class", resiliencyNote: "x", isDefault: true },
+    { id: "node:worker-1", name: "Local path on node: worker-1", kind: "local-path", resiliencyNote: "node-pinned", isDefault: false },
+  ]),
+}));
+
+// DB mock: insert returns a row or throws; delete records; findFirst returns row.
+const dbState: {
+  insertError: Error | null;
+  regRow: Record<string, unknown> | undefined;
+} = { insertError: null, regRow: undefined };
+const deletes: unknown[] = [];
+
+vi.mock("@/db", () => ({
+  db: {
+    query: {
+      registeredStorageTarget: { findFirst: async () => dbState.regRow },
+    },
+    insert: () => ({
+      values: (vals: Record<string, unknown>) => ({
+        returning: async () => {
+          if (dbState.insertError) throw dbState.insertError;
+          return [{ id: "reg-uuid", ...vals }];
+        },
+      }),
+    }),
+    delete: () => ({
+      where: (w: unknown) => {
+        deletes.push(w);
+        return Promise.resolve(undefined);
+      },
+    }),
+  },
+}));
+
+import { GET, POST } from "@/app/api/storage-targets/route";
+import { DELETE } from "@/app/api/storage-targets/[id]/route";
+
+function postReq(body: unknown): Request {
+  return new Request("https://sup.example.com/api/storage-targets", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function delReq(id: string): [Request, { params: Promise<{ id: string }> }] {
+  return [
+    new Request(`https://sup.example.com/api/storage-targets/${id}`, {
+      method: "DELETE",
+    }),
+    { params: Promise.resolve({ id }) },
+  ];
+}
+
+beforeEach(() => {
+  authState.user = { id: "admin-1", email: "admin@example.com", role: "admin" };
+  dbState.insertError = null;
+  dbState.regRow = { id: "reg-uuid", name: "office-nfs" };
+  deletes.length = 0;
+});
+
+describe("GET /api/storage-targets", () => {
+  it("returns the discovered options (viewer)", async () => {
+    authState.user = { id: "v", email: "v@example.com", role: "viewer" };
+    const res = await GET(new Request("https://sup.example.com/api/storage-targets"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.targets[0].id).toBe("default");
+    expect(body.targets.some((t: { id: string }) => t.id === "node:worker-1")).toBe(true);
+  });
+});
+
+describe("POST /api/storage-targets", () => {
+  it("registers an NFS target → 201 (admin)", async () => {
+    const res = await POST(
+      postReq({
+        name: "office-nfs",
+        kind: "nfs",
+        config: { storageClassName: "nfs-client" },
+        resiliencyNote: "Off-cluster NFS",
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.target.name).toBe("office-nfs");
+  });
+
+  it("operator is forbidden (admin-only) → 403", async () => {
+    authState.user = { id: "op", email: "op@example.com", role: "operator" };
+    const res = await POST(
+      postReq({ name: "x", kind: "nfs", config: {} }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects an invalid kind → 400", async () => {
+    const res = await POST(postReq({ name: "x", kind: "bogus", config: {} }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("INVALID_BODY");
+  });
+
+  it("rejects a non-object config → 400", async () => {
+    const res = await POST(postReq({ name: "x", kind: "nfs", config: "nope" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an NFS target with no config.storageClassName → 400 INVALID_CONFIG", async () => {
+    const res = await POST(postReq({ name: "x", kind: "nfs", config: {} }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("INVALID_CONFIG");
+  });
+
+  it("rejects an NFS target with a blank config.storageClassName → 400 INVALID_CONFIG", async () => {
+    const res = await POST(
+      postReq({ name: "x", kind: "nfs", config: { storageClassName: "  " } }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("INVALID_CONFIG");
+  });
+
+  it("duplicate name → 409", async () => {
+    dbState.insertError = new Error(
+      "SQLITE_CONSTRAINT: UNIQUE constraint failed: registered_storage_target.name",
+    );
+    const res = await POST(
+      postReq({ name: "dup", kind: "nfs", config: { storageClassName: "nfs-client" } }),
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("NAME_TAKEN");
+  });
+
+  it("non-UNIQUE DB error is NOT masked as 409 → 500", async () => {
+    dbState.insertError = new Error("SQLITE_IOERR: disk I/O error");
+    const res = await POST(
+      postReq({ name: "x", kind: "nfs", config: { storageClassName: "nfs-client" } }),
+    );
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("DELETE /api/storage-targets/:id", () => {
+  it("rejects a discovered StorageClass id (sc:) → 400 NOT_DELETABLE", async () => {
+    const res = await DELETE(...delReq("sc:longhorn"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("NOT_DELETABLE");
+    expect(deletes.length).toBe(0);
+  });
+
+  it("rejects a discovered node id (node:) → 400 NOT_DELETABLE", async () => {
+    const res = await DELETE(...delReq("node:worker-1"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("NOT_DELETABLE");
+  });
+
+  it("rejects the default id → 400", async () => {
+    const res = await DELETE(...delReq("default"));
+    expect(res.status).toBe(400);
+  });
+
+  it("deletes a registered reg:<uuid> row → 200", async () => {
+    const res = await DELETE(...delReq("reg:reg-uuid"));
+    expect(res.status).toBe(200);
+    expect(deletes.length).toBe(1);
+    const body = await res.json();
+    expect(body.deleted.id).toBe("reg-uuid");
+  });
+
+  it("404 when the registered row is missing", async () => {
+    dbState.regRow = undefined;
+    const res = await DELETE(...delReq("reg:gone"));
+    expect(res.status).toBe(404);
+  });
+
+  it("operator is forbidden (admin-only) → 403", async () => {
+    authState.user = { id: "op", email: "op@example.com", role: "operator" };
+    const res = await DELETE(...delReq("reg:reg-uuid"));
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/supervisor/src/app/api/storage-targets/route.ts
+++ b/apps/supervisor/src/app/api/storage-targets/route.ts
@@ -1,11 +1,152 @@
 /**
- * GET /api/storage-targets (viewer) — live storage discovery.
- *
- * 501 PHASE1_PENDING: StorageClass/node discovery + registered-target merge +
- * resiliencyNote is jvcx.5. Auth-wrapped so the contract is exercisable now.
+ * /api/storage-targets (spec §6.7, §7)
+ *   GET  (viewer) — live discovery: StorageClasses + schedulable nodes
+ *                   (local-path) + registered NFS/custom targets, each with a
+ *                   resiliencyNote for the create-instance dropdown.
+ *   POST (admin)  — register an NFS/custom target (the kinds NOT discoverable
+ *                   live). For NFS, `config` should reference the dynamic
+ *                   `nfs-subdir-external-provisioner` StorageClass (§15 B3 — a
+ *                   dynamic SC, NOT a static PV), e.g.
+ *                   `{ "storageClassName": "nfs-client" }`.
  */
-import { withSupervisorAuth, phase1Pending } from "@/lib/auth";
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { registeredStorageTarget, type StorageTargetKind } from "@/db/schema";
+import { withSupervisorAuth } from "@/lib/auth";
+import { discoverStorageTargets } from "@/lib/storage";
+import { createLogger } from "@/lib/logger";
 
+const log = createLogger("api/storage-targets");
+
+/** GET /api/storage-targets — live discovery. */
 export const GET = withSupervisorAuth("viewer", async () => {
-  return phase1Pending();
+  const options = await discoverStorageTargets();
+  return NextResponse.json({ targets: options });
+});
+
+const VALID_KINDS: ReadonlySet<StorageTargetKind> = new Set([
+  "local-path",
+  "storage-class",
+  "nfs",
+  "cloud-csi",
+]);
+
+interface RegisterBody {
+  name?: unknown;
+  kind?: unknown;
+  config?: unknown;
+  resiliencyNote?: unknown;
+  isDefault?: unknown;
+}
+
+/**
+ * POST /api/storage-targets — register an NFS/custom target (admin only).
+ *
+ * Discovered kinds (StorageClasses, local-path nodes) are NOT stored — only
+ * targets that can't be discovered live (NFS / custom). Validates the body,
+ * inserts a `registered_storage_target` row, and returns 201. A duplicate name
+ * (the unique index) → 409.
+ */
+export const POST = withSupervisorAuth("admin", async (request) => {
+  let body: RegisterBody;
+  try {
+    body = (await request.json()) as RegisterBody;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON in request body", code: "INVALID_JSON" },
+      { status: 400 },
+    );
+  }
+
+  if (typeof body.name !== "string" || body.name.trim() === "") {
+    return NextResponse.json(
+      { error: "name is required", code: "INVALID_BODY" },
+      { status: 400 },
+    );
+  }
+  const name = body.name.trim();
+
+  if (typeof body.kind !== "string" || !VALID_KINDS.has(body.kind as StorageTargetKind)) {
+    return NextResponse.json(
+      {
+        error: "kind must be one of: local-path, storage-class, nfs, cloud-csi",
+        code: "INVALID_BODY",
+      },
+      { status: 400 },
+    );
+  }
+  const kind = body.kind as StorageTargetKind;
+
+  // config must be a JSON object (it's stored as JSON text and parsed back at
+  // resolution time — for NFS it should carry the dynamic provisioner's
+  // `storageClassName`).
+  if (
+    typeof body.config !== "object" ||
+    body.config === null ||
+    Array.isArray(body.config)
+  ) {
+    return NextResponse.json(
+      { error: "config must be a JSON object", code: "INVALID_BODY" },
+      { status: 400 },
+    );
+  }
+  const config = body.config as Record<string, unknown>;
+
+  // SC-backed kinds MUST carry a non-empty `config.storageClassName`. Per §15 B3
+  // NFS is a dynamic `nfs-subdir-external-provisioner` StorageClass, so a
+  // registered NFS (or storage-class / cloud-csi) target without one is unusable
+  // (it would silently fall back to the cluster default SC at PVC binding).
+  if (kind === "nfs" || kind === "storage-class" || kind === "cloud-csi") {
+    if (
+      typeof config.storageClassName !== "string" ||
+      config.storageClassName.trim() === ""
+    ) {
+      return NextResponse.json(
+        {
+          error: `config.storageClassName (non-empty string) is required for kind "${kind}"`,
+          code: "INVALID_CONFIG",
+        },
+        { status: 400 },
+      );
+    }
+  }
+
+  if (body.resiliencyNote !== undefined && typeof body.resiliencyNote !== "string") {
+    return NextResponse.json(
+      { error: "resiliencyNote must be a string", code: "INVALID_BODY" },
+      { status: 400 },
+    );
+  }
+
+  if (body.isDefault !== undefined && typeof body.isDefault !== "boolean") {
+    return NextResponse.json(
+      { error: "isDefault must be a boolean", code: "INVALID_BODY" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const [row] = await db
+      .insert(registeredStorageTarget)
+      .values({
+        name,
+        kind,
+        config: JSON.stringify(config),
+        resiliencyNote: (body.resiliencyNote as string | undefined) ?? null,
+        isDefault: (body.isDefault as boolean | undefined) ?? false,
+      })
+      .returning();
+
+    log.info("registered storage target", { name, kind });
+    return NextResponse.json({ target: row }, { status: 201 });
+  } catch (err) {
+    // Only a UNIQUE violation means the name is taken; any other error is a 500.
+    if (/unique/i.test(String(err))) {
+      return NextResponse.json(
+        { error: `A storage target named "${name}" already exists`, code: "NAME_TAKEN" },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
 });

--- a/apps/supervisor/src/app/instances/new/page.tsx
+++ b/apps/supervisor/src/app/instances/new/page.tsx
@@ -1,0 +1,92 @@
+export const dynamic = "force-dynamic";
+
+import Link from "next/link";
+import { headers } from "next/headers";
+import { validateAccessJWT, isCfAccessConfigured } from "@/lib/cf-access";
+import { resolveSupervisorUser } from "@/lib/auth";
+import { hasRole, type Role } from "@/lib/roles";
+import { createLogger } from "@/lib/logger";
+import { CreateInstanceForm } from "@/components/create-instance-form";
+
+const log = createLogger("instances/new");
+
+interface CurrentUser {
+  id: string;
+  email: string;
+  role: Role;
+}
+
+/**
+ * Resolve the current operator for this server-rendered page. Same precedence as
+ * `withSupervisorAuth` (CF Access in prod, SUPERVISOR_ADMIN_EMAIL in local dev).
+ * Kept local to the page (mirrors the dashboard's resolver) — there is no shared
+ * server-page auth helper yet.
+ */
+async function getCurrentUser(): Promise<CurrentUser | null> {
+  let email: string | null = null;
+
+  if (isCfAccessConfigured()) {
+    const hdrs = await headers();
+    const headerToken = hdrs.get("cf-access-jwt-assertion");
+    const cookie = hdrs.get("cookie");
+    const cookieToken = cookie?.match(/CF_Authorization=([^;]+)/)?.[1] ?? null;
+    const cfUser = await validateAccessJWT(headerToken ?? cookieToken);
+    email = cfUser?.email ?? null;
+  } else {
+    const adminEmail = process.env.SUPERVISOR_ADMIN_EMAIL;
+    email = adminEmail && adminEmail.length > 0 ? adminEmail : null;
+  }
+
+  if (!email) return null;
+
+  try {
+    const user = await resolveSupervisorUser(email);
+    return { id: user.id, email: user.email, role: user.role };
+  } catch (error) {
+    log.error("Failed to resolve current user", { error: String(error) });
+    return null;
+  }
+}
+
+export default async function NewInstancePage() {
+  const user = await getCurrentUser();
+
+  // Creating an instance requires operator (or admin). Viewers / unauthenticated
+  // users see a gentle gate rather than the form.
+  if (!user || !hasRole(user, "operator")) {
+    return (
+      <main className="mx-auto flex min-h-svh max-w-2xl flex-col items-center justify-center px-6 text-center">
+        <h1 className="text-2xl font-semibold">Create instance</h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          {user
+            ? "You need the operator role to create instances."
+            : "Not authenticated."}
+        </p>
+        <Link
+          href="/"
+          className="mt-6 text-sm text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
+        >
+          Back to dashboard
+        </Link>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-xl px-6 py-10">
+      <header className="border-b border-border pb-6">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Create instance
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Provision a new Remote Dev instance. Choose where its persistent data
+          lives — the resiliency note shows the trade-off for each option.
+        </p>
+      </header>
+
+      <section className="mt-8">
+        <CreateInstanceForm />
+      </section>
+    </main>
+  );
+}

--- a/apps/supervisor/src/app/page.tsx
+++ b/apps/supervisor/src/app/page.tsx
@@ -8,8 +8,9 @@ import {
   validateAccessJWT,
   isCfAccessConfigured,
 } from "@/lib/cf-access";
+import Link from "next/link";
 import { resolveSupervisorUser } from "@/lib/auth";
-import { type Role } from "@/lib/roles";
+import { hasRole, type Role } from "@/lib/roles";
 import { cn } from "@/lib/utils";
 import { createLogger } from "@/lib/logger";
 
@@ -121,9 +122,19 @@ export default async function DashboardPage() {
               : "Instances you own."}
           </p>
         </div>
-        <div className="text-right text-xs text-muted-foreground">
-          <div className="font-medium text-foreground">{user.email}</div>
-          <div className="uppercase tracking-wide">{user.role}</div>
+        <div className="flex items-center gap-4">
+          {hasRole(user, "operator") ? (
+            <Link
+              href="/instances/new"
+              className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90"
+            >
+              Create instance
+            </Link>
+          ) : null}
+          <div className="text-right text-xs text-muted-foreground">
+            <div className="font-medium text-foreground">{user.email}</div>
+            <div className="uppercase tracking-wide">{user.role}</div>
+          </div>
         </div>
       </header>
 
@@ -132,10 +143,24 @@ export default async function DashboardPage() {
           <div className="rounded-lg border border-dashed border-border px-6 py-16 text-center">
             <h2 className="text-base font-medium">No instances yet</h2>
             <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
-              Provisioning lands in a later Phase&nbsp;1 task (jvcx.4). Once
-              available, operators will create instances here and reach them at{" "}
-              <code className="font-mono text-xs">/&lt;slug&gt;</code> through the
-              router.
+              {hasRole(user, "operator") ? (
+                <>
+                  Use{" "}
+                  <span className="font-medium text-foreground">
+                    Create instance
+                  </span>{" "}
+                  to provision one. It will be reachable at{" "}
+                  <code className="font-mono text-xs">/&lt;slug&gt;</code> through
+                  the router.
+                </>
+              ) : (
+                <>
+                  Instances appear here once an operator provisions them; each is
+                  reachable at{" "}
+                  <code className="font-mono text-xs">/&lt;slug&gt;</code> through
+                  the router.
+                </>
+              )}
             </p>
           </div>
         ) : (
@@ -168,7 +193,7 @@ export default async function DashboardPage() {
       </section>
 
       <footer className="mt-10 text-xs text-muted-foreground">
-        Scaffold — Phase 1 in progress (remote-dev-jvcx.3).
+        Phase 1 in progress (remote-dev-jvcx.5).
       </footer>
     </main>
   );

--- a/apps/supervisor/src/components/create-instance-form.tsx
+++ b/apps/supervisor/src/components/create-instance-form.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+/**
+ * Create-instance form with a storage-target dropdown (spec §7).
+ *
+ * Mirrors the main app's "discover & select" UX (`/api/directories`): on mount
+ * it fetches the live storage options from `GET /api/storage-targets`, renders
+ * them in a <select>, and surfaces the SELECTED option's resiliencyNote so the
+ * operator sees the data-resiliency trade-off before provisioning. Submitting
+ * POSTs `/api/instances` with the chosen option id as `storageTargetId`.
+ *
+ * Client component — uses fetch + console for client-side errors (the server
+ * logger is server-only).
+ */
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+interface StorageTargetOption {
+  id: string;
+  name: string;
+  kind: string;
+  resiliencyNote: string;
+  isDefault: boolean;
+}
+
+const SLUG_PATTERN = /^[a-z][a-z0-9-]{0,14}$/;
+
+const inputClass =
+  "w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
+
+const labelClass = "text-sm font-medium";
+
+export function CreateInstanceForm() {
+  const router = useRouter();
+
+  const [slug, setSlug] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [storageTargetId, setStorageTargetId] = useState("default");
+
+  const [options, setOptions] = useState<StorageTargetOption[]>([]);
+  const [optionsLoading, setOptionsLoading] = useState(true);
+  const [optionsError, setOptionsError] = useState<string | null>(null);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  // Discover storage targets on mount.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch("/api/storage-targets");
+        if (!res.ok) {
+          throw new Error(`Failed to load storage targets (${res.status})`);
+        }
+        const data = (await res.json()) as { targets: StorageTargetOption[] };
+        if (cancelled) return;
+        setOptions(data.targets);
+        // Default the selection to the option flagged isDefault, else the first.
+        const preferred =
+          data.targets.find((t) => t.isDefault) ?? data.targets[0];
+        if (preferred) setStorageTargetId(preferred.id);
+      } catch (err) {
+        if (cancelled) return;
+        console.error("storage-targets fetch failed", err);
+        setOptionsError(
+          "Could not load storage targets. The cluster default will be used.",
+        );
+      } finally {
+        if (!cancelled) setOptionsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const selected = options.find((o) => o.id === storageTargetId);
+  const slugValid = slug === "" || SLUG_PATTERN.test(slug);
+  const canSubmit =
+    !submitting &&
+    SLUG_PATTERN.test(slug) &&
+    displayName.trim().length > 0;
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setFormError(null);
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/instances", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          slug,
+          displayName: displayName.trim(),
+          storageTargetId,
+        }),
+      });
+      if (res.status === 202) {
+        // Provisioning queued — back to the dashboard.
+        router.push("/");
+        router.refresh();
+        return;
+      }
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      setFormError(data.error ?? `Request failed (${res.status})`);
+    } catch (err) {
+      console.error("create instance failed", err);
+      setFormError("Network error while creating the instance.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-6">
+      <div className="space-y-2">
+        <label htmlFor="slug" className={labelClass}>
+          Slug
+        </label>
+        <input
+          id="slug"
+          name="slug"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          placeholder="alpha"
+          autoComplete="off"
+          spellCheck={false}
+          className={cn(inputClass, !slugValid && "border-destructive")}
+          aria-invalid={!slugValid}
+        />
+        <p className="text-xs text-muted-foreground">
+          1–15 chars, lowercase letter first, then lowercase letters, digits, or
+          hyphens. The instance is served at{" "}
+          <code className="font-mono">/{slug || "<slug>"}</code>.
+        </p>
+        {!slugValid ? (
+          <p className="text-xs text-destructive">Invalid slug format.</p>
+        ) : null}
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="displayName" className={labelClass}>
+          Display name
+        </label>
+        <input
+          id="displayName"
+          name="displayName"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          placeholder="Alpha"
+          autoComplete="off"
+          className={inputClass}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="storageTargetId" className={labelClass}>
+          Storage target
+        </label>
+        <select
+          id="storageTargetId"
+          name="storageTargetId"
+          value={storageTargetId}
+          onChange={(e) => setStorageTargetId(e.target.value)}
+          disabled={optionsLoading}
+          className={cn(inputClass, "appearance-none")}
+        >
+          {optionsLoading ? (
+            <option value="default">Loading…</option>
+          ) : (
+            options.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.name} — {o.resiliencyNote}
+              </option>
+            ))
+          )}
+        </select>
+        {optionsError ? (
+          <p className="text-xs text-destructive">{optionsError}</p>
+        ) : null}
+        {selected ? (
+          <div className="rounded-md border border-border bg-card px-3 py-2 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">
+              {selected.kind}
+            </span>{" "}
+            — {selected.resiliencyNote}
+          </div>
+        ) : null}
+      </div>
+
+      {formError ? (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {formError}
+        </div>
+      ) : null}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+        >
+          {submitting ? "Creating…" : "Create instance"}
+        </button>
+        <Link
+          href="/"
+          className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Cancel
+        </Link>
+      </div>
+    </form>
+  );
+}

--- a/apps/supervisor/src/controller/__tests__/reconciler.test.ts
+++ b/apps/supervisor/src/controller/__tests__/reconciler.test.ts
@@ -149,6 +149,41 @@ describe("reconcileInstances — requested → provisioning", () => {
     expect(allWrites).not.toContain(seenSecret!);
   });
 
+  it("builds the storage target from the row's snapshot (authoritative, jvcx.5)", async () => {
+    const snapshot = {
+      kind: "local-path",
+      storageClassName: "local-path",
+      nodeHostname: "worker-7",
+      size: "10Gi",
+    };
+    const { db } = makeDb([
+      row("requested", { storageConfigSnapshot: JSON.stringify(snapshot) }),
+    ]);
+    let seenStorage: unknown;
+    const provisionInstance = vi.fn(async (_r, opts) => {
+      seenStorage = opts.storage;
+    });
+    await reconcileInstances(baseDeps({ db, provisionInstance }));
+
+    expect(seenStorage).toMatchObject({
+      kind: "local-path",
+      storageClassName: "local-path",
+      nodeHostname: "worker-7",
+    });
+  });
+
+  it("falls back to the cluster default when the snapshot is absent (older rows)", async () => {
+    const { db } = makeDb([row("requested", { storageConfigSnapshot: null })]);
+    let seenStorage: { kind?: string; configSnapshot?: Record<string, unknown> } | undefined;
+    const provisionInstance = vi.fn(async (_r, opts) => {
+      seenStorage = opts.storage;
+    });
+    await reconcileInstances(baseDeps({ db, provisionInstance }));
+
+    expect(seenStorage?.kind).toBe("storage-class");
+    expect(seenStorage?.configSnapshot).toMatchObject({ isDefault: true });
+  });
+
   it("a ProvisioningError transitions the instance to error", async () => {
     const { db, updates } = makeDb([row("requested")]);
     const provisionInstance = vi.fn(async () => {

--- a/apps/supervisor/src/controller/reconciler.ts
+++ b/apps/supervisor/src/controller/reconciler.ts
@@ -41,7 +41,11 @@ import {
   type InstanceStatus,
 } from "@/db/schema";
 import { assertTransition } from "@/lib/instance-state";
-import { resolveDefaultStorageTarget } from "@/lib/storage";
+import {
+  resolveDefaultStorageTarget,
+  resolvedFromSnapshot,
+  type ResolvedStorageTarget,
+} from "@/lib/storage";
 import {
   provisionInstance as defaultProvisionInstance,
   checkInstanceReady as defaultCheckInstanceReady,
@@ -181,18 +185,44 @@ async function transition(
 }
 
 /**
+ * Build the PVC source for an instance from its SNAPSHOT (authoritative, §7).
+ * The snapshot was written at create time by `resolveStorageTarget`, so the
+ * reconciler rebuilds the PVC template from it WITHOUT re-querying the cluster —
+ * a later edit/delete of the target can't change an existing instance's volume.
+ *
+ * Falls back to the cluster default only when the snapshot is absent/empty/
+ * malformed (older rows from before storage targets, or a corrupt snapshot).
+ */
+function storageFromRow(row: InstanceRow): ResolvedStorageTarget {
+  const raw = row.storageConfigSnapshot;
+  if (raw && raw.trim() !== "") {
+    try {
+      const snapshot = JSON.parse(raw) as Record<string, unknown>;
+      return resolvedFromSnapshot(snapshot);
+    } catch (err) {
+      log.warn("storageConfigSnapshot unusable; falling back to cluster default", {
+        slug: row.slug,
+        error: String(err),
+      });
+    }
+  }
+  return resolveDefaultStorageTarget(row.storageRequest ?? undefined);
+}
+
+/**
  * Build the provisioning options for an instance (shared by the initial
  * `requested→provisioning` claim and the within-budget self-heal re-provision).
  * Generates a fresh UNIQUE AUTH_SECRET each call (never logged, never persisted).
+ *
+ * Storage is rebuilt from the row's authoritative `storageConfigSnapshot`
+ * (see {@link storageFromRow}), NOT re-resolved live.
  *
  * NOTE: `authorizedEmails`/seed handling is intentionally NOT wired in here —
  * the seed Job dispatch is deferred to Phase 2 (jvcx.8), see provisionInstance.
  */
 function buildProvisionOptions(row: InstanceRow): ProvisionOptions {
   const env = readProvisionEnv();
-  // Storage: snapshot is already on the row; re-resolve the default for the PVC
-  // template (jvcx.5 will resolve by storageTargetId from the snapshot).
-  const storage = resolveDefaultStorageTarget(row.storageRequest ?? undefined);
+  const storage = storageFromRow(row);
   return {
     image: env.image,
     host: env.host,

--- a/apps/supervisor/src/lib/__tests__/storage.test.ts
+++ b/apps/supervisor/src/lib/__tests__/storage.test.ts
@@ -1,8 +1,19 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import type {
+  V1StorageClassList,
+  V1NodeList,
+  V1Node,
+  V1StorageClass,
+} from "@kubernetes/client-node";
 import {
   resolveDefaultStorageTarget,
   toVolumeClaimTemplate,
+  discoverStorageTargets,
+  resolveStorageTarget,
+  resolvedFromSnapshot,
+  StorageTargetResolutionError,
   DATA_VOLUME_NAME,
+  type StorageClients,
 } from "@/lib/storage";
 
 const ENV_KEYS = [
@@ -13,6 +24,72 @@ const ENV_KEYS = [
 afterEach(() => {
   for (const k of ENV_KEYS) delete process.env[k];
 });
+
+// --- helpers ----------------------------------------------------------------
+
+function sc(name: string, provisioner: string, isDefault = false): V1StorageClass {
+  return {
+    metadata: {
+      name,
+      ...(isDefault
+        ? { annotations: { "storageclass.kubernetes.io/is-default-class": "true" } }
+        : {}),
+    },
+    provisioner,
+  } as V1StorageClass;
+}
+
+function node(
+  name: string,
+  opts: { controlPlane?: boolean; taintControlPlane?: boolean } = {},
+): V1Node {
+  const labels: Record<string, string> = {};
+  if (opts.controlPlane) labels["node-role.kubernetes.io/control-plane"] = "";
+  return {
+    metadata: { name, labels },
+    spec: opts.taintControlPlane
+      ? {
+          taints: [
+            {
+              key: "node-role.kubernetes.io/control-plane",
+              effect: "NoSchedule",
+            },
+          ],
+        }
+      : {},
+  } as V1Node;
+}
+
+/** A mock StorageClients returning the given SCs + nodes. */
+function makeClients(scs: V1StorageClass[], nodes: V1Node[]): StorageClients {
+  return {
+    storage: {
+      listStorageClass: vi.fn(
+        async () => ({ items: scs }) as V1StorageClassList,
+      ),
+    },
+    core: {
+      listNode: vi.fn(async () => ({ items: nodes }) as V1NodeList),
+    },
+  };
+}
+
+/** A db stub whose registeredStorageTarget queries return `rows`. */
+function makeDb(rows: Record<string, unknown>[]) {
+  return {
+    select: () => ({ from: async () => rows }),
+    query: {
+      registeredStorageTarget: {
+        findFirst: async ({ where }: { where?: unknown }) => {
+          void where;
+          return rows[0];
+        },
+      },
+    },
+  } as never;
+}
+
+// --- resolveDefaultStorageTarget (existing) ---------------------------------
 
 describe("resolveDefaultStorageTarget", () => {
   it("defaults to 10Gi and the cluster default SC when env unset", () => {
@@ -39,6 +116,8 @@ describe("resolveDefaultStorageTarget", () => {
     expect(resolveDefaultStorageTarget("5Gi").size).toBe("40Gi");
   });
 });
+
+// --- toVolumeClaimTemplate (existing) ---------------------------------------
 
 describe("toVolumeClaimTemplate", () => {
   it("produces a data PVC: RWO, requested size, no SC when undefined", () => {
@@ -78,5 +157,279 @@ describe("toVolumeClaimTemplate", () => {
       "worker-1",
     );
     expect(pvc.spec?.storageClassName).toBe("local-path");
+  });
+});
+
+// --- discoverStorageTargets -------------------------------------------------
+
+describe("discoverStorageTargets", () => {
+  it("always includes the `default` option first", async () => {
+    const opts = await discoverStorageTargets(makeClients([], []), makeDb([]));
+    expect(opts[0].id).toBe("default");
+    expect(opts[0].isDefault).toBe(true);
+  });
+
+  it("Longhorn SC → replicated note; cloud CSI provisioner → cloud-csi kind", async () => {
+    const clients = makeClients(
+      [
+        sc("longhorn", "driver.longhorn.io"),
+        sc("ebs", "ebs.csi.aws.com"),
+        sc("generic", "rancher.io/local-path"),
+      ],
+      [],
+    );
+    const opts = await discoverStorageTargets(clients, makeDb([]));
+
+    const longhorn = opts.find((o) => o.id === "sc:longhorn");
+    expect(longhorn?.kind).toBe("storage-class");
+    expect(longhorn?.resiliencyNote.toLowerCase()).toContain("replicated");
+
+    const ebs = opts.find((o) => o.id === "sc:ebs");
+    expect(ebs?.kind).toBe("cloud-csi");
+    expect(ebs?.resiliencyNote.toLowerCase()).toContain("reattaches");
+
+    const generic = opts.find((o) => o.id === "sc:generic");
+    expect(generic?.kind).toBe("storage-class");
+  });
+
+  it("flags the default-annotated SC as isDefault; the synthetic `default` is NOT (Fix 3)", async () => {
+    const clients = makeClients(
+      [sc("fast", "ebs.csi.aws.com", true)],
+      [],
+    );
+    const opts = await discoverStorageTargets(clients, makeDb([]));
+    const fast = opts.find((o) => o.id === "sc:fast");
+    expect(fast?.isDefault).toBe(true);
+    expect(fast?.name).toContain("default");
+    // Exactly one option is the default — the annotated SC, NOT the generic one.
+    expect(opts.find((o) => o.id === "default")?.isDefault).toBe(false);
+    expect(opts.filter((o) => o.isDefault)).toHaveLength(1);
+  });
+
+  it("the synthetic `default` IS isDefault when no SC carries the default annotation (Fix 3)", async () => {
+    const clients = makeClients(
+      [sc("longhorn", "driver.longhorn.io"), sc("generic", "rancher.io/local-path")],
+      [],
+    );
+    const opts = await discoverStorageTargets(clients, makeDb([]));
+    expect(opts.find((o) => o.id === "default")?.isDefault).toBe(true);
+    expect(opts.find((o) => o.id === "sc:longhorn")?.isDefault).toBe(false);
+    expect(opts.filter((o) => o.isDefault)).toHaveLength(1);
+  });
+
+  it("skips control-plane nodes (by label AND by NoSchedule taint)", async () => {
+    const clients = makeClients(
+      [],
+      [
+        node("cp", { controlPlane: true }),
+        node("cp-taint", { taintControlPlane: true }),
+        node("worker-1"),
+        node("worker-2"),
+      ],
+    );
+    const opts = await discoverStorageTargets(clients, makeDb([]));
+    const nodeIds = opts.filter((o) => o.id.startsWith("node:")).map((o) => o.id);
+    expect(nodeIds).toEqual(["node:worker-1", "node:worker-2"]);
+    const w1 = opts.find((o) => o.id === "node:worker-1");
+    expect(w1?.kind).toBe("local-path");
+    expect(w1?.resiliencyNote.toLowerCase()).toContain("no replication");
+  });
+
+  it("merges registered rows as reg:<id> with their kind + note", async () => {
+    const rows = [
+      {
+        id: "uuid-1",
+        name: "office-nfs",
+        kind: "nfs",
+        config: JSON.stringify({ storageClassName: "nfs-client" }),
+        resiliencyNote: "Off-cluster NFS",
+        isDefault: false,
+      },
+    ];
+    const opts = await discoverStorageTargets(makeClients([], []), makeDb(rows));
+    const reg = opts.find((o) => o.id === "reg:uuid-1");
+    expect(reg?.kind).toBe("nfs");
+    expect(reg?.name).toBe("office-nfs");
+    expect(reg?.resiliencyNote).toBe("Off-cluster NFS");
+  });
+
+  it("degrades to default + registered when a k8s list call throws (no cluster)", async () => {
+    const throwingClients: StorageClients = {
+      storage: {
+        listStorageClass: vi.fn(async () => {
+          throw new Error("no cluster");
+        }),
+      },
+      core: {
+        listNode: vi.fn(async () => {
+          throw new Error("no cluster");
+        }),
+      },
+    };
+    const rows = [
+      {
+        id: "uuid-1",
+        name: "office-nfs",
+        kind: "nfs",
+        config: "{}",
+        resiliencyNote: null,
+        isDefault: false,
+      },
+    ];
+    const opts = await discoverStorageTargets(throwingClients, makeDb(rows));
+    // No throw; default is present, no sc:/node: options, registered merged.
+    expect(opts.some((o) => o.id === "default")).toBe(true);
+    expect(opts.some((o) => o.id.startsWith("sc:"))).toBe(false);
+    expect(opts.some((o) => o.id.startsWith("node:"))).toBe(false);
+    expect(opts.some((o) => o.id === "reg:uuid-1")).toBe(true);
+  });
+});
+
+// --- resolveStorageTarget ---------------------------------------------------
+
+describe("resolveStorageTarget", () => {
+  it("null / 'default' → the cluster default target", async () => {
+    const a = await resolveStorageTarget(null);
+    const b = await resolveStorageTarget("default");
+    expect(a.id).toBeNull();
+    expect(a.kind).toBe("storage-class");
+    expect(b.id).toBeNull();
+  });
+
+  it("sc:<name> → storage-class, storageClassName set (longhorn → replicated)", async () => {
+    const clients = makeClients([sc("longhorn", "driver.longhorn.io")], []);
+    const t = await resolveStorageTarget("sc:longhorn", "10Gi", clients);
+    expect(t.kind).toBe("storage-class");
+    expect(t.storageClassName).toBe("longhorn");
+    expect(t.resiliencyNote.toLowerCase()).toContain("replicated");
+    expect(t.configSnapshot).toMatchObject({
+      kind: "storage-class",
+      storageClassName: "longhorn",
+    });
+  });
+
+  it("sc:<name> → cloud-csi when the provisioner is a cloud CSI driver", async () => {
+    const clients = makeClients([sc("ebs", "ebs.csi.aws.com")], []);
+    const t = await resolveStorageTarget("sc:ebs", "10Gi", clients);
+    expect(t.kind).toBe("cloud-csi");
+    expect(t.storageClassName).toBe("ebs");
+  });
+
+  it("node:<host> → local-path pinned to the node", async () => {
+    const t = await resolveStorageTarget("node:worker-3", "10Gi");
+    expect(t.kind).toBe("local-path");
+    expect(t.storageClassName).toBe("local-path");
+    expect(t.nodeHostname).toBe("worker-3");
+    expect(t.resiliencyNote.toLowerCase()).toContain("no replication");
+    // round-trips through the PVC template as a selected-node annotation.
+    const pvc = toVolumeClaimTemplate(t);
+    expect(pvc.metadata?.annotations?.["volume.kubernetes.io/selected-node"]).toBe(
+      "worker-3",
+    );
+  });
+
+  it("reg:<uuid> → uses the row's dynamic NFS StorageClass from config", async () => {
+    const rows = [
+      {
+        id: "uuid-1",
+        name: "office-nfs",
+        kind: "nfs",
+        config: JSON.stringify({ storageClassName: "nfs-client", server: "10.0.0.1" }),
+        resiliencyNote: "Off-cluster NFS",
+        isDefault: false,
+      },
+    ];
+    const t = await resolveStorageTarget("reg:uuid-1", "10Gi", undefined, makeDb(rows));
+    expect(t.kind).toBe("nfs");
+    expect(t.storageClassName).toBe("nfs-client");
+    expect(t.configSnapshot).toMatchObject({
+      kind: "nfs",
+      storageClassName: "nfs-client",
+      server: "10.0.0.1",
+    });
+  });
+
+  it("reg:<uuid> → a stray kind/size in config does NOT override the row (Fix 1)", async () => {
+    const rows = [
+      {
+        id: "uuid-1",
+        name: "office-nfs",
+        kind: "nfs",
+        // Hostile config: tries to masquerade as local-path with a tiny size.
+        config: JSON.stringify({
+          kind: "local-path",
+          size: "1Mi",
+          storageClassName: "nfs-client",
+        }),
+        resiliencyNote: "Off-cluster NFS",
+        isDefault: false,
+      },
+    ];
+    const t = await resolveStorageTarget("reg:uuid-1", "10Gi", undefined, makeDb(rows));
+    // Row's authoritative kind + the resolved size win over the config keys.
+    expect(t.kind).toBe("nfs");
+    expect(t.size).toBe("10Gi");
+    expect(t.configSnapshot).toMatchObject({
+      kind: "nfs",
+      size: "10Gi",
+      storageClassName: "nfs-client",
+    });
+    // The round-trip via resolvedFromSnapshot keeps the authoritative kind.
+    expect(resolvedFromSnapshot(t.configSnapshot).kind).toBe("nfs");
+  });
+
+  it("reg:<uuid> → NOT_FOUND when the row is missing", async () => {
+    await expect(
+      resolveStorageTarget("reg:missing", "10Gi", undefined, makeDb([])),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("unknown id form → UNKNOWN_ID", async () => {
+    await expect(resolveStorageTarget("bogus:x")).rejects.toBeInstanceOf(
+      StorageTargetResolutionError,
+    );
+    await expect(resolveStorageTarget("bogus:x")).rejects.toMatchObject({
+      code: "UNKNOWN_ID",
+    });
+  });
+});
+
+// --- resolvedFromSnapshot ---------------------------------------------------
+
+describe("resolvedFromSnapshot", () => {
+  it("round-trips a local-path snapshot back to a ResolvedStorageTarget", () => {
+    const snapshot = {
+      kind: "local-path",
+      storageClassName: "local-path",
+      nodeHostname: "worker-1",
+      size: "10Gi",
+    };
+    const t = resolvedFromSnapshot(snapshot);
+    expect(t.kind).toBe("local-path");
+    expect(t.storageClassName).toBe("local-path");
+    expect(t.nodeHostname).toBe("worker-1");
+    expect(t.size).toBe("10Gi");
+    // The PVC template rebuilt from it pins the node.
+    const pvc = toVolumeClaimTemplate(t);
+    expect(pvc.metadata?.annotations?.["volume.kubernetes.io/selected-node"]).toBe(
+      "worker-1",
+    );
+  });
+
+  it("round-trips a storage-class snapshot (cloud-csi kind preserved)", () => {
+    const t = resolvedFromSnapshot({
+      kind: "cloud-csi",
+      storageClassName: "ebs",
+      size: "20Gi",
+    });
+    expect(t.kind).toBe("cloud-csi");
+    expect(t.storageClassName).toBe("ebs");
+    expect(t.size).toBe("20Gi");
+  });
+
+  it("throws MALFORMED_SNAPSHOT on an invalid kind", () => {
+    expect(() => resolvedFromSnapshot({ kind: "weird", size: "10Gi" })).toThrow(
+      StorageTargetResolutionError,
+    );
   });
 });

--- a/apps/supervisor/src/lib/storage.ts
+++ b/apps/supervisor/src/lib/storage.ts
@@ -1,20 +1,39 @@
 /**
  * Storage target resolution → PVC template (spec §7).
  *
- * jvcx.4 ships ONLY the minimal default resolver + the `toVolumeClaimTemplate`
- * translation interface. jvcx.5 will add:
- *   - `discoverStorageTargets()` — list StorageClasses + schedulable nodes (one
- *     `local-path on <node>` option each) + merged `registered_storage_target` rows.
- *   - `resolveStorageTarget(id)` — resolve a chosen target id to a
- *     ResolvedStorageTarget using the full 4-backend table (local-path /
- *     storage-class / nfs / cloud-csi), with per-backend resiliency notes and
- *     node affinity.
- * For now only the cluster-default resolver exists, and `POST /api/instances`
- * uses it when no `storageTargetId` is supplied.
+ * Three layers:
+ *   1. {@link resolveDefaultStorageTarget} — the cluster-default resolver (env
+ *      driven). Used when no `storageTargetId` is supplied.
+ *   2. {@link discoverStorageTargets} — LIVE discovery: StorageClasses + each
+ *      schedulable node (local-path) + merged `registered_storage_target` rows,
+ *      surfaced as {@link StorageTargetOption}s for the create-instance dropdown.
+ *   3. {@link resolveStorageTarget} — resolve a chosen option id (the stable
+ *      id scheme below) to a {@link ResolvedStorageTarget} via the 4-backend §7
+ *      translation table; {@link resolvedFromSnapshot} rebuilds the same shape
+ *      from a persisted `instance.storageConfigSnapshot` WITHOUT touching the
+ *      cluster (the snapshot is authoritative — later target edits/deletes must
+ *      not change an existing instance's volume).
+ *
+ * Option id scheme (round-trips a selected dropdown option):
+ *   - `default`        → the cluster default StorageClass (env-driven).
+ *   - `sc:<name>`      → a discovered StorageClass.
+ *   - `node:<host>`    → local-path pinned to node `<host>`.
+ *   - `reg:<uuid>`     → a `registered_storage_target` row (NFS / custom).
  */
 
-import type { V1PersistentVolumeClaim } from "@kubernetes/client-node";
+import type {
+  V1PersistentVolumeClaim,
+  CoreV1Api,
+  StorageV1Api,
+} from "@kubernetes/client-node";
+import { eq } from "drizzle-orm";
+import { db as defaultDb } from "@/db";
+import { registeredStorageTarget } from "@/db/schema";
 import type { StorageTargetKind } from "@/db/schema";
+import { getCoreV1Api, getStorageV1Api } from "@/lib/k8s";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("Storage");
 
 /** Fallback request size when neither env nor caller supplies one. */
 const FALLBACK_STORAGE_SIZE = "10Gi";
@@ -22,24 +41,96 @@ const FALLBACK_STORAGE_SIZE = "10Gi";
 /** The PVC name used inside a StatefulSet's volumeClaimTemplates. */
 export const DATA_VOLUME_NAME = "data";
 
+/** Annotation k8s sets on the default StorageClass. */
+const DEFAULT_SC_ANNOTATION = "storageclass.kubernetes.io/is-default-class";
+
+/** Annotation the rancher local-path provisioner honours to pin a PVC's node. */
+const SELECTED_NODE_ANNOTATION = "volume.kubernetes.io/selected-node";
+
+/** StorageClass name the rancher local-path provisioner ships with. */
+const LOCAL_PATH_SC = "local-path";
+
+/** Longhorn's CSI provisioner — replicated, survives node loss. */
+const LONGHORN_PROVISIONER = "driver.longhorn.io";
+
+/**
+ * Known cloud CSI provisioners. A volume from one of these reattaches on node
+ * loss within its AZ (cross-AZ is a manual recovery — see §8.5).
+ */
+const CLOUD_CSI_PROVISIONERS: ReadonlySet<string> = new Set([
+  "ebs.csi.aws.com",
+  "pd.csi.storage.gke.io",
+  "disk.csi.azure.com",
+]);
+
+/** Control-plane node labels — these nodes are skipped for local-path options. */
+const CONTROL_PLANE_LABELS = [
+  "node-role.kubernetes.io/control-plane",
+  "node-role.kubernetes.io/master",
+];
+
+/** Resiliency notes surfaced in the dropdown (§7). */
+const RESILIENCY = {
+  longhorn: "Replicated (Longhorn); survives node loss.",
+  cloudCsi: "Cloud volume; reattaches on node loss within its AZ.",
+  storageClassGeneric:
+    "Dynamic StorageClass; resiliency depends on the backing provisioner.",
+  localPath:
+    "Node-pinned (local-path); NO replication — data is lost if the node is lost.",
+} as const;
+
+/** A discoverable / selectable storage option for the create-instance dropdown. */
+export interface StorageTargetOption {
+  /** Stable option id: "default" | "sc:<name>" | "node:<host>" | "reg:<uuid>". */
+  id: string;
+  /** Human label for the dropdown. */
+  name: string;
+  kind: StorageTargetKind;
+  /** Surfaced in the dropdown so the operator sees the trade-off (§7). */
+  resiliencyNote: string;
+  isDefault: boolean;
+}
+
 /**
  * A resolved storage target: everything needed to build a PVC template plus the
  * snapshot we persist on the instance row so later target edits/deletes don't
  * corrupt existing instances (§7).
  */
 export interface ResolvedStorageTarget {
-  /** Registered target id, or null for the cluster default. */
+  /** The option id this was resolved from, or null for the cluster default. */
   id: string | null;
   kind: StorageTargetKind;
   /** undefined → use the cluster's default StorageClass. */
   storageClassName?: string;
   /** e.g. "10Gi". */
   size: string;
-  /** local-path node affinity hostname (jvcx.5 sets this for node-pinned targets). */
+  /** local-path node affinity hostname (set for node-pinned targets). */
   nodeHostname?: string;
   resiliencyNote: string;
   /** Persisted verbatim into `instance.storageConfigSnapshot`. */
   configSnapshot: Record<string, unknown>;
+}
+
+/** The clients storage discovery / resolution needs, injected for testability. */
+export interface StorageClients {
+  core: Pick<CoreV1Api, "listNode">;
+  storage: Pick<StorageV1Api, "listStorageClass">;
+}
+
+/** Real clients (lazy; throws if no cluster — callers handle that). */
+export function defaultStorageClients(): StorageClients {
+  return { core: getCoreV1Api(), storage: getStorageV1Api() };
+}
+
+/** Typed error for an unknown / unresolvable option id (API maps to 400/404). */
+export class StorageTargetResolutionError extends Error {
+  constructor(
+    readonly code: "UNKNOWN_ID" | "NOT_FOUND" | "MALFORMED_SNAPSHOT",
+    message: string,
+  ) {
+    super(message);
+    this.name = "StorageTargetResolutionError";
+  }
 }
 
 /**
@@ -51,8 +142,7 @@ export interface ResolvedStorageTarget {
  *   - SUPERVISOR_DEFAULT_STORAGE_SIZE (optional) — falls back to the caller's
  *     `size`, then to "10Gi".
  *
- * Kind is reported as `storage-class` (a named or default dynamic provisioner);
- * jvcx.5 refines this when registered/local-path targets are selectable.
+ * Kind is reported as `storage-class` (a named or default dynamic provisioner).
  */
 export function resolveDefaultStorageTarget(
   size?: string,
@@ -81,6 +171,435 @@ export function resolveDefaultStorageTarget(
   };
 }
 
+/** Classify a StorageClass provisioner → (kind, resiliencyNote). */
+function classifyProvisioner(provisioner: string | undefined): {
+  kind: StorageTargetKind;
+  resiliencyNote: string;
+} {
+  if (provisioner === LONGHORN_PROVISIONER) {
+    return { kind: "storage-class", resiliencyNote: RESILIENCY.longhorn };
+  }
+  if (provisioner && CLOUD_CSI_PROVISIONERS.has(provisioner)) {
+    return { kind: "cloud-csi", resiliencyNote: RESILIENCY.cloudCsi };
+  }
+  return {
+    kind: "storage-class",
+    resiliencyNote: RESILIENCY.storageClassGeneric,
+  };
+}
+
+/** True if a node is a control-plane node (skipped for local-path options). */
+function isControlPlaneNode(labels: Record<string, string> | undefined, taints: { key: string; effect: string }[] | undefined): boolean {
+  if (labels) {
+    for (const label of CONTROL_PLANE_LABELS) {
+      if (label in labels) return true;
+    }
+  }
+  if (taints) {
+    for (const t of taints) {
+      if (
+        CONTROL_PLANE_LABELS.includes(t.key) &&
+        t.effect === "NoSchedule"
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Live discovery of selectable storage targets (§7).
+ *
+ *  - StorageClasses → one `sc:<name>` option each (Longhorn → replicated note,
+ *    a known cloud CSI provisioner → cloud-csi kind, else a generic note). The
+ *    SC annotated as default is flagged `isDefault`.
+ *  - Schedulable nodes (control-plane nodes skipped) → one `node:<host>`
+ *    local-path option each.
+ *  - `registered_storage_target` rows → `reg:<id>` options (NFS / custom).
+ *  - The `default` cluster option is ALWAYS included first.
+ *
+ * Resilient: if a k8s list call fails (e.g. no cluster in local dev), it logs a
+ * warning and degrades to `default` + any registered rows rather than throwing,
+ * so the dropdown still renders.
+ */
+export async function discoverStorageTargets(
+  clients?: StorageClients,
+  database = defaultDb,
+): Promise<StorageTargetOption[]> {
+  const def = resolveDefaultStorageTarget();
+
+  // Discovered StorageClass + node options are gathered separately so we can
+  // decide the synthetic `default` option's `isDefault` honestly: it should be
+  // the default ONLY when no discovered StorageClass is the cluster-annotated
+  // default — otherwise the form (which selects the first `isDefault`) would
+  // always pick the generic `default` over the real annotated SC.
+  const scNodeOptions: StorageTargetOption[] = [];
+  let hasAnnotatedDefault = false;
+
+  // K8s discovery — best-effort. A failure degrades to default + registered.
+  let resolved: StorageClients | null = null;
+  try {
+    resolved = clients ?? defaultStorageClients();
+  } catch (err) {
+    log.warn("k8s clients unavailable; storage discovery degraded to default + registered", {
+      error: String(err),
+    });
+  }
+
+  if (resolved) {
+    // StorageClasses.
+    try {
+      const scList = await resolved.storage.listStorageClass();
+      for (const sc of scList.items) {
+        const name = sc.metadata?.name;
+        if (!name) continue;
+        const { kind, resiliencyNote } = classifyProvisioner(sc.provisioner);
+        const isDefault =
+          sc.metadata?.annotations?.[DEFAULT_SC_ANNOTATION] === "true";
+        if (isDefault) hasAnnotatedDefault = true;
+        scNodeOptions.push({
+          id: `sc:${name}`,
+          name: `StorageClass: ${name}${isDefault ? " (default)" : ""}`,
+          kind,
+          resiliencyNote,
+          isDefault,
+        });
+      }
+    } catch (err) {
+      log.warn("listStorageClass failed; skipping StorageClass options", {
+        error: String(err),
+      });
+    }
+
+    // Nodes (local-path, skip control-plane).
+    try {
+      const nodeList = await resolved.core.listNode();
+      for (const node of nodeList.items) {
+        const host = node.metadata?.name;
+        if (!host) continue;
+        if (isControlPlaneNode(node.metadata?.labels, node.spec?.taints)) {
+          continue;
+        }
+        scNodeOptions.push({
+          id: `node:${host}`,
+          name: `Local path on node: ${host}`,
+          kind: "local-path",
+          resiliencyNote: RESILIENCY.localPath,
+          isDefault: false,
+        });
+      }
+    } catch (err) {
+      log.warn("listNode failed; skipping local-path node options", {
+        error: String(err),
+      });
+    }
+  }
+
+  // The synthetic cluster-default option is ALWAYS first; it is the default only
+  // when no discovered SC carries the cluster default-class annotation.
+  const options: StorageTargetOption[] = [
+    {
+      id: "default",
+      name: def.storageClassName
+        ? `Cluster default (${def.storageClassName})`
+        : "Cluster default StorageClass",
+      kind: "storage-class",
+      resiliencyNote: def.resiliencyNote,
+      isDefault: !hasAnnotatedDefault,
+    },
+    ...scNodeOptions,
+  ];
+
+  // Registered targets (NFS / custom) — always merged (no cluster needed).
+  try {
+    const rows = await database.select().from(registeredStorageTarget);
+    for (const row of rows) {
+      options.push({
+        id: `reg:${row.id}`,
+        name: row.name,
+        kind: row.kind,
+        resiliencyNote:
+          row.resiliencyNote ??
+          "Registered storage target; resiliency depends on the backing storage.",
+        isDefault: row.isDefault,
+      });
+    }
+  } catch (err) {
+    log.warn("registered_storage_target query failed; skipping registered options", {
+      error: String(err),
+    });
+  }
+
+  return options;
+}
+
+/** Resolve a `sc:<name>` id by looking the StorageClass up live for its kind. */
+async function resolveStorageClassId(
+  name: string,
+  size: string,
+  clients: StorageClients,
+): Promise<ResolvedStorageTarget> {
+  let provisioner: string | undefined;
+  try {
+    const scList = await clients.storage.listStorageClass();
+    provisioner = scList.items.find((sc) => sc.metadata?.name === name)
+      ?.provisioner;
+  } catch (err) {
+    // Couldn't read the SC; proceed with a generic note (the SC name is still
+    // valid as a PVC reference — a missing SC fails later at PVC binding).
+    log.warn("listStorageClass failed while resolving sc:<name>; using generic note", {
+      name,
+      error: String(err),
+    });
+  }
+  const { kind, resiliencyNote } = classifyProvisioner(provisioner);
+  return {
+    id: `sc:${name}`,
+    kind,
+    storageClassName: name,
+    size,
+    resiliencyNote,
+    configSnapshot: {
+      kind,
+      storageClassName: name,
+      size,
+    },
+  };
+}
+
+/** Resolve a registered `reg:<uuid>` id from the DB row. */
+async function resolveRegisteredId(
+  uuid: string,
+  size: string,
+  database: typeof defaultDb,
+): Promise<ResolvedStorageTarget> {
+  const row = await database.query.registeredStorageTarget.findFirst({
+    where: eq(registeredStorageTarget.id, uuid),
+  });
+  if (!row) {
+    throw new StorageTargetResolutionError(
+      "NOT_FOUND",
+      `Registered storage target "${uuid}" not found`,
+    );
+  }
+
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(row.config) as Record<string, unknown>;
+  } catch {
+    throw new StorageTargetResolutionError(
+      "MALFORMED_SNAPSHOT",
+      `Registered storage target "${uuid}" has malformed config JSON`,
+    );
+  }
+
+  // For NFS we use the dynamic nfs-subdir-external-provisioner StorageClass
+  // named in the row's config (§15 B3 — a dynamic SC, NOT a static PV).
+  const storageClassName =
+    typeof config.storageClassName === "string"
+      ? config.storageClassName
+      : undefined;
+
+  // A registered target whose kind expects a StorageClass but lacks one is
+  // unusable (it would yield a PVC with no SC → the cluster default, not the
+  // intended backend). Warn loudly; POST validation should have rejected it.
+  if (
+    (row.kind === "nfs" ||
+      row.kind === "storage-class" ||
+      row.kind === "cloud-csi") &&
+    !storageClassName
+  ) {
+    log.warn(
+      "registered storage target is missing a storageClassName; PVC will fall back to the cluster default SC",
+      { id: uuid, kind: row.kind },
+    );
+  }
+
+  return {
+    id: `reg:${uuid}`,
+    kind: row.kind,
+    storageClassName,
+    size,
+    resiliencyNote:
+      row.resiliencyNote ??
+      "Registered storage target; resiliency depends on the backing storage.",
+    // The snapshot is the row's config plus the resolved fields — the
+    // authoritative record so a later edit/delete of the row can't change the
+    // instance's volume. The explicit fields (kind/storageClassName/size) are
+    // spread LAST so a stray key in `config` can never override them.
+    configSnapshot: {
+      ...config,
+      kind: row.kind,
+      storageClassName,
+      size,
+    },
+  };
+}
+
+/**
+ * Resolve a chosen storage-target option id to a {@link ResolvedStorageTarget}
+ * via the §7 4-backend table.
+ *
+ *   - `default` / null → {@link resolveDefaultStorageTarget}.
+ *   - `sc:<name>`      → storage-class (or cloud-csi per the live provisioner).
+ *   - `node:<host>`    → local-path pinned to the node.
+ *   - `reg:<uuid>`     → the registered row's config (NFS uses its dynamic SC).
+ *
+ * Throws {@link StorageTargetResolutionError} for an unknown id form or a
+ * missing registered row (the API maps these to 400 / 404).
+ */
+export async function resolveStorageTarget(
+  id: string | null,
+  size?: string,
+  clients?: StorageClients,
+  database = defaultDb,
+): Promise<ResolvedStorageTarget> {
+  if (id === null || id === "" || id === "default") {
+    return resolveDefaultStorageTarget(size);
+  }
+
+  const resolvedSize =
+    process.env.SUPERVISOR_DEFAULT_STORAGE_SIZE || size || FALLBACK_STORAGE_SIZE;
+
+  if (id.startsWith("sc:")) {
+    const name = id.slice("sc:".length);
+    if (!name) {
+      throw new StorageTargetResolutionError(
+        "UNKNOWN_ID",
+        `Malformed StorageClass id "${id}"`,
+      );
+    }
+    // Client acquisition may fail when no cluster is reachable (e.g. the API
+    // process in local dev). Degrade to a generic classification rather than
+    // failing the whole request — the SC name is still a valid PVC reference.
+    let resolvedClients: StorageClients | null = null;
+    try {
+      resolvedClients = clients ?? defaultStorageClients();
+    } catch (err) {
+      log.warn("k8s clients unavailable while resolving sc:<name>; using generic note", {
+        name,
+        error: String(err),
+      });
+    }
+    if (!resolvedClients) {
+      const { kind, resiliencyNote } = classifyProvisioner(undefined);
+      return {
+        id: `sc:${name}`,
+        kind,
+        storageClassName: name,
+        size: resolvedSize,
+        resiliencyNote,
+        configSnapshot: { kind, storageClassName: name, size: resolvedSize },
+      };
+    }
+    return resolveStorageClassId(name, resolvedSize, resolvedClients);
+  }
+
+  if (id.startsWith("node:")) {
+    const host = id.slice("node:".length);
+    if (!host) {
+      throw new StorageTargetResolutionError(
+        "UNKNOWN_ID",
+        `Malformed node id "${id}"`,
+      );
+    }
+    return {
+      id,
+      kind: "local-path",
+      storageClassName: LOCAL_PATH_SC,
+      nodeHostname: host,
+      size: resolvedSize,
+      resiliencyNote: RESILIENCY.localPath,
+      configSnapshot: {
+        kind: "local-path",
+        storageClassName: LOCAL_PATH_SC,
+        nodeHostname: host,
+        size: resolvedSize,
+      },
+    };
+  }
+
+  if (id.startsWith("reg:")) {
+    const uuid = id.slice("reg:".length);
+    if (!uuid) {
+      throw new StorageTargetResolutionError(
+        "UNKNOWN_ID",
+        `Malformed registered-target id "${id}"`,
+      );
+    }
+    return resolveRegisteredId(uuid, resolvedSize, database);
+  }
+
+  throw new StorageTargetResolutionError(
+    "UNKNOWN_ID",
+    `Unknown storage target id "${id}"`,
+  );
+}
+
+/**
+ * Rebuild a {@link ResolvedStorageTarget} from a persisted
+ * `instance.storageConfigSnapshot` WITHOUT touching the cluster. The snapshot is
+ * authoritative (§7): the reconciler builds the PVC template from this so a
+ * later edit/delete of a storage target never changes an existing instance's
+ * volume.
+ *
+ * Recognises the shape written by every resolver above:
+ *   { kind, storageClassName?, nodeHostname?, size, ... }
+ *
+ * The returned `id` is intentionally `null`: a snapshot-rebuilt target is not
+ * tied to a live option id (the original `sc:`/`node:`/`reg:` id is not part of
+ * the snapshot, and a `reg:` row may since have been edited/deleted). It is used
+ * only to build the PVC template — never written back to `instance.storageTargetId`.
+ */
+export function resolvedFromSnapshot(
+  snapshot: Record<string, unknown>,
+): ResolvedStorageTarget {
+  const kind = snapshot.kind;
+  if (
+    kind !== "local-path" &&
+    kind !== "storage-class" &&
+    kind !== "nfs" &&
+    kind !== "cloud-csi"
+  ) {
+    throw new StorageTargetResolutionError(
+      "MALFORMED_SNAPSHOT",
+      `Storage snapshot has invalid kind "${String(kind)}"`,
+    );
+  }
+
+  const size =
+    typeof snapshot.size === "string" && snapshot.size
+      ? snapshot.size
+      : FALLBACK_STORAGE_SIZE;
+  const storageClassName =
+    typeof snapshot.storageClassName === "string" && snapshot.storageClassName
+      ? snapshot.storageClassName
+      : undefined;
+  const nodeHostname =
+    typeof snapshot.nodeHostname === "string" && snapshot.nodeHostname
+      ? snapshot.nodeHostname
+      : undefined;
+
+  let resiliencyNote: string;
+  if (kind === "local-path") resiliencyNote = RESILIENCY.localPath;
+  else if (kind === "cloud-csi") resiliencyNote = RESILIENCY.cloudCsi;
+  else if (kind === "nfs")
+    resiliencyNote = "Off-cluster (NFS); availability depends on the NFS server.";
+  else resiliencyNote = RESILIENCY.storageClassGeneric;
+
+  return {
+    id: null,
+    kind,
+    storageClassName,
+    nodeHostname,
+    size,
+    resiliencyNote,
+    // Round-trip the snapshot verbatim (it stays authoritative).
+    configSnapshot: snapshot,
+  };
+}
+
 /**
  * Translate a resolved storage target into a StatefulSet `volumeClaimTemplate`.
  *
@@ -90,10 +609,13 @@ export function resolveDefaultStorageTarget(
  *   - `resources.requests.storage = t.size`
  *   - `storageClassName` only when set (undefined ⇒ cluster default SC)
  *
- * When `nodeHostname` is present (local-path, jvcx.5), pin the volume to that
- * node via a `volume.kubernetes.io/selected-node` annotation — the rancher
- * local-path provisioner honours this to place the host directory on the named
- * node so the data follows the pod's node affinity.
+ * When `nodeHostname` is present (local-path), pin the volume to that node via a
+ * `volume.kubernetes.io/selected-node` annotation — the rancher local-path
+ * provisioner honours this to place the host directory on the named node so the
+ * data follows the pod's node affinity.
+ *
+ * NFS uses the dynamic `nfs-subdir-external-provisioner` StorageClass (§15 B3),
+ * so it needs nothing beyond `storageClassName` here — no static PV wiring.
  */
 export function toVolumeClaimTemplate(
   t: ResolvedStorageTarget,
@@ -104,7 +626,7 @@ export function toVolumeClaimTemplate(
       ...(t.nodeHostname
         ? {
             annotations: {
-              "volume.kubernetes.io/selected-node": t.nodeHostname,
+              [SELECTED_NODE_ANNOTATION]: t.nodeHostname,
             },
           }
         : {}),


### PR DESCRIPTION
## Summary
Phase 1 / jvcx.5: storage targets for `apps/supervisor` (spec §7). Live discovery of StorageClasses + schedulable nodes (local-path) + registered NFS/custom targets, the 4-backend PVC translation with per-backend resiliency notes, a register/delete API, and a create-instance form with a storage dropdown. Instance creation snapshots the chosen target so later edits/deletes can't corrupt existing instances.

## What's included
- **Discovery** (`storage.ts`): `discoverStorageTargets()` lists StorageClasses (Longhorn→replicated, EBS/GKE/Azure CSI→cloud-csi, else generic; honors the cluster-default annotation), schedulable nodes (control-plane skipped) as `local-path on <node>`, and merged `registered_storage_target` rows. Degrades to default+registered when the cluster is unreachable. Option-id scheme `default | sc:<name> | node:<host> | reg:<uuid>`.
- **Resolution** (§7 4-backend table): `resolveStorageTarget(id)` → `ResolvedStorageTarget`; `resolvedFromSnapshot(snapshot)` rebuilds the PVC from the instance's snapshot WITHOUT re-querying the cluster (snapshot is authoritative).
- **API**: `GET /api/storage-targets` (viewer), `POST` (admin, register NFS/custom — validates `config.storageClassName`), `DELETE /:id` (admin, only `reg:` rows; never affects existing instances).
- **Instance creation**: `POST /api/instances` resolves an optional `storageTargetId`, snapshots its config onto the row; the reconciler builds the volumeClaimTemplate from that snapshot (falls back to the cluster default only when absent).
- **UI**: a create-instance form (operator-gated) with slug + displayName + a storage `<select>` showing each option's resiliency note.

## Review fixes folded in
configSnapshot now lets authoritative `kind`/`size` win over a stray `config` key; exactly one option is `isDefault` (a cluster-annotated SC wins over the generic `default`); registered SC-backed targets must carry a non-empty `config.storageClassName` (400 otherwise); documented the intentional `id:null` from snapshots.

## Test plan
- 180 supervisor tests (+38 across this PR): discovery (provisioner classification, default-SC, control-plane skip, graceful degradation), resolution + snapshot round-trip for all 4 backends, API gates/validation, instance-create snapshotting.
- ROOT gates green (typecheck/lint/**test:run 1353**/build) — main app unaffected. SUPERVISOR gates green (**test 180**). `bun.lock` unchanged.

remote-dev-jvcx.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)