### PR TITLE
fix(docker): copy workspace package.json files before frozen install in instance image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Instance image Dockerfile: copy the workspace `package.json` files (apps/*, packages/*) before `bun install --frozen-lockfile` — the root manifest declares workspaces, so a frozen install needs every member's manifest present (build failed with "lockfile had changes, but lockfile is frozen").
 - Instance image Dockerfile: copy `bun` from the `build-deps` stage instead of an unexpanded `${BUN_VERSION}` image ref in the `runtime` stage (the global ARG is out of scope there) — this broke the k8s instance image build (`invalid reference format`).
 - Startup commands no longer lose their first character when oh-my-zsh's periodic auto-update prompt appears during shell init. `createSession` now suppresses shell-init update prompts (`DISABLE_AUTO_UPDATE`/`DISABLE_UPDATE_PROMPT`) and waits for the shell to settle before typing. (remote-dev-w75y)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,14 @@ ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo PATH=/usr/local/ca
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 
 COPY package.json bun.lockb* bun.lock* ./
+# Workspace members (root package.json declares workspaces: packages/*, apps/*).
+# `bun install --frozen-lockfile` validates the unified lockfile against ALL
+# members, so each member's package.json must be present before install.
+# NOTE: add a line here when a new apps/* or packages/* workspace is created.
+COPY apps/supervisor/package.json ./apps/supervisor/package.json
+COPY apps/supervisor-router/package.json ./apps/supervisor-router/package.json
+COPY packages/domain/package.json ./packages/domain/package.json
+COPY packages/mobile/package.json ./packages/mobile/package.json
 RUN bun install --frozen-lockfile
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Second latent bug in the never-before-built k8s instance image (CI run #131, `build-deps` stage):
```
RUN bun install --frozen-lockfile
error: lockfile had changes, but lockfile is frozen
```
Root `package.json` declares `workspaces: ["packages/*", "apps/*"]`, but `build-deps` copied only the root manifest+lockfile. `--frozen-lockfile` validates the unified lockfile against every workspace member, so their `package.json`s must be present.

## Fix
COPY the 4 members' `package.json` (apps/supervisor, apps/supervisor-router, packages/domain, packages/mobile) before the install (kept the manifest-first layer-caching pattern; no `--parents` since the Dockerfile pins `dockerfile:1.7` where it's labs-only).

## Verification
- Reproduced the exact fixed `build-deps` COPY set in a temp dir → `bun install --frozen-lockfile` **passed the frozen check, exit 0** (3410 packages).
- `docker buildx build --check` → no warnings.
- Lockfile itself is in sync (frozen install passes locally with full workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)