### PR TITLE
feat(notifications): signal-vs-noise overhaul (epic y5ch) [1/3]

### DIFF
--- a/crates/rdv/src/commands/hook.rs
+++ b/crates/rdv/src/commands/hook.rs
@@ -37,6 +37,9 @@ enum HookCommand {
         /// Optional message body
         #[arg(long)]
         body: Option<String>,
+        /// [y5ch.8] Signal class: actionable | passive | error (default passive).
+        #[arg(long)]
+        severity: Option<String>,
     },
     /// Handle SessionEnd hook: report session ended
     SessionEnd,
@@ -472,8 +475,12 @@ async fn check_beads_unfinished() -> Option<String> {
 /// to continue working) and returns early without reporting idle.
 async fn handle_stop(
     client: &Client,
-    agent: Option<String>,
-    reason: Option<String>,
+    // [y5ch.2] agent/reason were only used to build the now-removed clean-stop
+    // notification. They stay in the signature (callers pass them positionally)
+    // but are unused; the leading underscore avoids an unused-variable warning
+    // without an #[allow].
+    _agent: Option<String>,
+    _reason: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let Some(sid) = client.session_id() else {
         return Ok(());
@@ -518,20 +525,15 @@ async fn handle_stop(
         eprintln!("warning: failed to report idle status: {e}");
     }
 
-    // Send notification
-    let title = match &agent {
-        Some(a) => format!("Agent stopped: {a}"),
-        None => "Agent stopped".to_string(),
-    };
-    let payload = json!({
-        "sessionId": sid,
-        "type": "agent_exited",
-        "title": title,
-        "body": reason.unwrap_or_else(|| "Session ended normally".to_string()),
-    });
-    let _ = client.post_json("/internal/notify", &payload).await;
+    // [y5ch.2] A clean stop is PASSIVE — it creates NO user notification here.
+    // The old "Session ended normally" notify POST was the single biggest source
+    // of notification noise and has been removed. Stuck/crashed agents now
+    // surface via the server-side PID-liveness sweep (y5ch.9, emits agent_stuck),
+    // and "agent needs you" surfaces via the Notification hook (waiting status).
+    // The idle status report above and the peer "finished work" broadcast below
+    // remain.
 
-    // Broadcast "finished work" to peers
+    // Broadcast "finished work" to peers (in-band signal, not a user notification).
     let finished_payload = json!({ "fromSessionId": sid, "body": "finished work" });
     let _ = client
         .post_json("/internal/peers/messages/send", &finished_payload)
@@ -601,16 +603,24 @@ pub async fn run(
         HookCommand::Stop { agent, reason } => {
             handle_stop(client, agent, reason).await?;
         }
-        HookCommand::Notify { event, body } => {
+        HookCommand::Notify {
+            event,
+            body,
+            severity,
+        } => {
             let Some(sid) = client.session_id() else {
                 return Ok(());
             };
 
+            // [y5ch.8] Forward an explicit severity so an agent can emit a
+            // CTA-bearing actionable notice (e.g. a permission-style prompt);
+            // defaults to passive/info to keep ad-hoc notifies low-noise.
             let payload = json!({
                 "sessionId": sid,
                 "type": "info",
                 "title": event,
                 "body": body.unwrap_or_default(),
+                "severity": severity.unwrap_or_else(|| "passive".to_string()),
             });
             let _ = client.post_json("/internal/notify", &payload).await;
         }
@@ -716,4 +726,36 @@ pub async fn run(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod stop_tests {
+    /// [y5ch.2] Guard: the clean-stop path must not POST to /internal/notify.
+    /// A clean agent stop is passive and must create NO user notification —
+    /// this source-level assertion proves the noise POST stays gone.
+    #[test]
+    fn handle_stop_source_has_no_notify_post() {
+        let src = include_str!("hook.rs");
+        let start = src
+            .find("async fn handle_stop")
+            .expect("handle_stop exists");
+        // End the slice at the NEXT top-level item — the immediately following
+        // `fn drain_stdin` (a plain fn). Searching only for `\nasync fn ` would
+        // overshoot past drain_stdin into `pub async fn run`, whose Notify arm
+        // legitimately POSTs /internal/notify, yielding a false positive.
+        let after = &src[start + 1..];
+        let end = after
+            .find("\nfn ")
+            .map(|i| start + 1 + i)
+            .unwrap_or(src.len());
+        let body = &src[start..end];
+        assert!(
+            !body.contains("/internal/notify"),
+            "handle_stop must not call /internal/notify (y5ch.2 noise source)"
+        );
+        assert!(
+            body.contains("finished work"),
+            "peer broadcast must remain after y5ch.2"
+        );
+    }
 }

--- a/drizzle/0019_notification_severity_coalesce_prefs.sql
+++ b/drizzle/0019_notification_severity_coalesce_prefs.sql
@@ -1,0 +1,30 @@
+-- [y5ch] Notifications signal-vs-noise overhaul (epic remote-dev-y5ch).
+--
+-- SQLite path uses `db:push` for fresh/dev databases; this hand-written
+-- migration mirrors the 0014-0018 raw-SQL convention so existing SQLite
+-- deployments can be upgraded in place without data loss.
+--
+-- SQLite cannot ADD a NOT NULL column without a constant DEFAULT. `severity`
+-- and `count` carry SQL defaults already. `updated_at`'s real default is the
+-- app's $defaultFn (like created_at); we add it with a constant epoch default
+-- (0) purely so the ADD COLUMN succeeds against existing rows — every insert
+-- from the application supplies the value, so the constant is only ever a
+-- backfill for pre-existing rows, which we then align to created_at below.
+ALTER TABLE `notification_event` ADD `severity` text DEFAULT 'passive' NOT NULL;--> statement-breakpoint
+ALTER TABLE `notification_event` ADD `coalesce_key` text;--> statement-breakpoint
+ALTER TABLE `notification_event` ADD `count` integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE `notification_event` ADD `meta` text;--> statement-breakpoint
+ALTER TABLE `notification_event` ADD `updated_at` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+-- Backfill: align updated_at with created_at for rows that predate the column.
+UPDATE `notification_event` SET `updated_at` = `created_at` WHERE `updated_at` = 0;--> statement-breakpoint
+CREATE INDEX `notification_event_coalesce_idx` ON `notification_event` (`user_id`,`session_id`,`coalesce_key`,`read_at`);--> statement-breakpoint
+CREATE TABLE `notification_preferences` (
+	`user_id` text PRIMARY KEY NOT NULL,
+	`push_by_type` text DEFAULT '{}' NOT NULL,
+	`muted_session_ids` text DEFAULT '[]' NOT NULL,
+	`quiet_hours_start` integer,
+	`quiet_hours_end` integer,
+	`min_push_severity` text DEFAULT 'actionable' NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/pg/0002_real_jamie_braddock.sql
+++ b/drizzle/pg/0002_real_jamie_braddock.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "notification_preferences" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"push_by_type" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"muted_session_ids" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"quiet_hours_start" integer,
+	"quiet_hours_end" integer,
+	"min_push_severity" text DEFAULT 'actionable' NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "notification_event" ADD COLUMN "severity" text DEFAULT 'passive' NOT NULL;--> statement-breakpoint
+ALTER TABLE "notification_event" ADD COLUMN "coalesce_key" text;--> statement-breakpoint
+ALTER TABLE "notification_event" ADD COLUMN "count" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "notification_event" ADD COLUMN "meta" jsonb;--> statement-breakpoint
+-- [y5ch.1] updated_at is NOT NULL but its default is JS-side ($defaultFn, like
+-- created_at). Adding a bare NOT NULL column to a populated table errors. We must
+-- avoid a non-constant (volatile) default like now(): under Postgres that forces
+-- a FULL TABLE REWRITE of notification_event under AccessExclusiveLock (deploy
+-- outage). Instead add with a CONSTANT default (no rewrite — PG fast-paths a
+-- constant fill), backfill from created_at, then drop the default so future
+-- inserts go through the app's $defaultFn — mirroring the SQLite 0019 pattern.
+ALTER TABLE "notification_event" ADD COLUMN "updated_at" timestamp with time zone DEFAULT '1970-01-01 00:00:00+00' NOT NULL;--> statement-breakpoint
+UPDATE "notification_event" SET "updated_at" = "created_at";--> statement-breakpoint
+ALTER TABLE "notification_event" ALTER COLUMN "updated_at" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "notification_preferences" ADD CONSTRAINT "notification_preferences_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "notification_event_coalesce_idx" ON "notification_event" USING btree ("user_id","session_id","coalesce_key","read_at");

--- a/drizzle/pg/meta/0002_snapshot.json
+++ b/drizzle/pg/meta/0002_snapshot.json
@@ -1,0 +1,8217 @@
+{
+  "id": "c51fbdf6-3b38-4519-b7ad-703dd6319103",
+  "prevId": "ed771b98-ced5-4510-ba16-5916182708e2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_activity_event": {
+      "name": "agent_activity_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_provider": {
+          "name": "agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_activity_user_idx": {
+          "name": "agent_activity_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_activity_session_idx": {
+          "name": "agent_activity_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_activity_provider_idx": {
+          "name": "agent_activity_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_activity_event_type_idx": {
+          "name": "agent_activity_event_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_activity_created_idx": {
+          "name": "agent_activity_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_activity_event_user_id_user_id_fk": {
+          "name": "agent_activity_event_user_id_user_id_fk",
+          "tableFrom": "agent_activity_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_activity_event_session_id_terminal_session_id_fk": {
+          "name": "agent_activity_event_session_id_terminal_session_id_fk",
+          "tableFrom": "agent_activity_event",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_config": {
+      "name": "agent_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_type": {
+          "name": "config_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_config_user_idx": {
+          "name": "agent_config_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_config_project_idx": {
+          "name": "agent_config_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_config_unique_idx": {
+          "name": "agent_config_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "config_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_config_user_id_user_id_fk": {
+          "name": "agent_config_user_id_user_id_fk",
+          "tableFrom": "agent_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_config_project_id_project_id_fk": {
+          "name": "agent_config_project_id_project_id_fk",
+          "tableFrom": "agent_config",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_daily_stats": {
+      "name": "agent_daily_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_provider": {
+          "name": "agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "command_count": {
+          "name": "command_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_daily_stats_unique_idx": {
+          "name": "agent_daily_stats_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_daily_stats_user_date_idx": {
+          "name": "agent_daily_stats_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_daily_stats_user_id_user_id_fk": {
+          "name": "agent_daily_stats_user_id_user_id_fk",
+          "tableFrom": "agent_daily_stats",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_peer_message": {
+      "name": "agent_peer_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_session_id": {
+          "name": "from_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_session_name": {
+          "name": "from_session_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_session_id": {
+          "name": "to_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_user_message": {
+          "name": "is_user_message",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "peer_message_project_created_idx": {
+          "name": "peer_message_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peer_message_to_session_idx": {
+          "name": "peer_message_to_session_idx",
+          "columns": [
+            {
+              "expression": "to_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peer_message_channel_created_idx": {
+          "name": "peer_message_channel_created_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peer_message_parent_idx": {
+          "name": "peer_message_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_peer_message_from_session_id_terminal_session_id_fk": {
+          "name": "agent_peer_message_from_session_id_terminal_session_id_fk",
+          "tableFrom": "agent_peer_message",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "from_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_peer_message_to_session_id_terminal_session_id_fk": {
+          "name": "agent_peer_message_to_session_id_terminal_session_id_fk",
+          "tableFrom": "agent_peer_message",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "to_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_peer_message_channel_id_channel_id_fk": {
+          "name": "agent_peer_message_channel_id_channel_id_fk",
+          "tableFrom": "agent_peer_message",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile_json_config": {
+      "name": "agent_profile_json_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_valid": {
+          "name": "is_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validation_errors": {
+          "name": "validation_errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_profile_json_config_profile_idx": {
+          "name": "agent_profile_json_config_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_profile_json_config_user_idx": {
+          "name": "agent_profile_json_config_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_profile_json_config_unique_idx": {
+          "name": "agent_profile_json_config_unique_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_json_config_profile_id_agent_profile_id_fk": {
+          "name": "agent_profile_json_config_profile_id_agent_profile_id_fk",
+          "tableFrom": "agent_profile_json_config",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_profile_json_config_user_id_user_id_fk": {
+          "name": "agent_profile_json_config_user_id_user_id_fk",
+          "tableFrom": "agent_profile_json_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile": {
+      "name": "agent_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "config_dir": {
+          "name": "config_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_profile_user_idx": {
+          "name": "agent_profile_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_profile_default_idx": {
+          "name": "agent_profile_default_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_user_id_user_id_fk": {
+          "name": "agent_profile_user_id_user_id_fk",
+          "tableFrom": "agent_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "api_key_user_idx": {
+          "name": "api_key_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_prefix_idx": {
+          "name": "api_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_user_id_user_id_fk": {
+          "name": "api_key_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appearance_settings": {
+      "name": "appearance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appearance_mode": {
+          "name": "appearance_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "light_color_scheme": {
+          "name": "light_color_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ocean'"
+        },
+        "dark_color_scheme": {
+          "name": "dark_color_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'midnight'"
+        },
+        "terminal_opacity": {
+          "name": "terminal_opacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "terminal_blur": {
+          "name": "terminal_blur",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terminal_cursor_style": {
+          "name": "terminal_cursor_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "appearance_settings_user_idx": {
+          "name": "appearance_settings_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appearance_settings_user_id_user_id_fk": {
+          "name": "appearance_settings_user_id_user_id_fk",
+          "tableFrom": "appearance_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "appearance_settings_user_id_unique": {
+          "name": "appearance_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authorized_user": {
+      "name": "authorized_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authorized_user_email_unique": {
+          "name": "authorized_user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_group": {
+      "name": "channel_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "channel_group_project_idx": {
+          "name": "channel_group_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_group_project_name_idx": {
+          "name": "channel_group_project_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_group_project_id_project_id_fk": {
+          "name": "channel_group_project_id_project_id_fk",
+          "tableFrom": "channel_group",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_read_state": {
+      "name": "channel_read_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "channel_read_state_unique_idx": {
+          "name": "channel_read_state_unique_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_read_state_user_idx": {
+          "name": "channel_read_state_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_read_state_channel_id_channel_id_fk": {
+          "name": "channel_read_state_channel_id_channel_id_fk",
+          "tableFrom": "channel_read_state",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_read_state_user_id_user_id_fk": {
+          "name": "channel_read_state_user_id_user_id_fk",
+          "tableFrom": "channel_read_state",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel": {
+      "name": "channel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "channel_project_idx": {
+          "name": "channel_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_group_idx": {
+          "name": "channel_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_project_name_idx": {
+          "name": "channel_project_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_project_id_project_id_fk": {
+          "name": "channel_project_id_project_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_group_id_channel_group_id_fk": {
+          "name": "channel_group_id_channel_group_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "channel_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.color_scheme": {
+      "name": "color_scheme",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color_definitions": {
+          "name": "color_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_palette": {
+          "name": "terminal_palette",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_built_in": {
+          "name": "is_built_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "color_scheme_category_idx": {
+          "name": "color_scheme_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "color_scheme_sort_idx": {
+          "name": "color_scheme_sort_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.command_execution": {
+      "name": "command_execution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "command_execution_execution_idx": {
+          "name": "command_execution_execution_idx",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "command_execution_command_idx": {
+          "name": "command_execution_command_idx",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "command_execution_execution_id_schedule_execution_id_fk": {
+          "name": "command_execution_execution_id_schedule_execution_id_fk",
+          "tableFrom": "command_execution",
+          "tableTo": "schedule_execution",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "command_execution_command_id_schedule_command_id_fk": {
+          "name": "command_execution_command_id_schedule_command_id_fk",
+          "tableFrom": "command_execution",
+          "tableTo": "schedule_command",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_account_metadata": {
+      "name": "github_account_metadata",
+      "schema": "",
+      "columns": {
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config_dir": {
+          "name": "config_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_account_metadata_user_idx": {
+          "name": "github_account_metadata_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_account_metadata_user_id_user_id_fk": {
+          "name": "github_account_metadata_user_id_user_id_fk",
+          "tableFrom": "github_account_metadata",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_branch_protection": {
+      "name": "github_branch_protection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_protected": {
+          "name": "is_protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_review": {
+          "name": "requires_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "required_reviewers": {
+          "name": "required_reviewers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "requires_status_checks": {
+          "name": "requires_status_checks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "required_checks": {
+          "name": "required_checks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allows_force_pushes": {
+          "name": "allows_force_pushes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allows_deletions": {
+          "name": "allows_deletions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_branch_protection_repo_branch_idx": {
+          "name": "github_branch_protection_repo_branch_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_branch_protection_repository_id_github_repository_id_fk": {
+          "name": "github_branch_protection_repository_id_github_repository_id_fk",
+          "tableFrom": "github_branch_protection",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_change_notification": {
+      "name": "github_change_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_pr_count": {
+          "name": "new_pr_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "new_issue_count": {
+          "name": "new_issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_notifications_user_repo_idx": {
+          "name": "github_notifications_user_repo_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_notifications_user_idx": {
+          "name": "github_notifications_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_change_notification_user_id_user_id_fk": {
+          "name": "github_change_notification_user_id_user_id_fk",
+          "tableFrom": "github_change_notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_change_notification_repository_id_github_repository_id_fk": {
+          "name": "github_change_notification_repository_id_github_repository_id_fk",
+          "tableFrom": "github_change_notification",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue": {
+      "name": "github_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "assignees": {
+          "name": "assignees",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_pull_request": {
+          "name": "is_pull_request",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_issue_repo_idx": {
+          "name": "github_issue_repo_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_issue_repo_number_idx": {
+          "name": "github_issue_repo_number_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_issue_state_idx": {
+          "name": "github_issue_state_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_issue_cached_idx": {
+          "name": "github_issue_cached_idx",
+          "columns": [
+            {
+              "expression": "cached_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_repository_id_github_repository_id_fk": {
+          "name": "github_issue_repository_id_github_repository_id_fk",
+          "tableFrom": "github_issue",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_pull_request": {
+      "name": "github_pull_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ci_status": {
+          "name": "ci_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pr_repo_idx": {
+          "name": "github_pr_repo_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pr_repo_number_idx": {
+          "name": "github_pr_repo_number_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pr_state_idx": {
+          "name": "github_pr_state_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_pull_request_repository_id_github_repository_id_fk": {
+          "name": "github_pull_request_repository_id_github_repository_id_fk",
+          "tableFrom": "github_pull_request",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository": {
+      "name": "github_repository",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_repo_user_idx": {
+          "name": "github_repo_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repo_github_id_idx": {
+          "name": "github_repo_github_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_user_id_user_id_fk": {
+          "name": "github_repository_user_id_user_id_fk",
+          "tableFrom": "github_repository",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_stats": {
+      "name": "github_repository_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "open_pr_count": {
+          "name": "open_pr_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "open_issue_count": {
+          "name": "open_issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ci_status": {
+          "name": "ci_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ci_status_details": {
+          "name": "ci_status_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch_protected": {
+          "name": "branch_protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "branch_protection_details": {
+          "name": "branch_protection_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recent_commits": {
+          "name": "recent_commits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_repo_stats_repo_idx": {
+          "name": "github_repo_stats_repo_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repo_stats_expires_idx": {
+          "name": "github_repo_stats_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_stats_repository_id_github_repository_id_fk": {
+          "name": "github_repository_stats_repository_id_github_repository_id_fk",
+          "tableFrom": "github_repository_stats",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_repository_stats_repository_id_unique": {
+          "name": "github_repository_stats_repository_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_stats_preferences": {
+      "name": "github_stats_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_pr_count": {
+          "name": "show_pr_count",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_issue_count": {
+          "name": "show_issue_count",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_ci_status": {
+          "name": "show_ci_status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_recent_commits": {
+          "name": "show_recent_commits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_branch_protection": {
+          "name": "show_branch_protection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "refresh_interval_minutes": {
+          "name": "refresh_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_stats_prefs_user_idx": {
+          "name": "github_stats_prefs_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_stats_prefs_project_idx": {
+          "name": "github_stats_prefs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_stats_preferences_user_id_user_id_fk": {
+          "name": "github_stats_preferences_user_id_user_id_fk",
+          "tableFrom": "github_stats_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_stats_preferences_project_id_project_id_fk": {
+          "name": "github_stats_preferences_project_id_project_id_fk",
+          "tableFrom": "github_stats_preferences",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.litellm_config": {
+      "name": "litellm_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_start": {
+          "name": "auto_start",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4000
+        },
+        "master_key": {
+          "name": "master_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "litellm_config_user_id_user_id_fk": {
+          "name": "litellm_config_user_id_user_id_fk",
+          "tableFrom": "litellm_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "litellm_config_user_id_unique": {
+          "name": "litellm_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.litellm_model": {
+      "name": "litellm_model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "litellm_model": {
+          "name": "litellm_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base": {
+          "name": "api_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_headers": {
+          "name": "extra_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "litellm_model_user_idx": {
+          "name": "litellm_model_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "litellm_model_user_id_user_id_fk": {
+          "name": "litellm_model_user_id_user_id_fk",
+          "tableFrom": "litellm_model",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_discovered_resource": {
+      "name": "mcp_discovered_resource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_discovered_resource_server_idx": {
+          "name": "mcp_discovered_resource_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_discovered_resource_unique_idx": {
+          "name": "mcp_discovered_resource_unique_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_discovered_resource_server_id_mcp_server_id_fk": {
+          "name": "mcp_discovered_resource_server_id_mcp_server_id_fk",
+          "tableFrom": "mcp_discovered_resource",
+          "tableTo": "mcp_server",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_discovered_tool": {
+      "name": "mcp_discovered_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_discovered_tool_server_idx": {
+          "name": "mcp_discovered_tool_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_discovered_tool_unique_idx": {
+          "name": "mcp_discovered_tool_unique_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_discovered_tool_server_id_mcp_server_id_fk": {
+          "name": "mcp_discovered_tool_server_id_mcp_server_id_fk",
+          "tableFrom": "mcp_discovered_tool",
+          "tableTo": "mcp_server",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server": {
+      "name": "mcp_server",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdio'"
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_start": {
+          "name": "auto_start",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_server_user_idx": {
+          "name": "mcp_server_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_server_project_idx": {
+          "name": "mcp_server_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_server_enabled_idx": {
+          "name": "mcp_server_enabled_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_user_id_user_id_fk": {
+          "name": "mcp_server_user_id_user_id_fk",
+          "tableFrom": "mcp_server",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_server_project_id_project_id_fk": {
+          "name": "mcp_server_project_id_project_id_fk",
+          "tableFrom": "mcp_server",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_preferences": {
+      "name": "node_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_working_directory": {
+          "name": "default_working_directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_shell": {
+          "name": "default_shell",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_command": {
+          "name": "startup_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_repo_path": {
+          "name": "local_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_agent_provider": {
+          "name": "default_agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_provider_settings": {
+          "name": "agent_provider_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment_vars": {
+          "name": "environment_vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_files": {
+          "name": "pinned_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_identity_name": {
+          "name": "git_identity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_identity_email": {
+          "name": "git_identity_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_sensitive": {
+          "name": "is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "node_pref_owner_idx": {
+          "name": "node_pref_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "node_pref_owner_user_idx": {
+          "name": "node_pref_owner_user_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_preferences_user_id_user_id_fk": {
+          "name": "node_preferences_user_id_user_id_fk",
+          "tableFrom": "node_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_event": {
+      "name": "notification_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_name": {
+          "name": "session_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'passive'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coalesce_key": {
+          "name": "coalesce_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "notification_event_user_created_idx": {
+          "name": "notification_event_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_event_user_read_idx": {
+          "name": "notification_event_user_read_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_event_coalesce_idx": {
+          "name": "notification_event_coalesce_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_event_user_id_user_id_fk": {
+          "name": "notification_event_user_id_user_id_fk",
+          "tableFrom": "notification_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_event_session_id_terminal_session_id_fk": {
+          "name": "notification_event_session_id_terminal_session_id_fk",
+          "tableFrom": "notification_event",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "push_by_type": {
+          "name": "push_by_type",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "muted_session_ids": {
+          "name": "muted_session_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_push_severity": {
+          "name": "min_push_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'actionable'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_user_id_fk": {
+          "name": "notification_preferences_user_id_user_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.port_claim": {
+      "name": "port_claim",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variable_name": {
+          "name": "variable_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listening": {
+          "name": "is_listening",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "port_claim_session_idx": {
+          "name": "port_claim_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "port_claim_user_idx": {
+          "name": "port_claim_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "port_claim_port_idx": {
+          "name": "port_claim_port_idx",
+          "columns": [
+            {
+              "expression": "port",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "port_claim_session_port_unique": {
+          "name": "port_claim_session_port_unique",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "port",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "port_claim_session_id_terminal_session_id_fk": {
+          "name": "port_claim_session_id_terminal_session_id_fk",
+          "tableFrom": "port_claim",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "port_claim_user_id_user_id_fk": {
+          "name": "port_claim_user_id_user_id_fk",
+          "tableFrom": "port_claim",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "port_claim_project_id_project_id_fk": {
+          "name": "port_claim_project_id_project_id_fk",
+          "tableFrom": "port_claim",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.port_registry": {
+      "name": "port_registry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variable_name": {
+          "name": "variable_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "port_registry_user_idx": {
+          "name": "port_registry_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "port_registry_project_idx": {
+          "name": "port_registry_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "port_registry_user_port_idx": {
+          "name": "port_registry_user_port_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "port",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "port_registry_user_port_var_unique": {
+          "name": "port_registry_user_port_var_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "port",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variable_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "port_registry_project_id_project_id_fk": {
+          "name": "port_registry_project_id_project_id_fk",
+          "tableFrom": "port_registry",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "port_registry_user_id_user_id_fk": {
+          "name": "port_registry_user_id_user_id_fk",
+          "tableFrom": "port_registry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_appearance_settings": {
+      "name": "profile_appearance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appearance_mode": {
+          "name": "appearance_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "light_color_scheme": {
+          "name": "light_color_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ocean'"
+        },
+        "dark_color_scheme": {
+          "name": "dark_color_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'midnight'"
+        },
+        "terminal_opacity": {
+          "name": "terminal_opacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "terminal_blur": {
+          "name": "terminal_blur",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terminal_cursor_style": {
+          "name": "terminal_cursor_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_appearance_profile_idx": {
+          "name": "profile_appearance_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profile_appearance_user_idx": {
+          "name": "profile_appearance_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_appearance_settings_profile_id_agent_profile_id_fk": {
+          "name": "profile_appearance_settings_profile_id_agent_profile_id_fk",
+          "tableFrom": "profile_appearance_settings",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_appearance_settings_user_id_user_id_fk": {
+          "name": "profile_appearance_settings_user_id_user_id_fk",
+          "tableFrom": "profile_appearance_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_appearance_settings_profile_id_unique": {
+          "name": "profile_appearance_settings_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_git_identity": {
+      "name": "profile_git_identity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ssh_key_path": {
+          "name": "ssh_key_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpg_key_id": {
+          "name": "gpg_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_git_identity_profile_idx": {
+          "name": "profile_git_identity_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_git_identity_profile_id_agent_profile_id_fk": {
+          "name": "profile_git_identity_profile_id_agent_profile_id_fk",
+          "tableFrom": "profile_git_identity",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_git_identity_profile_id_unique": {
+          "name": "profile_git_identity_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_secrets_config": {
+      "name": "profile_secrets_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_secrets_config_profile_idx": {
+          "name": "profile_secrets_config_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profile_secrets_config_user_idx": {
+          "name": "profile_secrets_config_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_secrets_config_profile_id_agent_profile_id_fk": {
+          "name": "profile_secrets_config_profile_id_agent_profile_id_fk",
+          "tableFrom": "profile_secrets_config",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_secrets_config_user_id_user_id_fk": {
+          "name": "profile_secrets_config_user_id_user_id_fk",
+          "tableFrom": "profile_secrets_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_secrets_config_profile_id_unique": {
+          "name": "profile_secrets_config_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_github_account_link": {
+      "name": "project_github_account_link",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_gh_link_account_idx": {
+          "name": "project_gh_link_account_idx",
+          "columns": [
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_github_account_link_project_id_project_id_fk": {
+          "name": "project_github_account_link_project_id_project_id_fk",
+          "tableFrom": "project_github_account_link",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_group": {
+      "name": "project_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_group_id": {
+          "name": "parent_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_group_user_idx": {
+          "name": "project_group_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_parent_idx": {
+          "name": "project_group_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_user_id_user_id_fk": {
+          "name": "project_group_user_id_user_id_fk",
+          "tableFrom": "project_group",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_parent_group_id_project_group_id_fk": {
+          "name": "project_group_parent_group_id_project_group_id_fk",
+          "tableFrom": "project_group",
+          "tableTo": "project_group",
+          "columnsFrom": [
+            "parent_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_profile_link": {
+      "name": "project_profile_link",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_profile_link_profile_idx": {
+          "name": "project_profile_link_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_profile_link_project_id_project_id_fk": {
+          "name": "project_profile_link_project_id_project_id_fk",
+          "tableFrom": "project_profile_link",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_profile_link_profile_id_agent_profile_id_fk": {
+          "name": "project_profile_link_profile_id_agent_profile_id_fk",
+          "tableFrom": "project_profile_link",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_repository": {
+      "name": "project_repository",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_repo_project_user_idx": {
+          "name": "project_repo_project_user_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_repo_user_idx": {
+          "name": "project_repo_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_repository_project_id_project_id_fk": {
+          "name": "project_repository_project_id_project_id_fk",
+          "tableFrom": "project_repository",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_repository_repository_id_github_repository_id_fk": {
+          "name": "project_repository_repository_id_github_repository_id_fk",
+          "tableFrom": "project_repository",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_repository_user_id_user_id_fk": {
+          "name": "project_repository_user_id_user_id_fk",
+          "tableFrom": "project_repository",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_secrets_config": {
+      "name": "project_secrets_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_secrets_project_user_idx": {
+          "name": "project_secrets_project_user_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_secrets_config_user_id_user_id_fk": {
+          "name": "project_secrets_config_user_id_user_id_fk",
+          "tableFrom": "project_secrets_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_secrets_config_project_id_project_id_fk": {
+          "name": "project_secrets_config_project_id_project_id_fk",
+          "tableFrom": "project_secrets_config",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_task": {
+      "name": "project_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "subtasks": {
+          "name": "subtasks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_task_key": {
+          "name": "agent_task_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_task_user_idx": {
+          "name": "project_task_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_task_project_idx": {
+          "name": "project_task_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_task_user_project_idx": {
+          "name": "project_task_user_project_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_task_session_idx": {
+          "name": "project_task_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_task_agent_key_idx": {
+          "name": "project_task_agent_key_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_task_user_id_user_id_fk": {
+          "name": "project_task_user_id_user_id_fk",
+          "tableFrom": "project_task",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_task_project_id_project_id_fk": {
+          "name": "project_task_project_id_project_id_fk",
+          "tableFrom": "project_task",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_task_session_id_terminal_session_id_fk": {
+          "name": "project_task_session_id_terminal_session_id_fk",
+          "tableFrom": "project_task",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_auto_created": {
+          "name": "is_auto_created",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_user_idx": {
+          "name": "project_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_idx": {
+          "name": "project_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_user_id_user_id_fk": {
+          "name": "project_user_id_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_id_project_group_id_fk": {
+          "name": "project_group_id_project_group_id_fk",
+          "tableFrom": "project",
+          "tableTo": "project_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_token": {
+      "name": "push_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fcm_token": {
+          "name": "fcm_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "push_token_user_idx": {
+          "name": "push_token_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_token_fcm_token_idx": {
+          "name": "push_token_fcm_token_idx",
+          "columns": [
+            {
+              "expression": "fcm_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_token_user_id_user_id_fk": {
+          "name": "push_token_user_id_user_id_fk",
+          "tableFrom": "push_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_command": {
+      "name": "schedule_command",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delay_before_seconds": {
+          "name": "delay_before_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "continue_on_error": {
+          "name": "continue_on_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "schedule_command_schedule_idx": {
+          "name": "schedule_command_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedule_command_order_idx": {
+          "name": "schedule_command_order_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_command_schedule_id_session_schedule_id_fk": {
+          "name": "schedule_command_schedule_id_session_schedule_id_fk",
+          "tableFrom": "schedule_command",
+          "tableTo": "session_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_execution": {
+      "name": "schedule_execution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_count": {
+          "name": "command_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "schedule_execution_schedule_idx": {
+          "name": "schedule_execution_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedule_execution_started_idx": {
+          "name": "schedule_execution_started_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_execution_schedule_id_session_schedule_id_fk": {
+          "name": "schedule_execution_schedule_id_session_schedule_id_fk",
+          "tableFrom": "schedule_execution",
+          "tableTo": "session_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_memory": {
+      "name": "session_memory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_memory_user_idx": {
+          "name": "session_memory_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_memory_project_idx": {
+          "name": "session_memory_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_memory_type_idx": {
+          "name": "session_memory_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_memory_user_id_user_id_fk": {
+          "name": "session_memory_user_id_user_id_fk",
+          "tableFrom": "session_memory",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_memory_project_id_project_id_fk": {
+          "name": "session_memory_project_id_project_id_fk",
+          "tableFrom": "session_memory",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_recording": {
+      "name": "session_recording",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_cols": {
+          "name": "terminal_cols",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 80
+        },
+        "terminal_rows": {
+          "name": "terminal_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_recording_user_idx": {
+          "name": "session_recording_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_recording_created_idx": {
+          "name": "session_recording_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_recording_user_id_user_id_fk": {
+          "name": "session_recording_user_id_user_id_fk",
+          "tableFrom": "session_recording",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_schedule": {
+      "name": "session_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'one-time'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/Los_Angeles'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_delay_seconds": {
+          "name": "retry_delay_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "timeout_seconds": {
+          "name": "timeout_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_status": {
+          "name": "last_run_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_schedule_user_idx": {
+          "name": "session_schedule_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_schedule_session_idx": {
+          "name": "session_schedule_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_schedule_next_run_idx": {
+          "name": "session_schedule_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_schedule_user_id_user_id_fk": {
+          "name": "session_schedule_user_id_user_id_fk",
+          "tableFrom": "session_schedule",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_schedule_session_id_terminal_session_id_fk": {
+          "name": "session_schedule_session_id_terminal_session_id_fk",
+          "tableFrom": "session_schedule",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_template": {
+      "name": "session_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_name_pattern": {
+          "name": "session_name_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_command": {
+          "name": "startup_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_template_user_idx": {
+          "name": "session_template_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_template_usage_idx": {
+          "name": "session_template_usage_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usage_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_template_project_idx": {
+          "name": "session_template_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_template_user_id_user_id_fk": {
+          "name": "session_template_user_id_user_id_fk",
+          "tableFrom": "session_template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_template_project_id_project_id_fk": {
+          "name": "session_template_project_id_project_id_fk",
+          "tableFrom": "session_template",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup_config": {
+      "name": "setup_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "working_directory": {
+          "name": "working_directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_port": {
+          "name": "next_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3000
+        },
+        "terminal_port": {
+          "name": "terminal_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3001
+        },
+        "wsl_distribution": {
+          "name": "wsl_distribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_start": {
+          "name": "auto_start",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "check_for_updates": {
+          "name": "check_for_updates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssh_connection": {
+      "name": "ssh_connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 22
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_passphrase": {
+          "name": "has_passphrase",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password_enc": {
+          "name": "password_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "known_hosts_policy": {
+          "name": "known_hosts_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'accept-new'"
+        },
+        "extra_options": {
+          "name": "extra_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ssh_connection_user_project_idx": {
+          "name": "ssh_connection_user_project_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssh_connection_user_id_user_id_fk": {
+          "name": "ssh_connection_user_id_user_id_fk",
+          "tableFrom": "ssh_connection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ssh_connection_project_id_project_id_fk": {
+          "name": "ssh_connection_project_id_project_id_fk",
+          "tableFrom": "ssh_connection",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_update_cache": {
+      "name": "system_update_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_release_json": {
+          "name": "cached_release_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_state_json": {
+          "name": "deployment_state_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_dependency": {
+      "name": "task_dependency",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "task_dep_blocker_idx": {
+          "name": "task_dep_blocker_idx",
+          "columns": [
+            {
+              "expression": "blocker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_dep_blocked_idx": {
+          "name": "task_dep_blocked_idx",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_dependency_blocker_id_project_task_id_fk": {
+          "name": "task_dependency_blocker_id_project_task_id_fk",
+          "tableFrom": "task_dependency",
+          "tableTo": "project_task",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_dependency_blocked_id_project_task_id_fk": {
+          "name": "task_dependency_blocked_id_project_task_id_fk",
+          "tableFrom": "task_dependency",
+          "tableTo": "project_task",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_dependency_blocker_id_blocked_id_pk": {
+          "name": "task_dependency_blocker_id_blocked_id_pk",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.terminal_session": {
+      "name": "terminal_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tmux_session_name": {
+          "name": "tmux_session_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worktree_branch": {
+          "name": "worktree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worktree_type": {
+          "name": "worktree_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_type": {
+          "name": "terminal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'shell'"
+        },
+        "agent_provider": {
+          "name": "agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_exit_state": {
+          "name": "agent_exit_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_exit_code": {
+          "name": "agent_exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_exited_at": {
+          "name": "agent_exited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_restart_count": {
+          "name": "agent_restart_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "agent_activity_status": {
+          "name": "agent_activity_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_metadata": {
+          "name": "type_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orchestrator_role": {
+          "name": "orchestrator_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "terminal_session_user_status_idx": {
+          "name": "terminal_session_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "terminal_session_user_order_idx": {
+          "name": "terminal_session_user_order_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tab_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "terminal_session_project_idx": {
+          "name": "terminal_session_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "terminal_session_type_idx": {
+          "name": "terminal_session_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "terminal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "terminal_session_scope_unique_idx": {
+          "name": "terminal_session_scope_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "terminal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "terminal_session_user_id_user_id_fk": {
+          "name": "terminal_session_user_id_user_id_fk",
+          "tableFrom": "terminal_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_session_github_repo_id_github_repository_id_fk": {
+          "name": "terminal_session_github_repo_id_github_repository_id_fk",
+          "tableFrom": "terminal_session",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "github_repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "terminal_session_project_id_project_id_fk": {
+          "name": "terminal_session_project_id_project_id_fk",
+          "tableFrom": "terminal_session",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_session_profile_id_agent_profile_id_fk": {
+          "name": "terminal_session_profile_id_agent_profile_id_fk",
+          "tableFrom": "terminal_session",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "terminal_session_tmux_session_name_unique": {
+          "name": "terminal_session_tmux_session_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmux_session_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trash_item": {
+      "name": "trash_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_name": {
+          "name": "resource_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trashed_at": {
+          "name": "trashed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "trash_item_user_type_idx": {
+          "name": "trash_item_user_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trash_item_expires_idx": {
+          "name": "trash_item_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trash_item_resource_idx": {
+          "name": "trash_item_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trash_item_user_id_user_id_fk": {
+          "name": "trash_item_user_id_user_id_fk",
+          "tableFrom": "trash_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_email": {
+      "name": "user_email",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_email_user_idx": {
+          "name": "user_email_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_email_user_id_user_id_fk": {
+          "name": "user_email_user_id_user_id_fk",
+          "tableFrom": "user_email",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_email_unique": {
+          "name": "user_email_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_working_directory": {
+          "name": "default_working_directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_shell": {
+          "name": "default_shell",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_command": {
+          "name": "startup_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xterm_scrollback": {
+          "name": "xterm_scrollback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10000
+        },
+        "tmux_history_limit": {
+          "name": "tmux_history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 50000
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'tokyo-night'"
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 14
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'''JetBrainsMono Nerd Font Mono'', monospace'"
+        },
+        "active_node_id": {
+          "name": "active_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_node_type": {
+          "name": "active_node_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_node_id": {
+          "name": "pinned_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_node_type": {
+          "name": "pinned_node_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_follow_active_session": {
+          "name": "auto_follow_active_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_agent_provider": {
+          "name": "default_agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_provider_settings": {
+          "name": "agent_provider_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beads_sidebar_collapsed": {
+          "name": "beads_sidebar_collapsed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "beads_sidebar_width": {
+          "name": "beads_sidebar_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 320
+        },
+        "beads_closed_retention_days": {
+          "name": "beads_closed_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 7
+        },
+        "beads_section_expanded": {
+          "name": "beads_section_expanded",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "name": "verificationToken_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worktree_trash_metadata": {
+      "name": "worktree_trash_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trash_item_id": {
+          "name": "trash_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_local_path": {
+          "name": "repo_local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worktree_branch": {
+          "name": "worktree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worktree_original_path": {
+          "name": "worktree_original_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worktree_trash_path": {
+          "name": "worktree_trash_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_project_id": {
+          "name": "original_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_project_name": {
+          "name": "original_project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "worktree_trash_repo_idx": {
+          "name": "worktree_trash_repo_idx",
+          "columns": [
+            {
+              "expression": "github_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "worktree_trash_metadata_trash_item_id_trash_item_id_fk": {
+          "name": "worktree_trash_metadata_trash_item_id_trash_item_id_fk",
+          "tableFrom": "worktree_trash_metadata",
+          "tableTo": "trash_item",
+          "columnsFrom": [
+            "trash_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worktree_trash_metadata_github_repo_id_github_repository_id_fk": {
+          "name": "worktree_trash_metadata_github_repo_id_github_repository_id_fk",
+          "tableFrom": "worktree_trash_metadata",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "github_repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "worktree_trash_metadata_trash_item_id_unique": {
+          "name": "worktree_trash_metadata_trash_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trash_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/pg/meta/_journal.json
+++ b/drizzle/pg/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1780512948277,
       "tag": "0001_past_swordsman",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1780521414350,
+      "tag": "0002_real_jamie_braddock",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/notifications/preferences/route.ts
+++ b/src/app/api/notifications/preferences/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { withApiAuth, errorResponse, parseJsonBody } from "@/lib/api";
+import * as Prefs from "@/services/notification-preferences-service";
+import type { UpdatePrefsInput } from "@/services/notification-preferences-service";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("api/notifications/preferences");
+
+// GET /api/notifications/preferences — current notification prefs for the user.
+export const GET = withApiAuth(async (_request, { userId }) => {
+  try {
+    const raw = await Prefs.getRawPrefs(userId);
+    return NextResponse.json(
+      raw ?? {
+        pushByType: {},
+        mutedSessionIds: [],
+        quietHoursStart: null,
+        quietHoursEnd: null,
+        minPushSeverity: "actionable",
+      },
+    );
+  } catch (error) {
+    log.error("Error reading notification prefs", { error: String(error) });
+    return errorResponse("Failed to read preferences", 500);
+  }
+});
+
+// PUT /api/notifications/preferences — upsert (partial) notification prefs.
+export const PUT = withApiAuth(async (request, { userId }) => {
+  try {
+    const result = await parseJsonBody<UpdatePrefsInput>(request);
+    if ("error" in result) return result.error;
+    await Prefs.upsertPrefs(userId, result.data);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    log.error("Error updating notification prefs", { error: String(error) });
+    return errorResponse("Failed to update preferences", 500);
+  }
+});

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -28,7 +28,7 @@ export const POST = withApiAuth(async (request, { userId }) => {
       title,
       body: body ?? undefined,
     });
-    return NextResponse.json(notification ?? { debounced: true });
+    return NextResponse.json(notification ?? { suppressed: true });
   } catch (error) {
     log.error("Error creating notification", { error: String(error) });
     return errorResponse("Failed to create notification", 500);

--- a/src/components/mobile/notifications/MobileNotificationRow.tsx
+++ b/src/components/mobile/notifications/MobileNotificationRow.tsx
@@ -55,9 +55,13 @@ export function MobileNotificationRow({
 
   const isUnread = !notification.readAt;
 
-  // The halo only animates on session-waiting rows. Other notification
-  // types are unread-only and don't carry the "needs attention" semantic.
-  const showHalo = notification.type === "agent_waiting" && isUnread;
+  // [y5ch.8] Severity — not a hardcoded type check — drives the visual signal.
+  // actionable + error both carry the "needs attention" semantic; the pulsing
+  // halo animates on those when unread. Passive rows stay quiet.
+  const isActionable =
+    notification.severity === "actionable" || notification.severity === "error";
+  const showHalo = isActionable && isUnread;
+  const count = notification.count ?? 1;
 
   // Right-swipe = "mark unread". The server has no mark-unread endpoint, so
   // letting users swipe a read row right would commit a no-op gesture (and
@@ -272,6 +276,15 @@ export function MobileNotificationRow({
             )}
           >
             {notification.title}
+            {/* [y5ch.8] coalesced-count badge: N collapsed lifecycle pings. */}
+            {count > 1 ? (
+              <span
+                data-testid="mobile-notification-count"
+                className="ml-1.5 rounded-full bg-muted px-1.5 text-[10px] text-muted-foreground"
+              >
+                ×{count}
+              </span>
+            ) : null}
           </p>
           {notification.body ? (
             <p

--- a/src/components/mobile/notifications/__tests__/MobileNotificationRow.test.tsx
+++ b/src/components/mobile/notifications/__tests__/MobileNotificationRow.test.tsx
@@ -12,6 +12,7 @@ import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/re
 
 import { MobileNotificationRow } from "@/components/mobile/notifications/MobileNotificationRow";
 import type { NotificationEvent } from "@/types/notification";
+import { notificationSeverity } from "@/types/notification";
 
 // Mock the reduced-motion hook so individual tests can opt into the
 // reduced-motion code path. Default = false so the halo test below still
@@ -30,16 +31,21 @@ afterEach(() => {
 function makeNotification(
   over: Partial<NotificationEvent> = {}
 ): NotificationEvent {
+  const type = over.type ?? "agent_waiting";
   return {
     id: "n1",
     userId: "u1",
     sessionId: "s1",
     sessionName: "main",
-    type: "agent_waiting",
+    type,
+    severity: notificationSeverity(type),
     title: "Agent needs you",
     body: "Approve the pending edit",
+    count: 1,
+    meta: null,
     readAt: null,
     createdAt: new Date(Date.now() - 60_000),
+    updatedAt: new Date(Date.now() - 60_000),
     ...over,
   };
 }
@@ -76,7 +82,7 @@ describe("MobileNotificationRow", () => {
     expect(screen.queryByTestId("mobile-notification-halo")).toBeNull();
   });
 
-  it("does not render the halo for non-agent_waiting notifications even when unread", () => {
+  it("does not render the halo for passive notifications even when unread", () => {
     render(
       <MobileNotificationRow
         notification={makeNotification({ type: "info" })}
@@ -90,6 +96,47 @@ describe("MobileNotificationRow", () => {
     // But the dot still reads as unread.
     const dot = screen.getByTestId("mobile-notification-dot");
     expect(dot.className).toMatch(/bg-\[var\(--color-signal-attention-solid\)\]/);
+  });
+
+  it("[y5ch.8] renders the halo for an unread error-severity notification", () => {
+    render(
+      <MobileNotificationRow
+        notification={makeNotification({ type: "agent_error" })}
+        onTap={vi.fn()}
+        onLongPress={vi.fn()}
+        onDelete={vi.fn()}
+        onToggleRead={vi.fn()}
+      />
+    );
+    // Severity drives the halo now (agent_error → error → actionable signal).
+    expect(screen.queryByTestId("mobile-notification-halo")).not.toBeNull();
+  });
+
+  it("[y5ch.8] renders a ×N count badge when the row is coalesced", () => {
+    render(
+      <MobileNotificationRow
+        notification={makeNotification({ count: 3 })}
+        onTap={vi.fn()}
+        onLongPress={vi.fn()}
+        onDelete={vi.fn()}
+        onToggleRead={vi.fn()}
+      />
+    );
+    const badge = screen.getByTestId("mobile-notification-count");
+    expect(badge.textContent).toBe("×3");
+  });
+
+  it("[y5ch.8] omits the count badge when count is 1", () => {
+    render(
+      <MobileNotificationRow
+        notification={makeNotification({ count: 1 })}
+        onTap={vi.fn()}
+        onLongPress={vi.fn()}
+        onDelete={vi.fn()}
+        onToggleRead={vi.fn()}
+      />
+    );
+    expect(screen.queryByTestId("mobile-notification-count")).toBeNull();
   });
 
   it("does NOT render a colored side-stripe (no border-l-2)", () => {

--- a/src/components/mobile/notifications/__tests__/NotificationsTab.test.tsx
+++ b/src/components/mobile/notifications/__tests__/NotificationsTab.test.tsx
@@ -13,6 +13,7 @@ import userEvent from "@testing-library/user-event";
 
 import { NotificationsTab } from "@/components/mobile/notifications/NotificationsTab";
 import type { NotificationEvent } from "@/types/notification";
+import { notificationSeverity } from "@/types/notification";
 
 // Pending-delete + scheduling now lives in NotificationContext (see P1-A
 // fix). The test harness models the contract: scheduleDelete adds to the
@@ -109,16 +110,21 @@ import { toast } from "sonner";
 function makeNotification(
   over: Partial<NotificationEvent> = {}
 ): NotificationEvent {
+  const type = over.type ?? "agent_waiting";
   return {
     id: "n1",
     userId: "u1",
     sessionId: "s1",
     sessionName: "main",
-    type: "agent_waiting",
+    type,
+    severity: notificationSeverity(type),
     title: "Agent needs you",
     body: "Approve the pending edit",
+    count: 1,
+    meta: null,
     readAt: null,
     createdAt: new Date(Date.now() - 60_000),
+    updatedAt: new Date(Date.now() - 60_000),
     ...over,
   };
 }

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -161,7 +161,18 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
   const markReadRef = useRef<((ids: string[]) => void) | null>(null);
 
   const addNotification = useCallback((notification: NotificationEvent) => {
-    setNotifications((prev) => [notification, ...prev].slice(0, MAX_NOTIFICATIONS));
+    // [y5ch.5] Upsert by id: a coalesced server row arrives with the SAME id and
+    // a higher count, so replace the existing list entry in place (keeping its
+    // position) instead of stacking a duplicate. New ids prepend as before.
+    setNotifications((prev) => {
+      const idx = prev.findIndex((n) => n.id === notification.id);
+      if (idx >= 0) {
+        const next = prev.slice();
+        next[idx] = notification;
+        return next;
+      }
+      return [notification, ...prev].slice(0, MAX_NOTIFICATIONS);
+    });
     fireNotificationToast(notification, jumpHandlerRef.current, markReadRef.current);
   }, []);
 

--- a/src/db/__tests__/schema-column-diff.test.ts
+++ b/src/db/__tests__/schema-column-diff.test.ts
@@ -57,8 +57,8 @@ describe("schema column diff (sqlite-core vs pg-core)", () => {
     const sqliteTables = [...sqlite.keys()].sort();
     const pgTables = [...pg.keys()].sort();
     expect(pgTables).toEqual(sqliteTables);
-    // Sanity: the full schema is 61 tables.
-    expect(sqliteTables).toHaveLength(61);
+    // Sanity: the full schema is 62 tables (+1 for notification_preferences, y5ch.6).
+    expect(sqliteTables).toHaveLength(62);
   });
 
   // One assertion per table so a failure names the offending table.

--- a/src/db/__tests__/schema-parity.test.ts
+++ b/src/db/__tests__/schema-parity.test.ts
@@ -34,7 +34,7 @@ type Equal<A, B> =
 // Compiles only when its argument resolves to the literal `true`.
 type Expect<T extends true> = T;
 
-// Per-table $inferSelect / $inferInsert parity for ALL 61 tables. A drift makes
+// Per-table $inferSelect / $inferInsert parity for ALL 62 tables. A drift makes
 // one of these `false`, which is a compile error on the `true[]` annotation.
 type _SchemaParity = [
   // users
@@ -230,9 +230,10 @@ void _parityHolds;
 
 // Trivial runtime test so vitest treats this file as a (passing) suite. The
 // real guarantee is the compile-time tuple above, enforced by `tsc`.
-it("schema.sqlite and schema.pg expose the same 61 table exports", () => {
+it("schema.sqlite and schema.pg expose the same 62 table exports", () => {
   const sqliteTables = Object.keys(sqliteSchema).sort();
   const pgTables = Object.keys(pgSchema).sort();
   expect(sqliteTables).toEqual(pgTables);
-  expect(sqliteTables).toHaveLength(61);
+  // [y5ch.6] +1 for notification_preferences.
+  expect(sqliteTables).toHaveLength(62);
 });

--- a/src/db/schema.def.ts
+++ b/src/db/schema.def.ts
@@ -17,11 +17,11 @@ import type { AgentProviderType, WorktreeType } from "@/types/session";
 import type { TerminalType, AgentExitState } from "@/types/terminal-type";
 import type { AppearanceMode, ColorSchemeCategory, ColorSchemeId } from "@/types/appearance";
 import type { TaskPriority, TaskStatus, TaskSource } from "@/types/task";
-import type { NotificationType } from "@/types/notification";
+import type { NotificationType, NotificationSeverity, NotificationMeta } from "@/types/notification";
 import type { ChannelType } from "@/types/channels";
 
 // Re-exported so the verbatim import block above (consumed by the codegen extractor) is not flagged as unused.
-export type { AdapterAccountType, SessionStatus, CIStatusState, PRState, ScheduleType, ScheduleStatus, ExecutionStatus, AgentProvider, AgentConfigType, MCPTransport, AgentProviderType, WorktreeType, TerminalType, AgentExitState, AppearanceMode, ColorSchemeCategory, ColorSchemeId, TaskPriority, TaskStatus, TaskSource, NotificationType, ChannelType };
+export type { AdapterAccountType, SessionStatus, CIStatusState, PRState, ScheduleType, ScheduleStatus, ExecutionStatus, AgentProvider, AgentConfigType, MCPTransport, AgentProviderType, WorktreeType, TerminalType, AgentExitState, AppearanceMode, ColorSchemeCategory, ColorSchemeId, TaskPriority, TaskStatus, TaskSource, NotificationType, NotificationSeverity, NotificationMeta, ChannelType };
 
 // DSL vocabulary lives in the shared generator core so both this app and the
 // supervisor app describe their schemas with one set of types. Re-exported here
@@ -960,14 +960,26 @@ export const schema: SchemaDefinition = [
       { field: "sessionId", dbName: "session_id", kind: "text", references: { table: "terminalSessions", column: "id", onDelete: "set null" } },
       { field: "sessionName", dbName: "session_name", kind: "text" },
       { field: "type", dbName: "type", kind: "text", notNull: true, typeBrand: "NotificationType" },
+      // [y5ch.1] Signal class derived from `type` (actionable | passive | error).
+      { field: "severity", dbName: "severity", kind: "text", notNull: true, typeBrand: "NotificationSeverity", default: { kind: "value", value: "\"passive\"" } },
       { field: "title", dbName: "title", kind: "text", notNull: true },
       { field: "body", dbName: "body", kind: "text" },
+      // [y5ch.5] Coalescing: rows sharing this key collapse into one open notification.
+      { field: "coalesceKey", dbName: "coalesce_key", kind: "text" },
+      // [y5ch.5] Number of collapsed events (1 normally).
+      { field: "count", dbName: "count", kind: "integer", notNull: true, default: { kind: "value", value: "1" } },
+      // [y5ch.8] Structured client-routing payload (deep-link, CTA, duration, result).
+      { field: "meta", dbName: "meta", kind: "json", typeBrand: "NotificationMeta | null" },
       { field: "readAt", dbName: "read_at", kind: "timestampMs" },
       { field: "createdAt", dbName: "created_at", kind: "timestampMs", notNull: true, default: { kind: "fn", fn: "now" } },
+      // [y5ch.1] Last time the (possibly coalesced) row was touched.
+      { field: "updatedAt", dbName: "updated_at", kind: "timestampMs", notNull: true, default: { kind: "fn", fn: "now" } },
     ],
     indexes: [
       { name: "notification_event_user_created_idx", columns: ["userId","createdAt"] },
       { name: "notification_event_user_read_idx", columns: ["userId","readAt"] },
+      // [y5ch.5] Lookup for coalescing an open (unread) row in a group.
+      { name: "notification_event_coalesce_idx", columns: ["userId","sessionId","coalesceKey","readAt"] },
     ],
   },
   {
@@ -985,6 +997,25 @@ export const schema: SchemaDefinition = [
     indexes: [
       { name: "push_token_user_idx", columns: ["userId"] },
       { name: "push_token_fcm_token_idx", columns: ["fcmToken"], unique: true },
+    ],
+  },
+  {
+    // [y5ch.6] Per-user notification preferences: per-type push opt-out,
+    // per-session mute, quiet hours, and the minimum severity allowed to push.
+    exportName: "notificationPreferences",
+    sqlName: "notification_preferences",
+    columns: [
+      { field: "userId", dbName: "user_id", kind: "text", primaryKey: true, references: { table: "users", column: "id", onDelete: "cascade" } },
+      // Per-type push opt-out. JSON: { [NotificationType]: boolean }. Missing = on.
+      { field: "pushByType", dbName: "push_by_type", kind: "json", typeBrand: "Record<string, boolean>", notNull: true, default: { kind: "value", value: "{}" } },
+      // Per-session mute. JSON: array of sessionId strings.
+      { field: "mutedSessionIds", dbName: "muted_session_ids", kind: "json", typeBrand: "string[]", notNull: true, default: { kind: "value", value: "[]" } },
+      // Quiet hours (local tz, 0-23). null = disabled.
+      { field: "quietHoursStart", dbName: "quiet_hours_start", kind: "integer" },
+      { field: "quietHoursEnd", dbName: "quiet_hours_end", kind: "integer" },
+      // Minimum severity allowed to push. Default actionable (drops passive).
+      { field: "minPushSeverity", dbName: "min_push_severity", kind: "text", notNull: true, typeBrand: "NotificationSeverity", default: { kind: "value", value: "\"actionable\"" } },
+      { field: "updatedAt", dbName: "updated_at", kind: "timestampMs", notNull: true, default: { kind: "fn", fn: "now" } },
     ],
   },
   {

--- a/src/db/schema.pg.ts
+++ b/src/db/schema.pg.ts
@@ -12,7 +12,7 @@ import type { AgentProviderType, WorktreeType } from "@/types/session";
 import type { TerminalType, AgentExitState } from "@/types/terminal-type";
 import type { AppearanceMode, ColorSchemeCategory, ColorSchemeId } from "@/types/appearance";
 import type { TaskPriority, TaskStatus, TaskSource } from "@/types/task";
-import type { NotificationType } from "@/types/notification";
+import type { NotificationType, NotificationSeverity, NotificationMeta } from "@/types/notification";
 import type { ChannelType } from "@/types/channels";
 
 export const users = pgTable(
@@ -917,14 +917,20 @@ export const notificationEvents = pgTable(
     sessionId: text("session_id").references(() => terminalSessions.id, { onDelete: "set null" }),
     sessionName: text("session_name"),
     type: text("type").$type<NotificationType>().notNull(),
+    severity: text("severity").$type<NotificationSeverity>().notNull().default("passive"),
     title: text("title").notNull(),
     body: text("body"),
+    coalesceKey: text("coalesce_key"),
+    count: integer("count").notNull().default(1),
+    meta: jsonb("meta").$type<NotificationMeta | null>(),
     readAt: timestamp("read_at", { withTimezone: true, mode: "date" }),
     createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().$defaultFn(() => new Date()),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" }).notNull().$defaultFn(() => new Date()),
   },
   (table) => [
     index("notification_event_user_created_idx").on(table.userId, table.createdAt),
     index("notification_event_user_read_idx").on(table.userId, table.readAt),
+    index("notification_event_coalesce_idx").on(table.userId, table.sessionId, table.coalesceKey, table.readAt),
   ]
 );
 
@@ -943,6 +949,19 @@ export const pushTokens = pgTable(
     index("push_token_user_idx").on(table.userId),
     uniqueIndex("push_token_fcm_token_idx").on(table.fcmToken),
   ]
+);
+
+export const notificationPreferences = pgTable(
+  "notification_preferences",
+  {
+    userId: text("user_id").primaryKey().references(() => users.id, { onDelete: "cascade" }),
+    pushByType: jsonb("push_by_type").$type<Record<string, boolean>>().notNull().default({}),
+    mutedSessionIds: jsonb("muted_session_ids").$type<string[]>().notNull().default([]),
+    quietHoursStart: integer("quiet_hours_start"),
+    quietHoursEnd: integer("quiet_hours_end"),
+    minPushSeverity: text("min_push_severity").$type<NotificationSeverity>().notNull().default("actionable"),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" }).notNull().$defaultFn(() => new Date()),
+  }
 );
 
 export const agentPeerMessages = pgTable(

--- a/src/db/schema.sqlite.ts
+++ b/src/db/schema.sqlite.ts
@@ -12,7 +12,7 @@ import type { AgentProviderType, WorktreeType } from "@/types/session";
 import type { TerminalType, AgentExitState } from "@/types/terminal-type";
 import type { AppearanceMode, ColorSchemeCategory, ColorSchemeId } from "@/types/appearance";
 import type { TaskPriority, TaskStatus, TaskSource } from "@/types/task";
-import type { NotificationType } from "@/types/notification";
+import type { NotificationType, NotificationSeverity, NotificationMeta } from "@/types/notification";
 import type { ChannelType } from "@/types/channels";
 
 export const users = sqliteTable(
@@ -918,14 +918,20 @@ export const notificationEvents = sqliteTable(
     sessionId: text("session_id").references(() => terminalSessions.id, { onDelete: "set null" }),
     sessionName: text("session_name"),
     type: text("type").$type<NotificationType>().notNull(),
+    severity: text("severity").$type<NotificationSeverity>().notNull().default("passive"),
     title: text("title").notNull(),
     body: text("body"),
+    coalesceKey: text("coalesce_key"),
+    count: integer("count").notNull().default(1),
+    meta: text("meta", { mode: "json" }).$type<NotificationMeta | null>(),
     readAt: integer("read_at", { mode: "timestamp_ms" }),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull().$defaultFn(() => new Date()),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull().$defaultFn(() => new Date()),
   },
   (table) => [
     index("notification_event_user_created_idx").on(table.userId, table.createdAt),
     index("notification_event_user_read_idx").on(table.userId, table.readAt),
+    index("notification_event_coalesce_idx").on(table.userId, table.sessionId, table.coalesceKey, table.readAt),
   ]
 );
 
@@ -944,6 +950,19 @@ export const pushTokens = sqliteTable(
     index("push_token_user_idx").on(table.userId),
     uniqueIndex("push_token_fcm_token_idx").on(table.fcmToken),
   ]
+);
+
+export const notificationPreferences = sqliteTable(
+  "notification_preferences",
+  {
+    userId: text("user_id").primaryKey().references(() => users.id, { onDelete: "cascade" }),
+    pushByType: text("push_by_type", { mode: "json" }).$type<Record<string, boolean>>().notNull().default({}),
+    mutedSessionIds: text("muted_session_ids", { mode: "json" }).$type<string[]>().notNull().default([]),
+    quietHoursStart: integer("quiet_hours_start"),
+    quietHoursEnd: integer("quiet_hours_end"),
+    minPushSeverity: text("min_push_severity").$type<NotificationSeverity>().notNull().default("actionable"),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull().$defaultFn(() => new Date()),
+  }
 );
 
 export const agentPeerMessages = sqliteTable(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -57,6 +57,7 @@ export const {
   taskDependencies,
   notificationEvents,
   pushTokens,
+  notificationPreferences,
   agentPeerMessages,
   channelGroups,
   channels,

--- a/src/lib/__tests__/notification-policy.test.ts
+++ b/src/lib/__tests__/notification-policy.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import {
+  applyNotificationPolicy,
+  inQuietHours,
+  type ResolvedNotificationPrefs,
+} from "@/lib/notification-policy";
+
+const base: ResolvedNotificationPrefs = {
+  pushByType: {},
+  mutedSessionIds: new Set(),
+  quietHours: null,
+  minPushSeverity: "actionable",
+};
+const at = (h: number) => {
+  const d = new Date();
+  d.setHours(h, 0, 0, 0);
+  return d;
+};
+
+describe("applyNotificationPolicy", () => {
+  it("suppresses push (but stores) when session is focused", () => {
+    const d = applyNotificationPolicy(
+      { userId: "u", sessionId: "s", type: "agent_waiting", title: "x" },
+      base,
+      { now: at(12), focused: true },
+    );
+    expect(d).toEqual({ store: true, push: false, reason: "session_focused" });
+  });
+
+  it("mutes both channels for a muted session", () => {
+    const prefs = { ...base, mutedSessionIds: new Set(["s"]) };
+    const d = applyNotificationPolicy(
+      { userId: "u", sessionId: "s", type: "agent_waiting", title: "x" },
+      prefs,
+      { now: at(12), focused: false },
+    );
+    expect(d.store).toBe(false);
+    expect(d.push).toBe(false);
+  });
+
+  it("drops passive below min severity (stores, no push)", () => {
+    const d = applyNotificationPolicy(
+      { userId: "u", type: "agent_exited", title: "x" },
+      base,
+      { now: at(12), focused: false },
+    );
+    expect(d.store).toBe(true);
+    expect(d.push).toBe(false);
+    expect(d.reason).toBe("below_min_severity");
+  });
+
+  it("honors per-type opt-out", () => {
+    const prefs = { ...base, pushByType: { agent_waiting: false } };
+    const d = applyNotificationPolicy(
+      { userId: "u", type: "agent_waiting", title: "x" },
+      prefs,
+      { now: at(12), focused: false },
+    );
+    expect(d.push).toBe(false);
+    expect(d.reason).toBe("type_opt_out");
+  });
+
+  it("pushes an actionable agent_waiting under defaults", () => {
+    const d = applyNotificationPolicy(
+      { userId: "u", sessionId: "s", type: "agent_waiting", title: "x" },
+      base,
+      { now: at(12), focused: false },
+    );
+    expect(d).toEqual({ store: true, push: true });
+  });
+
+  it("errors override quiet hours", () => {
+    const prefs = {
+      ...base,
+      quietHours: { startHour: 0, endHour: 23 },
+      minPushSeverity: "passive" as const,
+    };
+    const d = applyNotificationPolicy(
+      { userId: "u", type: "agent_error", title: "x" },
+      prefs,
+      { now: at(12), focused: false },
+    );
+    expect(d.push).toBe(true);
+  });
+
+  it("suppresses a non-error push during quiet hours", () => {
+    const prefs = { ...base, quietHours: { startHour: 0, endHour: 23 } };
+    const d = applyNotificationPolicy(
+      { userId: "u", type: "agent_waiting", title: "x" },
+      prefs,
+      { now: at(12), focused: false },
+    );
+    expect(d.push).toBe(false);
+    expect(d.reason).toBe("quiet_hours");
+  });
+
+  it("inQuietHours wraps midnight", () => {
+    expect(inQuietHours(at(23), { startHour: 22, endHour: 7 })).toBe(true);
+    expect(inQuietHours(at(3), { startHour: 22, endHour: 7 })).toBe(true);
+    expect(inQuietHours(at(12), { startHour: 22, endHour: 7 })).toBe(false);
+    expect(inQuietHours(at(12), null)).toBe(false);
+  });
+});
+
+describe("ResolvedNotificationPrefs shape (y5ch.6)", () => {
+  it("resolved prefs shape feeds the policy directly", () => {
+    const prefs: ResolvedNotificationPrefs = {
+      pushByType: { agent_exited: false },
+      mutedSessionIds: new Set(["s1"]),
+      quietHours: { startHour: 22, endHour: 7 },
+      minPushSeverity: "actionable",
+    };
+    expect(prefs.mutedSessionIds.has("s1")).toBe(true);
+    expect(prefs.pushByType.agent_exited).toBe(false);
+  });
+});

--- a/src/lib/notification-policy.ts
+++ b/src/lib/notification-policy.ts
@@ -1,0 +1,84 @@
+/**
+ * [y5ch.7] Pluggable notification policy hook.
+ *
+ * `applyNotificationPolicy` is the single "event JSON → channel-flag decision"
+ * gate. It is PURE (no I/O, no DB) so it is fully unit-testable: it takes the
+ * create-notification input, the user's resolved prefs, and a focus/now context,
+ * and returns `{ store, push, reason? }`. The notification service consults it
+ * before persisting + pushing.
+ */
+import type { CreateNotificationInput, NotificationSeverity } from "@/types/notification";
+import { notificationSeverity } from "@/types/notification";
+
+/** Resolved, already-merged prefs for one user (output of the prefs service). */
+export interface ResolvedNotificationPrefs {
+  /** Per-type push opt-out: `type → false` means "never push this type". */
+  pushByType: Partial<Record<string, boolean>>;
+  /** Per-session mute: sessionId present ⇒ suppress entirely (store + push). */
+  mutedSessionIds: ReadonlySet<string>;
+  /** Quiet hours in the user's local tz; null = disabled. */
+  quietHours: { startHour: number; endHour: number } | null;
+  /** Minimum severity that may push at all. */
+  minPushSeverity: NotificationSeverity;
+}
+
+export interface NotificationDecision {
+  /** Persist + broadcast an in-app notification row. */
+  store: boolean;
+  /** Dispatch an FCM push. */
+  push: boolean;
+  /** Human-readable reason when a channel is off (for logging only). */
+  reason?: string;
+}
+
+const SEVERITY_RANK: Record<NotificationSeverity, number> = {
+  passive: 0,
+  actionable: 1,
+  error: 2,
+};
+
+/** True when `now` falls inside the quiet-hours window (wraps midnight). */
+export function inQuietHours(
+  now: Date,
+  qh: { startHour: number; endHour: number } | null,
+): boolean {
+  if (!qh) return false;
+  const h = now.getHours();
+  return qh.startHour <= qh.endHour
+    ? h >= qh.startHour && h < qh.endHour
+    : h >= qh.startHour || h < qh.endHour; // wraps midnight (e.g. 22→7)
+}
+
+/**
+ * The policy hook. Default policy:
+ *   - per-session mute ⇒ neither store nor push.
+ *   - always store in-app (the panel is the durable record) unless session-muted.
+ *   - push only when: not focused (y5ch.4) AND type not opted out AND
+ *     severity ≥ minPushSeverity AND not in quiet hours.
+ *   - errors always push (override quiet hours) but still respect session mute,
+ *     focus, per-type opt-out, and the min-severity floor.
+ */
+export function applyNotificationPolicy(
+  input: CreateNotificationInput,
+  prefs: ResolvedNotificationPrefs,
+  ctx: { now: Date; focused: boolean },
+): NotificationDecision {
+  const severity = input.severity ?? notificationSeverity(input.type);
+
+  if (input.sessionId && prefs.mutedSessionIds.has(input.sessionId)) {
+    return { store: false, push: false, reason: "session_muted" };
+  }
+  if (ctx.focused) {
+    return { store: true, push: false, reason: "session_focused" };
+  }
+  if (prefs.pushByType[input.type] === false) {
+    return { store: true, push: false, reason: "type_opt_out" };
+  }
+  if (SEVERITY_RANK[severity] < SEVERITY_RANK[prefs.minPushSeverity]) {
+    return { store: true, push: false, reason: "below_min_severity" };
+  }
+  if (severity !== "error" && inQuietHours(ctx.now, prefs.quietHours)) {
+    return { store: true, push: false, reason: "quiet_hours" };
+  }
+  return { store: true, push: true };
+}

--- a/src/lib/notification-toast.ts
+++ b/src/lib/notification-toast.ts
@@ -5,6 +5,7 @@ type ToastVariant = "default" | "error" | "success" | "warning";
 
 const TYPE_TO_VARIANT: Record<NotificationType, ToastVariant> = {
   agent_error: "error",
+  agent_stuck: "error", // [y5ch.9] liveness sweep: agent process gone
   build_fail: "error",
   agent_complete: "success",
   agent_exited: "default",

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -165,6 +165,20 @@ function getConnectionsForSession(sessionId: string): TerminalConnection[] {
   return result;
 }
 
+/**
+ * [y5ch.4] True when `userId` has a currently-visible (focused) WebSocket
+ * connection attached to `sessionId`. Drives push suppression: if the user is
+ * already looking at the session, an FCM push for it is noise (the in-app row
+ * is still stored). `isVisible` is maintained by the client_focus/client_blur
+ * messages below.
+ */
+function isSessionFocusedByUser(userId: string, sessionId: string): boolean {
+  for (const conn of getConnectionsForSession(sessionId)) {
+    if (conn.userId === userId && conn.isVisible) return true;
+  }
+  return false;
+}
+
 /** Get any single active connection for a session (for internal API lookups) */
 function getAnyConnectionForSession(sessionId: string): TerminalConnection | undefined {
   const connIds = sessionConnections.get(sessionId);
@@ -667,7 +681,11 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
       )
       .catch((err) => agentStatusLog.error("Failed to persist activity status", { error: String(err) }));
 
-    // Create in-app notification for waiting/error statuses (fire-and-forget, with 5s debounce via service)
+    // [y5ch.3] Create an in-app notification only for waiting/error statuses
+    // (idle/ended/running/compacting/subagent never reach this branch — a clean
+    // stop is passive and produces no notification). Severity is explicit:
+    // waiting → actionable, error → error. Focus-awareness (y5ch.4) and
+    // coalescing/push-gating (y5ch.5/.10) are handled by createNotification.
     if (status === "waiting" || status === "error") {
       Promise.all([import("@/db"), import("@/db/schema"), import("drizzle-orm"), import("@/services/notification-service")])
         .then(async ([{ db }, { terminalSessions }, { eq }, NotificationService]) => {
@@ -677,26 +695,27 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
             columns: { name: true, userId: true },
           });
           if (!session) return;
-          const title = status === "waiting"
-            ? "Agent waiting for input"
-            : "Agent encountered an error";
-          const body = `Session "${session.name}" needs attention`;
+          const isWaiting = status === "waiting";
           const notification = await NotificationService.createNotification({
             userId: session.userId,
             sessionId,
             sessionName: session.name,
-            type: status === "waiting" ? "agent_waiting" : "agent_error",
-            title,
-            body,
+            type: isWaiting ? "agent_waiting" : "agent_error",
+            severity: isWaiting ? "actionable" : "error",
+            title: isWaiting ? "Agent waiting for input" : "Agent encountered an error",
+            body: `Session "${session.name}" needs attention`,
+            meta: { deepLinkSessionId: sessionId, cta: { label: "Open session", action: "open_session" } },
+            focused: isSessionFocusedByUser(session.userId, sessionId),
           });
-          if (!notification) return; // debounced
+          if (!notification) return; // coalesced or suppressed
           // Broadcast notification to clients for real-time update
           broadcastToClients({
             type: "notification",
             notification: {
               ...notification,
               createdAt: notification.createdAt instanceof Date ? notification.createdAt.toISOString() : notification.createdAt,
-              readAt: null,
+              updatedAt: notification.updatedAt instanceof Date ? notification.updatedAt.toISOString() : notification.updatedAt,
+              readAt: notification.readAt instanceof Date ? notification.readAt.toISOString() : notification.readAt,
             },
           });
         })
@@ -758,7 +777,8 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
   if (pathname === "/internal/notify" && req.method === "POST") {
     const payload = await parseRequestJson(req, res);
     if (!payload) return true; // invalid JSON already responded
-    const { sessionId, type, title, body: notifBody } = payload;
+    // [y5ch.3/.8] accept optional severity + meta from the CLI payload.
+    const { sessionId, type, title, body: notifBody, severity, meta } = payload;
     if (!sessionId || !type || !title) {
       sendJson(res, 400, { error: "Missing sessionId, type, or title" });
       return true;
@@ -778,14 +798,18 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
           type: type as import("@/types/notification").NotificationType,
           title: title as string,
           body: (notifBody as string) ?? undefined,
+          severity: (severity as import("@/types/notification").NotificationSeverity) ?? undefined,
+          meta: (meta as import("@/types/notification").NotificationMeta) ?? undefined,
+          focused: isSessionFocusedByUser(session.userId, sessionId as string),
         });
-        if (!notification) return; // debounced
+        if (!notification) return; // coalesced or suppressed
         broadcastToClients({
           type: "notification",
           notification: {
             ...notification,
             createdAt: notification.createdAt instanceof Date ? notification.createdAt.toISOString() : notification.createdAt,
-            readAt: null,
+            updatedAt: notification.updatedAt instanceof Date ? notification.updatedAt.toISOString() : notification.updatedAt,
+            readAt: notification.readAt instanceof Date ? notification.readAt.toISOString() : notification.readAt,
           },
         });
       })
@@ -1886,6 +1910,16 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       .then((PeerService) => PeerService.cleanupOldMessages())
       .catch((err) => peerLog.error("Periodic peer cleanup failed", { error: String(err) }));
   }, 60 * 60 * 1000);
+
+  // [y5ch.9] PID-liveness reconciliation sweep (30s). Clears stale
+  // running/waiting sessions whose agent process died and emits exactly one
+  // agent_stuck notification each. Lives here because the terminal server owns
+  // tmux; in multi-instance/supervisor mode each instance sweeps its own.
+  setInterval(() => {
+    import("@/services/session-liveness-service")
+      .then((svc) => svc.reconcileLiveness())
+      .catch((err) => log.error("Liveness sweep failed", { error: String(err) }));
+  }, 30_000);
 
   wss.on("connection", async (ws, req) => {
     const query = Object.fromEntries(new URL(req.url || "", "http://localhost").searchParams);

--- a/src/services/__tests__/notification-classification.test.ts
+++ b/src/services/__tests__/notification-classification.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import {
+  notificationSeverity,
+  notificationGroup,
+  type NotificationType,
+} from "@/types/notification";
+
+describe("notificationSeverity", () => {
+  it("classifies agent_waiting as actionable", () =>
+    expect(notificationSeverity("agent_waiting")).toBe("actionable"));
+  it("classifies agent_error and agent_stuck as error", () => {
+    expect(notificationSeverity("agent_error")).toBe("error");
+    expect(notificationSeverity("agent_stuck")).toBe("error");
+  });
+  it("classifies clean stop (agent_exited/agent_complete) as passive", () => {
+    expect(notificationSeverity("agent_exited")).toBe("passive");
+    expect(notificationSeverity("agent_complete")).toBe("passive");
+  });
+  it("waiting maps to actionable, stop maps to passive (no actionable stop)", () => {
+    expect(notificationSeverity("agent_waiting")).toBe("actionable");
+    expect(notificationSeverity("agent_exited")).toBe("passive");
+  });
+});
+
+describe("notificationGroup", () => {
+  it("collapses lifecycle pings into one group", () => {
+    expect(notificationGroup("agent_waiting")).toBe("agent_lifecycle");
+    expect(notificationGroup("agent_exited")).toBe("agent_lifecycle");
+  });
+  it("keeps info/update types in their own group", () =>
+    expect(notificationGroup("info")).toBe("info"));
+});
+
+describe("severity model exhaustiveness (y5ch.11)", () => {
+  it("every NotificationType resolves to a valid severity (exhaustive)", () => {
+    const all: NotificationType[] = [
+      "agent_waiting",
+      "agent_error",
+      "agent_complete",
+      "agent_exited",
+      "build_fail",
+      "session_closed",
+      "update_pending",
+      "update_applied",
+      "agent_stuck",
+      "info",
+    ];
+    for (const t of all) {
+      expect(["actionable", "passive", "error"]).toContain(
+        notificationSeverity(t),
+      );
+    }
+  });
+
+  it("every NotificationType resolves to a non-empty coalescing group", () => {
+    const all: NotificationType[] = [
+      "agent_waiting",
+      "agent_error",
+      "agent_complete",
+      "agent_exited",
+      "build_fail",
+      "session_closed",
+      "update_pending",
+      "update_applied",
+      "agent_stuck",
+      "info",
+    ];
+    for (const t of all) {
+      expect(notificationGroup(t).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("payload plumbing (y5ch.8)", () => {
+  it("CreateNotificationInput carries meta through to the event shape", () => {
+    const input: import("@/types/notification").CreateNotificationInput = {
+      userId: "u",
+      type: "agent_waiting",
+      title: "x",
+      meta: {
+        deepLinkSessionId: "s",
+        cta: { label: "Open", action: "open_session" },
+      },
+    };
+    expect(input.meta?.cta?.action).toBe("open_session");
+  });
+});

--- a/src/services/__tests__/notification-service.test.ts
+++ b/src/services/__tests__/notification-service.test.ts
@@ -1,0 +1,249 @@
+// @vitest-environment node
+/**
+ * [y5ch.5/.10] Integration tests for the notification service against a REAL
+ * in-memory libsql DB (so coalescing SQL + the policy push-gate run end-to-end).
+ *
+ * Strategy:
+ *   - Build a libsql `:memory:` client + drizzle over the real generated SQLite
+ *     schema, create the notification_event table, and expose it as `@/db`.
+ *   - Mock the prefs resolver so we can drive minPushSeverity / per-type opt-out
+ *     without a prefs row.
+ *   - Inject a fake push gateway + token repo and assert push fires ONLY when the
+ *     policy allows it (actionable/error, not opted-out, not below min severity).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createClient } from "@libsql/client/node";
+import { drizzle } from "drizzle-orm/libsql";
+import * as sqliteSchema from "@/db/schema.sqlite";
+
+// One shared in-memory DB for the whole file; truncated between tests.
+const rawClient = createClient({ url: ":memory:" });
+const memDb = drizzle(rawClient, { schema: sqliteSchema });
+
+vi.mock("@/db", () => ({ db: memDb }));
+
+// Default prefs: actionable+ push, no opt-outs, no quiet hours, no mutes.
+interface FakePrefs {
+  pushByType: Record<string, boolean>;
+  mutedSessionIds: Set<string>;
+  quietHours: { startHour: number; endHour: number } | null;
+  minPushSeverity: "actionable" | "passive" | "error";
+}
+const resolvePrefs = vi.fn<(userId: string) => Promise<FakePrefs>>(async () => ({
+  pushByType: {},
+  mutedSessionIds: new Set<string>(),
+  quietHours: null,
+  minPushSeverity: "actionable",
+}));
+vi.mock("@/services/notification-preferences-service", () => ({
+  resolvePrefs: (userId: string) => resolvePrefs(userId),
+}));
+
+async function createSchema() {
+  await rawClient.execute(`CREATE TABLE IF NOT EXISTS notification_event (
+    id text PRIMARY KEY NOT NULL,
+    user_id text NOT NULL,
+    session_id text,
+    session_name text,
+    type text NOT NULL,
+    severity text DEFAULT 'passive' NOT NULL,
+    title text NOT NULL,
+    body text,
+    coalesce_key text,
+    count integer DEFAULT 1 NOT NULL,
+    meta text,
+    read_at integer,
+    created_at integer NOT NULL,
+    updated_at integer NOT NULL
+  )`);
+}
+
+// Fake push DI captured per-test.
+const sendToTokens = vi.fn(async () => ({ staleTokens: [] as string[] }));
+const fakeGateway = { sendToTokens };
+const fakeTokenRepo = {
+  findByUser: vi.fn(async () => [{ fcmToken: "tok-1" }]),
+  deleteByTokens: vi.fn(async () => {}),
+};
+
+async function loadService() {
+  vi.resetModules();
+  const svc = await import("../notification-service");
+  // Re-inject DI on the fresh module instance.
+  svc.setPushGateway(fakeGateway as never);
+  svc.setPushTokenRepository(fakeTokenRepo as never);
+  return svc;
+}
+
+beforeEach(async () => {
+  await createSchema();
+  await rawClient.execute("DELETE FROM notification_event");
+  sendToTokens.mockClear();
+  fakeTokenRepo.findByUser.mockClear();
+  resolvePrefs.mockClear();
+  resolvePrefs.mockImplementation(async () => ({
+    pushByType: {},
+    mutedSessionIds: new Set<string>(),
+    quietHours: null,
+    minPushSeverity: "actionable",
+  }));
+});
+
+describe("createNotification — push gate (y5ch.10)", () => {
+  it("does NOT push a passive agent_exited (below min severity)", async () => {
+    const svc = await loadService();
+    const n = await svc.createNotification({
+      userId: "u1",
+      sessionId: "s1",
+      type: "agent_exited",
+      title: "stopped",
+    });
+    expect(n).not.toBeNull();
+    expect(n?.severity).toBe("passive");
+    // Allow the fire-and-forget dispatch microtask to settle.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sendToTokens).not.toHaveBeenCalled();
+  });
+
+  it("pushes an actionable agent_waiting", async () => {
+    const svc = await loadService();
+    await svc.createNotification({
+      userId: "u1",
+      sessionId: "s1",
+      type: "agent_waiting",
+      title: "needs you",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sendToTokens).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT push when the type is opted out", async () => {
+    resolvePrefs.mockImplementation(async () => ({
+      pushByType: { agent_waiting: false },
+      mutedSessionIds: new Set<string>(),
+      quietHours: null,
+      minPushSeverity: "actionable",
+    }));
+    const svc = await loadService();
+    await svc.createNotification({
+      userId: "u1",
+      sessionId: "s1",
+      type: "agent_waiting",
+      title: "needs you",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sendToTokens).not.toHaveBeenCalled();
+  });
+
+  it("does NOT store or push for a muted session (returns null)", async () => {
+    resolvePrefs.mockImplementation(async () => ({
+      pushByType: {},
+      mutedSessionIds: new Set<string>(["s1"]),
+      quietHours: null,
+      minPushSeverity: "actionable",
+    }));
+    const svc = await loadService();
+    const n = await svc.createNotification({
+      userId: "u1",
+      sessionId: "s1",
+      type: "agent_waiting",
+      title: "needs you",
+    });
+    expect(n).toBeNull();
+    const rows = await svc.listNotifications("u1");
+    expect(rows.length).toBe(0);
+  });
+});
+
+describe("createNotification — coalescing (y5ch.5)", () => {
+  it("collapses two waiting events for one session into a count=2 row", async () => {
+    const svc = await loadService();
+    await svc.createNotification({ userId: "u1", sessionId: "s1", type: "agent_waiting", title: "first" });
+    const second = await svc.createNotification({ userId: "u1", sessionId: "s1", type: "agent_waiting", title: "second" });
+    expect(second?.count).toBe(2);
+    expect(second?.title).toBe("second"); // refreshed in place
+    const rows = await svc.listNotifications("u1");
+    expect(rows.length).toBe(1);
+    expect(rows[0].count).toBe(2);
+  });
+
+  it("collapses agent_waiting + agent_exited into the same lifecycle group", async () => {
+    const svc = await loadService();
+    await svc.createNotification({ userId: "u1", sessionId: "s1", type: "agent_waiting", title: "waiting" });
+    // agent_exited shares the agent_lifecycle group, so it merges (not a new row).
+    const merged = await svc.createNotification({ userId: "u1", sessionId: "s1", type: "agent_exited", title: "exited" });
+    expect(merged?.count).toBe(2);
+    const rows = await svc.listNotifications("u1");
+    expect(rows.length).toBe(1);
+  });
+
+  it("does NOT collapse different groups (waiting vs build_fail)", async () => {
+    const svc = await loadService();
+    await svc.createNotification({ userId: "u1", sessionId: "s1", type: "agent_waiting", title: "waiting" });
+    await svc.createNotification({ userId: "u1", sessionId: "s1", type: "build_fail", title: "build broke" });
+    const rows = await svc.listNotifications("u1");
+    expect(rows.length).toBe(2);
+  });
+
+  it("starts a fresh row after the prior one is read (clear boundary)", async () => {
+    const svc = await loadService();
+    const first = await svc.createNotification({ userId: "u1", sessionId: "s1", type: "agent_waiting", title: "first" });
+    await svc.markRead("u1", [first!.id]);
+    const second = await svc.createNotification({ userId: "u1", sessionId: "s1", type: "agent_waiting", title: "second" });
+    expect(second?.count).toBe(1);
+    const rows = await svc.listNotifications("u1");
+    expect(rows.length).toBe(2);
+  });
+
+  it("does not coalesce across users", async () => {
+    const svc = await loadService();
+    await svc.createNotification({ userId: "u1", sessionId: "s1", type: "agent_waiting", title: "u1" });
+    await svc.createNotification({ userId: "u2", sessionId: "s1", type: "agent_waiting", title: "u2" });
+    expect((await svc.listNotifications("u1")).length).toBe(1);
+    expect((await svc.listNotifications("u2")).length).toBe(1);
+  });
+
+  it("does not coalesce a session-less (null sessionId) notification", async () => {
+    const svc = await loadService();
+    await svc.createNotification({ userId: "u1", type: "info", title: "a" });
+    await svc.createNotification({ userId: "u1", type: "info", title: "b" });
+    const rows = await svc.listNotifications("u1");
+    expect(rows.length).toBe(2);
+  });
+
+  it("[fix #3] increments count atomically from the DB value (not a stale JS read)", async () => {
+    const svc = await loadService();
+    // Seed an OPEN lifecycle row already at count=5 directly in the DB.
+    const now = Date.now();
+    await rawClient.execute({
+      sql: `INSERT INTO notification_event
+        (id, user_id, session_id, type, severity, title, coalesce_key, count, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: ["seed-1", "u1", "s1", "agent_waiting", "actionable", "seeded", "agent_lifecycle", 5, now, now],
+    });
+    // A coalescing event must read the DB's current 5 and store 6 — an RMW that
+    // trusted a stale in-memory count would regress this to 2.
+    const merged = await svc.createNotification({ userId: "u1", sessionId: "s1", type: "agent_waiting", title: "next" });
+    expect(merged?.count).toBe(6);
+    const rows = await svc.listNotifications("u1");
+    expect(rows.length).toBe(1);
+    expect(rows[0].count).toBe(6);
+  });
+
+  it("[fix #3] concurrent coalescing events do not lose increments", async () => {
+    const svc = await loadService();
+    // Establish the open row, then fire several events "concurrently". With an
+    // atomic `count + 1` UPDATE every event is counted; a read-modify-write
+    // would let interleaved reads clobber each other and undercount.
+    await svc.createNotification({ userId: "u1", sessionId: "s1", type: "agent_waiting", title: "seed" });
+    await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        svc.createNotification({ userId: "u1", sessionId: "s1", type: "agent_waiting", title: `c${i}` }),
+      ),
+    );
+    const rows = await svc.listNotifications("u1");
+    expect(rows.length).toBe(1);
+    // 1 seed + 5 coalesced = 6.
+    expect(rows[0].count).toBe(6);
+  });
+});

--- a/src/services/__tests__/session-liveness-service.test.ts
+++ b/src/services/__tests__/session-liveness-service.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment node
+/**
+ * [y5ch.9] Tests for the PID-liveness reconciliation sweep.
+ *
+ * We mock `node:child_process` execFile (the tmux pane-PID probe), `@/db` (the
+ * candidate query + the status-clear update), and `@/services/notification-service`
+ * (so we can assert exactly one agent_stuck is emitted per cleared session).
+ *
+ * The "alive" case uses the test process's own PID (process.pid) so the real
+ * `process.kill(pid, 0)` probe sees a live process — mirrors the deploy/status
+ * route test's pattern.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// --- mock state, mutated per test -----------------------------------------
+interface FakeSession {
+  id: string;
+  name: string;
+  userId: string;
+  tmuxSessionName: string;
+  agentActivityStatus: string;
+}
+const state: {
+  candidates: FakeSession[];
+  tmuxPid: Record<string, string | null>; // tmuxSessionName → pid string, or null = no session
+  updates: Array<{ id: string; set: Record<string, unknown> }>;
+} = { candidates: [], tmuxPid: {}, updates: [] };
+
+const createNotification =
+  vi.fn<(input: Record<string, unknown>) => Promise<{ id: string }>>(async () => ({ id: "n1" }));
+
+// tmux pane-pid probe: execFileAsync("tmux", ["list-panes", "-t", name, "-F", "#{pane_pid}"])
+vi.mock("node:child_process", () => ({
+  execFile: (
+    _cmd: string,
+    args: string[],
+    cb: (err: Error | null, out: { stdout: string; stderr: string }) => void,
+  ) => {
+    const tIdx = args.indexOf("-t");
+    const name = tIdx >= 0 ? args[tIdx + 1] : "";
+    const pid = state.tmuxPid[name];
+    if (pid == null) {
+      cb(new Error("no such session"), { stdout: "", stderr: "no session" });
+    } else {
+      cb(null, { stdout: `${pid}\n`, stderr: "" });
+    }
+  },
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    query: {
+      terminalSessions: {
+        findMany: vi.fn(async () => state.candidates),
+      },
+    },
+    update: vi.fn(() => ({
+      set: (set: Record<string, unknown>) => ({
+        where: async () => {
+          // capture the id from the most recent candidate loop via closure isn't
+          // possible here; the service calls update().set().where(eq(id, s.id)).
+          // We record set payloads; ids are asserted via createNotification args.
+          state.updates.push({ id: "<captured-by-where>", set });
+          return undefined;
+        },
+      }),
+    })),
+  },
+}));
+
+// Drizzle helpers are imported by the service; stub them to no-ops/passthroughs.
+vi.mock("drizzle-orm", () => ({
+  and: (...args: unknown[]) => ({ and: args }),
+  eq: (a: unknown, b: unknown) => ({ eq: [a, b] }),
+  inArray: (a: unknown, b: unknown) => ({ inArray: [a, b] }),
+  ne: (a: unknown, b: unknown) => ({ ne: [a, b] }),
+}));
+
+vi.mock("@/db/schema", () => ({
+  terminalSessions: {
+    id: "id",
+    name: "name",
+    userId: "userId",
+    tmuxSessionName: "tmuxSessionName",
+    agentActivityStatus: "agentActivityStatus",
+    agentExitState: "agentExitState",
+    status: "status",
+  },
+}));
+
+vi.mock("@/services/notification-service", () => ({
+  createNotification: (input: Record<string, unknown>) => createNotification(input),
+}));
+
+beforeEach(() => {
+  state.candidates = [];
+  state.tmuxPid = {};
+  state.updates = [];
+  createNotification.mockClear();
+  vi.resetModules();
+});
+
+async function loadService() {
+  return import("../session-liveness-service");
+}
+
+describe("reconcileLiveness", () => {
+  it("clears a session whose pane PID is dead and emits one agent_stuck", async () => {
+    state.candidates = [
+      { id: "s1", name: "main", userId: "u1", tmuxSessionName: "rdv-s1", agentActivityStatus: "running" },
+    ];
+    // A PID that is essentially guaranteed not to exist.
+    state.tmuxPid = { "rdv-s1": "2147483646" };
+
+    const { reconcileLiveness } = await loadService();
+    const n = await reconcileLiveness();
+
+    expect(n).toBe(1);
+    expect(createNotification).toHaveBeenCalledTimes(1);
+    const arg = createNotification.mock.calls[0][0] as {
+      type: string;
+      severity: string;
+      sessionId: string;
+    };
+    expect(arg.type).toBe("agent_stuck");
+    expect(arg.severity).toBe("error");
+    expect(arg.sessionId).toBe("s1");
+    // status was cleared
+    expect(state.updates.length).toBe(1);
+    expect(state.updates[0].set).toMatchObject({ agentActivityStatus: "idle", agentExitState: "exited" });
+  });
+
+  it("leaves a session alone when its pane PID is alive", async () => {
+    state.candidates = [
+      { id: "s2", name: "live", userId: "u1", tmuxSessionName: "rdv-s2", agentActivityStatus: "waiting" },
+    ];
+    state.tmuxPid = { "rdv-s2": String(process.pid) }; // the test process is alive
+
+    const { reconcileLiveness } = await loadService();
+    const n = await reconcileLiveness();
+
+    expect(n).toBe(0);
+    expect(createNotification).not.toHaveBeenCalled();
+    expect(state.updates.length).toBe(0);
+  });
+
+  it("treats a missing tmux session as dead (clears it)", async () => {
+    state.candidates = [
+      { id: "s3", name: "gone", userId: "u1", tmuxSessionName: "rdv-s3", agentActivityStatus: "running" },
+    ];
+    state.tmuxPid = {}; // no session → probe errors → treated as dead
+
+    const { reconcileLiveness } = await loadService();
+    const n = await reconcileLiveness();
+
+    expect(n).toBe(1);
+    expect(createNotification).toHaveBeenCalledTimes(1);
+    const arg = createNotification.mock.calls[0][0] as { type: string };
+    expect(arg.type).toBe("agent_stuck");
+  });
+
+  it("returns 0 and notifies nothing when there are no alive-state candidates", async () => {
+    state.candidates = [];
+    const { reconcileLiveness } = await loadService();
+    const n = await reconcileLiveness();
+    expect(n).toBe(0);
+    expect(createNotification).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/tmux-service.test.ts
+++ b/src/services/__tests__/tmux-service.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+/**
+ * [y5ch fix #2] Guard the send-keys literal-mode argv: a payload that starts
+ * with `-` must be typed literally, which requires the `--` end-of-options
+ * delimiter before the payload. Without it tmux parses e.g. "-X" as a flag.
+ *
+ * We mock @/lib/exec so sessionExists() (execFileNoThrow has-session) succeeds
+ * and capture every execFile argv to assert the delimiter placement.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const execFileCalls: string[][] = [];
+
+vi.mock("@/lib/exec", () => ({
+  execFile: vi.fn(async (_cmd: string, args: string[]) => {
+    execFileCalls.push(args);
+    return { stdout: "", stderr: "" };
+  }),
+  execFileNoThrow: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 })),
+  execFileCheck: vi.fn(async () => true),
+}));
+
+beforeEach(() => {
+  execFileCalls.length = 0;
+});
+
+async function loadService() {
+  return import("../tmux-service");
+}
+
+/** The argv of the literal send-keys call (the one carrying `-l`). */
+function literalSendKeysArgs(): string[] | undefined {
+  return execFileCalls.find((a) => a[0] === "send-keys" && a.includes("-l"));
+}
+
+describe("sendKeys literal mode (`--` delimiter)", () => {
+  it("passes a `-`-prefixed payload after `--` so it is typed literally", async () => {
+    const { sendKeys } = await loadService();
+    await sendKeys("rdv-test", "-X cancel", false);
+
+    const args = literalSendKeysArgs();
+    expect(args).toBeDefined();
+    // …, "-l", "--", "<payload>"
+    expect(args).toEqual(["send-keys", "-t", "rdv-test", "-l", "--", "-X cancel"]);
+    // The delimiter must immediately precede the payload (last element).
+    const dashIdx = args!.indexOf("--");
+    expect(dashIdx).toBe(args!.length - 2);
+    expect(args![args!.length - 1]).toBe("-X cancel");
+  });
+
+  it("types a markdown '- item' payload literally (not as a flag)", async () => {
+    const { sendKeys } = await loadService();
+    await sendKeys("rdv-test", "- item one", false);
+
+    const args = literalSendKeysArgs();
+    expect(args).toEqual(["send-keys", "-t", "rdv-test", "-l", "--", "- item one"]);
+  });
+
+  it("still sends Enter as a key name (no payload, no delimiter) when pressEnter", async () => {
+    const { sendKeys } = await loadService();
+    await sendKeys("rdv-test", "ls", true);
+
+    const enter = execFileCalls.find((a) => a.includes("Enter"));
+    expect(enter).toEqual(["send-keys", "-t", "rdv-test", "Enter"]);
+  });
+});

--- a/src/services/notification-preferences-service.ts
+++ b/src/services/notification-preferences-service.ts
@@ -1,0 +1,97 @@
+/**
+ * [y5ch.6] User notification preferences service.
+ *
+ * Reads/writes the `notificationPreferences` row for a user and resolves it into
+ * the `ResolvedNotificationPrefs` shape consumed by the policy hook
+ * (`@/lib/notification-policy`). A missing row yields sane defaults:
+ * actionable-and-up pushes, no per-type opt-outs, no muted sessions, no quiet hours.
+ */
+import { db } from "@/db";
+import { notificationPreferences } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import type { ResolvedNotificationPrefs } from "@/lib/notification-policy";
+import type { NotificationSeverity } from "@/types/notification";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("NotificationPreferences");
+
+const DEFAULTS: ResolvedNotificationPrefs = {
+  pushByType: {},
+  mutedSessionIds: new Set(),
+  quietHours: null,
+  minPushSeverity: "actionable",
+};
+
+/** Resolve the effective prefs for a user (the shape the policy hook consumes). */
+export async function resolvePrefs(userId: string): Promise<ResolvedNotificationPrefs> {
+  const row = await db.query.notificationPreferences.findFirst({
+    where: eq(notificationPreferences.userId, userId),
+  });
+  if (!row) return DEFAULTS;
+  return {
+    pushByType: row.pushByType ?? {},
+    mutedSessionIds: new Set(row.mutedSessionIds ?? []),
+    quietHours:
+      row.quietHoursStart != null && row.quietHoursEnd != null
+        ? { startHour: row.quietHoursStart, endHour: row.quietHoursEnd }
+        : null,
+    minPushSeverity: row.minPushSeverity ?? "actionable",
+  };
+}
+
+export interface UpdatePrefsInput {
+  pushByType?: Record<string, boolean>;
+  mutedSessionIds?: string[];
+  quietHoursStart?: number | null;
+  quietHoursEnd?: number | null;
+  minPushSeverity?: NotificationSeverity;
+}
+
+/** Raw row for the prefs API (so the client can render the current settings). */
+export async function getRawPrefs(userId: string) {
+  return (
+    (await db.query.notificationPreferences.findFirst({
+      where: eq(notificationPreferences.userId, userId),
+    })) ?? null
+  );
+}
+
+export async function upsertPrefs(userId: string, input: UpdatePrefsInput): Promise<void> {
+  await db
+    .insert(notificationPreferences)
+    .values({
+      userId,
+      pushByType: input.pushByType ?? {},
+      mutedSessionIds: input.mutedSessionIds ?? [],
+      quietHoursStart: input.quietHoursStart ?? null,
+      quietHoursEnd: input.quietHoursEnd ?? null,
+      minPushSeverity: input.minPushSeverity ?? "actionable",
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: notificationPreferences.userId,
+      set: {
+        ...(input.pushByType !== undefined && { pushByType: input.pushByType }),
+        ...(input.mutedSessionIds !== undefined && { mutedSessionIds: input.mutedSessionIds }),
+        ...(input.quietHoursStart !== undefined && { quietHoursStart: input.quietHoursStart }),
+        ...(input.quietHoursEnd !== undefined && { quietHoursEnd: input.quietHoursEnd }),
+        ...(input.minPushSeverity !== undefined && { minPushSeverity: input.minPushSeverity }),
+        updatedAt: new Date(),
+      },
+    });
+  log.info("Notification prefs updated", { userId });
+}
+
+/**
+ * Convenience used by the row long-press ActionSheet: toggle one session's mute
+ * state, returning the new state (true = now muted).
+ */
+export async function toggleSessionMute(userId: string, sessionId: string): Promise<boolean> {
+  const raw = await getRawPrefs(userId);
+  const current = new Set(raw?.mutedSessionIds ?? []);
+  const nowMuted = !current.has(sessionId);
+  if (nowMuted) current.add(sessionId);
+  else current.delete(sessionId);
+  await upsertPrefs(userId, { mutedSessionIds: [...current] });
+  return nowMuted;
+}

--- a/src/services/notification-service.ts
+++ b/src/services/notification-service.ts
@@ -1,7 +1,14 @@
 import { db } from "@/db";
 import { notificationEvents } from "@/db/schema";
-import { eq, and, desc, isNull, inArray, count } from "drizzle-orm";
-import type { NotificationEvent, CreateNotificationInput } from "@/types/notification";
+import { eq, and, desc, isNull, inArray, count, gt, sql } from "drizzle-orm";
+import type {
+  NotificationEvent,
+  CreateNotificationInput,
+  NotificationSeverity,
+} from "@/types/notification";
+import { notificationSeverity, notificationGroup } from "@/types/notification";
+import { applyNotificationPolicy } from "@/lib/notification-policy";
+import { resolvePrefs } from "@/services/notification-preferences-service";
 import type { PushNotificationGateway } from "@/application/ports/PushNotificationGateway";
 import type { PushTokenRepository } from "@/application/ports/PushTokenRepository";
 import { resolveTerminalServerUrl } from "@/lib/terminal-server-url";
@@ -23,52 +30,118 @@ export function setPushTokenRepository(repo: PushTokenRepository): void {
   pushTokenRepo = repo;
 }
 
-// Debounce: prevent duplicate notifications per (userId, sessionId, type) within 5s window
-const recentNotifications = new Map<string, number>();
-const DEBOUNCE_MS = 5000;
-const MAX_DEBOUNCE_ENTRIES = 1000;
+/**
+ * [y5ch.5] Window after which an open notification is considered "closed" and a
+ * new event starts a fresh row instead of coalescing. The clear boundary: a
+ * read (markRead) OR this window elapsing closes the group.
+ */
+const COALESCE_WINDOW_MS = 60_000;
 
-function debounceKey(userId: string, sessionId: string | undefined, type: string): string {
-  return `${userId}:${sessionId ?? "none"}:${type}`;
-}
+/**
+ * [y5ch] Create a notification, applying the policy + prefs gate, then coalescing
+ * by `(userId, sessionId, group)` into a mutable open row. Returns the stored
+ * row, or `null` when the policy suppresses storage entirely (e.g. session muted).
+ *
+ * The FCM push is dispatched only when `decision.push` is true (severity-gated,
+ * per-type/per-session opt-out, focus-aware, quiet-hours — see notification-policy).
+ */
+export async function createNotification(
+  input: CreateNotificationInput,
+): Promise<NotificationEvent | null> {
+  const severity = input.severity ?? notificationSeverity(input.type);
+  const prefs = await resolvePrefs(input.userId);
+  const decision = applyNotificationPolicy(input, prefs, {
+    now: new Date(),
+    focused: input.focused ?? false,
+  });
 
-/** Evict stale entries when the debounce map grows too large */
-function evictStaleEntries(): void {
-  if (recentNotifications.size <= MAX_DEBOUNCE_ENTRIES) return;
-  const now = Date.now();
-  for (const [key, timestamp] of recentNotifications) {
-    if (now - timestamp > DEBOUNCE_MS) recentNotifications.delete(key);
+  if (!decision.store) {
+    log.debug("Notification suppressed", { type: input.type, reason: decision.reason });
+    return null;
   }
-}
 
-export async function createNotification(input: CreateNotificationInput): Promise<NotificationEvent | null> {
-  const key = debounceKey(input.userId, input.sessionId, input.type);
-  const now = Date.now();
-  const last = recentNotifications.get(key);
-  if (last && now - last < DEBOUNCE_MS) return null; // debounced
+  // [y5ch.5] Coalesce repeated events in the same group into one open row.
+  const notification = await upsertCoalesced(input, severity);
 
-  recentNotifications.set(key, now);
-  if (recentNotifications.size > MAX_DEBOUNCE_ENTRIES) evictStaleEntries();
-
-  const [row] = await db.insert(notificationEvents).values({
-    userId: input.userId,
-    sessionId: input.sessionId ?? null,
-    sessionName: input.sessionName ?? null,
-    type: input.type,
-    title: input.title,
-    body: input.body ?? null,
-  }).returning();
-
-  const notification = mapRow(row);
-
-  // Fire-and-forget push notification dispatch
-  if (pushGateway && pushTokenRepo) {
-    dispatchPush(notification).catch((err) =>
-      log.warn("Push notification dispatch failed", { error: String(err) })
-    );
+  // [y5ch.10] FCM push fires only when the policy allows it.
+  if (decision.push) {
+    if (pushGateway && pushTokenRepo) {
+      dispatchPush(notification).catch((err) =>
+        log.warn("Push notification dispatch failed", { error: String(err) }),
+      );
+    }
+  } else {
+    log.debug("Push gated off", { type: input.type, reason: decision.reason });
   }
 
   return notification;
+}
+
+/**
+ * [y5ch.5] Collapse repeated notifications in the same
+ * `(userId, sessionId, coalesceKey)` group into one OPEN (unread) row by bumping
+ * `count` and refreshing `title`/`body`/`meta`/`severity`/`updatedAt`, instead of
+ * inserting a new row or dropping it (the old 5s debounce behavior).
+ *
+ * Clear boundary: the merge query requires `isNull(readAt)` (so reading a row
+ * closes the group) AND `updatedAt > cutoff` (so an idle group older than
+ * COALESCE_WINDOW_MS starts fresh). A `null` sessionId never coalesces.
+ */
+async function upsertCoalesced(
+  input: CreateNotificationInput,
+  severity: NotificationSeverity,
+): Promise<NotificationEvent> {
+  const coalesceKey = notificationGroup(input.type);
+  const cutoff = new Date(Date.now() - COALESCE_WINDOW_MS);
+
+  const existing = input.sessionId
+    ? await db.query.notificationEvents.findFirst({
+        where: and(
+          eq(notificationEvents.userId, input.userId),
+          eq(notificationEvents.sessionId, input.sessionId),
+          eq(notificationEvents.coalesceKey, coalesceKey),
+          isNull(notificationEvents.readAt),
+          gt(notificationEvents.updatedAt, cutoff),
+        ),
+      })
+    : null;
+
+  if (existing) {
+    const [updated] = await db
+      .update(notificationEvents)
+      .set({
+        title: input.title,
+        body: input.body ?? null,
+        type: input.type,
+        severity,
+        meta: input.meta ?? null,
+        // [y5ch.5] Atomic increment in SQL — a read-modify-write (count+1 in JS)
+        // would lose increments when concurrent events coalesce into the same
+        // row, undercounting the ×N badge. `count + 1` is computed by the DB.
+        count: sql`${notificationEvents.count} + 1`,
+        updatedAt: new Date(),
+      })
+      .where(eq(notificationEvents.id, existing.id))
+      .returning();
+    return mapRow(updated);
+  }
+
+  const [row] = await db
+    .insert(notificationEvents)
+    .values({
+      userId: input.userId,
+      sessionId: input.sessionId ?? null,
+      sessionName: input.sessionName ?? null,
+      type: input.type,
+      severity,
+      title: input.title,
+      body: input.body ?? null,
+      coalesceKey,
+      count: 1,
+      meta: input.meta ?? null,
+    })
+    .returning();
+  return mapRow(row);
 }
 
 /** Dispatch push notification to all user devices (fire-and-forget). */
@@ -86,8 +159,14 @@ async function dispatchPush(notification: NotificationEvent): Promise<void> {
       data: {
         notificationId: notification.id,
         type: notification.type,
+        // [y5ch.8] severity + count let the client route/badge without a refetch.
+        severity: notification.severity,
+        count: String(notification.count),
         ...(notification.sessionId && { sessionId: notification.sessionId }),
         ...(notification.sessionName && { sessionName: notification.sessionName }),
+        ...(notification.meta?.deepLinkSessionId && {
+          deepLinkSessionId: notification.meta.deepLinkSessionId,
+        }),
       },
     }
   );
@@ -178,15 +257,22 @@ export async function broadcastDismissed(opts: { userId: string; ids?: string[];
 }
 
 function mapRow(row: typeof notificationEvents.$inferSelect): NotificationEvent {
+  const type = row.type as NotificationEvent["type"];
   return {
     id: row.id,
     userId: row.userId,
     sessionId: row.sessionId,
     sessionName: row.sessionName,
-    type: row.type as NotificationEvent["type"],
+    type,
+    // [y5ch.1] default severity from the classifier when the column is null
+    // (pre-migration rows / inserts that predate the severity column).
+    severity: (row.severity as NotificationSeverity | null) ?? notificationSeverity(type),
     title: row.title,
     body: row.body,
+    count: row.count ?? 1,
+    meta: row.meta ?? null,
     readAt: row.readAt,
     createdAt: row.createdAt,
+    updatedAt: row.updatedAt ?? row.createdAt,
   };
 }

--- a/src/services/session-liveness-service.ts
+++ b/src/services/session-liveness-service.ts
@@ -1,0 +1,113 @@
+/**
+ * [y5ch.9] PID-liveness reconciliation sweep.
+ *
+ * The real "agent crashed / stopped responding" signal. For each DB session in
+ * an alive-ish activity state (running | waiting | compacting | subagent), we
+ * resolve its tmux pane PID and probe it with `process.kill(pid, 0)`. If the
+ * tmux session is gone or the process is dead, the agent crashed/exited: we
+ * clear the stale status and emit exactly one `agent_stuck` (error) notification
+ * per transition.
+ *
+ * Runs ONLY on the terminal server (it owns tmux); started by terminal.ts.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { db } from "@/db";
+import { terminalSessions } from "@/db/schema";
+import { and, eq, inArray, ne } from "drizzle-orm";
+import { createLogger } from "@/lib/logger";
+import * as NotificationService from "@/services/notification-service";
+
+const log = createLogger("SessionLiveness");
+const execFileAsync = promisify(execFile);
+
+/** Activity states that imply the agent process should be alive. */
+const ALIVE_STATES = ["running", "waiting", "compacting", "subagent"] as const;
+
+/** POSIX liveness probe — kill(pid,0) throws ESRCH when the process is gone. */
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM ⇒ exists but not ours (still alive). ESRCH ⇒ dead.
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/** Resolve the pane PID of a tmux session, or null if the session is gone. */
+async function tmuxPanePid(tmuxSessionName: string): Promise<number | null> {
+  try {
+    const { stdout } = await execFileAsync("tmux", [
+      "list-panes",
+      "-t",
+      tmuxSessionName,
+      "-F",
+      "#{pane_pid}",
+    ]);
+    const first = stdout.split("\n").find((l) => l.trim().length > 0);
+    const pid = first ? parseInt(first.trim(), 10) : NaN;
+    return Number.isNaN(pid) ? null : pid;
+  } catch {
+    return null; // no such session
+  }
+}
+
+/**
+ * One reconciliation pass. Clears stale alive-state sessions whose agent process
+ * is dead, emitting exactly one agent_stuck (error) notification per transition.
+ * Returns the number of sessions cleared.
+ */
+export async function reconcileLiveness(): Promise<number> {
+  const candidates = await db.query.terminalSessions.findMany({
+    where: and(
+      eq(terminalSessions.status, "active"),
+      inArray(terminalSessions.agentActivityStatus, [...ALIVE_STATES]),
+      // [y5ch.9 risk #5] skip sessions mid-restart — restart_agent kills +
+      // recreates the tmux session, so a sweep landing mid-restart would see a
+      // missing session and emit a false agent_stuck.
+      ne(terminalSessions.agentExitState, "restarting"),
+    ),
+    columns: {
+      id: true,
+      name: true,
+      userId: true,
+      tmuxSessionName: true,
+      agentActivityStatus: true,
+    },
+  });
+
+  let cleared = 0;
+  for (const s of candidates) {
+    const pid = await tmuxPanePid(s.tmuxSessionName);
+    const alive = pid != null && pidAlive(pid);
+    if (alive) continue;
+
+    // Transition out of an alive state → mark exited + notify once.
+    await db
+      .update(terminalSessions)
+      .set({ agentActivityStatus: "idle", agentExitState: "exited" })
+      .where(eq(terminalSessions.id, s.id));
+
+    await NotificationService.createNotification({
+      userId: s.userId,
+      sessionId: s.id,
+      sessionName: s.name,
+      type: "agent_stuck",
+      severity: "error",
+      title: "Agent stopped responding",
+      body: `Session "${s.name}" was ${s.agentActivityStatus} but its process is gone.`,
+      meta: {
+        deepLinkSessionId: s.id,
+        cta: { label: "Open session", action: "open_session" },
+      },
+    });
+    cleared++;
+    log.warn("Cleared stale agent session", {
+      sessionId: s.id,
+      prevStatus: s.agentActivityStatus,
+    });
+  }
+  if (cleared > 0) log.info("Liveness sweep cleared sessions", { cleared });
+  return cleared;
+}

--- a/src/services/tmux-service.ts
+++ b/src/services/tmux-service.ts
@@ -273,8 +273,14 @@ export async function sendKeys(
     // Send command text in literal mode (-l) to avoid tmux interpreting
     // special characters like !, #, \, etc. This ensures the exact text
     // is sent to the terminal/application.
+    //
+    // The `--` end-of-options delimiter is required so a payload that itself
+    // starts with `-` (e.g. "-X", or a markdown "- item") is typed literally
+    // instead of being parsed by tmux as send-keys flags. Without it, such a
+    // payload is silently dropped/misinterpreted (literal-mode correctness +
+    // a minor injection surface as more dynamic commands route through here).
     if (command) {
-      await execFile("tmux", ["send-keys", "-t", sessionName, "-l", command]);
+      await execFile("tmux", ["send-keys", "-t", sessionName, "-l", "--", command]);
     }
 
     // Send Enter key separately. This works reliably across shells and

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,5 +1,11 @@
 /**
- * Notification types for in-app notification panel
+ * Notification types for in-app notification panel.
+ *
+ * [y5ch] Notifications carry a `severity` class derived from their `type`.
+ * Severity drives push-gating (y5ch.10), the client halo/dot (y5ch.8), and
+ * coalescing grouping (y5ch.5). The classifier `notificationSeverity()` is the
+ * single source of truth (type → severity), consumed by the terminal server,
+ * the policy hook, and the FCM gate.
  */
 
 export type NotificationType =
@@ -11,7 +17,71 @@ export type NotificationType =
   | "session_closed"
   | "update_pending"
   | "update_applied"
+  | "agent_stuck" // [y5ch] emitted by the liveness sweep (y5ch.9)
   | "info";
+
+/** [y5ch] Signal class. Drives push-gating, client halo, coalescing. */
+export type NotificationSeverity = "actionable" | "passive" | "error";
+
+/**
+ * [y5ch] Single source of truth: type → severity.
+ *
+ *   - actionable: the agent needs the human (waiting, build failed, update ready).
+ *   - error:      something broke or the agent is stuck/crashed.
+ *   - passive:    informational lifecycle pings (clean stop/complete/closed/info).
+ */
+export function notificationSeverity(type: NotificationType): NotificationSeverity {
+  switch (type) {
+    case "agent_waiting": // agent needs the human → actionable
+    case "build_fail":
+    case "update_pending":
+      return "actionable";
+    case "agent_error":
+    case "agent_stuck":
+      return "error";
+    case "agent_complete":
+    case "agent_exited":
+    case "session_closed":
+    case "update_applied":
+    case "info":
+      return "passive";
+    default:
+      return "passive";
+  }
+}
+
+/**
+ * [y5ch] Coalescing group key (y5ch.5). Notifications sharing
+ * `(userId, sessionId, group)` collapse into ONE open row rather than stacking.
+ * Lifecycle pings per session collapse together; failures collapse together;
+ * everything else coalesces only with the same type.
+ */
+export function notificationGroup(type: NotificationType): string {
+  switch (type) {
+    case "agent_waiting":
+    case "agent_complete":
+    case "agent_exited":
+    case "agent_stuck":
+      return "agent_lifecycle"; // collapse repeated lifecycle pings per session
+    case "agent_error":
+    case "build_fail":
+      return "agent_failure";
+    default:
+      return type; // update_pending/applied/session_closed/info coalesce only with same type
+  }
+}
+
+/** [y5ch] Richer payload for client routing/CTA (y5ch.8). */
+export interface NotificationMeta {
+  /** Session to deep-link into when tapped. */
+  deepLinkSessionId?: string;
+  /** Optional CTA label + action verb the client maps to a handler. */
+  cta?: { label: string; action: "open_session" | "view_diff" | "rerun" | "dismiss" };
+  /** Agent run duration in ms (clean-complete summaries). */
+  durationMs?: number;
+  /** Terminal result, e.g. "success" | "failed" | exit code as string. */
+  result?: string;
+}
 
 export interface NotificationEvent {
   id: string;
@@ -19,10 +89,18 @@ export interface NotificationEvent {
   sessionId: string | null;
   sessionName: string | null;
   type: NotificationType;
+  /** [y5ch] Signal class derived from `type` (or explicitly overridden). */
+  severity: NotificationSeverity;
   title: string;
   body: string | null;
+  /** [y5ch] Coalescing count: 1 normally, >1 when collapsed. */
+  count: number;
+  /** [y5ch] Structured client-routing payload (deep-link, duration, result). */
+  meta: NotificationMeta | null;
   readAt: Date | null;
   createdAt: Date;
+  /** [y5ch] Last time the (possibly coalesced) row was touched. */
+  updatedAt: Date;
 }
 
 export interface CreateNotificationInput {
@@ -32,4 +110,10 @@ export interface CreateNotificationInput {
   type: NotificationType;
   title: string;
   body?: string;
+  /** [y5ch] Override; defaults to notificationSeverity(type). */
+  severity?: NotificationSeverity;
+  /** [y5ch] Structured client-routing payload (y5ch.8). */
+  meta?: NotificationMeta;
+  /** [y5ch] true when the target session is currently focused by the user (y5ch.4). */
+  focused?: boolean;
 }

--- a/tests/components/NotificationPanel.test.tsx
+++ b/tests/components/NotificationPanel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 import { NotificationPanel } from "@/components/notifications/NotificationPanel";
 import type { NotificationEvent } from "@/types/notification";
+import { notificationSeverity } from "@/types/notification";
 
 // The panel pulls everything off context; we stub it so we can drive the
 // notifications array directly.
@@ -20,16 +21,21 @@ import { useNotificationContext } from "@/contexts/NotificationContext";
 import { toast } from "sonner";
 
 function makeNotification(overrides: Partial<NotificationEvent> = {}): NotificationEvent {
+  const type = overrides.type ?? "info";
   return {
     id: "n1",
     userId: "u1",
     sessionId: null,
     sessionName: null,
-    type: "info",
+    type,
+    severity: notificationSeverity(type),
     title: "Hello",
     body: null,
+    count: 1,
+    meta: null,
     readAt: null,
     createdAt: new Date("2026-04-30T12:00:00Z"),
+    updatedAt: new Date("2026-04-30T12:00:00Z"),
     ...overrides,
   };
 }


### PR DESCRIPTION
## Epic y5ch — Notifications: signal-vs-noise overhaul

Part 1 of 3 in the cmux/manaflow-inspired enhancement series. **Merge this first** — it's the foundation the other two stack on.

### What this does
Makes agent-lifecycle notifications typed-by-source instead of noisy:
- **Severity model** (actionable / passive / error) on every notification type
- **Stops the push spam** — a clean agent stop ("Session ended normally") is now a silent status change, not a cross-device push (was `crates/rdv/src/commands/hook.rs` firing on every stop)
- **Stop vs Notification split** — passive idle ≠ actionable "needs you"
- **Focus-aware suppression** — no push when you're already viewing that session
- **Real coalescing** (replaces the weak 5s debounce) with a clear-boundary on read
- **Per-type / per-session muting + quiet hours** + a pluggable policy hook
- **PID-liveness sweep** — clears stale state and emits one `agent_stuck` signal (the real "stuck" detector)

### Gates
lint 0 · typecheck clean · vitest 1709 passed · `cargo build/test -p rdv` 12 passed · schema codegen-in-sync.

### Review
Independent code review: **READY** — no Critical/Important issues.

### Notes
- Quiet-hours uses server-local tz (follow-up); no prefs UI yet (service + route + tests landed).
- Schema via `schema.def.ts` + codegen; migrations `drizzle/0019` + `drizzle/pg/0002`.

Beads: `remote-dev-y5ch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
