### PR TITLE
ci(release): build release tarball on Node 24 (remote-dev-8o3v)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   BUN_VERSION: "latest"
-  NODE_VERSION: "22"
+  NODE_VERSION: "24"
 
 jobs:
   # ─── Build web application (shared across platforms) ──────────────────────


### PR DESCRIPTION
## Summary

One-line CI fix: bump `NODE_VERSION` from `"22"` to `"24"` in `.github/workflows/release.yml`.

## Why

`release.yml` builds the web app + native modules under bun (oven-sh/setup-bun), and current `oven/bun` reports as Node 24 / NODE_MODULE_VERSION 137 — so `bun install` + `bun run build`/`terminal:build` compile better-sqlite3 + node-pty at ABI 137. The `build-release` job then sets up Node via `NODE_VERSION` (was 22, ABI 127) and `node-gyp rebuild`s them; the resulting tarball's native ABI and runtime Node were mismatched (same class as the instance-image bug fixed in remote-dev-nxbv: a Node-22 runtime cannot load ABI-137 natives).

Bumping to Node 24 aligns the release toolchain + runtime with what bun compiles and with the instance image (`node:24-trixie-slim`). This is the distributed server tarball only — it does NOT affect dev.bryanli.net (that deploys via `scripts/deploy.ts`).

## Test plan

Workflow-only change, YAML validated; `release.yml` runs on tag push so it'll be exercised on the next `vX.Y.Z` tag.

bd issue: remote-dev-8o3v

🤖 Generated with [Claude Code](https://claude.com/claude-code)