### PR TITLE
fix(router): strip Content-Encoding/Length on proxied responses (Bun fetch auto-decompresses)

### DIFF
--- a/apps/supervisor-router/src/lib/__tests__/proxy.test.ts
+++ b/apps/supervisor-router/src/lib/__tests__/proxy.test.ts
@@ -195,6 +195,140 @@ describe("proxyHttp — upstream failure", () => {
   });
 });
 
+/**
+ * Bun's `fetch` (undici) auto-decompresses gzip/br/deflate bodies but leaves the
+ * upstream `Content-Encoding` (and a now-stale `Content-Length`) on the returned
+ * Response. Forwarding those verbatim makes the client try to decode an
+ * already-decoded body (ZlibError / corruption). `proxyHttp` must strip both
+ * framing headers when an encoding is present, and leave uncompressed responses
+ * (with their accurate `Content-Length`) untouched.
+ */
+describe("proxyHttp — Content-Encoding stripping (Bun fetch auto-decompresses)", () => {
+  /** A fetch stub that returns a fixed upstream Response. */
+  function fetchReturning(response: Response): typeof fetch {
+    return vi.fn(async () => response) as unknown as typeof fetch;
+  }
+
+  it("strips Content-Encoding AND Content-Length, preserving status + body bytes", async () => {
+    // Mimics what Bun hands back: the body is ALREADY plaintext, yet the
+    // headers still advertise gzip and the (pre-decompression) length.
+    const body = JSON.stringify({ ok: true, instances: ["alpha", "beta"] });
+    const upstream = new Response(body, {
+      status: 200,
+      headers: {
+        "content-encoding": "gzip",
+        "content-length": "42",
+        "content-type": "application/json",
+      },
+    });
+    const req = new Request("https://dev.example.com/alpha/api/instances");
+    const res = await proxyHttp(
+      req,
+      BASE,
+      "/alpha/api/instances",
+      fetchReturning(upstream),
+    );
+
+    expect(res.status).toBe(200);
+    // The misleading framing headers are gone…
+    expect(res.headers.get("content-encoding")).toBeNull();
+    expect(res.headers.get("content-length")).toBeNull();
+    // …other headers survive…
+    expect(res.headers.get("content-type")).toBe("application/json");
+    // …and the (already-decompressed) body is forwarded byte-for-byte.
+    expect(await res.text()).toBe(body);
+  });
+
+  it("strips a non-gzip encoding (br) too and preserves the body", async () => {
+    const body = "<!doctype html><title>dashboard</title>";
+    const upstream = new Response(body, {
+      status: 200,
+      headers: {
+        "content-encoding": "br",
+        "content-length": "999",
+        "content-type": "text/html; charset=utf-8",
+      },
+    });
+    const req = new Request("https://dev.example.com/alpha/");
+    const res = await proxyHttp(req, BASE, "/alpha/", fetchReturning(upstream));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-encoding")).toBeNull();
+    expect(res.headers.get("content-length")).toBeNull();
+    expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(await res.text()).toBe(body);
+  });
+
+  it("preserves statusText and other headers on an encoded response", async () => {
+    const body = "compressed-then-decoded";
+    const upstream = new Response(body, {
+      status: 503,
+      statusText: "Service Unavailable",
+      headers: {
+        "content-encoding": "deflate",
+        "content-length": "7",
+        "retry-after": "30",
+      },
+    });
+    const req = new Request("https://dev.example.com/alpha/api/health");
+    const res = await proxyHttp(
+      req,
+      BASE,
+      "/alpha/api/health",
+      fetchReturning(upstream),
+    );
+
+    expect(res.status).toBe(503);
+    expect(res.statusText).toBe("Service Unavailable");
+    expect(res.headers.get("content-encoding")).toBeNull();
+    expect(res.headers.get("content-length")).toBeNull();
+    expect(res.headers.get("retry-after")).toBe("30");
+    expect(await res.text()).toBe(body);
+  });
+
+  it("leaves an UNCOMPRESSED response untouched (Content-Length preserved)", async () => {
+    const body = "plain uncompressed body";
+    const upstream = new Response(body, {
+      status: 200,
+      headers: {
+        "content-length": String(new TextEncoder().encode(body).length),
+        "content-type": "text/plain; charset=utf-8",
+      },
+    });
+    const req = new Request("https://dev.example.com/alpha/api/ping");
+    const res = await proxyHttp(
+      req,
+      BASE,
+      "/alpha/api/ping",
+      fetchReturning(upstream),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-encoding")).toBeNull();
+    // No encoding ⇒ the accurate Content-Length must be left intact.
+    expect(res.headers.get("content-length")).toBe(
+      String(new TextEncoder().encode(body).length),
+    );
+    expect(res.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(await res.text()).toBe(body);
+  });
+
+  it("compares binary body bytes (arrayBuffer) on an encoded response", async () => {
+    const bytes = new Uint8Array([0x7b, 0x22, 0x6f, 0x6b, 0x22, 0x7d]); // {"ok"}
+    const upstream = new Response(bytes, {
+      status: 200,
+      headers: { "content-encoding": "gzip", "content-length": "20" },
+    });
+    const req = new Request("https://dev.example.com/alpha/x");
+    const res = await proxyHttp(req, BASE, "/alpha/x", fetchReturning(upstream));
+
+    expect(res.headers.get("content-encoding")).toBeNull();
+    expect(res.headers.get("content-length")).toBeNull();
+    const got = new Uint8Array(await res.arrayBuffer());
+    expect(Array.from(got)).toEqual(Array.from(bytes));
+  });
+});
+
 describe("buildWsUpgradeHeaders", () => {
   it("carries auth + WS negotiation headers, omits absent ones", () => {
     const req = new Request("https://dev.example.com/alpha/ws", {

--- a/apps/supervisor-router/src/lib/proxy.ts
+++ b/apps/supervisor-router/src/lib/proxy.ts
@@ -3,7 +3,9 @@
  *
  * - HTTP: `fetch` the upstream with the SAME method/headers/body/path/query,
  *   `redirect: "manual"` (the router never follows redirects on the client's
- *   behalf), and return the upstream Response unchanged.
+ *   behalf), and return the upstream Response — stripping `Content-Encoding`
+ *   and `Content-Length` when the upstream compressed, because the fetch impl
+ *   auto-decompresses the body so those framing headers no longer describe it.
  * - WebSocket: bridge a Bun `ServerWebSocket` (client side) to an upstream
  *   `new WebSocket(url, { headers })` (instance side). Client→upstream messages
  *   are buffered until the upstream socket opens; both directions are then piped
@@ -102,7 +104,10 @@ function forwardHttpHeaders(req: Request, clientIp: string | null): Headers {
 /**
  * Proxy an HTTP request to `upstreamBase` + `path` + the original query string.
  * Returns the upstream Response (streamed through), or a 502 if the upstream is
- * unreachable.
+ * unreachable. When the upstream response carries a `Content-Encoding`, that
+ * header and `Content-Length` are stripped before returning: the fetch impl
+ * already decompressed the body, so the originals would mislead the client into
+ * decoding plaintext (ZlibError / corruption).
  *
  * `server` (the Bun.serve instance) is threaded through only to resolve the
  * peer IP for `X-Forwarded-For`; it's optional so unit tests can omit it.
@@ -131,7 +136,25 @@ export async function proxyHttp(
   }
 
   try {
-    return await fetchImpl(target, init);
+    const upstream = await fetchImpl(target, init);
+    // Bun's fetch auto-decompresses the body but leaves the upstream
+    // Content-Encoding (and a now-stale Content-Length) on the headers.
+    // Returning that unchanged makes the client try to decode an
+    // already-decoded body (ZlibError / corruption). When an encoding is
+    // present, strip both framing headers and re-stream the identity body;
+    // Bun re-frames it (chunked). Uncompressed responses are returned as-is so
+    // their accurate Content-Length is preserved.
+    if (upstream.headers.has("content-encoding")) {
+      const headers = new Headers(upstream.headers);
+      headers.delete("content-encoding");
+      headers.delete("content-length");
+      return new Response(upstream.body, {
+        status: upstream.status,
+        statusText: upstream.statusText,
+        headers,
+      });
+    }
+    return upstream;
   } catch (error) {
     log.warn("Upstream HTTP request failed", {
       error: String(error),


### PR DESCRIPTION
## Summary

Fixes a `Content-Encoding` bug in the Supervisor router's HTTP proxy. Bun's `fetch` **auto-decompresses** upstream gzip/br/deflate bodies but leaves the upstream `Content-Encoding`/`Content-Length` on the `Response` headers; `proxyHttp` returned that verbatim, so clients (and Cloudflare) received a **gzip-labeled plaintext body** → `ZlibError` / corrupted responses.

**Confirmed live in the homelab:** hitting the Supervisor *directly* returns valid gzip (`1f8b…`); *through the router* returned `Content-Encoding: gzip` on a plaintext body for every compressed response — including the dashboard root `/`.

**Fix:** when the upstream response carries a `Content-Encoding`, strip it + `Content-Length` and re-stream the (already-decompressed) body; uncompressed responses are returned unchanged so their accurate `Content-Length` is preserved.

This is a pre-existing latent proxy bug (instance proxying hit it too); it surfaced now because **Option C** (PR #326) puts the gzipped Supervisor dashboard on the router's default path.

## Test plan
- `apps/supervisor-router`: typecheck ✅ · lint ✅ · **119 tests** ✅ (was 114; +5 covering gzip/br/deflate stripping, uncompressed passthrough, binary body, and status/statusText/other-header preservation).

## Follow-up (deploy)
Rebuild the router image → re-pin k3s-infra `rdv-router` → ArgoCD redeploy → re-verify the dashboard root serves a valid (un-mangled) body through the router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
