### PR TITLE
fix(docker): get k8s instance image building (drop invalid bun rebuild)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Instance image Dockerfile: removed the invalid `RUN bun rebuild better-sqlite3 node-pty` line from the build stage — `bun` has no `rebuild` subcommand (the build failed with `error: Script not found "rebuild"`), and the step was redundant: the native modules are already compiled during `bun install --frozen-lockfile` because they are listed in the root `package.json` `trustedDependencies`.
 - Instance image Dockerfile: copy the workspace `package.json` files (apps/*, packages/*) before `bun install --frozen-lockfile` — the root manifest declares workspaces, so a frozen install needs every member's manifest present (build failed with "lockfile had changes, but lockfile is frozen").
 - Instance image Dockerfile: copy `bun` from the `build-deps` stage instead of an unexpanded `${BUN_VERSION}` image ref in the `runtime` stage (the global ARG is out of scope there) — this broke the k8s instance image build (`invalid reference format`).
 - Startup commands no longer lose their first character when oh-my-zsh's periodic auto-update prompt appears during shell init. `createSession` now suppresses shell-init update prompts (`DISABLE_AUTO_UPDATE`/`DISABLE_UPDATE_PROMPT`) and waits for the shell to settle before typing. (remote-dev-w75y)

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,10 +78,10 @@ WORKDIR /app
 
 COPY . .
 
-# Rebuild native modules (better-sqlite3, node-pty) for the target arch.
-# If this fails, the resulting image would crash at runtime with cryptic NAPI
-# errors — fail the build loudly here instead.
-RUN bun rebuild better-sqlite3 node-pty
+# Native modules (better-sqlite3, node-pty) are compiled during the
+# `bun install --frozen-lockfile` in the build-deps stage because they are
+# listed in the root package.json `trustedDependencies`, with the build-essential
+# + python3 toolchain present there. No separate rebuild step is needed.
 
 # Slug-aware image: build ONCE with a sentinel basePath, then rewrite the
 # sentinel to the real per-instance slug at container start (docker/entrypoint.sh).


### PR DESCRIPTION
## Summary
Third latent bug in the never-before-built k8s instance image (CI run #132, `build` stage): `RUN bun rebuild better-sqlite3 node-pty` → `error: Script not found "rebuild"`. `bun` has no `rebuild` subcommand, and it's redundant — `better-sqlite3` + `node-pty` are in `trustedDependencies`, so `bun install --frozen-lockfile` already compiles them in `build-deps`. Removed the line.

## Verification — local native-arch builds of all three workflow images
- `rdv-instance` → exit 0 (image's own native-ABI smoke test `native modules OK` confirms the removed rebuild was redundant).
- `rdv-supervisor` → exit 0, zero changes.
- `rdv-router` → exit 0, zero changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)