### PR TITLE
feat(chat): agent-native chat & coordination (epic x386) [4/6]

### DIFF
--- a/crates/rdv/src/commands/hook.rs
+++ b/crates/rdv/src/commands/hook.rs
@@ -120,6 +120,20 @@ fn strip_mention_tokens(body: &str) -> String {
     result
 }
 
+/// [x386 hardening] Strip control/escape characters from a peer-derived string
+/// before rendering it to a peer's TUI digest. The digest is machine-read by
+/// peer agents AND printed to a terminal, so a crafted note/branch/name
+/// containing raw ANSI/OSC escapes (e.g. `\x1b]0;...\x07`) or embedded newlines
+/// could spoof "⚠ COLLISION" / section-header lines or hijack the terminal.
+/// We drop every C0 control byte (0x00–0x1f, which includes ESC 0x1b, CR, LF)
+/// and DEL (0x7f); the surviving text is inert. The replacement leaves the ESC
+/// gone so an OSC/CSI sequence degrades to harmless literal characters.
+fn sanitize_for_digest(s: &str) -> String {
+    s.chars()
+        .filter(|c| !c.is_control())
+        .collect()
+}
+
 // ── Status reporting ────────────────────────────────────────────────
 
 /// Report an agent activity status to the terminal server.
@@ -136,74 +150,141 @@ async fn report_status(client: &Client, status: &str) {
 
 // ── Peer digest ─────────────────────────────────────────────────────
 
-const PEER_HEADER: &str = "\u{2500}\u{2500} Peers \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}";
-const PEER_FOOTER: &str = "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}";
+// [x386.12] Start-digest section headers (em-dash rules).
+const TEAM_HEADER: &str = "\u{2500}\u{2500} Team (who's working on what) \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}";
+const GOTCHA_HEADER: &str = "\u{2500}\u{2500} Recent gotchas \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}";
+const MESSAGES_HEADER: &str = "\u{2500}\u{2500} New messages \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}";
+const SECTION_RULE: &str = "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}";
 
-/// Print a compact peer status table and any new messages to stderr.
+/// [x386.12/.14] Read-peers START DIGEST printed to stderr at the first
+/// PreToolUse so the agent reads it before acting. Three sections:
+///   - Team: who's-working-on-what (work-context + claimed bd issues)
+///   - Recent gotchas: tagged notes from #agents (`rdv peer note`)
+///   - Collisions: another active session on the same branch/worktree/issue
+///   - New messages: durable-cursor backlog (auto-acked)
+///
+/// The heavy joins live server-side (`/internal/peers/digest`); this renders
+/// the payload. The "New messages" section uses the durable cursor so repeated
+/// calls don't re-show the same items.
 async fn print_peer_digest(client: &Client) {
     let Some(sid) = client.session_id() else {
         return;
     };
 
-    // Fetch peers
-    let peer_query = [("sessionId", sid)];
-    let peers_result: Result<serde_json::Value, _> = client
-        .get_with_query("/internal/peers/list", &peer_query)
+    // ── Team / gotchas / collisions (server-built digest) ────────────────
+    let digest_query = [("sessionId", sid)];
+    let digest: Result<serde_json::Value, _> = client
+        .get_with_query("/internal/peers/digest", &digest_query)
         .await;
 
-    // Fetch new messages using timestamp sentinel
-    let ts_file = format!("/tmp/rdv-peer-poll-{sid}");
-    let since = std::fs::read_to_string(&ts_file)
-        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
-    let now = chrono::Utc::now().to_rfc3339();
-
-    let msg_query = [("sessionId", sid), ("since", since.as_str())];
-    let messages_result: Result<serde_json::Value, _> = client
-        .get_with_query("/internal/peers/messages/poll", &msg_query)
-        .await;
-
-    // Always update timestamp to avoid re-processing on failure
-    let _ = std::fs::write(&ts_file, &now);
-
-    // Print peers section if there are peers
-    if let Ok(resp) = &peers_result {
-        if let Some(peers) = resp.get("peers").and_then(|v| v.as_array()) {
+    if let Ok(d) = &digest {
+        // Team section.
+        if let Some(peers) = d.get("peers").and_then(|v| v.as_array()) {
             if !peers.is_empty() {
-                eprintln!("{PEER_HEADER}");
+                eprintln!("{TEAM_HEADER}");
                 for peer in peers {
-                    let name = peer.get("name").and_then(|v| v.as_str()).unwrap_or("unknown");
-                    let status = peer
-                        .get("agentActivityStatus")
+                    // All peer-derived strings are control-char-stripped so a
+                    // crafted name/branch/issue can't inject escapes or newlines.
+                    let name = sanitize_for_digest(
+                        peer.get("name").and_then(|v| v.as_str()).unwrap_or("unknown"),
+                    );
+                    let status = sanitize_for_digest(
+                        peer.get("status").and_then(|v| v.as_str()).unwrap_or("unknown"),
+                    );
+                    let branch = sanitize_for_digest(
+                        peer.get("branch").and_then(|v| v.as_str()).unwrap_or(""),
+                    );
+                    let issue_id = peer
+                        .get("claimedIssueId")
                         .and_then(|v| v.as_str())
-                        .unwrap_or("unknown");
-                    let summary = peer
-                        .get("peerSummary")
+                        .map(sanitize_for_digest);
+                    let issue_title = peer
+                        .get("claimedIssueTitle")
                         .and_then(|v| v.as_str())
-                        .unwrap_or("");
-                    if summary.is_empty() {
-                        eprintln!("  {name} [{status}]");
+                        .map(sanitize_for_digest);
+                    let work = match (issue_id.as_deref(), issue_title.as_deref()) {
+                        (Some(id), Some(title)) => format!(" \u{b7} {id} {title}"),
+                        (Some(id), None) => format!(" \u{b7} {id}"),
+                        _ => " \u{b7} (no claimed issue)".to_string(),
+                    };
+                    let branch_part = if branch.is_empty() {
+                        String::new()
                     } else {
-                        eprintln!("  {name} [{status}]: {summary}");
-                    }
+                        format!(" {branch}")
+                    };
+                    eprintln!("  {name} [{status}]{branch_part}{work}");
                 }
-                eprintln!("{PEER_FOOTER}");
+                eprintln!("{SECTION_RULE}");
+            }
+        }
+
+        // Recent gotchas.
+        if let Some(gotchas) = d.get("gotchas").and_then(|v| v.as_array()) {
+            if !gotchas.is_empty() {
+                eprintln!("{GOTCHA_HEADER}");
+                for g in gotchas {
+                    let from = sanitize_for_digest(
+                        g.get("from").and_then(|v| v.as_str()).unwrap_or("peer"),
+                    );
+                    let raw_body = g.get("body").and_then(|v| v.as_str()).unwrap_or("");
+                    let body = sanitize_for_digest(&strip_mention_tokens(raw_body));
+                    eprintln!("  \u{26a0} {from}: {body}");
+                }
+                eprintln!("{SECTION_RULE}");
+            }
+        }
+
+        // Collisions.
+        if let Some(collisions) = d.get("collisions").and_then(|v| v.as_array()) {
+            for c in collisions {
+                let peer_name = sanitize_for_digest(
+                    c.get("peerName").and_then(|v| v.as_str()).unwrap_or("a peer"),
+                );
+                let reason = sanitize_for_digest(
+                    c.get("reason").and_then(|v| v.as_str()).unwrap_or("work"),
+                );
+                let value = sanitize_for_digest(
+                    c.get("value").and_then(|v| v.as_str()).unwrap_or(""),
+                );
+                eprintln!(
+                    "\u{26a0} COLLISION: {peer_name} shares your {reason} {value} \u{2014} coordinate before pushing."
+                );
             }
         }
     }
 
-    // Print new messages if any
+    // ── New messages (durable cursor, auto-acked) ────────────────────────
+    let msg_query = [("sessionId", sid), ("cursor", "durable")];
+    let messages_result: Result<serde_json::Value, _> = client
+        .get_with_query("/internal/peers/messages/poll", &msg_query)
+        .await;
+
     if let Ok(resp) = messages_result {
         if let Some(messages) = resp.get("messages").and_then(|v| v.as_array()) {
-            for msg in messages {
-                let from = msg
-                    .get("fromSessionName")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown");
-                let raw_body = msg.get("body").and_then(|v| v.as_str()).unwrap_or("");
-                let body = strip_mention_tokens(raw_body);
-                let is_broadcast = msg.get("toSessionId").map_or(true, |v| v.is_null());
-                let target = if is_broadcast { " (broadcast)" } else { "" };
-                eprintln!("\u{1f4e8} Peer message from {from}{target}: {body}");
+            if !messages.is_empty() {
+                eprintln!("{MESSAGES_HEADER}");
+                // Ack the batch so the next digest doesn't re-show them.
+                let ids: Vec<&str> = messages
+                    .iter()
+                    .filter_map(|m| m.get("id").and_then(|v| v.as_str()))
+                    .collect();
+                if !ids.is_empty() {
+                    let ack = json!({ "sessionId": sid, "messageIds": ids });
+                    let _ = client.post_json("/internal/peers/ack-batch", &ack).await;
+                }
+                for msg in messages {
+                    let from = sanitize_for_digest(
+                        msg.get("fromSessionName")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown"),
+                    );
+                    let raw_body = msg.get("body").and_then(|v| v.as_str()).unwrap_or("");
+                    let body = sanitize_for_digest(&strip_mention_tokens(raw_body));
+                    let is_broadcast = msg.get("toSessionId").map_or(true, |v| v.is_null());
+                    let target = if is_broadcast { " (broadcast)" } else { "" };
+                    eprintln!("\u{1f4e8} {from}{target}: {body}");
+                }
+                eprintln!("{SECTION_RULE}");
             }
         }
     }
@@ -246,7 +327,11 @@ async fn broadcast_git_push_to_peers(client: &Client, command: &str) {
     let _ = client.post_json("/internal/peers/messages/send", &payload).await;
 }
 
-/// Broadcast session start once per session (sentinel at /tmp/rdv-peer-start-{sid}).
+/// [x386.6] Check IN once per session (sentinel at /tmp/rdv-peer-start-{sid}).
+/// Posts a structured check-in to the per-project #agents channel — branch +
+/// claimed bd issue (omitted when the loose join has no confidence) — so peers
+/// see who joined and what they're on. Replaces the old "session started"
+/// broadcast. bd remains the work tracker; this is awareness only.
 async fn broadcast_session_start(client: &Client) {
     let Some(sid) = client.session_id() else {
         return;
@@ -256,8 +341,44 @@ async fn broadcast_session_start(client: &Client) {
         return;
     }
     let _ = std::fs::write(&sentinel, "1");
-    let payload = json!({ "fromSessionId": sid, "body": "session started" });
-    let _ = client.post_json("/internal/peers/messages/send", &payload).await;
+
+    // Fetch work-context to enrich the check-in (best-effort).
+    let ctx_query = [("sessionId", sid)];
+    let ctx: Option<serde_json::Value> = client
+        .get_with_query::<serde_json::Value, _>("/internal/work-context", &ctx_query)
+        .await
+        .ok()
+        .and_then(|v| v.get("context").cloned());
+
+    let body = build_checkin_body(ctx.as_ref());
+    let payload = json!({ "fromSessionId": sid, "channelName": "agents", "body": body });
+    let _ = client.post_json("/internal/channels/send", &payload).await;
+}
+
+/// Build the check-in message body from an optional work-context payload.
+fn build_checkin_body(ctx: Option<&serde_json::Value>) -> String {
+    let branch = ctx
+        .and_then(|c| c.get("branch"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty());
+    let confidence = ctx
+        .and_then(|c| c.get("joinConfidence"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("none");
+    let issue_id = ctx
+        .and_then(|c| c.get("claimedIssueId"))
+        .and_then(|v| v.as_str());
+
+    let branch_part = match branch {
+        Some(b) => format!(" \u{2014} branch {b}"),
+        None => String::new(),
+    };
+    // Only mention the issue when the join is confident (omit on "none").
+    let issue_part = match (confidence, issue_id) {
+        ("none", _) | (_, None) => String::new(),
+        (_, Some(id)) => format!(", working on {id}"),
+    };
+    format!("checked in{branch_part}{issue_part}")
 }
 
 // ── Proxy state reporting ───────────────────────────────────────────
@@ -530,13 +651,27 @@ async fn handle_stop(
     // of notification noise and has been removed. Stuck/crashed agents now
     // surface via the server-side PID-liveness sweep (y5ch.9, emits agent_stuck),
     // and "agent needs you" surfaces via the Notification hook (waiting status).
-    // The idle status report above and the peer "finished work" broadcast below
-    // remain.
+    // The idle status report above and the peer check-out below remain.
 
-    // Broadcast "finished work" to peers (in-band signal, not a user notification).
-    let finished_payload = json!({ "fromSessionId": sid, "body": "finished work" });
+    // [x386.6] Check OUT to #agents (in-band awareness, not a user notification).
+    // Replaces the old "finished work" broadcast with a structured check-out
+    // attributed to the agent as a system speaker in the per-project channel.
+    let ctx_query = [("sessionId", sid)];
+    let branch = client
+        .get_with_query::<serde_json::Value, _>("/internal/work-context", &ctx_query)
+        .await
+        .ok()
+        .and_then(|v| v.get("context").cloned())
+        .and_then(|c| c.get("branch").and_then(|v| v.as_str()).map(String::from))
+        .filter(|s| !s.is_empty());
+    let checkout_body = match branch {
+        Some(b) => format!("checked out \u{2014} branch {b}"),
+        None => "checked out".to_string(),
+    };
+    let checkout_payload =
+        json!({ "fromSessionId": sid, "channelName": "agents", "body": checkout_body });
     let _ = client
-        .post_json("/internal/peers/messages/send", &finished_payload)
+        .post_json("/internal/channels/send", &checkout_payload)
         .await;
 
     Ok(())
@@ -753,9 +888,59 @@ mod stop_tests {
             !body.contains("/internal/notify"),
             "handle_stop must not call /internal/notify (y5ch.2 noise source)"
         );
+        // [x386.6] The peer awareness post remains, now as a structured check-out
+        // to the #agents channel (replaces the old "finished work" broadcast).
         assert!(
-            body.contains("finished work"),
-            "peer broadcast must remain after y5ch.2"
+            body.contains("checked out"),
+            "peer check-out must remain after y5ch.2 / x386.6"
         );
+        assert!(
+            body.contains("/internal/channels/send"),
+            "check-out must post to the #agents channel"
+        );
+    }
+}
+
+#[cfg(test)]
+mod sanitize_tests {
+    use super::sanitize_for_digest;
+
+    #[test]
+    fn strips_ansi_osc_and_csi_escapes() {
+        // A crafted note trying to set the terminal title (OSC) + recolor (CSI).
+        let attack = "\u{1b}]0;pwned\u{07}\u{1b}[31mhello";
+        let out = sanitize_for_digest(attack);
+        // No ESC (0x1b) or BEL (0x07) survive; the payload is inert literal text.
+        assert!(!out.contains('\u{1b}'), "ESC must be stripped");
+        assert!(!out.contains('\u{07}'), "BEL must be stripped");
+        assert_eq!(out, "]0;pwned[31mhello");
+    }
+
+    #[test]
+    fn strips_newlines_so_fake_section_lines_cannot_be_injected() {
+        // An attacker embedding a newline + a spoofed COLLISION line.
+        let attack = "ok\n\u{26a0} COLLISION: spoofed shares your branch main";
+        let out = sanitize_for_digest(attack);
+        assert!(!out.contains('\n'), "newlines must be stripped");
+        // Renders as a single inert line (the warning glyph itself is harmless).
+        assert_eq!(
+            out,
+            "ok\u{26a0} COLLISION: spoofed shares your branch main"
+        );
+    }
+
+    #[test]
+    fn preserves_ordinary_text_and_unicode() {
+        let s = "feat/x386.11 \u{2014} \u{b7} \u{26a0} caf\u{e9}";
+        assert_eq!(sanitize_for_digest(s), s);
+    }
+
+    #[test]
+    fn strips_c1_control_introducers() {
+        // 0x9b is the 8-bit CSI introducer; 0x9d is 8-bit OSC. Both are C1
+        // controls and must be dropped.
+        let attack = "a\u{9b}31mb\u{9d}0;x";
+        let out = sanitize_for_digest(attack);
+        assert_eq!(out, "a31mb0;x");
     }
 }

--- a/crates/rdv/src/commands/peer.rs
+++ b/crates/rdv/src/commands/peer.rs
@@ -34,6 +34,14 @@ enum PeerCommand {
         /// 1-2 sentence summary of current work
         text: String,
     },
+    /// Broadcast a gotcha / heads-up / progress note to project peers (#agents)
+    Note {
+        /// Note body
+        body: String,
+        /// Kind of note (default: gotcha)
+        #[arg(long, value_parser = ["gotcha", "heads-up", "progress"], default_value = "gotcha")]
+        kind: String,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -197,15 +205,33 @@ pub async fn run(
             }
         }
         PeerCommand::Messages { since } => {
+            // [x386.4] When no explicit `--since` is given, use the DURABLE
+            // delivery cursor (cursor=durable) so repeated calls don't re-show
+            // the same messages and non-MCP providers reach exactly-once parity
+            // with the MCP push path. We ack the returned batch afterwards. An
+            // explicit `--since` keeps the legacy timestamp scan for ad-hoc
+            // human queries.
+            let use_durable = since.is_none();
             let since_str = since.unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string());
-            let mut query: Vec<(&str, &str)> =
-                vec![("sessionId", sid), ("since", since_str.as_str())];
+            let mut query: Vec<(&str, &str)> = vec![("sessionId", sid)];
+            if use_durable {
+                query.push(("cursor", "durable"));
+            } else {
+                query.push(("since", since_str.as_str()));
+            }
             if let Some(pid) = project_id.as_deref() {
                 query.push(("projectId", pid));
             }
             let resp: MessageListResponse = client
                 .get_with_query("/internal/peers/messages/poll", &query)
                 .await?;
+
+            // Ack the durable batch so the next poll doesn't re-surface them.
+            if use_durable && !resp.messages.is_empty() {
+                let ids: Vec<&str> = resp.messages.iter().map(|m| m.id.as_str()).collect();
+                let ack = json!({ "sessionId": sid, "messageIds": ids });
+                let _ = client.post_json("/internal/peers/ack-batch", &ack).await;
+            }
 
             if human {
                 if resp.messages.is_empty() {
@@ -233,6 +259,27 @@ pub async fn run(
                 println!("Summary updated.");
             } else {
                 println!("{}", json!({ "ok": true }));
+            }
+        }
+        PeerCommand::Note { body, kind } => {
+            // [x386.13] Post a typed note to the project's #agents channel. The
+            // `[kind]` prefix lets the start digest's gotcha filter surface it
+            // distinctly from regular chatter. Reuses the durable channel-send
+            // → delivery path (no new server table).
+            let tagged = format!("[{kind}] {body}");
+            let payload = json!({
+                "fromSessionId": sid,
+                "channelName": "agents",
+                "body": tagged,
+            });
+            client
+                .post_json("/internal/channels/send", &payload)
+                .await?;
+
+            if human {
+                println!("Note posted to #agents ({kind}).");
+            } else {
+                println!("{}", json!({ "ok": true, "kind": kind }));
             }
         }
     }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -163,19 +163,51 @@ verifies whether each agent CLI is installed and resolves its version.
 
 ## 5. Agent peer communication (summary)
 
-Agents in the **same project** can discover each other and coordinate. The
-architecture is **push-first**: messages arrive instantly via the `rdv` MCP server's
-push notifications, with the Claude Code **PreToolUse hook** polling as a reliable
-fallback.
+Agents in the **same project** can discover each other and coordinate. **bd
+(beads) tracks the work** (issues, status, assignment); **chat tracks awareness**
+— who's-active-right-now, gotchas, heads-ups, and overlap warnings that bd does
+not hold. Do **not** duplicate task state in chat.
 
-- The `rdv` MCP server is auto-registered into each Claude Code profile's
-  `.claude/settings.json` at session creation (`installAgentHooks()`), alongside the
-  activity-reporting lifecycle hooks (PreToolUse, PreCompact, Notification, Stop,
-  SubagentStop, PostToolUse, SessionEnd).
-- MCP tools handle the **write** side: `send_message`, `send_to_channel`,
-  `set_summary`. **Read** operations (list peers, read channels) go through the
-  `rdv` CLI — see [`RDV_CLI.md`](./RDV_CLI.md) (`rdv peer …`, `rdv channel …`).
-- Messages are stored project-scoped with a 24-hour TTL.
+**Reliable delivery (every message reaches the agent exactly once).** Each
+message gets a per-recipient **durable inbox** row (`message_delivery`) that
+advances `pending → delivered → acked`:
+
+- **Long-lived MCP subscription** — the `rdv` MCP server keeps a persistent Unix
+  socket and surfaces pushed messages instantly, **acking** each so the server
+  marks it delivered. On (re)connect it requests a **replay** of anything it
+  missed (compaction, brief disconnect), driven by a durable per-session cursor.
+- **Poll fallback** — the four non-MCP providers (Codex, Gemini, OpenCode,
+  Antigravity) have no MCP server, so they rely on `rdv peer messages`, which
+  now reads the same durable delivery state and auto-acks the batch it returns.
+  This gives MCP and poll providers **exactly-once parity**.
+- **Channel subscriptions** — a channel's broadcasts auto-deliver only to
+  subscribed sessions (`#general` is auto-subscribe for all; opt out with
+  `direct_only`). Non-subscribers still get **@mentions** and replies-to-them.
+- **TTL** — awareness chat is ephemeral; messages prune after
+  `RDV_CHAT_TTL_DAYS` (default 14), but **never** while an unacked delivery
+  remains, so a long-disconnected agent never loses something it hasn't seen.
+
+The `rdv` MCP server is auto-registered into each Claude Code profile's
+`.claude/settings.json` at session creation (`installAgentHooks()`), alongside
+the lifecycle hooks (PreToolUse, PreCompact, Notification, Stop, SubagentStop,
+PostToolUse, SessionEnd). MCP tools handle the **write** side (`send_message`,
+`send_to_channel`, `set_summary`); read paths go through the `rdv` CLI.
+
+**Coordination discipline (check in → read peers → check out).**
+
+1. **Check in** (automatic, first PreToolUse) — a structured post to the
+   per-project `#agents` channel: *"checked in — branch …, working on …"*.
+2. **Read peers** (the **start digest**, printed at session start) — who's
+   working on what (branch + claimed bd issue), recent gotchas, and any
+   **collision** (another active session on your branch / worktree / claimed
+   issue). Read it before acting.
+3. **Post gotchas** — when you discover a footgun, `rdv peer note "<body>"`
+   (optionally `--kind heads-up|progress`) broadcasts it to `#agents` so it
+   surfaces in every peer's next start digest.
+4. **Check out** (automatic, on Stop) — *"checked out — branch …"* to `#agents`.
+
+> Note on "acked": the MCP ack means the message was **surfaced to the client**,
+> the strongest signal MCP logging affords — not a guaranteed human/agent read.
 
 For the full design (Unix-socket push relay, internal endpoints, dedup), see the
 "Agent Peer Communication" section of [`ARCHITECTURE.md`](./ARCHITECTURE.md).

--- a/docs/RDV_CLI.md
+++ b/docs/RDV_CLI.md
@@ -242,15 +242,27 @@ The first positional argument is always the target `<session-id>`.
 ## peer
 
 Inter-agent communication scoped to the current project (see [`AGENTS.md`](./AGENTS.md)
-§5). Read paths use the CLI; the push/write paths also flow through the `rdv` MCP
-server.
+§5). **bd tracks the work; chat tracks awareness.** Read paths use the CLI; the
+push/write paths also flow through the `rdv` MCP server with a durable
+per-recipient inbox (exactly-once across MCP push and poll).
 
 | Subcommand | Purpose |
 |------------|---------|
 | `rdv peer list` | List peer agents in the same project |
 | `rdv peer send <body> [--to <session-id>]` | Send a message (omit `--to` to broadcast) |
 | `rdv peer messages [--since <iso-ts>]` | Poll for new peer messages |
+| `rdv peer note <body> [--kind gotcha\|heads-up\|progress]` | Broadcast a gotcha / heads-up / progress note to `#agents` (surfaces in peers' start digest) |
 | `rdv peer summary <text>` | Set your work summary visible to peers |
+
+Without `--since`, `rdv peer messages` uses the **durable delivery cursor** and
+**auto-acks** what it returns, so repeated calls don't re-show the same items
+(this is the poll-fallback path for non-MCP providers). Pass `--since <iso-ts>`
+for an ad-hoc timestamp scan that does not advance the cursor.
+
+Lifecycle posts to `#agents` happen automatically: a **check-in** (branch +
+claimed bd issue) on session start and a **check-out** on Stop. The **start
+digest** printed at session start lists who's-working-on-what, recent gotchas,
+and collisions (another active session on your branch / worktree / claimed issue).
 
 ## channel
 

--- a/drizzle/0023_add_chat_coordination.sql
+++ b/drizzle/0023_add_chat_coordination.sql
@@ -1,0 +1,58 @@
+-- [x386] Agent-native chat & coordination (epic remote-dev-x386).
+--
+-- SQLite path uses `db:push` for fresh/dev databases; this hand-written
+-- migration mirrors the 0014-0022 raw-SQL convention so existing SQLite
+-- deployments can be upgraded in place. Four new tables: message_delivery,
+-- message_replay_cursor, channel_subscription, agent_work_context. All
+-- referenced tables (agent_peer_message, terminal_session, channel) already
+-- exist, so no ordering constraints beyond that. The generated dialect file is
+-- src/db/schema.sqlite.ts via `bun run db:codegen`; the Postgres equivalent is
+-- drizzle/pg/0005_misty_red_ghost.sql.
+CREATE TABLE `message_delivery` (
+	`id` text PRIMARY KEY NOT NULL,
+	`message_id` text NOT NULL,
+	`to_session_id` text NOT NULL,
+	`project_id` text NOT NULL,
+	`state` text DEFAULT 'pending' NOT NULL,
+	`channel_kind` text,
+	`delivered_at` integer,
+	`acked_at` integer,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`message_id`) REFERENCES `agent_peer_message`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`to_session_id`) REFERENCES `terminal_session`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `message_delivery_msg_session_idx` ON `message_delivery` (`message_id`,`to_session_id`);--> statement-breakpoint
+CREATE INDEX `message_delivery_session_state_idx` ON `message_delivery` (`to_session_id`,`state`,`created_at`);--> statement-breakpoint
+CREATE TABLE `message_replay_cursor` (
+	`session_id` text PRIMARY KEY NOT NULL,
+	`last_acked_at` integer,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`session_id`) REFERENCES `terminal_session`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `channel_subscription` (
+	`id` text PRIMARY KEY NOT NULL,
+	`channel_id` text NOT NULL,
+	`session_id` text NOT NULL,
+	`mode` text DEFAULT 'auto_deliver' NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`channel_id`) REFERENCES `channel`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`session_id`) REFERENCES `terminal_session`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `channel_subscription_unique_idx` ON `channel_subscription` (`channel_id`,`session_id`);--> statement-breakpoint
+CREATE TABLE `agent_work_context` (
+	`session_id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`branch` text,
+	`worktree_path` text,
+	`activity_status` text,
+	`claimed_issue_id` text,
+	`claimed_issue_title` text,
+	`join_confidence` text,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`session_id`) REFERENCES `terminal_session`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `agent_work_context_project_idx` ON `agent_work_context` (`project_id`);

--- a/drizzle/pg/0005_youthful_hex.sql
+++ b/drizzle/pg/0005_youthful_hex.sql
@@ -1,0 +1,48 @@
+CREATE TABLE "agent_work_context" (
+	"session_id" text PRIMARY KEY NOT NULL,
+	"project_id" text NOT NULL,
+	"branch" text,
+	"worktree_path" text,
+	"activity_status" text,
+	"claimed_issue_id" text,
+	"claimed_issue_title" text,
+	"join_confidence" text,
+	"updated_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "channel_subscription" (
+	"id" text PRIMARY KEY NOT NULL,
+	"channel_id" text NOT NULL,
+	"session_id" text NOT NULL,
+	"mode" text DEFAULT 'auto_deliver' NOT NULL,
+	"created_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "message_delivery" (
+	"id" text PRIMARY KEY NOT NULL,
+	"message_id" text NOT NULL,
+	"to_session_id" text NOT NULL,
+	"project_id" text NOT NULL,
+	"state" text DEFAULT 'pending' NOT NULL,
+	"channel_kind" text,
+	"delivered_at" timestamp with time zone,
+	"acked_at" timestamp with time zone,
+	"created_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "message_replay_cursor" (
+	"session_id" text PRIMARY KEY NOT NULL,
+	"last_acked_at" timestamp with time zone,
+	"updated_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "agent_work_context" ADD CONSTRAINT "agent_work_context_session_id_terminal_session_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."terminal_session"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "channel_subscription" ADD CONSTRAINT "channel_subscription_channel_id_channel_id_fk" FOREIGN KEY ("channel_id") REFERENCES "public"."channel"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "channel_subscription" ADD CONSTRAINT "channel_subscription_session_id_terminal_session_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."terminal_session"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "message_delivery" ADD CONSTRAINT "message_delivery_message_id_agent_peer_message_id_fk" FOREIGN KEY ("message_id") REFERENCES "public"."agent_peer_message"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "message_delivery" ADD CONSTRAINT "message_delivery_to_session_id_terminal_session_id_fk" FOREIGN KEY ("to_session_id") REFERENCES "public"."terminal_session"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "message_replay_cursor" ADD CONSTRAINT "message_replay_cursor_session_id_terminal_session_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."terminal_session"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "agent_work_context_project_idx" ON "agent_work_context" USING btree ("project_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "channel_subscription_unique_idx" ON "channel_subscription" USING btree ("channel_id","session_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "message_delivery_msg_session_idx" ON "message_delivery" USING btree ("message_id","to_session_id");--> statement-breakpoint
+CREATE INDEX "message_delivery_session_state_idx" ON "message_delivery" USING btree ("to_session_id","state","created_at");

--- a/drizzle/pg/meta/0005_snapshot.json
+++ b/drizzle/pg/meta/0005_snapshot.json
@@ -1,0 +1,9892 @@
+{
+  "id": "b3778870-782d-4957-b11d-dd6508fcb5bd",
+  "prevId": "1953f29b-1588-4c91-b0e4-2fdd8ca4b9d7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_activity_event": {
+      "name": "agent_activity_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_provider": {
+          "name": "agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_activity_user_idx": {
+          "name": "agent_activity_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_activity_session_idx": {
+          "name": "agent_activity_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_activity_provider_idx": {
+          "name": "agent_activity_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_activity_event_type_idx": {
+          "name": "agent_activity_event_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_activity_created_idx": {
+          "name": "agent_activity_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_activity_event_user_id_user_id_fk": {
+          "name": "agent_activity_event_user_id_user_id_fk",
+          "tableFrom": "agent_activity_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_activity_event_session_id_terminal_session_id_fk": {
+          "name": "agent_activity_event_session_id_terminal_session_id_fk",
+          "tableFrom": "agent_activity_event",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_config": {
+      "name": "agent_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_type": {
+          "name": "config_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_config_user_idx": {
+          "name": "agent_config_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_config_project_idx": {
+          "name": "agent_config_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_config_unique_idx": {
+          "name": "agent_config_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "config_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_config_user_id_user_id_fk": {
+          "name": "agent_config_user_id_user_id_fk",
+          "tableFrom": "agent_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_config_project_id_project_id_fk": {
+          "name": "agent_config_project_id_project_id_fk",
+          "tableFrom": "agent_config",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_daily_stats": {
+      "name": "agent_daily_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_provider": {
+          "name": "agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "command_count": {
+          "name": "command_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_daily_stats_unique_idx": {
+          "name": "agent_daily_stats_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_daily_stats_user_date_idx": {
+          "name": "agent_daily_stats_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_daily_stats_user_id_user_id_fk": {
+          "name": "agent_daily_stats_user_id_user_id_fk",
+          "tableFrom": "agent_daily_stats",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_peer_message": {
+      "name": "agent_peer_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_session_id": {
+          "name": "from_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_session_name": {
+          "name": "from_session_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_session_id": {
+          "name": "to_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_user_message": {
+          "name": "is_user_message",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "peer_message_project_created_idx": {
+          "name": "peer_message_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peer_message_to_session_idx": {
+          "name": "peer_message_to_session_idx",
+          "columns": [
+            {
+              "expression": "to_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peer_message_channel_created_idx": {
+          "name": "peer_message_channel_created_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "peer_message_parent_idx": {
+          "name": "peer_message_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_peer_message_from_session_id_terminal_session_id_fk": {
+          "name": "agent_peer_message_from_session_id_terminal_session_id_fk",
+          "tableFrom": "agent_peer_message",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "from_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_peer_message_to_session_id_terminal_session_id_fk": {
+          "name": "agent_peer_message_to_session_id_terminal_session_id_fk",
+          "tableFrom": "agent_peer_message",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "to_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_peer_message_channel_id_channel_id_fk": {
+          "name": "agent_peer_message_channel_id_channel_id_fk",
+          "tableFrom": "agent_peer_message",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile_json_config": {
+      "name": "agent_profile_json_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_valid": {
+          "name": "is_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validation_errors": {
+          "name": "validation_errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_profile_json_config_profile_idx": {
+          "name": "agent_profile_json_config_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_profile_json_config_user_idx": {
+          "name": "agent_profile_json_config_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_profile_json_config_unique_idx": {
+          "name": "agent_profile_json_config_unique_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_json_config_profile_id_agent_profile_id_fk": {
+          "name": "agent_profile_json_config_profile_id_agent_profile_id_fk",
+          "tableFrom": "agent_profile_json_config",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_profile_json_config_user_id_user_id_fk": {
+          "name": "agent_profile_json_config_user_id_user_id_fk",
+          "tableFrom": "agent_profile_json_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_profile": {
+      "name": "agent_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "config_dir": {
+          "name": "config_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_profile_user_idx": {
+          "name": "agent_profile_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_profile_default_idx": {
+          "name": "agent_profile_default_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_profile_user_id_user_id_fk": {
+          "name": "agent_profile_user_id_user_id_fk",
+          "tableFrom": "agent_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run": {
+      "name": "agent_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_config_id": {
+          "name": "trigger_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_provider": {
+          "name": "agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_flags": {
+          "name": "agent_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_user_idx": {
+          "name": "agent_run_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_schedule_idx": {
+          "name": "agent_run_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_trigger_idx": {
+          "name": "agent_run_trigger_idx",
+          "columns": [
+            {
+              "expression": "trigger_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_status_idx": {
+          "name": "agent_run_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_trigger_head_idx": {
+          "name": "agent_run_trigger_head_idx",
+          "columns": [
+            {
+              "expression": "trigger_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_user_id_user_id_fk": {
+          "name": "agent_run_user_id_user_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_project_id_project_id_fk": {
+          "name": "agent_run_project_id_project_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_run_schedule_id_agent_schedule_id_fk": {
+          "name": "agent_run_schedule_id_agent_schedule_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "agent_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_run_trigger_config_id_trigger_config_id_fk": {
+          "name": "agent_run_trigger_config_id_trigger_config_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "trigger_config",
+          "columnsFrom": [
+            "trigger_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_run_session_id_terminal_session_id_fk": {
+          "name": "agent_run_session_id_terminal_session_id_fk",
+          "tableFrom": "agent_run",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_schedule": {
+      "name": "agent_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_provider": {
+          "name": "agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "agent_flags": {
+          "name": "agent_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worktree_type": {
+          "name": "worktree_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recurring'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/Los_Angeles'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_schedule_user_idx": {
+          "name": "agent_schedule_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_schedule_next_run_idx": {
+          "name": "agent_schedule_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_schedule_user_id_user_id_fk": {
+          "name": "agent_schedule_user_id_user_id_fk",
+          "tableFrom": "agent_schedule",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_schedule_project_id_project_id_fk": {
+          "name": "agent_schedule_project_id_project_id_fk",
+          "tableFrom": "agent_schedule",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_work_context": {
+      "name": "agent_work_context",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_status": {
+          "name": "activity_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_issue_id": {
+          "name": "claimed_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_issue_title": {
+          "name": "claimed_issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "join_confidence": {
+          "name": "join_confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_work_context_project_idx": {
+          "name": "agent_work_context_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_work_context_session_id_terminal_session_id_fk": {
+          "name": "agent_work_context_session_id_terminal_session_id_fk",
+          "tableFrom": "agent_work_context",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "api_key_user_idx": {
+          "name": "api_key_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_prefix_idx": {
+          "name": "api_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_user_id_user_id_fk": {
+          "name": "api_key_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appearance_settings": {
+      "name": "appearance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appearance_mode": {
+          "name": "appearance_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "light_color_scheme": {
+          "name": "light_color_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ocean'"
+        },
+        "dark_color_scheme": {
+          "name": "dark_color_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'midnight'"
+        },
+        "terminal_opacity": {
+          "name": "terminal_opacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "terminal_blur": {
+          "name": "terminal_blur",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terminal_cursor_style": {
+          "name": "terminal_cursor_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "appearance_settings_user_idx": {
+          "name": "appearance_settings_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appearance_settings_user_id_user_id_fk": {
+          "name": "appearance_settings_user_id_user_id_fk",
+          "tableFrom": "appearance_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "appearance_settings_user_id_unique": {
+          "name": "appearance_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authorized_user": {
+      "name": "authorized_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authorized_user_email_unique": {
+          "name": "authorized_user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_group": {
+      "name": "channel_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "channel_group_project_idx": {
+          "name": "channel_group_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_group_project_name_idx": {
+          "name": "channel_group_project_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_group_project_id_project_id_fk": {
+          "name": "channel_group_project_id_project_id_fk",
+          "tableFrom": "channel_group",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_read_state": {
+      "name": "channel_read_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_message_id": {
+          "name": "last_read_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "channel_read_state_unique_idx": {
+          "name": "channel_read_state_unique_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_read_state_user_idx": {
+          "name": "channel_read_state_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_read_state_channel_id_channel_id_fk": {
+          "name": "channel_read_state_channel_id_channel_id_fk",
+          "tableFrom": "channel_read_state",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_read_state_user_id_user_id_fk": {
+          "name": "channel_read_state_user_id_user_id_fk",
+          "tableFrom": "channel_read_state",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_subscription": {
+      "name": "channel_subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto_deliver'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "channel_subscription_unique_idx": {
+          "name": "channel_subscription_unique_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_subscription_channel_id_channel_id_fk": {
+          "name": "channel_subscription_channel_id_channel_id_fk",
+          "tableFrom": "channel_subscription",
+          "tableTo": "channel",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_subscription_session_id_terminal_session_id_fk": {
+          "name": "channel_subscription_session_id_terminal_session_id_fk",
+          "tableFrom": "channel_subscription",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel": {
+      "name": "channel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "channel_project_idx": {
+          "name": "channel_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_group_idx": {
+          "name": "channel_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_project_name_idx": {
+          "name": "channel_project_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_project_id_project_id_fk": {
+          "name": "channel_project_id_project_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_group_id_channel_group_id_fk": {
+          "name": "channel_group_id_channel_group_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "channel_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.color_scheme": {
+      "name": "color_scheme",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color_definitions": {
+          "name": "color_definitions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_palette": {
+          "name": "terminal_palette",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_built_in": {
+          "name": "is_built_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "color_scheme_category_idx": {
+          "name": "color_scheme_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "color_scheme_sort_idx": {
+          "name": "color_scheme_sort_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.command_execution": {
+      "name": "command_execution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_id": {
+          "name": "command_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "command_execution_execution_idx": {
+          "name": "command_execution_execution_idx",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "command_execution_command_idx": {
+          "name": "command_execution_command_idx",
+          "columns": [
+            {
+              "expression": "command_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "command_execution_execution_id_schedule_execution_id_fk": {
+          "name": "command_execution_execution_id_schedule_execution_id_fk",
+          "tableFrom": "command_execution",
+          "tableTo": "schedule_execution",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "command_execution_command_id_schedule_command_id_fk": {
+          "name": "command_execution_command_id_schedule_command_id_fk",
+          "tableFrom": "command_execution",
+          "tableTo": "schedule_command",
+          "columnsFrom": [
+            "command_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crown_candidate": {
+      "name": "crown_candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "crown_run_id": {
+          "name": "crown_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff": {
+          "name": "diff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff_stats": {
+          "name": "diff_stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "crown_candidate_run_idx": {
+          "name": "crown_candidate_run_idx",
+          "columns": [
+            {
+              "expression": "crown_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crown_candidate_crown_run_id_crown_run_id_fk": {
+          "name": "crown_candidate_crown_run_id_crown_run_id_fk",
+          "tableFrom": "crown_candidate",
+          "tableTo": "crown_run",
+          "columnsFrom": [
+            "crown_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crown_candidate_run_id_agent_run_id_fk": {
+          "name": "crown_candidate_run_id_agent_run_id_fk",
+          "tableFrom": "crown_candidate",
+          "tableTo": "agent_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crown_run": {
+      "name": "crown_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_provider": {
+          "name": "agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "candidate_count": {
+          "name": "candidate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_model": {
+          "name": "judge_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "winner_candidate_id": {
+          "name": "winner_candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crown_reason": {
+          "name": "crown_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "crown_run_user_idx": {
+          "name": "crown_run_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crown_run_user_id_user_id_fk": {
+          "name": "crown_run_user_id_user_id_fk",
+          "tableFrom": "crown_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crown_run_project_id_project_id_fk": {
+          "name": "crown_run_project_id_project_id_fk",
+          "tableFrom": "crown_run",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_account_metadata": {
+      "name": "github_account_metadata",
+      "schema": "",
+      "columns": {
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config_dir": {
+          "name": "config_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_account_metadata_user_idx": {
+          "name": "github_account_metadata_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_account_metadata_user_id_user_id_fk": {
+          "name": "github_account_metadata_user_id_user_id_fk",
+          "tableFrom": "github_account_metadata",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_branch_protection": {
+      "name": "github_branch_protection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_protected": {
+          "name": "is_protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_review": {
+          "name": "requires_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "required_reviewers": {
+          "name": "required_reviewers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "requires_status_checks": {
+          "name": "requires_status_checks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "required_checks": {
+          "name": "required_checks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allows_force_pushes": {
+          "name": "allows_force_pushes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allows_deletions": {
+          "name": "allows_deletions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_branch_protection_repo_branch_idx": {
+          "name": "github_branch_protection_repo_branch_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_branch_protection_repository_id_github_repository_id_fk": {
+          "name": "github_branch_protection_repository_id_github_repository_id_fk",
+          "tableFrom": "github_branch_protection",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_change_notification": {
+      "name": "github_change_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_pr_count": {
+          "name": "new_pr_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "new_issue_count": {
+          "name": "new_issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_notifications_user_repo_idx": {
+          "name": "github_notifications_user_repo_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_notifications_user_idx": {
+          "name": "github_notifications_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_change_notification_user_id_user_id_fk": {
+          "name": "github_change_notification_user_id_user_id_fk",
+          "tableFrom": "github_change_notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_change_notification_repository_id_github_repository_id_fk": {
+          "name": "github_change_notification_repository_id_github_repository_id_fk",
+          "tableFrom": "github_change_notification",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue": {
+      "name": "github_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "assignees": {
+          "name": "assignees",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_pull_request": {
+          "name": "is_pull_request",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_issue_repo_idx": {
+          "name": "github_issue_repo_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_issue_repo_number_idx": {
+          "name": "github_issue_repo_number_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_issue_state_idx": {
+          "name": "github_issue_state_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_issue_cached_idx": {
+          "name": "github_issue_cached_idx",
+          "columns": [
+            {
+              "expression": "cached_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_repository_id_github_repository_id_fk": {
+          "name": "github_issue_repository_id_github_repository_id_fk",
+          "tableFrom": "github_issue",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_pull_request": {
+      "name": "github_pull_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ci_status": {
+          "name": "ci_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pr_repo_idx": {
+          "name": "github_pr_repo_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pr_repo_number_idx": {
+          "name": "github_pr_repo_number_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pr_state_idx": {
+          "name": "github_pr_state_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_pull_request_repository_id_github_repository_id_fk": {
+          "name": "github_pull_request_repository_id_github_repository_id_fk",
+          "tableFrom": "github_pull_request",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository": {
+      "name": "github_repository",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_repo_user_idx": {
+          "name": "github_repo_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repo_github_id_idx": {
+          "name": "github_repo_github_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_user_id_user_id_fk": {
+          "name": "github_repository_user_id_user_id_fk",
+          "tableFrom": "github_repository",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repository_stats": {
+      "name": "github_repository_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "open_pr_count": {
+          "name": "open_pr_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "open_issue_count": {
+          "name": "open_issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ci_status": {
+          "name": "ci_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ci_status_details": {
+          "name": "ci_status_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch_protected": {
+          "name": "branch_protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "branch_protection_details": {
+          "name": "branch_protection_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recent_commits": {
+          "name": "recent_commits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_repo_stats_repo_idx": {
+          "name": "github_repo_stats_repo_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repo_stats_expires_idx": {
+          "name": "github_repo_stats_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_stats_repository_id_github_repository_id_fk": {
+          "name": "github_repository_stats_repository_id_github_repository_id_fk",
+          "tableFrom": "github_repository_stats",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_repository_stats_repository_id_unique": {
+          "name": "github_repository_stats_repository_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "repository_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_stats_preferences": {
+      "name": "github_stats_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_pr_count": {
+          "name": "show_pr_count",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_issue_count": {
+          "name": "show_issue_count",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_ci_status": {
+          "name": "show_ci_status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_recent_commits": {
+          "name": "show_recent_commits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_branch_protection": {
+          "name": "show_branch_protection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "refresh_interval_minutes": {
+          "name": "refresh_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_stats_prefs_user_idx": {
+          "name": "github_stats_prefs_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_stats_prefs_project_idx": {
+          "name": "github_stats_prefs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_stats_preferences_user_id_user_id_fk": {
+          "name": "github_stats_preferences_user_id_user_id_fk",
+          "tableFrom": "github_stats_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_stats_preferences_project_id_project_id_fk": {
+          "name": "github_stats_preferences_project_id_project_id_fk",
+          "tableFrom": "github_stats_preferences",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.litellm_config": {
+      "name": "litellm_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_start": {
+          "name": "auto_start",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4000
+        },
+        "master_key": {
+          "name": "master_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "litellm_config_user_id_user_id_fk": {
+          "name": "litellm_config_user_id_user_id_fk",
+          "tableFrom": "litellm_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "litellm_config_user_id_unique": {
+          "name": "litellm_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.litellm_model": {
+      "name": "litellm_model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "litellm_model": {
+          "name": "litellm_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base": {
+          "name": "api_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_headers": {
+          "name": "extra_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "litellm_model_user_idx": {
+          "name": "litellm_model_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "litellm_model_user_id_user_id_fk": {
+          "name": "litellm_model_user_id_user_id_fk",
+          "tableFrom": "litellm_model",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_discovered_resource": {
+      "name": "mcp_discovered_resource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_discovered_resource_server_idx": {
+          "name": "mcp_discovered_resource_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_discovered_resource_unique_idx": {
+          "name": "mcp_discovered_resource_unique_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_discovered_resource_server_id_mcp_server_id_fk": {
+          "name": "mcp_discovered_resource_server_id_mcp_server_id_fk",
+          "tableFrom": "mcp_discovered_resource",
+          "tableTo": "mcp_server",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_discovered_tool": {
+      "name": "mcp_discovered_tool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_discovered_tool_server_idx": {
+          "name": "mcp_discovered_tool_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_discovered_tool_unique_idx": {
+          "name": "mcp_discovered_tool_unique_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_discovered_tool_server_id_mcp_server_id_fk": {
+          "name": "mcp_discovered_tool_server_id_mcp_server_id_fk",
+          "tableFrom": "mcp_discovered_tool",
+          "tableTo": "mcp_server",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server": {
+      "name": "mcp_server",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stdio'"
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_start": {
+          "name": "auto_start",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_server_user_idx": {
+          "name": "mcp_server_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_server_project_idx": {
+          "name": "mcp_server_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_server_enabled_idx": {
+          "name": "mcp_server_enabled_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_server_user_id_user_id_fk": {
+          "name": "mcp_server_user_id_user_id_fk",
+          "tableFrom": "mcp_server",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_server_project_id_project_id_fk": {
+          "name": "mcp_server_project_id_project_id_fk",
+          "tableFrom": "mcp_server",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_delivery": {
+      "name": "message_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_session_id": {
+          "name": "to_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "channel_kind": {
+          "name": "channel_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_delivery_msg_session_idx": {
+          "name": "message_delivery_msg_session_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_delivery_session_state_idx": {
+          "name": "message_delivery_session_state_idx",
+          "columns": [
+            {
+              "expression": "to_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_delivery_message_id_agent_peer_message_id_fk": {
+          "name": "message_delivery_message_id_agent_peer_message_id_fk",
+          "tableFrom": "message_delivery",
+          "tableTo": "agent_peer_message",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_delivery_to_session_id_terminal_session_id_fk": {
+          "name": "message_delivery_to_session_id_terminal_session_id_fk",
+          "tableFrom": "message_delivery",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "to_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_replay_cursor": {
+      "name": "message_replay_cursor",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_acked_at": {
+          "name": "last_acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "message_replay_cursor_session_id_terminal_session_id_fk": {
+          "name": "message_replay_cursor_session_id_terminal_session_id_fk",
+          "tableFrom": "message_replay_cursor",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_proxy_token": {
+      "name": "model_proxy_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_slug": {
+          "name": "instance_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_scope": {
+          "name": "provider_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"anthropic\"]'"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "model_proxy_token_prefix_idx": {
+          "name": "model_proxy_token_prefix_idx",
+          "columns": [
+            {
+              "expression": "token_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_proxy_token_session_idx": {
+          "name": "model_proxy_token_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_proxy_token_user_idx": {
+          "name": "model_proxy_token_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_proxy_token_user_id_user_id_fk": {
+          "name": "model_proxy_token_user_id_user_id_fk",
+          "tableFrom": "model_proxy_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_proxy_token_session_id_terminal_session_id_fk": {
+          "name": "model_proxy_token_session_id_terminal_session_id_fk",
+          "tableFrom": "model_proxy_token",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_usage_event": {
+      "name": "model_usage_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_slug": {
+          "name": "instance_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_micro_usd": {
+          "name": "cost_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "model_usage_session_idx": {
+          "name": "model_usage_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_usage_user_idx": {
+          "name": "model_usage_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_usage_instance_idx": {
+          "name": "model_usage_instance_idx",
+          "columns": [
+            {
+              "expression": "instance_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_usage_created_idx": {
+          "name": "model_usage_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.node_preferences": {
+      "name": "node_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_working_directory": {
+          "name": "default_working_directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_shell": {
+          "name": "default_shell",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_command": {
+          "name": "startup_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_repo_path": {
+          "name": "local_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_agent_provider": {
+          "name": "default_agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_provider_settings": {
+          "name": "agent_provider_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment_vars": {
+          "name": "environment_vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_files": {
+          "name": "pinned_files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_identity_name": {
+          "name": "git_identity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_identity_email": {
+          "name": "git_identity_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_sensitive": {
+          "name": "is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "node_pref_owner_idx": {
+          "name": "node_pref_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "node_pref_owner_user_idx": {
+          "name": "node_pref_owner_user_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_preferences_user_id_user_id_fk": {
+          "name": "node_preferences_user_id_user_id_fk",
+          "tableFrom": "node_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_event": {
+      "name": "notification_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_name": {
+          "name": "session_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'passive'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coalesce_key": {
+          "name": "coalesce_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "notification_event_user_created_idx": {
+          "name": "notification_event_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_event_user_read_idx": {
+          "name": "notification_event_user_read_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_event_coalesce_idx": {
+          "name": "notification_event_coalesce_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_event_user_id_user_id_fk": {
+          "name": "notification_event_user_id_user_id_fk",
+          "tableFrom": "notification_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_event_session_id_terminal_session_id_fk": {
+          "name": "notification_event_session_id_terminal_session_id_fk",
+          "tableFrom": "notification_event",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "push_by_type": {
+          "name": "push_by_type",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "muted_session_ids": {
+          "name": "muted_session_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_push_severity": {
+          "name": "min_push_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'actionable'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_user_id_fk": {
+          "name": "notification_preferences_user_id_user_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.port_claim": {
+      "name": "port_claim",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variable_name": {
+          "name": "variable_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listening": {
+          "name": "is_listening",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "port_claim_session_idx": {
+          "name": "port_claim_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "port_claim_user_idx": {
+          "name": "port_claim_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "port_claim_port_idx": {
+          "name": "port_claim_port_idx",
+          "columns": [
+            {
+              "expression": "port",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "port_claim_session_port_unique": {
+          "name": "port_claim_session_port_unique",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "port",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "port_claim_session_id_terminal_session_id_fk": {
+          "name": "port_claim_session_id_terminal_session_id_fk",
+          "tableFrom": "port_claim",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "port_claim_user_id_user_id_fk": {
+          "name": "port_claim_user_id_user_id_fk",
+          "tableFrom": "port_claim",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "port_claim_project_id_project_id_fk": {
+          "name": "port_claim_project_id_project_id_fk",
+          "tableFrom": "port_claim",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.port_registry": {
+      "name": "port_registry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variable_name": {
+          "name": "variable_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "port_registry_user_idx": {
+          "name": "port_registry_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "port_registry_project_idx": {
+          "name": "port_registry_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "port_registry_user_port_idx": {
+          "name": "port_registry_user_port_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "port",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "port_registry_user_port_var_unique": {
+          "name": "port_registry_user_port_var_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "port",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variable_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "port_registry_project_id_project_id_fk": {
+          "name": "port_registry_project_id_project_id_fk",
+          "tableFrom": "port_registry",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "port_registry_user_id_user_id_fk": {
+          "name": "port_registry_user_id_user_id_fk",
+          "tableFrom": "port_registry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_appearance_settings": {
+      "name": "profile_appearance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appearance_mode": {
+          "name": "appearance_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "light_color_scheme": {
+          "name": "light_color_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ocean'"
+        },
+        "dark_color_scheme": {
+          "name": "dark_color_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'midnight'"
+        },
+        "terminal_opacity": {
+          "name": "terminal_opacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "terminal_blur": {
+          "name": "terminal_blur",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "terminal_cursor_style": {
+          "name": "terminal_cursor_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_appearance_profile_idx": {
+          "name": "profile_appearance_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profile_appearance_user_idx": {
+          "name": "profile_appearance_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_appearance_settings_profile_id_agent_profile_id_fk": {
+          "name": "profile_appearance_settings_profile_id_agent_profile_id_fk",
+          "tableFrom": "profile_appearance_settings",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_appearance_settings_user_id_user_id_fk": {
+          "name": "profile_appearance_settings_user_id_user_id_fk",
+          "tableFrom": "profile_appearance_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_appearance_settings_profile_id_unique": {
+          "name": "profile_appearance_settings_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_git_identity": {
+      "name": "profile_git_identity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ssh_key_path": {
+          "name": "ssh_key_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpg_key_id": {
+          "name": "gpg_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_git_identity_profile_idx": {
+          "name": "profile_git_identity_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_git_identity_profile_id_agent_profile_id_fk": {
+          "name": "profile_git_identity_profile_id_agent_profile_id_fk",
+          "tableFrom": "profile_git_identity",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_git_identity_profile_id_unique": {
+          "name": "profile_git_identity_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_secrets_config": {
+      "name": "profile_secrets_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_secrets_config_profile_idx": {
+          "name": "profile_secrets_config_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profile_secrets_config_user_idx": {
+          "name": "profile_secrets_config_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_secrets_config_profile_id_agent_profile_id_fk": {
+          "name": "profile_secrets_config_profile_id_agent_profile_id_fk",
+          "tableFrom": "profile_secrets_config",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "profile_secrets_config_user_id_user_id_fk": {
+          "name": "profile_secrets_config_user_id_user_id_fk",
+          "tableFrom": "profile_secrets_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_secrets_config_profile_id_unique": {
+          "name": "profile_secrets_config_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_github_account_link": {
+      "name": "project_github_account_link",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_gh_link_account_idx": {
+          "name": "project_gh_link_account_idx",
+          "columns": [
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_github_account_link_project_id_project_id_fk": {
+          "name": "project_github_account_link_project_id_project_id_fk",
+          "tableFrom": "project_github_account_link",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_group": {
+      "name": "project_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_group_id": {
+          "name": "parent_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_group_user_idx": {
+          "name": "project_group_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_parent_idx": {
+          "name": "project_group_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_user_id_user_id_fk": {
+          "name": "project_group_user_id_user_id_fk",
+          "tableFrom": "project_group",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_parent_group_id_project_group_id_fk": {
+          "name": "project_group_parent_group_id_project_group_id_fk",
+          "tableFrom": "project_group",
+          "tableTo": "project_group",
+          "columnsFrom": [
+            "parent_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_profile_link": {
+      "name": "project_profile_link",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_profile_link_profile_idx": {
+          "name": "project_profile_link_profile_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_profile_link_project_id_project_id_fk": {
+          "name": "project_profile_link_project_id_project_id_fk",
+          "tableFrom": "project_profile_link",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_profile_link_profile_id_agent_profile_id_fk": {
+          "name": "project_profile_link_profile_id_agent_profile_id_fk",
+          "tableFrom": "project_profile_link",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_repository": {
+      "name": "project_repository",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_repo_project_user_idx": {
+          "name": "project_repo_project_user_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_repo_user_idx": {
+          "name": "project_repo_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_repository_project_id_project_id_fk": {
+          "name": "project_repository_project_id_project_id_fk",
+          "tableFrom": "project_repository",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_repository_repository_id_github_repository_id_fk": {
+          "name": "project_repository_repository_id_github_repository_id_fk",
+          "tableFrom": "project_repository",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_repository_user_id_user_id_fk": {
+          "name": "project_repository_user_id_user_id_fk",
+          "tableFrom": "project_repository",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_secrets_config": {
+      "name": "project_secrets_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_config": {
+          "name": "provider_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_secrets_project_user_idx": {
+          "name": "project_secrets_project_user_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_secrets_config_user_id_user_id_fk": {
+          "name": "project_secrets_config_user_id_user_id_fk",
+          "tableFrom": "project_secrets_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_secrets_config_project_id_project_id_fk": {
+          "name": "project_secrets_config_project_id_project_id_fk",
+          "tableFrom": "project_secrets_config",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_task": {
+      "name": "project_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "subtasks": {
+          "name": "subtasks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_task_key": {
+          "name": "agent_task_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_task_user_idx": {
+          "name": "project_task_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_task_project_idx": {
+          "name": "project_task_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_task_user_project_idx": {
+          "name": "project_task_user_project_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_task_session_idx": {
+          "name": "project_task_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_task_agent_key_idx": {
+          "name": "project_task_agent_key_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_task_user_id_user_id_fk": {
+          "name": "project_task_user_id_user_id_fk",
+          "tableFrom": "project_task",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_task_project_id_project_id_fk": {
+          "name": "project_task_project_id_project_id_fk",
+          "tableFrom": "project_task",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_task_session_id_terminal_session_id_fk": {
+          "name": "project_task_session_id_terminal_session_id_fk",
+          "tableFrom": "project_task",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_auto_created": {
+          "name": "is_auto_created",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_user_idx": {
+          "name": "project_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_group_idx": {
+          "name": "project_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_user_id_user_id_fk": {
+          "name": "project_user_id_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_id_project_group_id_fk": {
+          "name": "project_group_id_project_group_id_fk",
+          "tableFrom": "project",
+          "tableTo": "project_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_token": {
+      "name": "push_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fcm_token": {
+          "name": "fcm_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "push_token_user_idx": {
+          "name": "push_token_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_token_fcm_token_idx": {
+          "name": "push_token_fcm_token_idx",
+          "columns": [
+            {
+              "expression": "fcm_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_token_user_id_user_id_fk": {
+          "name": "push_token_user_id_user_id_fk",
+          "tableFrom": "push_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_command": {
+      "name": "schedule_command",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delay_before_seconds": {
+          "name": "delay_before_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "continue_on_error": {
+          "name": "continue_on_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "schedule_command_schedule_idx": {
+          "name": "schedule_command_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedule_command_order_idx": {
+          "name": "schedule_command_order_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_command_schedule_id_session_schedule_id_fk": {
+          "name": "schedule_command_schedule_id_session_schedule_id_fk",
+          "tableFrom": "schedule_command",
+          "tableTo": "session_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_execution": {
+      "name": "schedule_execution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_count": {
+          "name": "command_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "schedule_execution_schedule_idx": {
+          "name": "schedule_execution_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedule_execution_started_idx": {
+          "name": "schedule_execution_started_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_execution_schedule_id_session_schedule_id_fk": {
+          "name": "schedule_execution_schedule_id_session_schedule_id_fk",
+          "tableFrom": "schedule_execution",
+          "tableTo": "session_schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_memory": {
+      "name": "session_memory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_memory_user_idx": {
+          "name": "session_memory_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_memory_project_idx": {
+          "name": "session_memory_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_memory_type_idx": {
+          "name": "session_memory_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_memory_user_id_user_id_fk": {
+          "name": "session_memory_user_id_user_id_fk",
+          "tableFrom": "session_memory",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_memory_project_id_project_id_fk": {
+          "name": "session_memory_project_id_project_id_fk",
+          "tableFrom": "session_memory",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_recording": {
+      "name": "session_recording",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_cols": {
+          "name": "terminal_cols",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 80
+        },
+        "terminal_rows": {
+          "name": "terminal_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_recording_user_idx": {
+          "name": "session_recording_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_recording_created_idx": {
+          "name": "session_recording_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_recording_user_id_user_id_fk": {
+          "name": "session_recording_user_id_user_id_fk",
+          "tableFrom": "session_recording",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_schedule": {
+      "name": "session_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'one-time'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/Los_Angeles'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_delay_seconds": {
+          "name": "retry_delay_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "timeout_seconds": {
+          "name": "timeout_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_status": {
+          "name": "last_run_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_schedule_user_idx": {
+          "name": "session_schedule_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_schedule_session_idx": {
+          "name": "session_schedule_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_schedule_next_run_idx": {
+          "name": "session_schedule_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_schedule_user_id_user_id_fk": {
+          "name": "session_schedule_user_id_user_id_fk",
+          "tableFrom": "session_schedule",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_schedule_session_id_terminal_session_id_fk": {
+          "name": "session_schedule_session_id_terminal_session_id_fk",
+          "tableFrom": "session_schedule",
+          "tableTo": "terminal_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_template": {
+      "name": "session_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_name_pattern": {
+          "name": "session_name_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_command": {
+          "name": "startup_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_template_user_idx": {
+          "name": "session_template_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_template_usage_idx": {
+          "name": "session_template_usage_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usage_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_template_project_idx": {
+          "name": "session_template_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_template_user_id_user_id_fk": {
+          "name": "session_template_user_id_user_id_fk",
+          "tableFrom": "session_template",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_template_project_id_project_id_fk": {
+          "name": "session_template_project_id_project_id_fk",
+          "tableFrom": "session_template",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup_config": {
+      "name": "setup_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "working_directory": {
+          "name": "working_directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_port": {
+          "name": "next_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3000
+        },
+        "terminal_port": {
+          "name": "terminal_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3001
+        },
+        "wsl_distribution": {
+          "name": "wsl_distribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_start": {
+          "name": "auto_start",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "check_for_updates": {
+          "name": "check_for_updates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssh_connection": {
+      "name": "ssh_connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 22
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_passphrase": {
+          "name": "has_passphrase",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password_enc": {
+          "name": "password_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "known_hosts_policy": {
+          "name": "known_hosts_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'accept-new'"
+        },
+        "extra_options": {
+          "name": "extra_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ssh_connection_user_project_idx": {
+          "name": "ssh_connection_user_project_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssh_connection_user_id_user_id_fk": {
+          "name": "ssh_connection_user_id_user_id_fk",
+          "tableFrom": "ssh_connection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ssh_connection_project_id_project_id_fk": {
+          "name": "ssh_connection_project_id_project_id_fk",
+          "tableFrom": "ssh_connection",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_update_cache": {
+      "name": "system_update_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_release_json": {
+          "name": "cached_release_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_state_json": {
+          "name": "deployment_state_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_dependency": {
+      "name": "task_dependency",
+      "schema": "",
+      "columns": {
+        "blocker_id": {
+          "name": "blocker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "task_dep_blocker_idx": {
+          "name": "task_dep_blocker_idx",
+          "columns": [
+            {
+              "expression": "blocker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_dep_blocked_idx": {
+          "name": "task_dep_blocked_idx",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_dependency_blocker_id_project_task_id_fk": {
+          "name": "task_dependency_blocker_id_project_task_id_fk",
+          "tableFrom": "task_dependency",
+          "tableTo": "project_task",
+          "columnsFrom": [
+            "blocker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_dependency_blocked_id_project_task_id_fk": {
+          "name": "task_dependency_blocked_id_project_task_id_fk",
+          "tableFrom": "task_dependency",
+          "tableTo": "project_task",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_dependency_blocker_id_blocked_id_pk": {
+          "name": "task_dependency_blocker_id_blocked_id_pk",
+          "columns": [
+            "blocker_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.terminal_session": {
+      "name": "terminal_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tmux_session_name": {
+          "name": "tmux_session_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worktree_branch": {
+          "name": "worktree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worktree_type": {
+          "name": "worktree_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_type": {
+          "name": "terminal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'shell'"
+        },
+        "agent_provider": {
+          "name": "agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_exit_state": {
+          "name": "agent_exit_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_exit_code": {
+          "name": "agent_exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_exited_at": {
+          "name": "agent_exited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_restart_count": {
+          "name": "agent_restart_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "agent_activity_status": {
+          "name": "agent_activity_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_metadata": {
+          "name": "type_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orchestrator_role": {
+          "name": "orchestrator_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "terminal_session_user_status_idx": {
+          "name": "terminal_session_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "terminal_session_user_order_idx": {
+          "name": "terminal_session_user_order_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tab_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "terminal_session_project_idx": {
+          "name": "terminal_session_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "terminal_session_type_idx": {
+          "name": "terminal_session_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "terminal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "terminal_session_scope_unique_idx": {
+          "name": "terminal_session_scope_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "terminal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "terminal_session_user_id_user_id_fk": {
+          "name": "terminal_session_user_id_user_id_fk",
+          "tableFrom": "terminal_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_session_github_repo_id_github_repository_id_fk": {
+          "name": "terminal_session_github_repo_id_github_repository_id_fk",
+          "tableFrom": "terminal_session",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "github_repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "terminal_session_project_id_project_id_fk": {
+          "name": "terminal_session_project_id_project_id_fk",
+          "tableFrom": "terminal_session",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_session_profile_id_agent_profile_id_fk": {
+          "name": "terminal_session_profile_id_agent_profile_id_fk",
+          "tableFrom": "terminal_session",
+          "tableTo": "agent_profile",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "terminal_session_tmux_session_name_unique": {
+          "name": "terminal_session_tmux_session_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tmux_session_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trash_item": {
+      "name": "trash_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_name": {
+          "name": "resource_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trashed_at": {
+          "name": "trashed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "trash_item_user_type_idx": {
+          "name": "trash_item_user_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trash_item_expires_idx": {
+          "name": "trash_item_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trash_item_resource_idx": {
+          "name": "trash_item_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trash_item_user_id_user_id_fk": {
+          "name": "trash_item_user_id_user_id_fk",
+          "tableFrom": "trash_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_config": {
+      "name": "trigger_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "agent_provider": {
+          "name": "agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "agent_flags": {
+          "name": "agent_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "prompt_template": {
+          "name": "prompt_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worktree_type": {
+          "name": "worktree_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "trigger_config_user_idx": {
+          "name": "trigger_config_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_config_repo_idx": {
+          "name": "trigger_config_repo_idx",
+          "columns": [
+            {
+              "expression": "github_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_config_user_id_user_id_fk": {
+          "name": "trigger_config_user_id_user_id_fk",
+          "tableFrom": "trigger_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_config_project_id_project_id_fk": {
+          "name": "trigger_config_project_id_project_id_fk",
+          "tableFrom": "trigger_config",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_config_github_repo_id_github_repository_id_fk": {
+          "name": "trigger_config_github_repo_id_github_repository_id_fk",
+          "tableFrom": "trigger_config",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "github_repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_event": {
+      "name": "trigger_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_config_id": {
+          "name": "trigger_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched": {
+          "name": "matched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "trigger_event_config_idx": {
+          "name": "trigger_event_config_idx",
+          "columns": [
+            {
+              "expression": "trigger_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_event_trigger_config_id_trigger_config_id_fk": {
+          "name": "trigger_event_trigger_config_id_trigger_config_id_fk",
+          "tableFrom": "trigger_event",
+          "tableTo": "trigger_config",
+          "columnsFrom": [
+            "trigger_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_event_run_id_agent_run_id_fk": {
+          "name": "trigger_event_run_id_agent_run_id_fk",
+          "tableFrom": "trigger_event",
+          "tableTo": "agent_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_email": {
+      "name": "user_email",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_email_user_idx": {
+          "name": "user_email_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_email_user_id_user_id_fk": {
+          "name": "user_email_user_id_user_id_fk",
+          "tableFrom": "user_email",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_email_unique": {
+          "name": "user_email_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_working_directory": {
+          "name": "default_working_directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_shell": {
+          "name": "default_shell",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_command": {
+          "name": "startup_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xterm_scrollback": {
+          "name": "xterm_scrollback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10000
+        },
+        "tmux_history_limit": {
+          "name": "tmux_history_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 50000
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'tokyo-night'"
+        },
+        "font_size": {
+          "name": "font_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 14
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'''JetBrainsMono Nerd Font Mono'', monospace'"
+        },
+        "active_node_id": {
+          "name": "active_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_node_type": {
+          "name": "active_node_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_node_id": {
+          "name": "pinned_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_node_type": {
+          "name": "pinned_node_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_follow_active_session": {
+          "name": "auto_follow_active_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_agent_provider": {
+          "name": "default_agent_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_provider_settings": {
+          "name": "agent_provider_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beads_sidebar_collapsed": {
+          "name": "beads_sidebar_collapsed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "beads_sidebar_width": {
+          "name": "beads_sidebar_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 320
+        },
+        "beads_closed_retention_days": {
+          "name": "beads_closed_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 7
+        },
+        "beads_section_expanded": {
+          "name": "beads_section_expanded",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "name": "verificationToken_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worktree_trash_metadata": {
+      "name": "worktree_trash_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trash_item_id": {
+          "name": "trash_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_local_path": {
+          "name": "repo_local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worktree_branch": {
+          "name": "worktree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worktree_original_path": {
+          "name": "worktree_original_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worktree_trash_path": {
+          "name": "worktree_trash_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_project_id": {
+          "name": "original_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_project_name": {
+          "name": "original_project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "worktree_trash_repo_idx": {
+          "name": "worktree_trash_repo_idx",
+          "columns": [
+            {
+              "expression": "github_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "worktree_trash_metadata_trash_item_id_trash_item_id_fk": {
+          "name": "worktree_trash_metadata_trash_item_id_trash_item_id_fk",
+          "tableFrom": "worktree_trash_metadata",
+          "tableTo": "trash_item",
+          "columnsFrom": [
+            "trash_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worktree_trash_metadata_github_repo_id_github_repository_id_fk": {
+          "name": "worktree_trash_metadata_github_repo_id_github_repository_id_fk",
+          "tableFrom": "worktree_trash_metadata",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "github_repo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "worktree_trash_metadata_trash_item_id_unique": {
+          "name": "worktree_trash_metadata_trash_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trash_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/pg/meta/_journal.json
+++ b/drizzle/pg/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1780534956785,
       "tag": "0004_wise_maddog",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1780535315762,
+      "tag": "0005_youthful_hex",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/__tests__/schema-column-diff.test.ts
+++ b/src/db/__tests__/schema-column-diff.test.ts
@@ -57,11 +57,12 @@ describe("schema column diff (sqlite-core vs pg-core)", () => {
     const sqliteTables = [...sqlite.keys()].sort();
     const pgTables = [...pg.keys()].sort();
     expect(pgTables).toEqual(sqliteTables);
-    // Sanity: the full schema is 70 tables: 61 base +1 notification_preferences
-    // (y5ch) +2 model_proxy_token/model_usage_event (aehq) +6 oyej automation
-    // (agentSchedules, agentRuns, triggerConfigs, triggerEvents, crownRuns,
-    // crownCandidates).
-    expect(sqliteTables).toHaveLength(70);
+    // Sanity: 61 base + 1 (y5ch: notification_preferences) + 2 (aehq:
+    // model_proxy_token, model_usage_event) + 6 (oyej: agentSchedules,
+    // agentRuns, triggerConfigs, triggerEvents, crownRuns, crownCandidates)
+    // + 4 (x386: message_delivery, message_replay_cursor, channel_subscription,
+    // agent_work_context) = 74 tables.
+    expect(sqliteTables).toHaveLength(74);
   });
 
   // One assertion per table so a failure names the offending table.

--- a/src/db/__tests__/schema-parity.test.ts
+++ b/src/db/__tests__/schema-parity.test.ts
@@ -34,7 +34,7 @@ type Equal<A, B> =
 // Compiles only when its argument resolves to the literal `true`.
 type Expect<T extends true> = T;
 
-// Per-table $inferSelect / $inferInsert parity for ALL 70 tables. A drift makes
+// Per-table $inferSelect / $inferInsert parity for ALL 74 tables. A drift makes
 // one of these `false`, which is a compile error on the `true[]` annotation.
 type _SchemaParity = [
   // users
@@ -220,6 +220,16 @@ type _SchemaParity = [
   // sshConnections
   Expect<Equal<(typeof sqliteSchema.sshConnections)["$inferSelect"], (typeof pgSchema.sshConnections)["$inferSelect"]>>,
   Expect<Equal<(typeof sqliteSchema.sshConnections)["$inferInsert"], (typeof pgSchema.sshConnections)["$inferInsert"]>>,
+  // [y5ch.6] notificationPreferences
+  Expect<Equal<(typeof sqliteSchema.notificationPreferences)["$inferSelect"], (typeof pgSchema.notificationPreferences)["$inferSelect"]>>,
+  Expect<Equal<(typeof sqliteSchema.notificationPreferences)["$inferInsert"], (typeof pgSchema.notificationPreferences)["$inferInsert"]>>,
+  // [aehq] model-proxy tables
+  // modelProxyTokens
+  Expect<Equal<(typeof sqliteSchema.modelProxyTokens)["$inferSelect"], (typeof pgSchema.modelProxyTokens)["$inferSelect"]>>,
+  Expect<Equal<(typeof sqliteSchema.modelProxyTokens)["$inferInsert"], (typeof pgSchema.modelProxyTokens)["$inferInsert"]>>,
+  // modelUsageEvents
+  Expect<Equal<(typeof sqliteSchema.modelUsageEvents)["$inferSelect"], (typeof pgSchema.modelUsageEvents)["$inferSelect"]>>,
+  Expect<Equal<(typeof sqliteSchema.modelUsageEvents)["$inferInsert"], (typeof pgSchema.modelUsageEvents)["$inferInsert"]>>,
   // [oyej] automation tables
   // triggerConfigs
   Expect<Equal<(typeof sqliteSchema.triggerConfigs)["$inferSelect"], (typeof pgSchema.triggerConfigs)["$inferSelect"]>>,
@@ -239,6 +249,19 @@ type _SchemaParity = [
   // crownCandidates
   Expect<Equal<(typeof sqliteSchema.crownCandidates)["$inferSelect"], (typeof pgSchema.crownCandidates)["$inferSelect"]>>,
   Expect<Equal<(typeof sqliteSchema.crownCandidates)["$inferInsert"], (typeof pgSchema.crownCandidates)["$inferInsert"]>>,
+  // [x386] chat & coordination tables
+  // messageDelivery
+  Expect<Equal<(typeof sqliteSchema.messageDelivery)["$inferSelect"], (typeof pgSchema.messageDelivery)["$inferSelect"]>>,
+  Expect<Equal<(typeof sqliteSchema.messageDelivery)["$inferInsert"], (typeof pgSchema.messageDelivery)["$inferInsert"]>>,
+  // messageReplayCursor
+  Expect<Equal<(typeof sqliteSchema.messageReplayCursor)["$inferSelect"], (typeof pgSchema.messageReplayCursor)["$inferSelect"]>>,
+  Expect<Equal<(typeof sqliteSchema.messageReplayCursor)["$inferInsert"], (typeof pgSchema.messageReplayCursor)["$inferInsert"]>>,
+  // channelSubscription
+  Expect<Equal<(typeof sqliteSchema.channelSubscription)["$inferSelect"], (typeof pgSchema.channelSubscription)["$inferSelect"]>>,
+  Expect<Equal<(typeof sqliteSchema.channelSubscription)["$inferInsert"], (typeof pgSchema.channelSubscription)["$inferInsert"]>>,
+  // agentWorkContext
+  Expect<Equal<(typeof sqliteSchema.agentWorkContext)["$inferSelect"], (typeof pgSchema.agentWorkContext)["$inferSelect"]>>,
+  Expect<Equal<(typeof sqliteSchema.agentWorkContext)["$inferInsert"], (typeof pgSchema.agentWorkContext)["$inferInsert"]>>,
 ];
 
 // Force the assertion tuple to be evaluated: `true[]` only accepts a tuple
@@ -249,12 +272,13 @@ void _parityHolds;
 
 // Trivial runtime test so vitest treats this file as a (passing) suite. The
 // real guarantee is the compile-time tuple above, enforced by `tsc`.
-it("schema.sqlite and schema.pg expose the same 70 table exports", () => {
+it("schema.sqlite and schema.pg expose the same 74 table exports", () => {
   const sqliteTables = Object.keys(sqliteSchema).sort();
   const pgTables = Object.keys(pgSchema).sort();
   expect(sqliteTables).toEqual(pgTables);
-  // 61 base +1 notification_preferences (y5ch) +2 model_proxy_token,
-  // model_usage_event (aehq) +6 oyej automation (agentSchedules, agentRuns,
-  // triggerConfigs, triggerEvents, crownRuns, crownCandidates).
-  expect(sqliteTables).toHaveLength(70);
+  // 61 base + 1 (y5ch: notification_preferences) + 2 (aehq: model_proxy_token,
+  // model_usage_event) + 6 (oyej: agentSchedules, agentRuns, triggerConfigs,
+  // triggerEvents, crownRuns, crownCandidates) + 4 (x386: messageDelivery,
+  // messageReplayCursor, channelSubscription, agentWorkContext) = 74.
+  expect(sqliteTables).toHaveLength(74);
 });

--- a/src/db/schema.def.ts
+++ b/src/db/schema.def.ts
@@ -1519,4 +1519,86 @@ export const schema: SchemaDefinition = [
     ],
   },
   // [oyej] end automation platform tables.
+
+  // [x386] Agent-native chat & coordination (epic remote-dev-x386).
+  // Delivery layer (durable inbox + per-recipient state machine) + awareness
+  // layer (channel subscriptions + auto work-context with READ-ONLY bd join).
+  {
+    // Per-recipient delivery state for agent messages (durable inbox).
+    // One row per (messageId, toSessionId). Broadcasts/channels fan out to one
+    // row per subscribed recipient at send time. State advances
+    // pending → delivered → acked so a dropped MCP push is recoverable by poll.
+    exportName: "messageDelivery",
+    sqlName: "message_delivery",
+    columns: [
+      { field: "id", dbName: "id", kind: "text", primaryKey: true, default: { kind: "fn", fn: "uuid" } },
+      { field: "messageId", dbName: "message_id", kind: "text", notNull: true, references: { table: "agentPeerMessages", column: "id", onDelete: "cascade" } },
+      { field: "toSessionId", dbName: "to_session_id", kind: "text", notNull: true, references: { table: "terminalSessions", column: "id", onDelete: "cascade" } },
+      { field: "projectId", dbName: "project_id", kind: "text", notNull: true },
+      // pending = written, not yet pushed; delivered = pushed to a live MCP
+      // socket or returned by a poll; acked = surfaced to the agent.
+      { field: "state", dbName: "state", kind: "text", notNull: true, typeBrand: "\"pending\" | \"delivered\" | \"acked\"", default: { kind: "value", value: "\"pending\"" } },
+      // How it reached the agent (for parity metrics + debugging).
+      { field: "channelType", dbName: "channel_kind", kind: "text", typeBrand: "\"mcp_push\" | \"poll\" | null" },
+      { field: "deliveredAt", dbName: "delivered_at", kind: "timestampMs" },
+      { field: "ackedAt", dbName: "acked_at", kind: "timestampMs" },
+      { field: "createdAt", dbName: "created_at", kind: "timestampMs", notNull: true, default: { kind: "fn", fn: "now" } },
+    ],
+    indexes: [
+      { name: "message_delivery_msg_session_idx", columns: ["messageId","toSessionId"], unique: true },
+      // Replay/poll: "give me undelivered rows for this session, oldest first".
+      { name: "message_delivery_session_state_idx", columns: ["toSessionId","state","createdAt"] },
+    ],
+  },
+  {
+    // Durable per-session replay cursor (survives MCP server restarts; the /tmp
+    // sentinel in peer-server.ts is a fast cache, this DB row is source of truth).
+    exportName: "messageReplayCursor",
+    sqlName: "message_replay_cursor",
+    columns: [
+      { field: "sessionId", dbName: "session_id", kind: "text", primaryKey: true, references: { table: "terminalSessions", column: "id", onDelete: "cascade" } },
+      // Highest agent_peer_message.createdAt the session has acked.
+      { field: "lastAckedAt", dbName: "last_acked_at", kind: "timestampMs" },
+      { field: "updatedAt", dbName: "updated_at", kind: "timestampMs", notNull: true, default: { kind: "fn", fn: "now" } },
+    ],
+  },
+  {
+    // Which sessions auto-receive a channel's non-direct messages. Absence of a
+    // row means "direct/mention only" for that (channel, session).
+    exportName: "channelSubscription",
+    sqlName: "channel_subscription",
+    columns: [
+      { field: "id", dbName: "id", kind: "text", primaryKey: true, default: { kind: "fn", fn: "uuid" } },
+      { field: "channelId", dbName: "channel_id", kind: "text", notNull: true, references: { table: "channels", column: "id", onDelete: "cascade" } },
+      { field: "sessionId", dbName: "session_id", kind: "text", notNull: true, references: { table: "terminalSessions", column: "id", onDelete: "cascade" } },
+      // auto_deliver = push every channel message; direct_only = only @mentions/replies-to-me.
+      { field: "mode", dbName: "mode", kind: "text", notNull: true, typeBrand: "\"auto_deliver\" | \"direct_only\"", default: { kind: "value", value: "\"auto_deliver\"" } },
+      { field: "createdAt", dbName: "created_at", kind: "timestampMs", notNull: true, default: { kind: "fn", fn: "now" } },
+    ],
+    indexes: [
+      { name: "channel_subscription_unique_idx", columns: ["channelId","sessionId"], unique: true },
+    ],
+  },
+  {
+    // Last computed work-context snapshot per session (auto-derived; cache only).
+    // The claimed bd-issue fields are a READ-ONLY mirror for display and are
+    // NEVER written back to bd (bd remains the durable work tracker).
+    exportName: "agentWorkContext",
+    sqlName: "agent_work_context",
+    columns: [
+      { field: "sessionId", dbName: "session_id", kind: "text", primaryKey: true, references: { table: "terminalSessions", column: "id", onDelete: "cascade" } },
+      { field: "projectId", dbName: "project_id", kind: "text", notNull: true },
+      { field: "branch", dbName: "branch", kind: "text" },
+      { field: "worktreePath", dbName: "worktree_path", kind: "text" },
+      { field: "activityStatus", dbName: "activity_status", kind: "text" },
+      { field: "claimedIssueId", dbName: "claimed_issue_id", kind: "text" },
+      { field: "claimedIssueTitle", dbName: "claimed_issue_title", kind: "text" },
+      { field: "joinConfidence", dbName: "join_confidence", kind: "text", typeBrand: "\"branch\" | \"project\" | \"none\"" },
+      { field: "updatedAt", dbName: "updated_at", kind: "timestampMs", notNull: true, default: { kind: "fn", fn: "now" } },
+    ],
+    indexes: [
+      { name: "agent_work_context_project_idx", columns: ["projectId"] },
+    ],
+  },
+  // [x386] end chat & coordination tables.
 ];

--- a/src/db/schema.pg.ts
+++ b/src/db/schema.pg.ts
@@ -1426,3 +1426,63 @@ export const crownCandidates = pgTable(
     index("crown_candidate_run_idx").on(table.crownRunId),
   ]
 );
+
+export const messageDelivery = pgTable(
+  "message_delivery",
+  {
+    id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+    messageId: text("message_id").notNull().references(() => agentPeerMessages.id, { onDelete: "cascade" }),
+    toSessionId: text("to_session_id").notNull().references(() => terminalSessions.id, { onDelete: "cascade" }),
+    projectId: text("project_id").notNull(),
+    state: text("state").$type<"pending" | "delivered" | "acked">().notNull().default("pending"),
+    channelType: text("channel_kind").$type<"mcp_push" | "poll" | null>(),
+    deliveredAt: timestamp("delivered_at", { withTimezone: true, mode: "date" }),
+    ackedAt: timestamp("acked_at", { withTimezone: true, mode: "date" }),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().$defaultFn(() => new Date()),
+  },
+  (table) => [
+    uniqueIndex("message_delivery_msg_session_idx").on(table.messageId, table.toSessionId),
+    index("message_delivery_session_state_idx").on(table.toSessionId, table.state, table.createdAt),
+  ]
+);
+
+export const messageReplayCursor = pgTable(
+  "message_replay_cursor",
+  {
+    sessionId: text("session_id").primaryKey().references(() => terminalSessions.id, { onDelete: "cascade" }),
+    lastAckedAt: timestamp("last_acked_at", { withTimezone: true, mode: "date" }),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" }).notNull().$defaultFn(() => new Date()),
+  }
+);
+
+export const channelSubscription = pgTable(
+  "channel_subscription",
+  {
+    id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+    channelId: text("channel_id").notNull().references(() => channels.id, { onDelete: "cascade" }),
+    sessionId: text("session_id").notNull().references(() => terminalSessions.id, { onDelete: "cascade" }),
+    mode: text("mode").$type<"auto_deliver" | "direct_only">().notNull().default("auto_deliver"),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().$defaultFn(() => new Date()),
+  },
+  (table) => [
+    uniqueIndex("channel_subscription_unique_idx").on(table.channelId, table.sessionId),
+  ]
+);
+
+export const agentWorkContext = pgTable(
+  "agent_work_context",
+  {
+    sessionId: text("session_id").primaryKey().references(() => terminalSessions.id, { onDelete: "cascade" }),
+    projectId: text("project_id").notNull(),
+    branch: text("branch"),
+    worktreePath: text("worktree_path"),
+    activityStatus: text("activity_status"),
+    claimedIssueId: text("claimed_issue_id"),
+    claimedIssueTitle: text("claimed_issue_title"),
+    joinConfidence: text("join_confidence").$type<"branch" | "project" | "none">(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" }).notNull().$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("agent_work_context_project_idx").on(table.projectId),
+  ]
+);

--- a/src/db/schema.sqlite.ts
+++ b/src/db/schema.sqlite.ts
@@ -1427,3 +1427,63 @@ export const crownCandidates = sqliteTable(
     index("crown_candidate_run_idx").on(table.crownRunId),
   ]
 );
+
+export const messageDelivery = sqliteTable(
+  "message_delivery",
+  {
+    id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+    messageId: text("message_id").notNull().references(() => agentPeerMessages.id, { onDelete: "cascade" }),
+    toSessionId: text("to_session_id").notNull().references(() => terminalSessions.id, { onDelete: "cascade" }),
+    projectId: text("project_id").notNull(),
+    state: text("state").$type<"pending" | "delivered" | "acked">().notNull().default("pending"),
+    channelType: text("channel_kind").$type<"mcp_push" | "poll" | null>(),
+    deliveredAt: integer("delivered_at", { mode: "timestamp_ms" }),
+    ackedAt: integer("acked_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull().$defaultFn(() => new Date()),
+  },
+  (table) => [
+    uniqueIndex("message_delivery_msg_session_idx").on(table.messageId, table.toSessionId),
+    index("message_delivery_session_state_idx").on(table.toSessionId, table.state, table.createdAt),
+  ]
+);
+
+export const messageReplayCursor = sqliteTable(
+  "message_replay_cursor",
+  {
+    sessionId: text("session_id").primaryKey().references(() => terminalSessions.id, { onDelete: "cascade" }),
+    lastAckedAt: integer("last_acked_at", { mode: "timestamp_ms" }),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull().$defaultFn(() => new Date()),
+  }
+);
+
+export const channelSubscription = sqliteTable(
+  "channel_subscription",
+  {
+    id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+    channelId: text("channel_id").notNull().references(() => channels.id, { onDelete: "cascade" }),
+    sessionId: text("session_id").notNull().references(() => terminalSessions.id, { onDelete: "cascade" }),
+    mode: text("mode").$type<"auto_deliver" | "direct_only">().notNull().default("auto_deliver"),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull().$defaultFn(() => new Date()),
+  },
+  (table) => [
+    uniqueIndex("channel_subscription_unique_idx").on(table.channelId, table.sessionId),
+  ]
+);
+
+export const agentWorkContext = sqliteTable(
+  "agent_work_context",
+  {
+    sessionId: text("session_id").primaryKey().references(() => terminalSessions.id, { onDelete: "cascade" }),
+    projectId: text("project_id").notNull(),
+    branch: text("branch"),
+    worktreePath: text("worktree_path"),
+    activityStatus: text("activity_status"),
+    claimedIssueId: text("claimed_issue_id"),
+    claimedIssueTitle: text("claimed_issue_title"),
+    joinConfidence: text("join_confidence").$type<"branch" | "project" | "none">(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull().$defaultFn(() => new Date()),
+  },
+  (table) => [
+    index("agent_work_context_project_idx").on(table.projectId),
+  ]
+);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -81,4 +81,8 @@ export const {
   triggerEvents,
   crownRuns,
   crownCandidates,
+  messageDelivery,
+  messageReplayCursor,
+  channelSubscription,
+  agentWorkContext,
 } = active;

--- a/src/mcp/peer-server.ts
+++ b/src/mcp/peer-server.ts
@@ -116,13 +116,22 @@ function textResult(text: string) {
  * Handle an event pushed from the terminal server via Unix socket.
  * Formats it as human-readable text and sends via sendLoggingMessage().
  * Also advances the rdv CLI poll sentinel to prevent double-delivery.
+ *
+ * [x386.2] After surfacing the message, write an {type:"ack", messageId} frame
+ * back on the same connection so the terminal server can mark the delivery
+ * `acked`. A dropped ack is harmless — the terminal server keeps the row
+ * `delivered` and the poll fallback recovers it.
  */
-function handleSocketEvent(event: Record<string, unknown>): void {
+function handleSocketEvent(event: Record<string, unknown>, conn: net.Socket): void {
   const messageId = event.messageId as string | undefined;
 
-  // Dedup: skip if already delivered
+  // Dedup: skip if already delivered. Still re-ack so the server can advance a
+  // delivery that was re-pushed during a replay handshake (x386.3).
   if (messageId) {
-    if (deliveredMessageIds.has(messageId)) return;
+    if (deliveredMessageIds.has(messageId)) {
+      conn.write(JSON.stringify({ type: "ack", messageId }) + "\n");
+      return;
+    }
     deliveredMessageIds.add(messageId);
     // Evict oldest entry if set grows too large
     if (deliveredMessageIds.size > MAX_DELIVERED_IDS) {
@@ -165,7 +174,12 @@ function handleSocketEvent(event: Record<string, unknown>): void {
     level: "info",
     logger: "rdv",
     data: text,
-  }).catch(() => {});
+  })
+    .then(() => {
+      // Ack only after the client received the log notification.
+      if (messageId) conn.write(JSON.stringify({ type: "ack", messageId }) + "\n");
+    })
+    .catch(() => {}); // dropped ack → server keeps it "delivered"; poll recovers
 }
 
 // ── Unix socket listener ──────────────────────────────────────────────────────
@@ -179,6 +193,12 @@ function startSocketListener(): void {
   try { fs.unlinkSync(sockPath); } catch {}
 
   const sockServer = net.createServer((conn) => {
+    // [x386.3] On (re)connect, ask the terminal server to replay anything we
+    // missed while the socket was down (compaction, brief disconnect). Replayed
+    // events flow through the same handleSocketEvent path; the in-process dedup
+    // set + the server's durable cursor prevent double-surfacing.
+    conn.write(JSON.stringify({ type: "replay_request", sessionId: SESSION_ID }) + "\n");
+
     let buf = "";
     conn.on("data", (chunk: Buffer) => {
       buf += chunk.toString();
@@ -188,7 +208,9 @@ function startSocketListener(): void {
         buf = buf.slice(nl + 1);
         if (!line.trim()) continue;
         try {
-          handleSocketEvent(JSON.parse(line));
+          const msg = JSON.parse(line) as Record<string, unknown>;
+          // Both live pushes and replayed events carry frame:"event".
+          if (msg.frame === "event") handleSocketEvent(msg, conn);
         } catch { /* malformed JSON, skip */ }
       }
     });

--- a/src/server/mcp-push.test.ts
+++ b/src/server/mcp-push.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as net from "node:net";
+import * as fs from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  pushToMcpServer,
+  closeMcpSocket,
+  setDeliveredHook,
+  setReplayHook,
+  onMcpAck,
+  __setMcpSocketPathForTest,
+  type McpPushEvent,
+} from "./mcp-push";
+
+// A stub "MCP server": listens on the session's socket path, records every
+// event line it receives, and can be configured to echo back an {type:"ack"}
+// and/or send a {type:"replay_request"}. This exercises the bidirectional
+// protocol added in x386.2/.3 without a real Claude Code process.
+interface StubServer {
+  server: net.Server;
+  received: Record<string, unknown>[];
+  conns: net.Socket[];
+  /** Send a replay_request from the (first) connected client → terminal server. */
+  sendReplayRequest: (sessionId: string) => void;
+  close: () => Promise<void>;
+}
+
+function startStub(
+  sockPath: string,
+  opts: { autoAck?: boolean } = {},
+): Promise<StubServer> {
+  const received: Record<string, unknown>[] = [];
+  const conns: net.Socket[] = [];
+  const server = net.createServer((conn) => {
+    conns.push(conn);
+    let buf = "";
+    conn.on("data", (chunk: Buffer) => {
+      buf += chunk.toString();
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line.trim()) continue;
+        const msg = JSON.parse(line);
+        received.push(msg);
+        if (opts.autoAck && msg.frame === "event" && msg.messageId) {
+          conn.write(JSON.stringify({ type: "ack", messageId: msg.messageId }) + "\n");
+        }
+      }
+    });
+    conn.on("error", () => {});
+  });
+  return new Promise((resolve) => {
+    server.listen(sockPath, () => {
+      resolve({
+        server,
+        received,
+        conns,
+        sendReplayRequest: (sessionId: string) => {
+          conns[0]?.write(JSON.stringify({ type: "replay_request", sessionId }) + "\n");
+        },
+        close: () =>
+          new Promise<void>((res) => {
+            for (const c of conns) c.destroy();
+            server.close(() => res());
+          }),
+      });
+    });
+  });
+}
+
+/** Poll a predicate until true or timeout (events are async over the socket). */
+async function waitFor(pred: () => boolean, ms = 1000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > ms) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+function makeEvent(over: Partial<McpPushEvent> = {}): McpPushEvent {
+  return {
+    type: "peer_message",
+    messageId: "m1",
+    fromSessionId: "from-1",
+    fromSessionName: "alice",
+    toSessionId: "to-1",
+    body: "hello",
+    channelId: null,
+    channelName: null,
+    parentMessageId: null,
+    createdAt: new Date().toISOString(),
+    ...over,
+  };
+}
+
+let tmpDir: string;
+const SID = "sess-abc";
+let sockPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "rdv-mcp-test-"));
+  sockPath = join(tmpDir, `rdv-mcp-${SID}.sock`);
+  __setMcpSocketPathForTest((sid) => join(tmpDir, `rdv-mcp-${sid}.sock`));
+  setDeliveredHook(null);
+  setReplayHook(null);
+});
+
+afterEach(() => {
+  closeMcpSocket(SID);
+  __setMcpSocketPathForTest(null);
+  setDeliveredHook(null);
+  setReplayHook(null);
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("mcp-push ack-aware delivery (x386.2)", () => {
+  it("fires the delivered hook when the socket accepts the write", async () => {
+    const stub = await startStub(sockPath);
+    const delivered: Array<{ sid: string; mid: string }> = [];
+    setDeliveredHook((sid, mid) => delivered.push({ sid, mid }));
+
+    pushToMcpServer(SID, makeEvent({ messageId: "m1" }));
+
+    await waitFor(() => delivered.length > 0);
+    expect(delivered[0]).toEqual({ sid: SID, mid: "m1" });
+    // The MCP server received an {frame:"event"} envelope carrying the messageId.
+    await waitFor(() => stub.received.length > 0);
+    expect(stub.received[0]).toMatchObject({ frame: "event", messageId: "m1" });
+    await stub.close();
+  });
+
+  it("invokes the per-session ack handler when the MCP server acks", async () => {
+    const stub = await startStub(sockPath, { autoAck: true });
+    const acked: string[] = [];
+    onMcpAck(SID, (messageId) => acked.push(messageId));
+
+    pushToMcpServer(SID, makeEvent({ messageId: "m1" }));
+
+    await waitFor(() => acked.includes("m1"));
+    expect(acked).toEqual(["m1"]);
+    await stub.close();
+  });
+
+  it("leaves a push unacked when the MCP server never acks (poll recovers)", async () => {
+    const stub = await startStub(sockPath, { autoAck: false });
+    const acked: string[] = [];
+    onMcpAck(SID, (messageId) => acked.push(messageId));
+    const delivered: string[] = [];
+    setDeliveredHook((_sid, mid) => delivered.push(mid));
+
+    pushToMcpServer(SID, makeEvent({ messageId: "m1" }));
+
+    await waitFor(() => delivered.includes("m1"));
+    // Delivered but NOT acked — this is the "no silent loss" guarantee.
+    await new Promise((r) => setTimeout(r, 80));
+    expect(acked).toHaveLength(0);
+    await stub.close();
+  });
+});
+
+describe("mcp-push replay handshake (x386.3)", () => {
+  it("invokes the replay hook when the MCP server sends a replay_request", async () => {
+    const stub = await startStub(sockPath, { autoAck: true });
+    const replays: string[] = [];
+    setReplayHook(async (sid) => {
+      replays.push(sid);
+    });
+
+    // Establish the connection by pushing one event first.
+    pushToMcpServer(SID, makeEvent({ messageId: "m0" }));
+    await waitFor(() => stub.conns.length > 0);
+
+    // MCP server (re)connects → asks the terminal server to replay.
+    stub.sendReplayRequest(SID);
+
+    await waitFor(() => replays.includes(SID));
+    expect(replays).toEqual([SID]);
+    await stub.close();
+  });
+
+  it("the socket file must exist before a push connects", async () => {
+    // No stub started → no socket file → push is a no-op (cached negative).
+    const delivered: string[] = [];
+    setDeliveredHook((_sid, mid) => delivered.push(mid));
+    expect(fs.existsSync(sockPath)).toBe(false);
+    pushToMcpServer(SID, makeEvent({ messageId: "m1" }));
+    await new Promise((r) => setTimeout(r, 60));
+    expect(delivered).toHaveLength(0);
+  });
+});

--- a/src/server/mcp-push.ts
+++ b/src/server/mcp-push.ts
@@ -5,8 +5,21 @@
  * Unix sockets. Each MCP server process listens on /tmp/rdv-mcp-{sessionId}.sock
  * and relays events to Claude Code via sendLoggingMessage().
  *
- * Fire-and-forget: push failures are silently ignored (PreToolUse hook is the
- * reliable fallback). Connections are lazily established and cached.
+ * [x386.2/.3] The protocol is now BIDIRECTIONAL over the same Unix socket:
+ *   - terminal server → MCP server:  {type:"event", messageId, ...}  (a push)
+ *   - MCP server → terminal server:  {type:"ack", messageId}         (surfaced)
+ *   - MCP server → terminal server:  {type:"replay_request", sessionId} (reconnect)
+ *
+ * On a successful socket write the registered "delivered hook" marks the
+ * delivery `delivered`; when the MCP server acks, the per-session ack handler
+ * marks it `acked`. A dropped ack leaves the row `delivered` (the poll fallback
+ * recovers it) — there is no silent loss. On (re)connect the MCP server sends a
+ * replay_request; the registered "replay hook" re-pushes everything still
+ * undelivered for that session.
+ *
+ * This module deliberately holds NO import of the delivery service — the
+ * terminal server installs hooks at boot (`setDeliveredHook`/`setReplayHook`)
+ * so Clean-Architecture layering is preserved (mcp-push stays infrastructure).
  */
 
 import * as net from "node:net";
@@ -37,6 +50,8 @@ interface SocketEntry {
   lastErrorAt: number;
   /** Events queued while the socket is connecting. Flushed on connect. */
   pending: string[];
+  /** Inbound line buffer for ack / replay_request frames. */
+  inBuf: string;
 }
 
 const MAX_PENDING = 20;
@@ -44,20 +59,108 @@ const MAX_PENDING = 20;
 const sockets = new Map<string, SocketEntry>();
 const RETRY_COOLDOWN_MS = 5000;
 
+// ── Hooks installed by the terminal server at boot (layering boundary) ───────
+
+/** Called when a (session, message) write is accepted by the socket. */
+type DeliveredHook = (sessionId: string, messageId: string) => void;
+/** Called when the MCP server requests replay of its undelivered backlog. */
+type ReplayHook = (sessionId: string) => void | Promise<void>;
+/** Per-session handler invoked when the MCP server acks a messageId. */
+type AckHandler = (messageId: string) => void;
+
+let deliveredHook: DeliveredHook | null = null;
+let replayHook: ReplayHook | null = null;
+const ackHandlers = new Map<string, AckHandler>();
+
+/** Install the hook that marks a delivery `delivered` on socket-write success. */
+export function setDeliveredHook(fn: DeliveredHook | null): void {
+  deliveredHook = fn;
+}
+
+/** Install the hook that replays a session's undelivered backlog on reconnect. */
+export function setReplayHook(fn: ReplayHook | null): void {
+  replayHook = fn;
+}
+
+/** Register a per-session ack handler (advances delivery → acked). */
+export function onMcpAck(sessionId: string, handler: AckHandler): void {
+  ackHandlers.set(sessionId, handler);
+}
+
+// ── Socket path (overridable in tests) ───────────────────────────────────────
+
+let socketPathFn: (sessionId: string) => string = (sessionId) =>
+  `/tmp/rdv-mcp-${sessionId}.sock`;
+
 export function getMcpSocketPath(sessionId: string): string {
-  return `/tmp/rdv-mcp-${sessionId}.sock`;
+  return socketPathFn(sessionId);
+}
+
+/** Test seam: override the socket-path resolver (pass null to reset). */
+export function __setMcpSocketPathForTest(
+  fn: ((sessionId: string) => string) | null,
+): void {
+  socketPathFn = fn ?? ((sessionId) => `/tmp/rdv-mcp-${sessionId}.sock`);
+}
+
+// ── Inbound frame handling (acks + replay requests) ──────────────────────────
+
+/** Parse newline-delimited inbound frames from the MCP server for a session. */
+function handleInbound(sessionId: string, entry: SocketEntry, chunk: Buffer): void {
+  entry.inBuf += chunk.toString();
+  let nl: number;
+  while ((nl = entry.inBuf.indexOf("\n")) !== -1) {
+    const line = entry.inBuf.slice(0, nl);
+    entry.inBuf = entry.inBuf.slice(nl + 1);
+    if (!line.trim()) continue;
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      continue; // malformed frame, skip
+    }
+    if (msg.type === "ack" && typeof msg.messageId === "string") {
+      ackHandlers.get(sessionId)?.(msg.messageId);
+    } else if (msg.type === "replay_request") {
+      const sid = (typeof msg.sessionId === "string" && msg.sessionId) || sessionId;
+      Promise.resolve(replayHook?.(sid)).catch((err) =>
+        log.debug("Replay hook failed", { sessionId: sid, error: String(err) }),
+      );
+    }
+  }
+}
+
+/** Attach the inbound data/close listeners to a freshly created socket. */
+function wireSocket(sessionId: string, entry: SocketEntry, socket: net.Socket): void {
+  socket.on("data", (chunk: Buffer) => handleInbound(sessionId, entry, chunk));
+}
+
+// ── Push ─────────────────────────────────────────────────────────────────────
+
+/** Serialize an event into the bidirectional envelope. */
+function frame(event: McpPushEvent): string {
+  // The event's own `type` (peer_message | channel_message | mention) lives at
+  // the top level for back-compat with the original push format. The bidi
+  // protocol adds `frame: "event"` so the MCP server can discriminate a push
+  // from an inbound ack/replay frame without colliding with the event's `type`.
+  return JSON.stringify({ frame: "event", ...event }) + "\n";
 }
 
 /**
- * Push an event to a session's MCP server via Unix socket.
- * Fire-and-forget — failures are silently ignored.
+ * Push an event to a session's MCP server via Unix socket. On write success the
+ * delivered hook fires (marks the delivery `delivered`). The actual ack arrives
+ * asynchronously over the same socket and is handled by {@link handleInbound}.
+ *
+ * Returns true if the write was attempted on a live/connecting socket (i.e. the
+ * delivery is at least in-flight), false if the socket was unavailable (the
+ * delivery stays `pending` and the poll fallback will recover it).
  */
-export function pushToMcpServer(sessionId: string, event: McpPushEvent): void {
+export function pushToMcpServer(sessionId: string, event: McpPushEvent): boolean {
   const entry = sockets.get(sessionId);
 
-  // Fast path: already connected — write directly, no filesystem check
+  // Fast path: already connected — write directly, no filesystem check.
   if (entry?.state === "connected" && entry.socket) {
-    const data = JSON.stringify(event) + "\n";
+    const data = frame(event);
     entry.socket.write(data, (err) => {
       if (err) {
         log.debug("MCP socket write failed", { sessionId, error: String(err) });
@@ -65,46 +168,63 @@ export function pushToMcpServer(sessionId: string, event: McpPushEvent): void {
         entry.lastErrorAt = Date.now();
         entry.socket?.destroy();
         entry.socket = null;
+      } else if (event.messageId) {
+        deliveredHook?.(sessionId, event.messageId);
       }
     });
-    return;
+    return true;
   }
 
-  // Retry cooldown after error
+  // Retry cooldown after error.
   if (entry?.state === "disconnected" && Date.now() - entry.lastErrorAt < RETRY_COOLDOWN_MS) {
-    return;
+    return false;
   }
 
-  // Already connecting — queue the event (flushed on connect)
+  // Already connecting — queue the event (flushed on connect).
   if (entry?.state === "connecting") {
     if (entry.pending.length < MAX_PENDING) {
-      entry.pending.push(JSON.stringify(event) + "\n");
+      entry.pending.push(frame(event));
     }
-    return;
+    return true;
   }
 
-  // Check if socket file exists before attempting connection
+  // Check if socket file exists before attempting connection.
   const sockPath = getMcpSocketPath(sessionId);
   try {
     fs.accessSync(sockPath);
   } catch {
-    // Cache negative result so the cooldown rate-limits future accessSync calls
-    sockets.set(sessionId, { socket: null, state: "disconnected", lastErrorAt: Date.now(), pending: [] });
-    return;
+    // Cache negative result so the cooldown rate-limits future accessSync calls.
+    sockets.set(sessionId, {
+      socket: null,
+      state: "disconnected",
+      lastErrorAt: Date.now(),
+      pending: [],
+      inBuf: "",
+    });
+    return false;
   }
 
   // Not connected — connect and write.
   // Store socket immediately so closeMcpSocket() can destroy it during connecting.
-  const data = JSON.stringify(event) + "\n";
+  const data = frame(event);
   const socket = net.createConnection(sockPath);
-  const newEntry: SocketEntry = { socket, state: "connecting", lastErrorAt: 0, pending: [] };
+  const newEntry: SocketEntry = {
+    socket,
+    state: "connecting",
+    lastErrorAt: 0,
+    pending: [],
+    inBuf: "",
+  };
   sockets.set(sessionId, newEntry);
+  wireSocket(sessionId, newEntry, socket);
 
   socket.on("connect", () => {
     newEntry.state = "connected";
     log.debug("MCP socket connected", { sessionId });
-    socket.write(data);
-    // Flush any events queued while connecting
+    socket.write(data, (err) => {
+      if (!err && event.messageId) deliveredHook?.(sessionId, event.messageId);
+    });
+    // Flush any events queued while connecting.
     for (const queued of newEntry.pending) {
       socket.write(queued);
     }
@@ -124,6 +244,8 @@ export function pushToMcpServer(sessionId: string, event: McpPushEvent): void {
     newEntry.lastErrorAt = Date.now();
     newEntry.socket = null;
   });
+
+  return true;
 }
 
 /**
@@ -136,4 +258,5 @@ export function closeMcpSocket(sessionId: string): void {
     entry.socket.destroy();
   }
   sockets.delete(sessionId);
+  ackHandlers.delete(sessionId);
 }

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -256,36 +256,60 @@ function broadcastToUser(userId: string, data: Record<string, unknown>): void {
   }
 }
 
-// Cached module references for MCP push (avoids repeated dynamic import overhead)
+// Cached module reference for MCP push (avoids repeated dynamic import overhead)
 let _mcpPush: typeof import("@/server/mcp-push") | null = null;
-let _peerService: typeof import("@/services/peer-service") | null = null;
 
 async function getMcpPush() {
   return (_mcpPush ??= await import("@/server/mcp-push"));
 }
-async function getPeerService() {
-  return (_peerService ??= await import("@/services/peer-service"));
+
+// [x386.2] Sessions whose per-socket ack handler is already registered. The
+// handler advances delivery → acked when the MCP server confirms it surfaced a
+// message. Registered lazily the first time we push to a session.
+const ackHandlerRegistered = new Set<string>();
+
+/** Ensure the ack handler is installed for a session (idempotent). */
+function ensureMcpAckHandler(sessionId: string): void {
+  if (ackHandlerRegistered.has(sessionId)) return;
+  ackHandlerRegistered.add(sessionId);
+  getMcpPush()
+    .then(async (mp) => {
+      const MD = await import("@/services/message-delivery-service");
+      mp.onMcpAck(sessionId, (messageId) => {
+        MD.ackDelivery(messageId, sessionId).catch((err) =>
+          peerLog.debug("ackDelivery hook failed", { sessionId, error: String(err) }),
+        );
+      });
+    })
+    .catch(() => ackHandlerRegistered.delete(sessionId));
 }
 
-/** Push an MCP event to a single peer session (fire-and-forget). */
-function pushMcpEventToPeer(sessionId: string, event: import("@/server/mcp-push").McpPushEvent): void {
-  getMcpPush().then(({ pushToMcpServer }) => pushToMcpServer(sessionId, event)).catch(() => {});
-}
-
-/** Push an MCP event to all folder peers except the sender (fire-and-forget). */
-async function pushMcpEventToFolderPeers(
-  folderId: string,
-  fromSessionId: string,
-  buildEvent: (peerId: string) => import("@/server/mcp-push").McpPushEvent,
+/**
+ * [x386.2] Record durable delivery rows for a message, register ack handlers,
+ * then push to each recipient's MCP socket. Recipients that are not connected
+ * keep a `pending`/`delivered` row that the poll fallback recovers. `selfSid`
+ * is excluded.
+ */
+async function deliverToRecipients(
+  messageId: string,
+  projectId: string,
+  recipientSessionIds: string[],
+  buildEvent: (recipientSessionId: string) => import("@/server/mcp-push").McpPushEvent,
+  selfSid: string,
 ): Promise<void> {
+  const recipients = recipientSessionIds.filter((id) => id && id !== selfSid);
+  if (recipients.length === 0) return;
+  const MD = await import("@/services/message-delivery-service");
+  // Write delivery rows BEFORE pushing so a push that races ahead still has a
+  // row to mark `delivered`.
+  await MD.recordDeliveries(messageId, projectId, recipients);
   const { pushToMcpServer } = await getMcpPush();
-  const PeerService = await getPeerService();
-  const peers = await PeerService.getProjectPeers(folderId);
-  for (const peer of peers) {
-    if (peer.sessionId === fromSessionId) continue;
-    pushToMcpServer(peer.sessionId, buildEvent(peer.sessionId));
+  for (const sid of recipients) {
+    ensureMcpAckHandler(sid);
+    pushToMcpServer(sid, buildEvent(sid));
   }
 }
+
 
 /** Whether a terminal type has agent-like behavior (exit handling, restart). */
 function isAgentTerminalType(type: string): boolean {
@@ -1365,7 +1389,9 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
         },
       });
 
-      // Push to MCP server sockets (fire-and-forget)
+      // [x386.2] Record durable deliveries + push (ack-aware). Direct → the one
+      // recipient; broadcast → all project peers. Each gets a delivery row so a
+      // dropped push is recovered by the poll fallback.
       const senderSid = String(fromSessionId);
       const mcpEvent: import("@/server/mcp-push").McpPushEvent = {
         type: "peer_message",
@@ -1380,9 +1406,19 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
         createdAt: result.createdAt,
       };
       if (toSessionId) {
-        pushMcpEventToPeer(String(toSessionId), mcpEvent);
+        deliverToRecipients(result.messageId, result.projectId, [String(toSessionId)], () => mcpEvent, senderSid).catch(
+          (err) => peerLog.error("Failed to deliver direct peer message", { error: String(err) }),
+        );
       } else {
-        pushMcpEventToFolderPeers(result.projectId, senderSid, () => mcpEvent).catch(() => {});
+        const PeerSvc = await import("@/services/peer-service");
+        const peers = await PeerSvc.getProjectPeers(result.projectId);
+        deliverToRecipients(
+          result.messageId,
+          result.projectId,
+          peers.map((p) => p.sessionId),
+          () => mcpEvent,
+          senderSid,
+        ).catch((err) => peerLog.error("Failed to deliver broadcast peer message", { error: String(err) }));
       }
 
       sendJson(res, 200, { messageId: result.messageId, resolvedBody: result.resolvedBody });
@@ -1403,13 +1439,124 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
     }
 
     try {
-      const sinceDate = since ? new Date(since) : new Date(0);
+      // [x386.4] When the caller opts into the durable cursor (cursor=durable),
+      // use the delivery-state poll (exactly-once parity with MCP push) and
+      // mark returned rows `delivered` via poll. Otherwise keep the legacy
+      // timestamp scan for the chat-room UI / backward compat.
       const PeerService = await import("@/services/peer-service");
+      if (query.cursor === "durable") {
+        const messages = await PeerService.pollUndelivered(sessionId);
+        sendJson(res, 200, { messages });
+        return true;
+      }
+      const sinceDate = since ? new Date(since) : new Date(0);
       const messages = await PeerService.pollMessages(sessionId, sinceDate);
       sendJson(res, 200, { messages });
     } catch (err) {
       peerLog.error("Failed to poll peer messages", { error: String(err) });
       sendJson(res, 500, { error: "Failed to poll messages" });
+    }
+    return true;
+  }
+
+  // [x386.2] POST /internal/peers/ack { sessionId, messageId } — confirm receipt
+  // (parity path for poll/CLI acks; the socket-level ack is the primary path).
+  if (pathname === "/internal/peers/ack" && req.method === "POST") {
+    const payload = await parseRequestJson(req, res);
+    if (!payload) return true;
+    const { sessionId, messageId } = payload;
+    if (!sessionId || !messageId) {
+      sendJson(res, 400, { error: "Missing sessionId or messageId" });
+      return true;
+    }
+    try {
+      const MD = await import("@/services/message-delivery-service");
+      await MD.ackDelivery(String(messageId), String(sessionId));
+      sendJson(res, 200, { ok: true });
+    } catch (err) {
+      peerLog.error("Failed to ack delivery", { error: String(err) });
+      sendJson(res, 500, { error: "Failed to ack" });
+    }
+    return true;
+  }
+
+  // [x386.4] POST /internal/peers/ack-batch { sessionId, messageIds[] } — the
+  // non-MCP poll path acks everything it just surfaced so it isn't re-shown.
+  if (pathname === "/internal/peers/ack-batch" && req.method === "POST") {
+    const payload = await parseRequestJson(req, res);
+    if (!payload) return true;
+    const { sessionId, messageIds } = payload;
+    if (!sessionId || !Array.isArray(messageIds)) {
+      sendJson(res, 400, { error: "Missing sessionId or messageIds" });
+      return true;
+    }
+    try {
+      const MD = await import("@/services/message-delivery-service");
+      await MD.ackDeliveries(messageIds.map(String), String(sessionId));
+      sendJson(res, 200, { ok: true, acked: messageIds.length });
+    } catch (err) {
+      peerLog.error("Failed to ack delivery batch", { error: String(err) });
+      sendJson(res, 500, { error: "Failed to ack batch" });
+    }
+    return true;
+  }
+
+  // [x386.3] GET /internal/peers/replay?sessionId=xxx — the undelivered set for
+  // a session (same rows the socket replay handshake pushes). Used by tests and
+  // the CLI poll path without the socket.
+  if (pathname === "/internal/peers/replay" && req.method === "GET") {
+    const sessionId = query.sessionId as string;
+    if (!sessionId) {
+      sendJson(res, 400, { error: "Missing sessionId" });
+      return true;
+    }
+    try {
+      const MD = await import("@/services/message-delivery-service");
+      const rows = await MD.getUndelivered(sessionId, 50);
+      sendJson(res, 200, { messages: rows });
+    } catch (err) {
+      peerLog.error("Failed to fetch replay set", { error: String(err) });
+      sendJson(res, 500, { error: "Failed to fetch replay set" });
+    }
+    return true;
+  }
+
+  // [x386.11] GET /internal/work-context?sessionId=xxx — lightweight work
+  // context (branch/worktree/status) + READ-ONLY bd-issue join. Used by the
+  // Rust digest/collision + the chat UI.
+  if (pathname === "/internal/work-context" && req.method === "GET") {
+    const sessionId = query.sessionId as string;
+    if (!sessionId) {
+      sendJson(res, 400, { error: "Missing sessionId" });
+      return true;
+    }
+    try {
+      const WC = await import("@/services/work-context-service");
+      const ctx = await WC.computeWorkContext(sessionId);
+      sendJson(res, 200, { context: ctx });
+    } catch (err) {
+      peerLog.error("Failed to compute work context", { error: String(err) });
+      sendJson(res, 500, { error: "Failed to compute work context" });
+    }
+    return true;
+  }
+
+  // [x386.12/.14] GET /internal/peers/digest?sessionId=xxx — start digest:
+  // who's-working-on-what (work-context + claimed bd issues) + recent gotchas +
+  // collisions. The heavy joins live in TS; the Rust hook just renders this.
+  if (pathname === "/internal/peers/digest" && req.method === "GET") {
+    const sessionId = query.sessionId as string;
+    if (!sessionId) {
+      sendJson(res, 400, { error: "Missing sessionId" });
+      return true;
+    }
+    try {
+      const WC = await import("@/services/work-context-service");
+      const digest = await WC.buildStartDigest(sessionId);
+      sendJson(res, 200, digest);
+    } catch (err) {
+      peerLog.error("Failed to build peer digest", { error: String(err) });
+      sendJson(res, 500, { error: "Failed to build digest" });
     }
     return true;
   }
@@ -1585,7 +1732,14 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
       if (!resolvedChannelId && channelName) {
         const ctx = await getSessionFolderContext(fromSessionId as string);
         if (ctx) {
-          resolvedChannelId = await resolveChannelName(ctx.folderId, channelName as string);
+          // [x386.6/.13] The per-project #agents system channel is auto-created
+          // on demand (check-in/out + `rdv peer note` target it).
+          if (channelName === "agents") {
+            const ChannelService = await import("@/services/channel-service");
+            resolvedChannelId = await ChannelService.getAgentsChannelId(ctx.folderId);
+          } else {
+            resolvedChannelId = await resolveChannelName(ctx.folderId, channelName as string);
+          }
         }
         if (!resolvedChannelId) {
           sendJson(res, 404, { error: `Channel '${channelName}' not found` });
@@ -1644,18 +1798,42 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
           if (ch) resolvedChannelName = ch.name;
         } catch { /* non-critical, name will be null in push */ }
       }
-      pushMcpEventToFolderPeers(result.projectId, chSenderSid, (peerId) => ({
-        type: mentions.has(peerId) ? "mention" : "channel_message",
-        messageId: result.messageId,
-        fromSessionId: chSenderSid,
-        fromSessionName: result.senderName,
-        toSessionId: null,
-        body: result.resolvedBody,
-        channelId: effectiveChannelId,
-        channelName: resolvedChannelName,
-        parentMessageId: parentMessageId ? String(parentMessageId) : null,
-        createdAt: result.createdAt,
-      })).catch(() => {});
+      // [x386.5/.7] Recipient set = channel auto-deliver subscribers ∪ @mentioned
+      // sessions (mentions always delivered, even if unsubscribed). Each gets a
+      // durable delivery row; non-subscribers get only their mentions.
+      void (async () => {
+        try {
+          const PeerSvc = await import("@/services/peer-service");
+          const ChanSubs = await import("@/services/channel-subscription-service");
+          const peers = await PeerSvc.getProjectPeers(result.projectId);
+          const peerIds = peers.map((p) => p.sessionId);
+          const autoDeliver = effectiveChannelId
+            ? await ChanSubs.getAutoDeliverSessions(effectiveChannelId, peerIds)
+            : peerIds;
+          const recipientSet = new Set<string>(autoDeliver);
+          for (const m of mentions) recipientSet.add(m);
+          await deliverToRecipients(
+            result.messageId,
+            result.projectId,
+            [...recipientSet],
+            (peerId) => ({
+              type: mentions.has(peerId) ? "mention" : "channel_message",
+              messageId: result.messageId,
+              fromSessionId: chSenderSid,
+              fromSessionName: result.senderName,
+              toSessionId: null,
+              body: result.resolvedBody,
+              channelId: effectiveChannelId,
+              channelName: resolvedChannelName,
+              parentMessageId: parentMessageId ? String(parentMessageId) : null,
+              createdAt: result.createdAt,
+            }),
+            chSenderSid,
+          );
+        } catch (err) {
+          peerLog.error("Failed to deliver channel message", { error: String(err) });
+        }
+      })();
 
       sendJson(res, 200, { messageId: result.messageId, resolvedBody: result.resolvedBody });
     } catch (err) {
@@ -1947,7 +2125,48 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
     });
   }
 
-  // Periodic peer message cleanup (hourly, 24h TTL)
+  // [x386.2/.3] Install the durable-delivery hooks into the MCP push manager
+  // once at boot. mcp-push.ts holds no service import (layering boundary); the
+  // terminal server is the only place that knows both the socket layer and the
+  // delivery service, so it wires them together here.
+  getMcpPush()
+    .then(async (mp) => {
+      const MD = await import("@/services/message-delivery-service");
+      // Socket-write success → delivery marked `delivered`.
+      mp.setDeliveredHook((sid, mid) => {
+        MD.markDelivered(mid, sid, "mcp_push").catch((err) =>
+          peerLog.debug("markDelivered hook failed", { sessionId: sid, error: String(err) }),
+        );
+      });
+      // MCP server (re)connect → replay everything still undelivered for it.
+      mp.setReplayHook(async (sid) => {
+        const rows = await MD.getUndelivered(sid, 50);
+        for (const r of rows) {
+          mp.pushToMcpServer(sid, {
+            type: r.channelId ? "channel_message" : r.toSessionId ? "peer_message" : "channel_message",
+            messageId: r.id,
+            fromSessionId: null,
+            fromSessionName: r.fromSessionName,
+            toSessionId: r.toSessionId,
+            body: r.body,
+            channelId: r.channelId,
+            channelName: null,
+            parentMessageId: r.parentMessageId,
+            createdAt: new Date(r.createdAt).toISOString(),
+          });
+        }
+      });
+    })
+    .catch((err) => peerLog.error("Failed to install MCP delivery hooks", { error: String(err) }));
+
+  // [x386.9] Prune the awareness-chat backlog once at boot (TTL), then hourly.
+  // Old messages with no unacked delivery are removed; bd remains the durable
+  // work tracker, chat is ephemeral awareness.
+  import("@/services/peer-service")
+    .then((PeerService) => PeerService.cleanupOldMessages())
+    .catch((err) => peerLog.error("Startup peer cleanup failed", { error: String(err) }));
+
+  // Periodic peer message cleanup (hourly TTL).
   setInterval(() => {
     import("@/services/peer-service")
       .then((PeerService) => PeerService.cleanupOldMessages())

--- a/src/services/agent-profile-service.ts
+++ b/src/services/agent-profile-service.ts
@@ -103,12 +103,29 @@ rdv context          # Discover your session ID, folder, and project path
 | \`rdv worktree cleanup\` | Clean up worktree, branches, and session |
 | \`rdv peer list\` | List peer agents in same folder |
 | \`rdv peer send "message"\` | Broadcast to peers |
+| \`rdv peer note "gotcha"\` | Broadcast a gotcha/heads-up to #agents |
 | \`rdv send text <id> "text"\` | Send text to another session PTY |
 | \`rdv screen <id> --human\` | View another session's screen |
 | \`rdv notification list --unread\` | Check notifications |
 | \`rdv status --human\` | System dashboard |
 
 Run \`rdv --help\` or \`rdv <command> --help\` for full documentation.
+
+## Team awareness (bd tracks work; chat tracks awareness)
+
+You share this project with peer agents. **bd (beads) is the work tracker; chat
+is the awareness layer** — do not duplicate task state in chat.
+
+- **Read the start digest** printed at session start (who's-working-on-what,
+  recent gotchas, and collisions) **before acting**. If it warns of a
+  **collision** (a peer on your branch / worktree / claimed bd issue),
+  coordinate before pushing.
+- When you discover a footgun, post it: \`rdv peer note "what to watch out for"\`
+  (add \`--kind heads-up\` or \`--kind progress\` as appropriate). It surfaces in
+  every peer's next start digest.
+- Check-in (on start) and check-out (on stop) to \`#agents\` happen automatically.
+- Peer messages reach you reliably (durable inbox + MCP subscription); non-Claude
+  agents should run \`rdv peer messages\` periodically to drain their inbox.
 `;
 
 /**

--- a/src/services/channel-service.ts
+++ b/src/services/channel-service.ts
@@ -130,6 +130,59 @@ export async function getGeneralChannelId(projectId: string): Promise<string> {
   return generalChannelId;
 }
 
+const AGENTS_CHANNEL_NAME = "agents";
+
+/** Cache for the per-project #agents channel id. */
+const agentsChannelCache = new Map<string, { id: string; expiresAt: number }>();
+
+/**
+ * [x386.6] Ensure a per-project `#agents` system channel exists and return its
+ * id. This is where structured check-in / check-out posts and `rdv peer note`
+ * gotchas/heads-ups land, attributed to the agent as a system speaker. Mirrors
+ * {@link getGeneralChannelId} but with `type: "system"`. Idempotent.
+ */
+export async function getAgentsChannelId(projectId: string): Promise<string> {
+  const cached = agentsChannelCache.get(projectId);
+  if (cached && cached.expiresAt > Date.now()) {
+    const ch = await db.query.channels.findFirst({
+      where: eq(channels.id, cached.id),
+      columns: { id: true },
+    });
+    if (ch) {
+      cached.expiresAt = Date.now() + CACHE_TTL_MS;
+      return cached.id;
+    }
+    agentsChannelCache.delete(projectId);
+  }
+
+  // Reuse the default group so #agents sits alongside #general.
+  const { groupId } = await ensureProjectChannels(projectId);
+
+  await db
+    .insert(channels)
+    .values({
+      projectId,
+      groupId,
+      name: AGENTS_CHANNEL_NAME,
+      displayName: "#agents",
+      type: "system",
+      topic: "Agent check-ins, check-outs, gotchas and heads-ups",
+    })
+    .onConflictDoNothing({ target: [channels.projectId, channels.name] });
+
+  const agents = await db.query.channels.findFirst({
+    where: and(eq(channels.projectId, projectId), eq(channels.name, AGENTS_CHANNEL_NAME)),
+    columns: { id: true },
+  });
+  if (!agents) {
+    throw new Error(`Failed to ensure #agents channel for project ${projectId}`);
+  }
+
+  agentsChannelCache.set(projectId, { id: agents.id, expiresAt: Date.now() + CACHE_TTL_MS });
+  log.debug("Agents channel ensured", { projectId, agentsChannelId: agents.id });
+  return agents.id;
+}
+
 // ─── Channel CRUD ───────────────────────────────────────────────────────────
 
 export interface CreateChannelParams {

--- a/src/services/channel-subscription-service.test.ts
+++ b/src/services/channel-subscription-service.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createClient, type Client } from "@libsql/client/node";
+import { drizzle } from "drizzle-orm/libsql";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as schema from "@/db/schema";
+
+let client: Client;
+let testDb: ReturnType<typeof drizzle<typeof schema>>;
+let tmpDir: string;
+
+vi.mock("@/db", () => ({
+  get db() {
+    return testDb;
+  },
+}));
+
+const DDL = [
+  `CREATE TABLE channel (
+    id TEXT PRIMARY KEY NOT NULL,
+    project_id TEXT NOT NULL,
+    group_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    type TEXT NOT NULL DEFAULT 'public',
+    topic TEXT,
+    is_default INTEGER NOT NULL DEFAULT 0,
+    created_by_session_id TEXT,
+    last_message_at INTEGER,
+    message_count INTEGER NOT NULL DEFAULT 0,
+    archived_at INTEGER,
+    created_at INTEGER NOT NULL
+  );`,
+  `CREATE TABLE channel_subscription (
+    id TEXT PRIMARY KEY NOT NULL,
+    channel_id TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    mode TEXT NOT NULL DEFAULT 'auto_deliver',
+    created_at INTEGER NOT NULL
+  );`,
+  `CREATE UNIQUE INDEX channel_subscription_unique_idx ON channel_subscription (channel_id, session_id);`,
+];
+
+async function resetDb(): Promise<void> {
+  tmpDir = mkdtempSync(join(tmpdir(), "rdv-chsub-test-"));
+  client = createClient({ url: `file:${join(tmpDir, "test.db")}` });
+  testDb = drizzle(client, { schema });
+  for (const stmt of DDL) await client.execute(stmt);
+}
+
+function cleanupDb(): void {
+  client?.close();
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+}
+
+import {
+  subscribe,
+  unsubscribe,
+  getSubscriptions,
+  getAutoDeliverSessions,
+} from "./channel-subscription-service";
+
+async function insertChannel(opts: {
+  id: string;
+  name: string;
+  isDefault?: boolean;
+  type?: string;
+}): Promise<void> {
+  await client.execute({
+    sql: `INSERT INTO channel (id, project_id, group_id, name, display_name, type, is_default, created_at)
+          VALUES (?, 'proj-1', 'grp-1', ?, ?, ?, ?, 0)`,
+    args: [opts.id, opts.name, `#${opts.name}`, opts.type ?? "public", opts.isDefault ? 1 : 0],
+  });
+}
+
+const PEERS = ["s1", "s2", "s3"];
+
+describe("ChannelSubscriptionService (x386.5)", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+  afterEach(() => {
+    cleanupDb();
+  });
+
+  describe("subscribe / unsubscribe", () => {
+    it("upserts a subscription and is idempotent on the unique index", async () => {
+      await insertChannel({ id: "ch", name: "auth-refactor" });
+      await subscribe("ch", "s1", "auto_deliver");
+      await subscribe("ch", "s1", "direct_only"); // update mode, not a 2nd row
+      const subs = await getSubscriptions("ch");
+      expect(subs).toHaveLength(1);
+      expect(subs[0]).toEqual({ sessionId: "s1", mode: "direct_only" });
+    });
+
+    it("unsubscribe removes the row", async () => {
+      await insertChannel({ id: "ch", name: "auth-refactor" });
+      await subscribe("ch", "s1");
+      await unsubscribe("ch", "s1");
+      expect(await getSubscriptions("ch")).toHaveLength(0);
+    });
+  });
+
+  describe("getAutoDeliverSessions", () => {
+    it("excludes a direct_only subscriber on a non-default channel", async () => {
+      await insertChannel({ id: "ch", name: "auth-refactor" });
+      await subscribe("ch", "s1", "auto_deliver");
+      await subscribe("ch", "s2", "direct_only");
+      // s3 has no row → opt-in only → excluded.
+      const out = await getAutoDeliverSessions("ch", PEERS);
+      expect(out.sort()).toEqual(["s1"]);
+    });
+
+    it("#general (default) auto-subscribes ALL peers unless direct_only", async () => {
+      await insertChannel({ id: "gen", name: "general", isDefault: true });
+      await subscribe("gen", "s2", "direct_only"); // opt OUT
+      const out = await getAutoDeliverSessions("gen", PEERS);
+      expect(out.sort()).toEqual(["s1", "s3"]);
+    });
+
+    it("#general matched by name even when is_default is not set", async () => {
+      await insertChannel({ id: "gen", name: "general", isDefault: false });
+      const out = await getAutoDeliverSessions("gen", PEERS);
+      expect(out.sort()).toEqual(["s1", "s2", "s3"]);
+    });
+
+    it("a non-default channel with no subscriptions delivers to nobody", async () => {
+      await insertChannel({ id: "ch", name: "random" });
+      expect(await getAutoDeliverSessions("ch", PEERS)).toEqual([]);
+    });
+
+    it("an explicit auto_deliver row on a non-default channel includes that session", async () => {
+      await insertChannel({ id: "ch", name: "random" });
+      await subscribe("ch", "s3", "auto_deliver");
+      expect(await getAutoDeliverSessions("ch", PEERS)).toEqual(["s3"]);
+    });
+  });
+
+  // [x386.7] @mention override is enforced at the SEND site (terminal.ts unions
+  // mentioned sessions into the recipient set), independent of subscription.
+  // Here we assert the building block: a direct_only subscriber is NOT in the
+  // auto-deliver set, so the union with mentions is what gives them the message.
+  describe("mention override building block (x386.7)", () => {
+    it("a direct_only subscriber is excluded from auto-deliver (mention adds them back)", async () => {
+      await insertChannel({ id: "ch", name: "auth-refactor" });
+      await subscribe("ch", "s2", "direct_only");
+      const auto = await getAutoDeliverSessions("ch", PEERS);
+      expect(auto).not.toContain("s2");
+      // Caller unions mentions: union(auto, ["s2"]) includes s2.
+      const recipients = new Set([...auto, "s2"]);
+      expect(recipients.has("s2")).toBe(true);
+    });
+  });
+});

--- a/src/services/channel-subscription-service.ts
+++ b/src/services/channel-subscription-service.ts
@@ -1,0 +1,94 @@
+/**
+ * ChannelSubscriptionService — explicit per-agent channel subscriptions.
+ *
+ * [x386.5] Channel messages used to push to ALL project peers, which floods
+ * agents. A subscription model fixes that: an agent only auto-receives a
+ * channel's broadcasts if it has an `auto_deliver` subscription (or the channel
+ * is the default `#general`, which is auto-subscribe for everyone unless an
+ * explicit `direct_only` row opts out). Without a row, an agent still gets
+ * direct @mentions and replies-to-it in that channel (handled at send time).
+ */
+
+import { db } from "@/db";
+import { channelSubscription, channels } from "@/db/schema";
+import { and, eq } from "drizzle-orm";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("ChannelSubscription");
+
+export type SubscriptionMode = "auto_deliver" | "direct_only";
+
+const GENERAL_CHANNEL_NAME = "general";
+
+/** Subscribe (or update the mode of) a session to a channel. Idempotent. */
+export async function subscribe(
+  channelId: string,
+  sessionId: string,
+  mode: SubscriptionMode = "auto_deliver",
+): Promise<void> {
+  await db
+    .insert(channelSubscription)
+    .values({ channelId, sessionId, mode })
+    .onConflictDoUpdate({
+      target: [channelSubscription.channelId, channelSubscription.sessionId],
+      set: { mode },
+    });
+  log.debug("Channel subscription upserted", { channelId, sessionId, mode });
+}
+
+/** Remove a session's subscription to a channel. */
+export async function unsubscribe(channelId: string, sessionId: string): Promise<void> {
+  await db
+    .delete(channelSubscription)
+    .where(
+      and(
+        eq(channelSubscription.channelId, channelId),
+        eq(channelSubscription.sessionId, sessionId),
+      ),
+    );
+}
+
+/** All subscription rows for a channel (used by delivery fan-out + tests). */
+export async function getSubscriptions(
+  channelId: string,
+): Promise<{ sessionId: string; mode: SubscriptionMode }[]> {
+  const rows = await db.query.channelSubscription.findMany({
+    where: eq(channelSubscription.channelId, channelId),
+    columns: { sessionId: true, mode: true },
+  });
+  return rows.map((r) => ({ sessionId: r.sessionId, mode: r.mode as SubscriptionMode }));
+}
+
+/**
+ * Resolve which of `projectPeers` should AUTO-RECEIVE a channel's non-direct
+ * messages. Rules:
+ *   - `#general` is the default channel: every peer auto-receives UNLESS it has
+ *     an explicit `direct_only` row.
+ *   - any other channel: a peer auto-receives only with an explicit
+ *     `auto_deliver` row.
+ *
+ * `projectPeers` is the candidate set (active agent sessions in the project);
+ * the returned list is always a subset of it. @mentioned sessions are added by
+ * the caller (x386.7) regardless of subscription.
+ */
+export async function getAutoDeliverSessions(
+  channelId: string,
+  projectPeers: string[],
+): Promise<string[]> {
+  const subs = await getSubscriptions(channelId);
+  const modeBySession = new Map(subs.map((s) => [s.sessionId, s.mode]));
+
+  // Is this the project's default #general channel?
+  const channel = await db.query.channels.findFirst({
+    where: eq(channels.id, channelId),
+    columns: { isDefault: true, name: true },
+  });
+  const isGeneral = !!channel && (channel.isDefault || channel.name === GENERAL_CHANNEL_NAME);
+
+  if (isGeneral) {
+    // Everyone except explicit direct_only opt-outs.
+    return projectPeers.filter((sid) => modeBySession.get(sid) !== "direct_only");
+  }
+  // Opt-in only.
+  return projectPeers.filter((sid) => modeBySession.get(sid) === "auto_deliver");
+}

--- a/src/services/message-delivery-service.test.ts
+++ b/src/services/message-delivery-service.test.ts
@@ -1,0 +1,321 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createClient, type Client } from "@libsql/client/node";
+import { drizzle } from "drizzle-orm/libsql";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as schema from "@/db/schema";
+
+// Real libsql on a TEMP FILE (not :memory:) — the delivery state machine, the
+// unique-index idempotency, and the monotonic cursor MAX() are all SQL behavior
+// that must run against a real engine. A file URL is required because
+// `ackDelivery` uses `db.transaction()`, and libsql's interactive transaction
+// runs on a separate connection: with `:memory:` each connection is a distinct
+// database, so plain queries after a transaction would see no tables. A shared
+// on-disk file makes all connections see the same schema + data.
+let client: Client;
+let testDb: ReturnType<typeof drizzle<typeof schema>>;
+let tmpDir: string;
+
+vi.mock("@/db", () => ({
+  get db() {
+    return testDb;
+  },
+}));
+
+// Minimal DDL: agent_peer_message (source rows) + the two x386.1 tables.
+const DDL = [
+  `CREATE TABLE agent_peer_message (
+    id TEXT PRIMARY KEY NOT NULL,
+    project_id TEXT NOT NULL,
+    from_session_id TEXT,
+    from_session_name TEXT NOT NULL,
+    to_session_id TEXT,
+    body TEXT NOT NULL,
+    is_user_message INTEGER NOT NULL DEFAULT 0,
+    channel_id TEXT,
+    parent_message_id TEXT,
+    reply_count INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL
+  );`,
+  `CREATE TABLE message_delivery (
+    id TEXT PRIMARY KEY NOT NULL,
+    message_id TEXT NOT NULL,
+    to_session_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending',
+    channel_kind TEXT,
+    delivered_at INTEGER,
+    acked_at INTEGER,
+    created_at INTEGER NOT NULL
+  );`,
+  `CREATE UNIQUE INDEX message_delivery_msg_session_idx ON message_delivery (message_id, to_session_id);`,
+  `CREATE INDEX message_delivery_session_state_idx ON message_delivery (to_session_id, state, created_at);`,
+  `CREATE TABLE message_replay_cursor (
+    session_id TEXT PRIMARY KEY NOT NULL,
+    last_acked_at INTEGER,
+    updated_at INTEGER NOT NULL
+  );`,
+];
+
+async function resetDb(): Promise<void> {
+  tmpDir = mkdtempSync(join(tmpdir(), "rdv-md-test-"));
+  client = createClient({ url: `file:${join(tmpDir, "test.db")}` });
+  testDb = drizzle(client, { schema });
+  for (const stmt of DDL) await client.execute(stmt);
+}
+
+function cleanupDb(): void {
+  client?.close();
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+}
+
+import {
+  recordDeliveries,
+  markDelivered,
+  ackDelivery,
+  ackDeliveries,
+  getUndelivered,
+  getReplayCursor,
+} from "./message-delivery-service";
+import { cleanupOldMessages } from "./peer-service";
+
+const PROJECT = "proj-1";
+
+/** Insert a source message and return its id. `agoMs` backdates createdAt. */
+async function insertMessage(opts: {
+  id: string;
+  toSessionId?: string | null;
+  channelId?: string | null;
+  body?: string;
+  from?: string;
+  agoMs?: number;
+}): Promise<string> {
+  const createdAt = Date.now() - (opts.agoMs ?? 0);
+  await client.execute({
+    sql: `INSERT INTO agent_peer_message
+      (id, project_id, from_session_id, from_session_name, to_session_id, body, channel_id, created_at)
+      VALUES (?, ?, NULL, ?, ?, ?, ?, ?)`,
+    args: [
+      opts.id,
+      PROJECT,
+      opts.from ?? "alice",
+      opts.toSessionId ?? null,
+      opts.body ?? "hello",
+      opts.channelId ?? null,
+      createdAt,
+    ],
+  });
+  return opts.id;
+}
+
+describe("MessageDeliveryService", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+  afterEach(() => {
+    cleanupDb();
+  });
+
+  describe("recordDeliveries", () => {
+    it("creates one pending row per recipient", async () => {
+      await insertMessage({ id: "m1" });
+      await recordDeliveries("m1", PROJECT, ["s1", "s2"]);
+      const rows = await getUndelivered("s1");
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ id: "m1", state: "pending" });
+      expect(await getUndelivered("s2")).toHaveLength(1);
+    });
+
+    it("is idempotent — calling twice yields a single row per (message, session)", async () => {
+      await insertMessage({ id: "m1" });
+      await recordDeliveries("m1", PROJECT, ["s1"]);
+      await recordDeliveries("m1", PROJECT, ["s1"]);
+      const all = await client.execute("SELECT COUNT(*) AS n FROM message_delivery WHERE message_id = 'm1'");
+      expect(Number(all.rows[0].n)).toBe(1);
+    });
+
+    it("de-dups recipients within a single call", async () => {
+      await insertMessage({ id: "m1" });
+      await recordDeliveries("m1", PROJECT, ["s1", "s1", "s1"]);
+      const all = await client.execute("SELECT COUNT(*) AS n FROM message_delivery WHERE message_id = 'm1'");
+      expect(Number(all.rows[0].n)).toBe(1);
+    });
+
+    it("is a no-op for an empty recipient list", async () => {
+      await insertMessage({ id: "m1" });
+      await recordDeliveries("m1", PROJECT, []);
+      const all = await client.execute("SELECT COUNT(*) AS n FROM message_delivery");
+      expect(Number(all.rows[0].n)).toBe(0);
+    });
+  });
+
+  describe("markDelivered", () => {
+    it("advances pending → delivered and records the channel", async () => {
+      await insertMessage({ id: "m1" });
+      await recordDeliveries("m1", PROJECT, ["s1"]);
+      await markDelivered("m1", "s1", "mcp_push");
+      const row = await client.execute("SELECT state, channel_kind FROM message_delivery WHERE message_id='m1'");
+      expect(row.rows[0].state).toBe("delivered");
+      expect(row.rows[0].channel_kind).toBe("mcp_push");
+    });
+
+    it("does NOT regress an already-acked row", async () => {
+      await insertMessage({ id: "m1" });
+      await recordDeliveries("m1", PROJECT, ["s1"]);
+      await ackDelivery("m1", "s1");
+      await markDelivered("m1", "s1", "poll");
+      const row = await client.execute("SELECT state FROM message_delivery WHERE message_id='m1'");
+      expect(row.rows[0].state).toBe("acked");
+    });
+  });
+
+  describe("ackDelivery + replay cursor", () => {
+    it("advances the cursor to the acked message's createdAt", async () => {
+      await insertMessage({ id: "m1", agoMs: 1000 });
+      await recordDeliveries("m1", PROJECT, ["s1"]);
+      await ackDelivery("m1", "s1");
+      const cursor = await getReplayCursor("s1");
+      expect(cursor).not.toBeNull();
+      const row = await client.execute("SELECT created_at FROM agent_peer_message WHERE id='m1'");
+      expect(cursor!.getTime()).toBe(Number(row.rows[0].created_at));
+    });
+
+    it("never moves the cursor backwards when acking an OLDER message", async () => {
+      // newer m2 acked first, then older m1
+      await insertMessage({ id: "m1", agoMs: 10_000 });
+      await insertMessage({ id: "m2", agoMs: 1_000 });
+      await recordDeliveries("m1", PROJECT, ["s1"]);
+      await recordDeliveries("m2", PROJECT, ["s1"]);
+      await ackDelivery("m2", "s1");
+      const afterNewer = await getReplayCursor("s1");
+      await ackDelivery("m1", "s1");
+      const afterOlder = await getReplayCursor("s1");
+      // Cursor stays at the NEWER (m2) timestamp.
+      expect(afterOlder!.getTime()).toBe(afterNewer!.getTime());
+    });
+
+    it("returns null cursor for a session that never acked", async () => {
+      expect(await getReplayCursor("never")).toBeNull();
+    });
+  });
+
+  describe("getUndelivered", () => {
+    it("returns only non-acked rows, oldest first", async () => {
+      await insertMessage({ id: "old", agoMs: 5000 });
+      await insertMessage({ id: "new", agoMs: 1000 });
+      await recordDeliveries("old", PROJECT, ["s1"]);
+      await recordDeliveries("new", PROJECT, ["s1"]);
+      await ackDelivery("old", "s1");
+      const rows = await getUndelivered("s1");
+      expect(rows.map((r) => r.id)).toEqual(["new"]);
+    });
+
+    it("orders multiple undelivered oldest-first", async () => {
+      await insertMessage({ id: "a", agoMs: 3000 });
+      await insertMessage({ id: "b", agoMs: 2000 });
+      await insertMessage({ id: "c", agoMs: 1000 });
+      await recordDeliveries("a", PROJECT, ["s1"]);
+      await recordDeliveries("b", PROJECT, ["s1"]);
+      await recordDeliveries("c", PROJECT, ["s1"]);
+      const rows = await getUndelivered("s1");
+      expect(rows.map((r) => r.id)).toEqual(["a", "b", "c"]);
+    });
+
+    it("joins channel + parent fields from the source message", async () => {
+      await insertMessage({ id: "m1", channelId: "ch-1", body: "ping" });
+      await recordDeliveries("m1", PROJECT, ["s1"]);
+      const [row] = await getUndelivered("s1");
+      expect(row).toMatchObject({ channelId: "ch-1", body: "ping", fromSessionName: "alice" });
+    });
+  });
+
+  describe("exactly-once across push + poll (x386.4 parity)", () => {
+    it("a broadcast to a non-MCP session is returned once, then never again after ack", async () => {
+      await insertMessage({ id: "b1", toSessionId: null });
+      await recordDeliveries("b1", PROJECT, ["gemini-session"]);
+
+      // First poll: returns the message, marks it delivered (not acked).
+      const first = await getUndelivered("gemini-session");
+      expect(first.map((r) => r.id)).toEqual(["b1"]);
+      await Promise.all(first.map((r) => markDelivered(r.id, "gemini-session", "poll")));
+
+      // Still undelivered (delivered != acked) — so a crash before ack re-shows it.
+      expect((await getUndelivered("gemini-session")).map((r) => r.id)).toEqual(["b1"]);
+
+      // CLI acks the batch.
+      await ackDeliveries(first.map((r) => r.id), "gemini-session");
+
+      // Second poll: nothing.
+      expect(await getUndelivered("gemini-session")).toHaveLength(0);
+    });
+
+    it("ackDeliveries advances the cursor and is safe on an empty list", async () => {
+      await ackDeliveries([], "s1"); // no throw
+      await insertMessage({ id: "m1", agoMs: 1000 });
+      await recordDeliveries("m1", PROJECT, ["s1"]);
+      await ackDeliveries(["m1"], "s1");
+      expect(await getReplayCursor("s1")).not.toBeNull();
+    });
+  });
+});
+
+// ── x386.9: TTL prune (cleanupOldMessages) ──────────────────────────────────
+// The peer-service TTL must never prune a message that still has an unacked
+// delivery, so a long-disconnected agent does not lose something it never saw.
+describe("cleanupOldMessages TTL (x386.9)", () => {
+  beforeEach(async () => {
+    await resetDb();
+    delete process.env.RDV_CHAT_TTL_DAYS;
+  });
+  afterEach(() => {
+    cleanupDb();
+    delete process.env.RDV_CHAT_TTL_DAYS;
+  });
+
+  const DAY = 86_400_000;
+
+  it("prunes an OLD message whose deliveries are all acked", async () => {
+    await insertMessage({ id: "old", agoMs: 30 * DAY });
+    await recordDeliveries("old", PROJECT, ["s1"]);
+    await ackDelivery("old", "s1");
+    const pruned = await cleanupOldMessages();
+    expect(pruned).toBe(1);
+    const left = await client.execute("SELECT COUNT(*) AS n FROM agent_peer_message");
+    expect(Number(left.rows[0].n)).toBe(0);
+  });
+
+  it("RETAINS an old message with an unacked (delivered) delivery", async () => {
+    await insertMessage({ id: "old", agoMs: 30 * DAY });
+    await recordDeliveries("old", PROJECT, ["s1"]);
+    await markDelivered("old", "s1", "mcp_push"); // delivered, not acked
+    const pruned = await cleanupOldMessages();
+    expect(pruned).toBe(0);
+    const left = await client.execute("SELECT COUNT(*) AS n FROM agent_peer_message");
+    expect(Number(left.rows[0].n)).toBe(1);
+  });
+
+  it("RETAINS a recent message even when fully acked", async () => {
+    await insertMessage({ id: "recent", agoMs: 1 * DAY });
+    await recordDeliveries("recent", PROJECT, ["s1"]);
+    await ackDelivery("recent", "s1");
+    const pruned = await cleanupOldMessages();
+    expect(pruned).toBe(0);
+  });
+
+  it("prunes an old message with NO delivery rows at all", async () => {
+    await insertMessage({ id: "orphan", agoMs: 30 * DAY });
+    const pruned = await cleanupOldMessages();
+    expect(pruned).toBe(1);
+  });
+
+  it("honors RDV_CHAT_TTL_DAYS override", async () => {
+    process.env.RDV_CHAT_TTL_DAYS = "2";
+    await insertMessage({ id: "threeDays", agoMs: 3 * DAY });
+    await recordDeliveries("threeDays", PROJECT, ["s1"]);
+    await ackDelivery("threeDays", "s1");
+    const pruned = await cleanupOldMessages();
+    expect(pruned).toBe(1);
+  });
+});

--- a/src/services/message-delivery-service.ts
+++ b/src/services/message-delivery-service.ts
@@ -1,0 +1,179 @@
+/**
+ * MessageDeliveryService — durable per-recipient inbox for agent messages.
+ *
+ * [x386.1] The `agent_peer_message` table has no per-recipient delivery state,
+ * so a dropped MCP push is lost forever (the poll was the only recovery, and it
+ * had no durable cursor). This service records one `message_delivery` row per
+ * (message, recipient) and advances it through a state machine:
+ *
+ *   pending → delivered → acked
+ *
+ * `pending`   the row exists but nothing has been pushed yet.
+ * `delivered` the message was pushed to a live MCP socket OR returned by a poll.
+ * `acked`     the MCP server (or CLI) confirmed it surfaced to the agent.
+ *
+ * A durable per-session replay cursor (`message_replay_cursor`) records the
+ * highest acked message timestamp so a reconnecting MCP server can replay
+ * exactly what it missed. This is the source of truth; the /tmp sentinel in
+ * peer-server.ts is only a fast cache.
+ */
+
+import { db } from "@/db";
+import { messageDelivery, messageReplayCursor, agentPeerMessages } from "@/db/schema";
+import { and, eq, sql } from "drizzle-orm";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("MessageDelivery");
+
+/** How a delivery reached the agent (parity metrics + debugging). */
+export type DeliveryChannel = "mcp_push" | "poll";
+
+/** An undelivered (pending|delivered, not acked) message row for a session. */
+export interface UndeliveredMessage {
+  /** The agent_peer_message id (NOT the delivery row id). */
+  id: string;
+  state: "pending" | "delivered" | "acked";
+  body: string;
+  fromSessionName: string;
+  toSessionId: string | null;
+  channelId: string | null;
+  parentMessageId: string | null;
+  createdAt: Date;
+}
+
+/**
+ * Create one pending delivery row per recipient. Idempotent via the unique
+ * (message_id, to_session_id) index — calling twice yields one row per pair.
+ */
+export async function recordDeliveries(
+  messageId: string,
+  projectId: string,
+  recipientSessionIds: string[],
+): Promise<void> {
+  if (recipientSessionIds.length === 0) return;
+  // De-dup the input so a caller passing the same recipient twice doesn't
+  // trip the unique index within a single insert batch (SQLite rejects the
+  // whole statement on an in-batch conflict even with onConflictDoNothing).
+  const unique = [...new Set(recipientSessionIds)];
+  await db
+    .insert(messageDelivery)
+    .values(unique.map((toSessionId) => ({ messageId, toSessionId, projectId })))
+    .onConflictDoNothing({
+      target: [messageDelivery.messageId, messageDelivery.toSessionId],
+    });
+}
+
+/**
+ * Mark a (message, session) delivered via a given channel. No-op if the row is
+ * already `acked` (delivery must never regress an ack).
+ */
+export async function markDelivered(
+  messageId: string,
+  sessionId: string,
+  via: DeliveryChannel,
+): Promise<void> {
+  await db
+    .update(messageDelivery)
+    .set({ state: "delivered", channelType: via, deliveredAt: new Date() })
+    .where(
+      and(
+        eq(messageDelivery.messageId, messageId),
+        eq(messageDelivery.toSessionId, sessionId),
+        sql`${messageDelivery.state} != 'acked'`,
+      ),
+    );
+}
+
+/**
+ * Confirm the agent surfaced the message; advances the durable replay cursor.
+ * The cursor is monotonic — acking an older message never moves it backwards.
+ */
+export async function ackDelivery(messageId: string, sessionId: string): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx
+      .update(messageDelivery)
+      .set({ state: "acked", ackedAt: new Date() })
+      .where(
+        and(
+          eq(messageDelivery.messageId, messageId),
+          eq(messageDelivery.toSessionId, sessionId),
+        ),
+      );
+    const msg = await tx.query.agentPeerMessages.findFirst({
+      where: eq(agentPeerMessages.id, messageId),
+      columns: { createdAt: true },
+    });
+    if (!msg?.createdAt) return;
+    const createdMs = msg.createdAt.getTime();
+    await tx
+      .insert(messageReplayCursor)
+      .values({ sessionId, lastAckedAt: msg.createdAt })
+      .onConflictDoUpdate({
+        target: messageReplayCursor.sessionId,
+        // Monotonic: never move the cursor backwards. SQLite stores the
+        // timestamp as epoch-ms, so compare against the literal ms value.
+        set: {
+          lastAckedAt: sql`MAX(COALESCE(${messageReplayCursor.lastAckedAt}, 0), ${createdMs})`,
+          updatedAt: new Date(),
+        },
+      });
+  });
+}
+
+/**
+ * Ack many (message, session) deliveries for one session. Used by the poll
+ * fallback (`/internal/peers/ack-batch`) so non-MCP providers reach the same
+ * exactly-once guarantee as the MCP push path.
+ */
+export async function ackDeliveries(messageIds: string[], sessionId: string): Promise<void> {
+  for (const messageId of messageIds) {
+    await ackDelivery(messageId, sessionId);
+  }
+}
+
+/**
+ * Undelivered (pending|delivered, not acked) messages for a session, oldest
+ * first. Joins the message body so callers can render/push without a second
+ * query. This is the single set both the MCP replay handshake and the CLI poll
+ * read from.
+ */
+export async function getUndelivered(
+  sessionId: string,
+  limit = 50,
+): Promise<UndeliveredMessage[]> {
+  const rows = await db
+    .select({
+      id: messageDelivery.messageId,
+      state: messageDelivery.state,
+      body: agentPeerMessages.body,
+      fromSessionName: agentPeerMessages.fromSessionName,
+      toSessionId: agentPeerMessages.toSessionId,
+      channelId: agentPeerMessages.channelId,
+      parentMessageId: agentPeerMessages.parentMessageId,
+      createdAt: agentPeerMessages.createdAt,
+    })
+    .from(messageDelivery)
+    .innerJoin(agentPeerMessages, eq(messageDelivery.messageId, agentPeerMessages.id))
+    .where(
+      and(
+        eq(messageDelivery.toSessionId, sessionId),
+        sql`${messageDelivery.state} != 'acked'`,
+      ),
+    )
+    .orderBy(agentPeerMessages.createdAt)
+    .limit(limit);
+  return rows;
+}
+
+/** The durable replay cursor (highest acked message time) for a session. */
+export async function getReplayCursor(sessionId: string): Promise<Date | null> {
+  const row = await db.query.messageReplayCursor.findFirst({
+    where: eq(messageReplayCursor.sessionId, sessionId),
+  });
+  return row?.lastAckedAt ?? null;
+}
+
+// Re-export the logger namespace name for callers that want to assert/log the
+// delivery channel without importing the table. (Keeps mcp-push.ts loosely
+// coupled — it installs a hook rather than importing this module directly.)
+export { log as _deliveryLog };

--- a/src/services/peer-service.ts
+++ b/src/services/peer-service.ts
@@ -5,9 +5,10 @@
 import { db } from "@/db";
 import { ltDate } from "@/db/sql-helpers";
 import { agentPeerMessages, terminalSessions } from "@/db/schema";
-import { eq, and, or, isNull, gt, inArray, sql, desc } from "drizzle-orm";
+import { eq, and, or, isNull, gt, inArray, lt, sql, desc } from "drizzle-orm";
 import { createLogger } from "@/lib/logger";
 import { safeJsonParse } from "@/lib/utils";
+import * as MD from "@/services/message-delivery-service";
 
 const log = createLogger("PeerService");
 
@@ -298,9 +299,63 @@ export async function setSummary(
   log.debug("Peer summary updated", { sessionId, summary });
 }
 
-/** @deprecated Messages are now permanent. This function is a no-op. */
-export async function cleanupOldMessages(): Promise<void> {
-  log.debug("Peer message cleanup skipped (messages are permanent)");
+/**
+ * [x386.4] Poll using durable delivery state instead of a client timestamp.
+ * Returns this session's undelivered messages and marks them `delivered` via
+ * the `poll` channel. The CLI acks the batch afterwards (`ack-batch`), giving
+ * non-MCP providers (Codex/Gemini/OpenCode/Antigravity) the same exactly-once
+ * semantics as the MCP push path. The timestamp-based {@link pollMessages} is
+ * kept for the chat-room UI / backward compat.
+ */
+export async function pollUndelivered(sessionId: string): Promise<PeerMessage[]> {
+  const rows = await MD.getUndelivered(sessionId, 100);
+  // Mark delivered (NOT acked — ack happens when the agent acknowledges; for
+  // poll providers with no socket ack the CLI acks the batch on read).
+  await Promise.all(rows.map((r) => MD.markDelivered(r.id, sessionId, "poll")));
+  return rows.map((r) =>
+    toMessageRow({
+      id: r.id,
+      fromSessionId: null,
+      fromSessionName: r.fromSessionName,
+      toSessionId: r.toSessionId,
+      body: r.body,
+      isUserMessage: false,
+      channelId: r.channelId,
+      parentMessageId: r.parentMessageId,
+      replyCount: 0,
+      createdAt: r.createdAt,
+    }),
+  );
+}
+
+// Awareness chat is ephemeral — the work TRACKER is beads, not chat. Prune old
+// messages after a configurable window, but NEVER a message that still has an
+// unacked delivery (so a long-disconnected agent doesn't lose what it never saw).
+const MESSAGE_TTL_DAYS = 14; // awareness window; tune via env RDV_CHAT_TTL_DAYS
+
+/**
+ * [x386.9] Prune messages older than the TTL that have no pending/delivered
+ * (unacked) delivery rows. Returns the number of messages deleted. Deleting a
+ * message cascades its `message_delivery` rows via the FK.
+ */
+export async function cleanupOldMessages(): Promise<number> {
+  const ttlDays = Number(process.env.RDV_CHAT_TTL_DAYS ?? MESSAGE_TTL_DAYS);
+  const cutoff = new Date(Date.now() - ttlDays * 86_400_000);
+  const stale = await db
+    .select({ id: agentPeerMessages.id })
+    .from(agentPeerMessages)
+    .where(
+      and(
+        lt(agentPeerMessages.createdAt, cutoff),
+        // No unacked delivery rows remain for this message.
+        sql`NOT EXISTS (SELECT 1 FROM message_delivery md WHERE md.message_id = ${agentPeerMessages.id} AND md.state != 'acked')`,
+      ),
+    );
+  if (stale.length === 0) return 0;
+  const ids = stale.map((s) => s.id);
+  await db.delete(agentPeerMessages).where(inArray(agentPeerMessages.id, ids)); // cascades delivery rows
+  log.info("Pruned old peer messages", { count: ids.length, ttlDays });
+  return ids.length;
 }
 
 /**

--- a/src/services/work-context-service.test.ts
+++ b/src/services/work-context-service.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createClient, type Client } from "@libsql/client/node";
+import { drizzle } from "drizzle-orm/libsql";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as schema from "@/db/schema";
+
+let client: Client;
+let testDb: ReturnType<typeof drizzle<typeof schema>>;
+let tmpDir: string;
+
+vi.mock("@/db", () => ({
+  get db() {
+    return testDb;
+  },
+}));
+
+// Mock the bd layer so the loose join is deterministic.
+const beadsAvailable = { value: true };
+const beadsRows: Record<string, Array<{ id: string; title: string; assignee: string | null; status: string }>> = {};
+let beadsThrows = false;
+
+vi.mock("@/lib/beads-db", () => ({
+  isBeadsAvailable: vi.fn(async () => beadsAvailable.value),
+  beadsQuery: vi.fn(async (_path: string, sql: string, params: unknown[]) => {
+    if (beadsThrows) throw new Error("dolt schema drift: unknown column");
+    // Branch-id query carries a param; project-fallback has none.
+    if (params.length > 0) {
+      const key = `id:${String(params[0])}`;
+      return beadsRows[key] ?? [];
+    }
+    return beadsRows["project"] ?? [];
+  }),
+}));
+
+const DDL = [
+  `CREATE TABLE terminal_session (
+    id TEXT PRIMARY KEY NOT NULL,
+    user_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    tmux_session_name TEXT NOT NULL,
+    project_path TEXT,
+    worktree_branch TEXT,
+    project_id TEXT NOT NULL,
+    terminal_type TEXT DEFAULT 'shell',
+    agent_activity_status TEXT,
+    type_metadata TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    pinned INTEGER NOT NULL DEFAULT 0,
+    tab_order INTEGER NOT NULL DEFAULT 0,
+    last_activity_at INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );`,
+  `CREATE TABLE agent_work_context (
+    session_id TEXT PRIMARY KEY NOT NULL,
+    project_id TEXT NOT NULL,
+    branch TEXT,
+    worktree_path TEXT,
+    activity_status TEXT,
+    claimed_issue_id TEXT,
+    claimed_issue_title TEXT,
+    join_confidence TEXT,
+    updated_at INTEGER NOT NULL
+  );`,
+  `CREATE INDEX agent_work_context_project_idx ON agent_work_context (project_id);`,
+];
+
+async function resetDb(): Promise<void> {
+  tmpDir = mkdtempSync(join(tmpdir(), "rdv-wc-test-"));
+  client = createClient({ url: `file:${join(tmpDir, "test.db")}` });
+  testDb = drizzle(client, { schema });
+  for (const stmt of DDL) await client.execute(stmt);
+}
+
+function cleanupDb(): void {
+  client?.close();
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+}
+
+import {
+  computeWorkContext,
+  getProjectWorkContexts,
+  extractIssueIdFromBranch,
+} from "./work-context-service";
+
+async function insertSession(opts: {
+  id: string;
+  branch?: string | null;
+  path?: string | null;
+  status?: string | null;
+  projectId?: string;
+}): Promise<void> {
+  await client.execute({
+    sql: `INSERT INTO terminal_session
+      (id, user_id, name, tmux_session_name, project_path, worktree_branch, project_id,
+       terminal_type, agent_activity_status, status, last_activity_at, created_at, updated_at)
+      VALUES (?, 'u1', ?, ?, ?, ?, ?, 'agent', ?, 'active', 0, 0, 0)`,
+    args: [
+      opts.id,
+      opts.id,
+      `tmux-${opts.id}`,
+      opts.path ?? null,
+      opts.branch ?? null,
+      opts.projectId ?? "proj-1",
+      opts.status ?? "running",
+    ],
+  });
+}
+
+describe("WorkContextService (x386.11)", () => {
+  beforeEach(async () => {
+    await resetDb();
+    beadsAvailable.value = true;
+    beadsThrows = false;
+    for (const k of Object.keys(beadsRows)) delete beadsRows[k];
+  });
+  afterEach(() => {
+    cleanupDb();
+    vi.clearAllMocks();
+  });
+
+  describe("extractIssueIdFromBranch", () => {
+    it("pulls the bd issue id from common branch shapes", () => {
+      // Dotted sub-issue id (x386.11) is the bd id even when the branch adds a slug.
+      expect(extractIssueIdFromBranch("feat/x386.11-foo")).toBe("x386.11");
+      // Hyphenated full id.
+      expect(extractIssueIdFromBranch("feat/remote-dev-x386")).toBe("remote-dev-x386");
+      // A plain hyphenated slug still yields the leading token (loose; falls
+      // back to project-level if bd has no such id).
+      expect(extractIssueIdFromBranch("feat/x386-chat")).toBe("x386-chat");
+      // No id-shaped token.
+      expect(extractIssueIdFromBranch("master")).toBeNull();
+      expect(extractIssueIdFromBranch(null)).toBeNull();
+    });
+  });
+
+  describe("computeWorkContext join confidence", () => {
+    it("branch: an in-progress issue matching the branch id → joinConfidence 'branch'", async () => {
+      // branch feat/x386 → extract "x386" wouldn't match the dotted regex; use a
+      // hyphenated id so the extractor returns it, and seed that id.
+      await insertSession({ id: "s1", branch: "feat/x386-foo", path: "/wt/s1" });
+      beadsRows["id:x386-foo"] = [{ id: "x386-foo", title: "Chat epic", assignee: "alice", status: "in_progress" }];
+      const ctx = await computeWorkContext("s1");
+      expect(ctx).toMatchObject({
+        claimedIssueId: "x386-foo",
+        claimedIssueTitle: "Chat epic",
+        joinConfidence: "branch",
+        branch: "feat/x386-foo",
+        worktreePath: "/wt/s1",
+        activityStatus: "running",
+      });
+    });
+
+    it("project: no branch id but one in-progress issue → joinConfidence 'project'", async () => {
+      await insertSession({ id: "s1", branch: "master", path: "/wt/s1" });
+      beadsRows["project"] = [{ id: "abc-9", title: "Loose match", assignee: null, status: "in_progress" }];
+      const ctx = await computeWorkContext("s1");
+      expect(ctx).toMatchObject({ claimedIssueId: "abc-9", joinConfidence: "project" });
+    });
+
+    it("none: bd unavailable → joinConfidence 'none', no throw", async () => {
+      beadsAvailable.value = false;
+      await insertSession({ id: "s1", branch: "feat/x386-foo", path: "/wt/s1" });
+      const ctx = await computeWorkContext("s1");
+      expect(ctx).toMatchObject({ claimedIssueId: null, joinConfidence: "none" });
+    });
+
+    it("none: no project_path → joinConfidence 'none'", async () => {
+      await insertSession({ id: "s1", branch: "feat/x386-foo", path: null });
+      const ctx = await computeWorkContext("s1");
+      expect(ctx?.joinConfidence).toBe("none");
+    });
+
+    it("degrades to 'none' when a bd query throws (schema drift)", async () => {
+      beadsThrows = true;
+      await insertSession({ id: "s1", branch: "feat/x386-foo", path: "/wt/s1" });
+      const ctx = await computeWorkContext("s1");
+      expect(ctx).toMatchObject({ claimedIssueId: null, joinConfidence: "none" });
+    });
+
+    it("returns null for a session with no project", async () => {
+      // No row inserted.
+      expect(await computeWorkContext("ghost")).toBeNull();
+    });
+  });
+
+  describe("persistence + getProjectWorkContexts", () => {
+    it("caches the snapshot and reads it back per project", async () => {
+      beadsAvailable.value = false;
+      await insertSession({ id: "s1", branch: "feat/a", path: "/wt/s1" });
+      await insertSession({ id: "s2", branch: "feat/b", path: "/wt/s2" });
+      await computeWorkContext("s1");
+      await computeWorkContext("s2");
+      const all = await getProjectWorkContexts("proj-1");
+      expect(all.map((c) => c.sessionId).sort()).toEqual(["s1", "s2"]);
+    });
+
+    it("re-computing updates the cached row in place (no duplicate)", async () => {
+      beadsAvailable.value = false;
+      await insertSession({ id: "s1", branch: "feat/a", path: "/wt/s1" });
+      await computeWorkContext("s1");
+      // Change branch, recompute.
+      await client.execute("UPDATE terminal_session SET worktree_branch='feat/b' WHERE id='s1'");
+      await computeWorkContext("s1");
+      const all = await getProjectWorkContexts("proj-1");
+      expect(all).toHaveLength(1);
+      expect(all[0].branch).toBe("feat/b");
+    });
+  });
+});

--- a/src/services/work-context-service.ts
+++ b/src/services/work-context-service.ts
@@ -1,0 +1,384 @@
+/**
+ * WorkContextService — the awareness layer beads does NOT hold.
+ *
+ * [x386.11] Per-session branch/worktree/folder/status/last-activity, plus a
+ * READ-ONLY view of the bd issue the agent has claimed. No task data is
+ * duplicated — bd is queried live via `beadsQuery`; we only mirror the claimed
+ * issue id/title for display and NEVER write back to bd.
+ *
+ * **The session → bd-issue join is intentionally loose** (there is no hard FK):
+ *   - a session's working dir is `terminalSessions.projectPath` (the worktree),
+ *     and bd is keyed by that path's `.beads/` Dolt DB;
+ *   - bd's `assignee`/`actor` is freetext (not a session UUID), so we join on
+ *     the **issue id embedded in the branch name** (e.g. `feat/x386-...` /
+ *     `feat/x386.11-...`) and fall back to "most recent in-progress issue in
+ *     this project" when the branch encodes no id.
+ * The result carries `joinConfidence: "branch" | "project" | "none"` so the UI
+ * and digest never over-trust a project-level guess.
+ *
+ * [x386.14] Also detects collisions — another active session sharing this
+ * session's branch, worktree path, or claimed bd issue — the most common cause
+ * of stepped-on work.
+ */
+
+import { db } from "@/db";
+import { terminalSessions, agentWorkContext, agentPeerMessages } from "@/db/schema";
+import { eq, and, like, desc, inArray } from "drizzle-orm";
+import { beadsQuery, isBeadsAvailable } from "@/lib/beads-db";
+import type { RowDataPacket } from "mysql2/promise";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("WorkContext");
+
+// Matches an issue id like "x386", "x386.11", "remote-dev-x386", "abc-1f2" in a
+// branch name. We strip a leading prefix segment (feat/, fix/, chore/, …) and
+// take the first token that looks like an id.
+const ISSUE_ID_IN_BRANCH = /([a-z0-9]+(?:-[a-z0-9]+)+(?:\.[0-9]+)?|[a-z0-9]+\.[0-9]+)/i;
+
+interface ClaimRow extends RowDataPacket {
+  id: string;
+  title: string;
+  assignee: string | null;
+  status: string;
+}
+
+export type JoinConfidence = "branch" | "project" | "none";
+
+export interface WorkContext {
+  sessionId: string;
+  projectId: string;
+  branch: string | null;
+  worktreePath: string | null;
+  activityStatus: string | null;
+  claimedIssueId: string | null;
+  claimedIssueTitle: string | null;
+  joinConfidence: JoinConfidence;
+}
+
+export interface Collision {
+  peerSessionId: string;
+  peerName: string;
+  reason: "branch" | "worktree" | "issue";
+  value: string;
+}
+
+/** Extract a bd issue id embedded in a branch name, if any. */
+export function extractIssueIdFromBranch(branch: string | null | undefined): string | null {
+  if (!branch) return null;
+  // Drop a conventional leading "type/" segment so "feat/x386.11-foo" → "x386.11-foo".
+  const tail = branch.includes("/") ? branch.slice(branch.indexOf("/") + 1) : branch;
+  const m = tail.match(ISSUE_ID_IN_BRANCH);
+  return m ? m[1] : null;
+}
+
+/**
+ * Compute (and cache) the work-context for a session, including the READ-ONLY
+ * bd-issue join. Persists a snapshot to `agent_work_context` so the chat UI and
+ * digest can read it without a live git/bd call. Returns null if the session
+ * has no project.
+ */
+export async function computeWorkContext(sessionId: string): Promise<WorkContext | null> {
+  const s = await db.query.terminalSessions.findFirst({
+    where: eq(terminalSessions.id, sessionId),
+    columns: {
+      projectId: true,
+      worktreeBranch: true,
+      projectPath: true,
+      agentActivityStatus: true,
+    },
+  });
+  if (!s?.projectId) return null;
+
+  let claimedIssueId: string | null = null;
+  let claimedIssueTitle: string | null = null;
+  let joinConfidence: JoinConfidence = "none";
+
+  const path = s.projectPath ?? null;
+  // bd Dolt schema can drift across bd versions (see beads_dolt_schema_coupling);
+  // wrap every bd query so a column rename degrades to joinConfidence:"none"
+  // instead of throwing.
+  if (path) {
+    try {
+      if (await isBeadsAvailable(path)) {
+        const branchIssue = extractIssueIdFromBranch(s.worktreeBranch);
+        if (branchIssue) {
+          const rows = await beadsQuery<ClaimRow>(
+            path,
+            "SELECT id, title, assignee, status FROM issues WHERE id = ? AND status = 'in_progress' LIMIT 1",
+            [branchIssue],
+          );
+          if (rows[0]) {
+            claimedIssueId = rows[0].id;
+            claimedIssueTitle = rows[0].title;
+            joinConfidence = "branch";
+          }
+        }
+        if (!claimedIssueId) {
+          // Fallback: any single in-progress issue in this project (loose).
+          const rows = await beadsQuery<ClaimRow>(
+            path,
+            "SELECT id, title, assignee, status FROM issues WHERE status = 'in_progress' ORDER BY updated_at DESC LIMIT 1",
+            [],
+          );
+          if (rows[0]) {
+            claimedIssueId = rows[0].id;
+            claimedIssueTitle = rows[0].title;
+            joinConfidence = "project";
+          }
+        }
+      }
+    } catch (err) {
+      log.debug("bd join failed; degrading to joinConfidence:none", {
+        sessionId,
+        error: String(err),
+      });
+      claimedIssueId = null;
+      claimedIssueTitle = null;
+      joinConfidence = "none";
+    }
+  }
+
+  const ctx: WorkContext = {
+    sessionId,
+    projectId: s.projectId,
+    branch: s.worktreeBranch ?? null,
+    worktreePath: path,
+    activityStatus: s.agentActivityStatus ?? null,
+    claimedIssueId,
+    claimedIssueTitle,
+    joinConfidence,
+  };
+
+  await db
+    .insert(agentWorkContext)
+    .values({
+      sessionId: ctx.sessionId,
+      projectId: ctx.projectId,
+      branch: ctx.branch,
+      worktreePath: ctx.worktreePath,
+      activityStatus: ctx.activityStatus,
+      claimedIssueId: ctx.claimedIssueId,
+      claimedIssueTitle: ctx.claimedIssueTitle,
+      joinConfidence: ctx.joinConfidence,
+    })
+    .onConflictDoUpdate({
+      target: agentWorkContext.sessionId,
+      set: {
+        projectId: ctx.projectId,
+        branch: ctx.branch,
+        worktreePath: ctx.worktreePath,
+        activityStatus: ctx.activityStatus,
+        claimedIssueId: ctx.claimedIssueId,
+        claimedIssueTitle: ctx.claimedIssueTitle,
+        joinConfidence: ctx.joinConfidence,
+        updatedAt: new Date(),
+      },
+    });
+
+  return ctx;
+}
+
+/** All cached work-contexts for a project (used by digest + collision). */
+export async function getProjectWorkContexts(projectId: string): Promise<WorkContext[]> {
+  const rows = await db.query.agentWorkContext.findMany({
+    where: eq(agentWorkContext.projectId, projectId),
+  });
+  return rows.map((r) => ({
+    sessionId: r.sessionId,
+    projectId: r.projectId,
+    branch: r.branch,
+    worktreePath: r.worktreePath,
+    activityStatus: r.activityStatus,
+    claimedIssueId: r.claimedIssueId,
+    claimedIssueTitle: r.claimedIssueTitle,
+    joinConfidence: (r.joinConfidence ?? "none") as JoinConfidence,
+  }));
+}
+
+/**
+ * [x386.14] Cached work-contexts for a project, restricted to sessions that are
+ * still **active or suspended**. `closeSession` flips `terminal_session.status`
+ * to `closed` but does NOT delete the row (so the work-context snapshot
+ * lingers); collision detection must ignore those stale snapshots, otherwise an
+ * agent resuming work on a branch/worktree/issue that a now-closed session used
+ * would see a phantom "⚠ COLLISION" in every start digest. Inner-joins
+ * `agent_work_context` against `terminal_session.status IN ('active','suspended')`
+ * — the same liveness filter `getProjectPeers` applies.
+ */
+export async function getActiveProjectWorkContexts(projectId: string): Promise<WorkContext[]> {
+  const rows = await db
+    .select({
+      sessionId: agentWorkContext.sessionId,
+      projectId: agentWorkContext.projectId,
+      branch: agentWorkContext.branch,
+      worktreePath: agentWorkContext.worktreePath,
+      activityStatus: agentWorkContext.activityStatus,
+      claimedIssueId: agentWorkContext.claimedIssueId,
+      claimedIssueTitle: agentWorkContext.claimedIssueTitle,
+      joinConfidence: agentWorkContext.joinConfidence,
+    })
+    .from(agentWorkContext)
+    .innerJoin(terminalSessions, eq(agentWorkContext.sessionId, terminalSessions.id))
+    .where(
+      and(
+        eq(agentWorkContext.projectId, projectId),
+        inArray(terminalSessions.status, ["active", "suspended"]),
+      ),
+    );
+  return rows.map((r) => ({
+    sessionId: r.sessionId,
+    projectId: r.projectId,
+    branch: r.branch,
+    worktreePath: r.worktreePath,
+    activityStatus: r.activityStatus,
+    claimedIssueId: r.claimedIssueId,
+    claimedIssueTitle: r.claimedIssueTitle,
+    joinConfidence: (r.joinConfidence ?? "none") as JoinConfidence,
+  }));
+}
+
+/**
+ * [x386.14] Detect collisions for a session: another active session in the same
+ * project sharing its branch, worktree path, or claimed bd issue. Reads the
+ * cached contexts, so callers that need fresh data should
+ * {@link computeWorkContext} first.
+ */
+export async function detectCollisions(sessionId: string): Promise<Collision[]> {
+  const me = await db.query.agentWorkContext.findFirst({
+    where: eq(agentWorkContext.sessionId, sessionId),
+  });
+  if (!me) return [];
+  // Only collide against sessions that are still active/suspended — a closed
+  // session's lingering work-context snapshot must not raise a phantom warning.
+  const peers = await getActiveProjectWorkContexts(me.projectId);
+  const out: Collision[] = [];
+  for (const p of peers) {
+    if (p.sessionId === sessionId) continue;
+    if (me.branch && p.branch === me.branch) {
+      out.push({ peerSessionId: p.sessionId, peerName: "", reason: "branch", value: me.branch });
+    } else if (me.worktreePath && p.worktreePath === me.worktreePath) {
+      out.push({ peerSessionId: p.sessionId, peerName: "", reason: "worktree", value: me.worktreePath });
+    } else if (me.claimedIssueId && p.claimedIssueId === me.claimedIssueId) {
+      out.push({ peerSessionId: p.sessionId, peerName: "", reason: "issue", value: me.claimedIssueId });
+    }
+  }
+  // Backfill peer names from terminalSessions in one query.
+  if (out.length > 0) {
+    const ids = [...new Set(out.map((c) => c.peerSessionId))];
+    const sessions = await db.query.terminalSessions.findMany({
+      where: inArray(terminalSessions.id, ids),
+      columns: { id: true, name: true },
+    });
+    const nameById = new Map(sessions.map((s) => [s.id, s.name]));
+    for (const c of out) c.peerName = nameById.get(c.peerSessionId) ?? "peer";
+  }
+  return out;
+}
+
+// ── Start digest (x386.12) ───────────────────────────────────────────────────
+
+const GOTCHA_PREFIX_RE = /^\[(gotcha|heads-up|progress)\]/i;
+
+export interface DigestPeer {
+  sessionId: string;
+  name: string;
+  status: string | null;
+  branch: string | null;
+  claimedIssueId: string | null;
+  claimedIssueTitle: string | null;
+  summary: string | null;
+  joinConfidence: JoinConfidence;
+}
+
+export interface DigestGotcha {
+  from: string;
+  body: string;
+  createdAt: string;
+}
+
+export interface StartDigest {
+  peers: DigestPeer[];
+  gotchas: DigestGotcha[];
+  collisions: Collision[];
+}
+
+/**
+ * [x386.12/.14] Build the start digest for a session: who's-working-on-what
+ * (work-context + claimed bd issues), recent gotchas/heads-ups posted to
+ * #agents (x386.13), and collisions. Recomputes the caller's own context first
+ * so collisions use fresh branch data.
+ */
+export async function buildStartDigest(sessionId: string): Promise<StartDigest> {
+  const me = await computeWorkContext(sessionId);
+  if (!me) return { peers: [], gotchas: [], collisions: [] };
+
+  const PeerService = await import("@/services/peer-service");
+  const [contexts, peerInfos] = await Promise.all([
+    getProjectWorkContexts(me.projectId),
+    PeerService.getProjectPeers(me.projectId),
+  ]);
+  const ctxById = new Map(contexts.map((c) => [c.sessionId, c]));
+
+  // Peers = the active project peers (excluding self), enriched with cached
+  // work-context where available.
+  const peers: DigestPeer[] = peerInfos
+    .filter((p) => p.sessionId !== sessionId)
+    .map((p) => {
+      const ctx = ctxById.get(p.sessionId);
+      return {
+        sessionId: p.sessionId,
+        name: p.name,
+        status: p.agentActivityStatus ?? ctx?.activityStatus ?? null,
+        branch: ctx?.branch ?? null,
+        claimedIssueId: ctx?.claimedIssueId ?? null,
+        claimedIssueTitle: ctx?.claimedIssueTitle ?? null,
+        summary: p.peerSummary,
+        joinConfidence: ctx?.joinConfidence ?? "none",
+      };
+    });
+
+  const gotchas = await getRecentGotchas(me.projectId, 5);
+  const collisions = await detectCollisions(sessionId);
+
+  return { peers, gotchas, collisions };
+}
+
+/**
+ * Most-recent gotcha/heads-up/progress notes in the project's #agents channel.
+ * These are messages whose body carries a `[gotcha]` / `[heads-up]` /
+ * `[progress]` prefix (written by `rdv peer note`, x386.13).
+ */
+export async function getRecentGotchas(projectId: string, limit = 5): Promise<DigestGotcha[]> {
+  const ChannelService = await import("@/services/channel-service");
+  let agentsChannelId: string;
+  try {
+    agentsChannelId = await ChannelService.getAgentsChannelId(projectId);
+  } catch {
+    return [];
+  }
+  // Filter to bracket-prefixed bodies in SQL so high-volume check-in/check-out
+  // chatter in #agents can't push tagged notes out of an over-fetched window.
+  // `LIKE '[%'` is a cheap prefix gate; the precise GOTCHA_PREFIX_RE below then
+  // rejects any non-note bracket (e.g. "[other]"). Newest-first, capped.
+  const rows = await db
+    .select({
+      fromSessionName: agentPeerMessages.fromSessionName,
+      body: agentPeerMessages.body,
+      createdAt: agentPeerMessages.createdAt,
+    })
+    .from(agentPeerMessages)
+    .where(and(eq(agentPeerMessages.channelId, agentsChannelId), like(agentPeerMessages.body, "[%")))
+    .orderBy(desc(agentPeerMessages.createdAt))
+    .limit(limit * 4);
+  return rows
+    .filter((m) => GOTCHA_PREFIX_RE.test(m.body))
+    .slice(0, limit)
+    .map((m) => ({
+      from: m.fromSessionName,
+      body: m.body,
+      createdAt: m.createdAt instanceof Date ? m.createdAt.toISOString() : String(m.createdAt),
+    }));
+}
+
+// Re-export so callers can assert against the namespaced logger if needed.
+export { log as _workContextLog };

--- a/tests/services/peer-collision.test.ts
+++ b/tests/services/peer-collision.test.ts
@@ -1,0 +1,185 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createClient, type Client } from "@libsql/client/node";
+import { drizzle } from "drizzle-orm/libsql";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as schema from "@/db/schema";
+
+// [x386.14] Collision detection over cached work-contexts. Two active sessions
+// sharing a branch, worktree path, or claimed bd issue are the most common
+// cause of stepped-on work.
+
+let client: Client;
+let testDb: ReturnType<typeof drizzle<typeof schema>>;
+let tmpDir: string;
+
+vi.mock("@/db", () => ({
+  get db() {
+    return testDb;
+  },
+}));
+
+const DDL = [
+  `CREATE TABLE terminal_session (
+    id TEXT PRIMARY KEY NOT NULL,
+    user_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    tmux_session_name TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    last_activity_at INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );`,
+  `CREATE TABLE agent_work_context (
+    session_id TEXT PRIMARY KEY NOT NULL,
+    project_id TEXT NOT NULL,
+    branch TEXT,
+    worktree_path TEXT,
+    activity_status TEXT,
+    claimed_issue_id TEXT,
+    claimed_issue_title TEXT,
+    join_confidence TEXT,
+    updated_at INTEGER NOT NULL
+  );`,
+  `CREATE INDEX agent_work_context_project_idx ON agent_work_context (project_id);`,
+];
+
+async function resetDb(): Promise<void> {
+  tmpDir = mkdtempSync(join(tmpdir(), "rdv-collision-test-"));
+  client = createClient({ url: `file:${join(tmpDir, "test.db")}` });
+  testDb = drizzle(client, { schema });
+  for (const stmt of DDL) await client.execute(stmt);
+}
+
+function cleanupDb(): void {
+  client?.close();
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+}
+
+import { detectCollisions } from "@/services/work-context-service";
+
+async function insertSession(id: string, name: string, status = "active"): Promise<void> {
+  await client.execute({
+    sql: `INSERT INTO terminal_session (id, user_id, name, tmux_session_name, project_id, status, last_activity_at, created_at, updated_at)
+          VALUES (?, 'u1', ?, ?, 'proj-1', ?, 0, 0, 0)`,
+    args: [id, name, `tmux-${id}`, status],
+  });
+}
+
+async function insertContext(opts: {
+  sessionId: string;
+  branch?: string | null;
+  worktreePath?: string | null;
+  issueId?: string | null;
+}): Promise<void> {
+  await client.execute({
+    sql: `INSERT INTO agent_work_context (session_id, project_id, branch, worktree_path, claimed_issue_id, join_confidence, updated_at)
+          VALUES (?, 'proj-1', ?, ?, ?, 'branch', 0)`,
+    args: [opts.sessionId, opts.branch ?? null, opts.worktreePath ?? null, opts.issueId ?? null],
+  });
+}
+
+describe("detectCollisions (x386.14)", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+  afterEach(() => {
+    cleanupDb();
+  });
+
+  it("flags a branch collision in BOTH directions for two sessions on the same branch", async () => {
+    await insertSession("s1", "alice");
+    await insertSession("s2", "bob");
+    await insertContext({ sessionId: "s1", branch: "feat/x386.11", worktreePath: "/wt/s1" });
+    await insertContext({ sessionId: "s2", branch: "feat/x386.11", worktreePath: "/wt/s2" });
+
+    const forS1 = await detectCollisions("s1");
+    expect(forS1).toHaveLength(1);
+    expect(forS1[0]).toMatchObject({ peerSessionId: "s2", peerName: "bob", reason: "branch", value: "feat/x386.11" });
+
+    const forS2 = await detectCollisions("s2");
+    expect(forS2).toHaveLength(1);
+    expect(forS2[0]).toMatchObject({ peerSessionId: "s1", peerName: "alice", reason: "branch" });
+  });
+
+  it("flags a worktree collision when branches differ but paths match", async () => {
+    await insertSession("s1", "alice");
+    await insertSession("s2", "bob");
+    await insertContext({ sessionId: "s1", branch: "feat/a", worktreePath: "/shared/wt" });
+    await insertContext({ sessionId: "s2", branch: "feat/b", worktreePath: "/shared/wt" });
+
+    const out = await detectCollisions("s1");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ reason: "worktree", value: "/shared/wt", peerName: "bob" });
+  });
+
+  it("flags an issue collision when only the claimed bd issue matches", async () => {
+    await insertSession("s1", "alice");
+    await insertSession("s2", "bob");
+    await insertContext({ sessionId: "s1", branch: "feat/a", worktreePath: "/wt/s1", issueId: "x386.6" });
+    await insertContext({ sessionId: "s2", branch: "feat/b", worktreePath: "/wt/s2", issueId: "x386.6" });
+
+    const out = await detectCollisions("s1");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ reason: "issue", value: "x386.6", peerName: "bob" });
+  });
+
+  it("returns no collisions for disjoint sessions", async () => {
+    await insertSession("s1", "alice");
+    await insertSession("s2", "bob");
+    await insertContext({ sessionId: "s1", branch: "feat/a", worktreePath: "/wt/s1", issueId: "x386.1" });
+    await insertContext({ sessionId: "s2", branch: "feat/b", worktreePath: "/wt/s2", issueId: "x386.2" });
+    expect(await detectCollisions("s1")).toEqual([]);
+  });
+
+  it("does not collide a session with itself", async () => {
+    await insertSession("s1", "alice");
+    await insertContext({ sessionId: "s1", branch: "feat/a", worktreePath: "/wt/s1" });
+    expect(await detectCollisions("s1")).toEqual([]);
+  });
+
+  it("returns [] when the session has no cached context", async () => {
+    expect(await detectCollisions("ghost")).toEqual([]);
+  });
+
+  it("ignores null branch/path/issue (no false collisions on shared nulls)", async () => {
+    await insertSession("s1", "alice");
+    await insertSession("s2", "bob");
+    // Both have null worktree_path and null issue — must NOT collide.
+    await insertContext({ sessionId: "s1", branch: "feat/a", worktreePath: null, issueId: null });
+    await insertContext({ sessionId: "s2", branch: "feat/b", worktreePath: null, issueId: null });
+    expect(await detectCollisions("s1")).toEqual([]);
+  });
+
+  // [x386.14 HIGH fix] closeSession sets status='closed' but does NOT delete the
+  // terminal_session row, so the work-context snapshot lingers. A closed peer
+  // sharing a branch/worktree/issue must NOT raise a phantom collision.
+  it("does NOT collide against a CLOSED peer sharing the branch", async () => {
+    await insertSession("s1", "alice", "active");
+    await insertSession("s2", "bob", "closed");
+    await insertContext({ sessionId: "s1", branch: "feat/x386.11", worktreePath: "/wt/s1" });
+    await insertContext({ sessionId: "s2", branch: "feat/x386.11", worktreePath: "/wt/s2" });
+    expect(await detectCollisions("s1")).toEqual([]);
+  });
+
+  it("does NOT collide against a closed peer sharing the worktree or claimed issue", async () => {
+    await insertSession("s1", "alice", "active");
+    await insertSession("s2", "bob", "closed");
+    await insertContext({ sessionId: "s1", branch: "feat/a", worktreePath: "/shared/wt", issueId: "x386.6" });
+    await insertContext({ sessionId: "s2", branch: "feat/b", worktreePath: "/shared/wt", issueId: "x386.6" });
+    expect(await detectCollisions("s1")).toEqual([]);
+  });
+
+  it("still collides against a SUSPENDED peer (suspended is live)", async () => {
+    await insertSession("s1", "alice", "active");
+    await insertSession("s2", "bob", "suspended");
+    await insertContext({ sessionId: "s1", branch: "feat/shared", worktreePath: "/wt/s1" });
+    await insertContext({ sessionId: "s2", branch: "feat/shared", worktreePath: "/wt/s2" });
+    const out = await detectCollisions("s1");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ peerName: "bob", reason: "branch", value: "feat/shared" });
+  });
+});

--- a/tests/services/start-digest.test.ts
+++ b/tests/services/start-digest.test.ts
@@ -1,0 +1,240 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createClient, type Client } from "@libsql/client/node";
+import { drizzle } from "drizzle-orm/libsql";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as schema from "@/db/schema";
+
+// [x386.12/.13] The start digest combines work-context (who's-working-on-what +
+// claimed bd issues), recent gotchas posted to #agents, and collisions.
+
+let client: Client;
+let testDb: ReturnType<typeof drizzle<typeof schema>>;
+let tmpDir: string;
+
+vi.mock("@/db", () => ({
+  get db() {
+    return testDb;
+  },
+}));
+
+// bd unavailable for the digest test — work-context branch is enough; the
+// claimed-issue path is covered in work-context-service.test.ts.
+vi.mock("@/lib/beads-db", () => ({
+  isBeadsAvailable: vi.fn(async () => false),
+  beadsQuery: vi.fn(async () => []),
+}));
+
+const DDL = [
+  `CREATE TABLE terminal_session (
+    id TEXT PRIMARY KEY NOT NULL,
+    user_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    tmux_session_name TEXT NOT NULL,
+    project_path TEXT,
+    worktree_branch TEXT,
+    project_id TEXT NOT NULL,
+    terminal_type TEXT DEFAULT 'shell',
+    agent_provider TEXT,
+    agent_activity_status TEXT,
+    type_metadata TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    pinned INTEGER NOT NULL DEFAULT 0,
+    tab_order INTEGER NOT NULL DEFAULT 0,
+    last_activity_at INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );`,
+  `CREATE TABLE agent_work_context (
+    session_id TEXT PRIMARY KEY NOT NULL,
+    project_id TEXT NOT NULL,
+    branch TEXT,
+    worktree_path TEXT,
+    activity_status TEXT,
+    claimed_issue_id TEXT,
+    claimed_issue_title TEXT,
+    join_confidence TEXT,
+    updated_at INTEGER NOT NULL
+  );`,
+  `CREATE INDEX agent_work_context_project_idx ON agent_work_context (project_id);`,
+  `CREATE TABLE channel_group (
+    id TEXT PRIMARY KEY NOT NULL,
+    project_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL
+  );`,
+  `CREATE UNIQUE INDEX channel_group_project_name_idx ON channel_group (project_id, name);`,
+  `CREATE TABLE channel (
+    id TEXT PRIMARY KEY NOT NULL,
+    project_id TEXT NOT NULL,
+    group_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    type TEXT NOT NULL DEFAULT 'public',
+    topic TEXT,
+    is_default INTEGER NOT NULL DEFAULT 0,
+    created_by_session_id TEXT,
+    last_message_at INTEGER,
+    message_count INTEGER NOT NULL DEFAULT 0,
+    archived_at INTEGER,
+    created_at INTEGER NOT NULL
+  );`,
+  `CREATE UNIQUE INDEX channel_project_name_idx ON channel (project_id, name);`,
+  `CREATE TABLE agent_peer_message (
+    id TEXT PRIMARY KEY NOT NULL,
+    project_id TEXT NOT NULL,
+    from_session_id TEXT,
+    from_session_name TEXT NOT NULL,
+    to_session_id TEXT,
+    body TEXT NOT NULL,
+    is_user_message INTEGER NOT NULL DEFAULT 0,
+    channel_id TEXT,
+    parent_message_id TEXT,
+    reply_count INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL
+  );`,
+];
+
+async function resetDb(): Promise<void> {
+  tmpDir = mkdtempSync(join(tmpdir(), "rdv-digest-test-"));
+  client = createClient({ url: `file:${join(tmpDir, "test.db")}` });
+  testDb = drizzle(client, { schema });
+  for (const stmt of DDL) await client.execute(stmt);
+}
+
+function cleanupDb(): void {
+  client?.close();
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+}
+
+import { buildStartDigest, getRecentGotchas } from "@/services/work-context-service";
+import { getAgentsChannelId } from "@/services/channel-service";
+
+async function insertSession(opts: {
+  id: string;
+  name: string;
+  branch?: string | null;
+  status?: string | null;
+}): Promise<void> {
+  await client.execute({
+    sql: `INSERT INTO terminal_session
+      (id, user_id, name, tmux_session_name, project_path, worktree_branch, project_id,
+       terminal_type, agent_provider, agent_activity_status, status, last_activity_at, created_at, updated_at)
+      VALUES (?, 'u1', ?, ?, '/wt/'||?, ?, 'proj-1', 'agent', 'claude', ?, 'active', 0, 0, 0)`,
+    args: [opts.id, opts.name, `tmux-${opts.id}`, opts.id, opts.branch ?? null, opts.status ?? "running"],
+  });
+}
+
+async function postGotcha(channelId: string, from: string, body: string, agoMs: number): Promise<void> {
+  await client.execute({
+    sql: `INSERT INTO agent_peer_message (id, project_id, from_session_name, body, channel_id, created_at)
+          VALUES (?, 'proj-1', ?, ?, ?, ?)`,
+    args: [`msg-${Math.random().toString(36).slice(2)}`, from, body, channelId, Date.now() - agoMs],
+  });
+}
+
+describe("buildStartDigest (x386.12)", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+  afterEach(() => {
+    cleanupDb();
+    vi.clearAllMocks();
+  });
+
+  it("includes peers (with branch) and recent gotchas, excludes self", async () => {
+    await insertSession({ id: "me", name: "me", branch: "feat/me" });
+    await insertSession({ id: "alice", name: "alice", branch: "feat/x386.11", status: "running" });
+    await insertSession({ id: "bob", name: "bob", branch: "feat/auth", status: "idle" });
+
+    // Pre-compute alice/bob contexts so the digest can enrich them with branch.
+    const WC = await import("@/services/work-context-service");
+    await WC.computeWorkContext("alice");
+    await WC.computeWorkContext("bob");
+
+    // A gotcha note in #agents.
+    const agentsId = await getAgentsChannelId("proj-1");
+    await postGotcha(agentsId, "carol", "[gotcha] db:push drops the FK after rebase", 1000);
+    await postGotcha(agentsId, "dave", "plain chatter, not a note", 500);
+
+    const digest = await buildStartDigest("me");
+
+    const names = digest.peers.map((p) => p.name).sort();
+    expect(names).toEqual(["alice", "bob"]);
+    expect(names).not.toContain("me");
+
+    const alice = digest.peers.find((p) => p.name === "alice");
+    expect(alice).toMatchObject({ branch: "feat/x386.11", status: "running" });
+
+    // Only the [gotcha]-tagged message is surfaced.
+    expect(digest.gotchas).toHaveLength(1);
+    expect(digest.gotchas[0]).toMatchObject({ from: "carol" });
+    expect(digest.gotchas[0].body).toContain("[gotcha]");
+  });
+
+  it("surfaces a branch collision in the digest's collisions section", async () => {
+    await insertSession({ id: "me", name: "me", branch: "feat/shared" });
+    await insertSession({ id: "alice", name: "alice", branch: "feat/shared" });
+    const WC = await import("@/services/work-context-service");
+    await WC.computeWorkContext("alice"); // alice cached on feat/shared
+
+    const digest = await buildStartDigest("me"); // recomputes "me" → collision
+    expect(digest.collisions).toHaveLength(1);
+    expect(digest.collisions[0]).toMatchObject({ peerName: "alice", reason: "branch", value: "feat/shared" });
+  });
+
+  it("returns empty sections when the session has no project", async () => {
+    const digest = await buildStartDigest("ghost");
+    expect(digest).toEqual({ peers: [], gotchas: [], collisions: [] });
+  });
+});
+
+describe("getRecentGotchas (x386.13 surfacing)", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+  afterEach(() => {
+    cleanupDb();
+    vi.clearAllMocks();
+  });
+
+  it("returns only tagged notes, newest first, capped at the limit", async () => {
+    const agentsId = await getAgentsChannelId("proj-1");
+    await postGotcha(agentsId, "a", "[gotcha] one", 5000);
+    await postGotcha(agentsId, "b", "[heads-up] two", 4000);
+    await postGotcha(agentsId, "c", "[progress] three", 3000);
+    await postGotcha(agentsId, "d", "just chatting", 2000);
+    await postGotcha(agentsId, "e", "[gotcha] four", 1000);
+
+    const gotchas = await getRecentGotchas("proj-1", 3);
+    expect(gotchas).toHaveLength(3);
+    // Newest first: e (1000ms ago), c (3000), b (4000).
+    expect(gotchas.map((g) => g.from)).toEqual(["e", "c", "b"]);
+    expect(gotchas.every((g) => /^\[(gotcha|heads-up|progress)\]/i.test(g.body))).toBe(true);
+  });
+
+  it("returns [] when there are no notes", async () => {
+    await getAgentsChannelId("proj-1");
+    expect(await getRecentGotchas("proj-1")).toEqual([]);
+  });
+
+  // [x386 LOW fix] Tagged notes must not be lost under heavy check-in/check-out
+  // chatter. The SQL prefix filter (`body LIKE '[%'`) means non-note posts never
+  // consume the fetch window, so an older gotcha still surfaces.
+  it("surfaces older gotchas even when newer check-in/out chatter dominates #agents", async () => {
+    const agentsId = await getAgentsChannelId("proj-1");
+    // One gotcha far in the past.
+    await postGotcha(agentsId, "carol", "[gotcha] the important footgun", 100_000);
+    // 30 newer non-note posts (check-ins / check-outs) — far more than limit*4.
+    for (let i = 0; i < 30; i++) {
+      await postGotcha(agentsId, `agent${i}`, `checked in — branch feat/b${i}`, 30_000 - i * 100);
+    }
+    const gotchas = await getRecentGotchas("proj-1", 5);
+    expect(gotchas).toHaveLength(1);
+    expect(gotchas[0]).toMatchObject({ from: "carol" });
+    expect(gotchas[0].body).toContain("[gotcha]");
+  });
+});


### PR DESCRIPTION
## Epic x386 — Agent-native chat & coordination

Part 4 of 6 in the cmux/manaflow-inspired enhancement series. **Stacked on `pr/automation`** (#352) — merge after parts 1–3.

> **Reframe:** beads stays the work *tracker*; chat becomes the in-flight *awareness* layer it doesn't hold — agents sharing gotchas/heads-ups and seeing who's touching what.

### What this does
- **Reliable delivery**: replaces the fire-and-forget `mcp-push.ts` with a bidirectional MCP subscription (push/ack/replay) + a durable `message_delivery` inbox + poll fallback for non-Claude agents
- **Channel subscriptions** for agents (auto-deliver, not just direct/broadcast)
- **Check-in / check-out** via lifecycle hooks posting to a per-project `#agents` channel
- **Read-peers start digest** (who's-working-on-what + recent gotchas), **`rdv peer note`** gotchas, and an **overlap/collision nudge**
- Auto work-context with a **read-only beads join** (`joinConfidence` tagged)

### Gates
lint 0 · typecheck clean · vitest 1888 · cargo build/test -p rdv · +4 tables (schema 74).

### Review
Independent review: one **High** fixed (collision false-positives against closed sessions) + digest control-char sanitization (anti-spoofing) + gotcha-query fix. Follow-ups (replay-on-idle-reconnect, unused cursor table, duplicate-display) filed as beads.

Beads: `remote-dev-x386`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
