### PR TITLE
fix(docker): copy bun from build-deps stage in instance image runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Instance image Dockerfile: copy `bun` from the `build-deps` stage instead of an unexpanded `${BUN_VERSION}` image ref in the `runtime` stage (the global ARG is out of scope there) — this broke the k8s instance image build (`invalid reference format`).
 - Startup commands no longer lose their first character when oh-my-zsh's periodic auto-update prompt appears during shell init. `createSession` now suppresses shell-init update prompts (`DISABLE_AUTO_UPDATE`/`DISABLE_UPDATE_PROMPT`) and waits for the shell to settle before typing. (remote-dev-w75y)
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,7 +138,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Bun for any scripts that need it at runtime (rdv process manager, migrations)
-COPY --from=oven/bun:${BUN_VERSION} /usr/local/bin/bun /usr/local/bin/bun
+COPY --from=build-deps /usr/local/bin/bun /usr/local/bin/bun
 
 # Create app user + state directory
 RUN useradd --create-home --shell /bin/bash --uid 10001 rdv \


### PR DESCRIPTION
## Summary
The k8s **instance image** build (root `Dockerfile`) failed on a real CI build (first time it was ever built — the main-app prod deploy builds on-host with bun, not via this Dockerfile):

```
Dockerfile:141  COPY --from=oven/bun:${BUN_VERSION} /usr/local/bin/bun /usr/local/bin/bun
ERROR: failed to parse stage name "oven/bun:${BUN_VERSION}": invalid reference format
```

`ARG BUN_VERSION` (global, line 37) is visible to `FROM` but **not inside the `runtime` stage** (`FROM node:${NODE_VERSION}`, line 114), so `${BUN_VERSION}` was left unexpanded in the `--from` reference.

## Fix
Copy `bun` from the existing `build-deps` stage (which *is* `oven/bun`-based and is an earlier stage) — a named-stage `--from` needs no ARG interpolation:
```
COPY --from=build-deps /usr/local/bin/bun /usr/local/bin/bun
```

## Verification
- Audited all three Dockerfiles — no other ARG-scope / invalid `--from` / missing-source issues (supervisor + router use `${BUN_VERSION}` only in `FROM`, which is fine).
- `docker buildx build --check` (BuildKit lint) → **"Check complete, no warnings found."** on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)