### PR TITLE
fix(db): PG sidecar stores fail in standalone build (pcm7) + migration tools

### DIFF
--- a/apps/supervisor/package.json
+++ b/apps/supervisor/package.json
@@ -17,7 +17,9 @@
     "db:codegen": "bun run scripts/codegen-schema.ts",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit migrate"
+    "db:migrate": "drizzle-kit migrate",
+    "db:migrate-supervisor-to-postgres": "bun run scripts/migrate-supervisor-to-postgres.ts",
+    "db:dump-supervisor-sql": "bun run scripts/dump-supervisor-sql.ts"
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.11.2",

--- a/apps/supervisor/scripts/dump-supervisor-sql.ts
+++ b/apps/supervisor/scripts/dump-supervisor-sql.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env bun
+/**
+ * Emit the Supervisor's SQLite registry as Postgres INSERT SQL (stdout), to be
+ * applied via `kubectl exec rdv-pg-1 -- psql` (no port-forward — unreliable over
+ * this link).
+ *
+ * The live supervisor runs an OLDER image, so its sqlite may be MISSING columns
+ * that the new schema added (e.g. db_config_snapshot). So we read the source's
+ * ACTUAL columns raw (libsql), and convert each by the TARGET pg column type
+ * (boolean / timestamptz / jsonb / text). Only the source∩target columns are
+ * copied; new target-only columns default to NULL. FK checks deferred via
+ * session_replication_role. Idempotent: ON CONFLICT DO NOTHING.
+ *
+ * NOTE: the supervisor schema uses only boolean + timestamp_ms (epoch MS) + text/
+ * json — no epoch-SECONDS columns — so date conversion is a simple new Date(ms).
+ *
+ * Usage: bun run apps/supervisor/scripts/dump-supervisor-sql.ts \
+ *          --from file:/abs/supervisor.db > /tmp/sup-data.sql
+ */
+import { createClient } from "@libsql/client/node";
+import { is } from "drizzle-orm";
+import { PgTable, getTableConfig } from "drizzle-orm/pg-core";
+import * as pgSchema from "../src/db/schema.pg";
+
+const fromIdx = process.argv.indexOf("--from");
+const from = fromIdx >= 0 ? process.argv[fromIdx + 1] : "";
+if (!from) {
+  console.error("need --from file:/path/supervisor.db");
+  process.exit(2);
+}
+const client = createClient({ url: from });
+
+function lit(raw: unknown, dataType: string): string {
+  if (raw === null || raw === undefined) return "NULL";
+  switch (dataType) {
+    case "boolean":
+      return Number(raw) ? "true" : "false";
+    case "date": {
+      // supervisor stores epoch milliseconds (timestamp_ms)
+      const ms = Number(raw);
+      return Number.isFinite(ms) ? `'${new Date(ms).toISOString()}'::timestamptz` : "NULL";
+    }
+    case "json":
+      // raw is already a JSON string in sqlite
+      return `'${String(raw).replace(/'/g, "''")}'::jsonb`;
+    case "number":
+    case "bigint":
+      return String(raw);
+    default:
+      return `'${String(raw).replace(/'/g, "''")}'`;
+  }
+}
+
+const out: string[] = ["BEGIN;", "SET session_replication_role = replica;"];
+let total = 0;
+for (const val of Object.values(pgSchema)) {
+  if (!is(val, PgTable)) continue;
+  const cfg = getTableConfig(val);
+  const tName = cfg.name;
+  const typeByCol = new Map(cfg.columns.map((c) => [c.name, c.dataType]));
+  // source columns actually present
+  const info = await client.execute(`PRAGMA table_info("${tName}")`);
+  const srcCols = (info.rows as Array<Record<string, unknown>>)
+    .map((r) => String(r.name))
+    .filter((c) => typeByCol.has(c)); // intersection with target
+  if (srcCols.length === 0) {
+    out.push(`-- ${tName}: SKIPPED (table absent in source)`);
+    continue;
+  }
+  const res = await client.execute(`SELECT * FROM "${tName}"`);
+  for (const row of res.rows as Array<Record<string, unknown>>) {
+    const vals = srcCols.map((c) => lit(row[c], typeByCol.get(c)!));
+    out.push(
+      `INSERT INTO "${tName}" (${srcCols.map((c) => `"${c}"`).join(", ")}) VALUES (${vals.join(", ")}) ON CONFLICT DO NOTHING;`,
+    );
+    total++;
+  }
+  out.push(`-- ${tName}: ${res.rows.length} rows`);
+}
+out.push("SET session_replication_role = origin;", "COMMIT;");
+console.log(out.join("\n"));
+console.error(`Emitted ${total} INSERTs.`);

--- a/apps/supervisor/scripts/migrate-supervisor-to-postgres.ts
+++ b/apps/supervisor/scripts/migrate-supervisor-to-postgres.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env bun
+/**
+ * One-off: copy the Supervisor's SQLite registry -> Postgres (rdv_supervisor).
+ *
+ * The main app's `db:migrate-to-postgres` CLI targets the main 60-table schema;
+ * the Supervisor has its own small schema (instance registry + auth), so this is
+ * its dedicated copy. Same technique: Drizzle libsql read -> Drizzle node-postgres
+ * write, so column modes handle all conversion (0/1->bool, epoch-ms->Date->
+ * timestamptz). FK checks are deferred via `session_replication_role = replica`
+ * (requires a SUPERUSER connection) so table order doesn't matter. Idempotent
+ * (onConflictDoNothing). The target PG schema must already exist — apply
+ * apps/supervisor/drizzle/pg first.
+ *
+ * Usage:
+ *   DATABASE_URL=postgresql://postgres:<pw>@localhost:5432/rdv_supervisor \
+ *   bun run apps/supervisor/scripts/migrate-supervisor-to-postgres.ts \
+ *     --from file:/abs/path/supervisor.db [--verify]
+ */
+import { createClient } from "@libsql/client/node";
+import { drizzle as drizzleLibsql } from "drizzle-orm/libsql";
+import { drizzle as drizzlePg } from "drizzle-orm/node-postgres";
+import { is, sql } from "drizzle-orm";
+import { SQLiteTable, getTableConfig } from "drizzle-orm/sqlite-core";
+import { Pool } from "pg";
+import * as sqliteSchema from "../src/db/schema.sqlite";
+import * as pgSchema from "../src/db/schema.pg";
+
+const argv = process.argv.slice(2);
+const fromIdx = argv.indexOf("--from");
+const fromUrl = fromIdx >= 0 ? argv[fromIdx + 1] : "";
+const verify = argv.includes("--verify");
+const toUrl = process.env.DATABASE_URL ?? "";
+if (!fromUrl || !toUrl.startsWith("postgres")) {
+  console.error(
+    "Usage: DATABASE_URL=postgresql://... bun run .../migrate-supervisor-to-postgres.ts --from file:/path/supervisor.db [--verify]",
+  );
+  process.exit(2);
+}
+
+const sqlite = drizzleLibsql(createClient({ url: fromUrl }), {
+  schema: sqliteSchema,
+});
+const pool = new Pool({ connectionString: toUrl });
+const pg = drizzlePg(pool, { schema: pgSchema });
+
+// Pair each exported SQLite table with its PG counterpart (same export name).
+const tables: Array<{ name: string; sqlName: string; sT: SQLiteTable; pT: unknown }> =
+  [];
+for (const [name, val] of Object.entries(sqliteSchema)) {
+  if (is(val, SQLiteTable)) {
+    const pT = (pgSchema as Record<string, unknown>)[name];
+    if (pT) tables.push({ name, sqlName: getTableConfig(val).name, sT: val, pT });
+  }
+}
+
+const BATCH = 200;
+let total = 0;
+await pool.query("SET session_replication_role = replica");
+try {
+  for (const { sqlName, sT, pT } of tables) {
+    const rows = (await sqlite.select().from(sT)) as Record<string, unknown>[];
+    for (let i = 0; i < rows.length; i += BATCH) {
+      const chunk = rows.slice(i, i + BATCH);
+      if (chunk.length)
+        await pg
+          .insert(pT as never)
+          .values(chunk as never)
+          .onConflictDoNothing();
+    }
+    console.log(`  ${sqlName}: copied ${rows.length}`);
+    total += rows.length;
+  }
+} finally {
+  await pool.query("SET session_replication_role = origin");
+}
+console.log(`Copied ${total} rows across ${tables.length} tables.`);
+
+if (verify) {
+  let mismatch = false;
+  for (const { sqlName, sT, pT } of tables) {
+    const src = (await sqlite.select({ c: sql<number>`count(*)` }).from(sT))[0]
+      ?.c;
+    const dst = (
+      (await pg
+        .select({ c: sql<number>`count(*)` })
+        .from(pT as never)) as { c: number }[]
+    )[0]?.c;
+    const ok = Number(src) === Number(dst);
+    if (!ok) mismatch = true;
+    console.log(`  verify ${sqlName}: sqlite=${src} pg=${dst} ${ok ? "OK" : "MISMATCH"}`);
+  }
+  if (mismatch) {
+    console.error("VERIFY FAILED");
+    await pool.end();
+    process.exit(1);
+  }
+}
+await pool.end();
+console.log("Supervisor migration complete.");

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "db:generate:pg": "drizzle-kit generate --config=drizzle.pg.config.ts",
     "db:push:pg": "drizzle-kit push --config=drizzle.pg.config.ts",
     "db:migrate-to-postgres": "bun run scripts/migrate-to-postgres/index.ts",
+    "db:dump-main-sql": "bun run scripts/dump-main-sql.ts",
     "db:seed": "bun run src/db/seed.ts",
     "db:migrate-agents": "bun run scripts/migrate-agent-sessions.ts",
     "db:migrate-github-accounts": "bun run scripts/migrate-github-accounts.ts",

--- a/scripts/dump-main-sql.ts
+++ b/scripts/dump-main-sql.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env bun
+/**
+ * Emit a remote-dev INSTANCE's SQLite data as Postgres INSERT SQL (stdout), to
+ * apply via `kubectl exec rdv-pg-1 -- psql` (port-forward is unreliable over
+ * this link). Type conversion is driven by the schema DEFINITION kinds (so the
+ * epoch-SECONDS tables — kind "timestampS" — convert with *1000, distinct from
+ * epoch-ms "timestampMs"). Only source∩schema columns are copied (tolerates an
+ * instance whose sqlite predates a column). FK + self-ref checks deferred via
+ * session_replication_role=replica (superuser). Idempotent: ON CONFLICT DO NOTHING.
+ *
+ * Usage: bun run scripts/dump-main-sql.ts --from file:/abs/sqlite.db > /tmp/x.sql
+ */
+import { createClient } from "@libsql/client/node";
+import { schema } from "../src/db/schema.def";
+
+const fromIdx = process.argv.indexOf("--from");
+const from = fromIdx >= 0 ? process.argv[fromIdx + 1] : "";
+if (!from) {
+  console.error("need --from file:/path/sqlite.db");
+  process.exit(2);
+}
+const client = createClient({ url: from });
+
+function lit(raw: unknown, kind: string): string {
+  if (raw === null || raw === undefined) return "NULL";
+  switch (kind) {
+    case "boolean":
+      return Number(raw) ? "true" : "false";
+    case "timestampMs": {
+      const ms = Number(raw);
+      return Number.isFinite(ms) ? `'${new Date(ms).toISOString()}'::timestamptz` : "NULL";
+    }
+    case "timestampS": {
+      const s = Number(raw);
+      return Number.isFinite(s) ? `'${new Date(s * 1000).toISOString()}'::timestamptz` : "NULL";
+    }
+    case "json":
+      return `'${String(raw).replace(/'/g, "''")}'::jsonb`;
+    case "integer":
+      return String(raw);
+    default:
+      return `'${String(raw).replace(/'/g, "''")}'`;
+  }
+}
+
+const out: string[] = ["BEGIN;", "SET session_replication_role = replica;"];
+let total = 0;
+for (const table of schema) {
+  const kindByCol = new Map(table.columns.map((c) => [c.dbName, c.kind as string]));
+  const info = await client.execute(`PRAGMA table_info("${table.sqlName}")`);
+  const srcCols = (info.rows as Array<Record<string, unknown>>)
+    .map((r) => String(r.name))
+    .filter((c) => kindByCol.has(c));
+  if (srcCols.length === 0) {
+    out.push(`-- ${table.sqlName}: SKIPPED (absent in source)`);
+    continue;
+  }
+  const res = await client.execute(`SELECT * FROM "${table.sqlName}"`);
+  for (const row of res.rows as Array<Record<string, unknown>>) {
+    const vals = srcCols.map((c) => lit(row[c], kindByCol.get(c)!));
+    out.push(
+      `INSERT INTO "${table.sqlName}" (${srcCols.map((c) => `"${c}"`).join(", ")}) VALUES (${vals.join(", ")}) ON CONFLICT DO NOTHING;`,
+    );
+    total++;
+  }
+  if (res.rows.length) out.push(`-- ${table.sqlName}: ${res.rows.length}`);
+}
+out.push("SET session_replication_role = origin;", "COMMIT;");
+console.log(out.join("\n"));
+console.error(`Emitted ${total} INSERTs across ${schema.length} tables.`);

--- a/src/infrastructure/analytics/SqliteAnalyticsStore.ts
+++ b/src/infrastructure/analytics/SqliteAnalyticsStore.ts
@@ -13,7 +13,7 @@
  *   - `flush` is a no-op (writes are synchronous, nothing is buffered).
  */
 
-import { createLogger } from "@/lib/logger";
+import { createLogger, type Logger } from "@/lib/logger";
 import { getAnalyticsDatabase } from "@/infrastructure/analytics/AnalyticsDatabase";
 import type {
   AnalyticsStore,
@@ -32,7 +32,17 @@ import type {
   LatencyPercentiles,
 } from "@/types/litellm";
 
-const log = createLogger("LiteLLMAnalytics");
+// The logger is resolved lazily (not at module top level) to avoid an import
+// cycle: sidecar-factory statically imports this module, AppLogger statically
+// imports sidecar-factory, and `@/lib/logger` re-exports AppLogger — calling
+// createLogger() at module-eval time would run before AppLogger finished
+// initializing (`createLogger is not a function`). Deferring the call to first
+// use breaks the cycle while keeping the import static (bundler-safe).
+let _log: Logger | null = null;
+function log(): Logger {
+  if (!_log) _log = createLogger("LiteLLMAnalytics");
+  return _log;
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -74,7 +84,7 @@ function parseConcatenatedSamples(raw: string | null): number[] {
     flat.sort((a, b) => a - b);
     return flat;
   } catch {
-    log.warn("Failed to parse latency samples", {
+    log().warn("Failed to parse latency samples", {
       samplePreview: raw.slice(0, 100),
     });
     return [];
@@ -253,9 +263,9 @@ export class SqliteAnalyticsStore implements AnalyticsStore {
 
     try {
       txn();
-      log.debug("Recorded batch", { count: payloads.length });
+      log().debug("Recorded batch", { count: payloads.length });
     } catch (err) {
-      log.error("Failed to record batch", {
+      log().error("Failed to record batch", {
         error: String(err),
         count: payloads.length,
       });
@@ -542,7 +552,7 @@ export class SqliteAnalyticsStore implements AnalyticsStore {
 
     const deletedCount = result.changes;
     if (deletedCount > 0) {
-      log.info("Pruned old request logs", { deletedCount, retentionDays });
+      log().info("Pruned old request logs", { deletedCount, retentionDays });
     }
 
     return Promise.resolve({ deletedCount });

--- a/src/infrastructure/persistence/__tests__/sidecar-factory.test.ts
+++ b/src/infrastructure/persistence/__tests__/sidecar-factory.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for `src/infrastructure/persistence/sidecar-factory.ts`.
+ *
+ * The factory selects the sidecar (logs + analytics) store implementation by
+ * dialect: Postgres stores when `DATABASE_URL` is a postgres URL, the
+ * better-sqlite3 stores otherwise. Dialect is read at call time via
+ * `isPostgres()` (which reads `process.env.DATABASE_URL`), and the factory
+ * memoizes the chosen store in module-level singletons. To exercise both paths
+ * we stub `DATABASE_URL` and re-import the factory with a fresh module registry
+ * (`vi.resetModules()`) between cases so the singleton cache does not leak.
+ *
+ * Regression guard for bug pcm7: the prior implementation loaded the
+ * dialect-specific modules with a lazy `require()`, whose interop did NOT
+ * survive Next.js standalone bundling — the named export resolved to undefined,
+ * yielding `TypeError: PgLogStore is not a constructor`. The factory now uses
+ * static top-level imports. This test asserts each path constructs the correct
+ * store class. Constructing the PG stores must NOT touch a live DB (they only
+ * build an in-memory write buffer and lazily get the pool on flush), so these
+ * cases run without any Postgres available.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+
+type SidecarFactoryModule = typeof import("../sidecar-factory");
+
+/** Re-import the factory with a clean module registry bound to the current env. */
+async function loadFactory(): Promise<SidecarFactoryModule> {
+  vi.resetModules();
+  return import("../sidecar-factory");
+}
+
+afterEach(() => {
+  if (ORIGINAL_DATABASE_URL === undefined) {
+    delete process.env.DATABASE_URL;
+  } else {
+    process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+  }
+  vi.unstubAllEnvs();
+});
+
+describe("sidecar-factory", () => {
+  it("returns the Postgres stores when DATABASE_URL targets Postgres", async () => {
+    vi.stubEnv("DATABASE_URL", "postgresql://user:pass@localhost:5432/rdv");
+
+    const factory = await loadFactory();
+    const { PgLogStore } = await import("../pg/PgLogStore");
+    const { PgAnalyticsStore } = await import("../pg/PgAnalyticsStore");
+
+    const logStore = factory.getLogStore();
+    const analyticsStore = factory.getAnalyticsStore();
+
+    expect(logStore).toBeInstanceOf(PgLogStore);
+    expect(analyticsStore).toBeInstanceOf(PgAnalyticsStore);
+    // The named exports must be real constructors (the bug had them undefined).
+    expect(logStore.constructor.name).toBe("PgLogStore");
+    expect(analyticsStore.constructor.name).toBe("PgAnalyticsStore");
+  });
+
+  it("returns the SQLite stores when DATABASE_URL is unset", async () => {
+    vi.stubEnv("DATABASE_URL", "");
+    delete process.env.DATABASE_URL;
+
+    const factory = await loadFactory();
+
+    const logStore = factory.getLogStore();
+    const analyticsStore = factory.getAnalyticsStore();
+
+    expect(logStore.constructor.name).toBe("BetterSqliteLogRepository");
+    expect(analyticsStore.constructor.name).toBe("SqliteAnalyticsStore");
+  });
+
+  it("memoizes each store as a process-wide singleton", async () => {
+    vi.stubEnv("DATABASE_URL", "postgres://user:pass@localhost:5432/rdv");
+
+    const factory = await loadFactory();
+
+    expect(factory.getLogStore()).toBe(factory.getLogStore());
+    expect(factory.getAnalyticsStore()).toBe(factory.getAnalyticsStore());
+  });
+});

--- a/src/infrastructure/persistence/pg/PgAnalyticsStore.ts
+++ b/src/infrastructure/persistence/pg/PgAnalyticsStore.ts
@@ -16,7 +16,7 @@
  * flattened, sorted number[]).
  */
 
-import { createLogger } from "@/lib/logger";
+import { createLogger, type Logger } from "@/lib/logger";
 import type {
   AnalyticsStore,
   AnalyticsSummary,
@@ -37,7 +37,17 @@ import type { PoolClient } from "pg";
 import { getSidecarPool } from "./sidecar-db";
 import { PgWriteBuffer } from "./PgWriteBuffer";
 
-const log = createLogger("PgAnalyticsStore");
+// The logger is resolved lazily (not at module top level) to avoid an import
+// cycle: sidecar-factory statically imports this module, AppLogger statically
+// imports sidecar-factory, and `@/lib/logger` re-exports AppLogger — calling
+// createLogger() at module-eval time would run before AppLogger finished
+// initializing (`createLogger is not a function`). Deferring the call to first
+// use breaks the cycle while keeping the import static (bundler-safe).
+let _log: Logger | null = null;
+function log(): Logger {
+  if (!_log) _log = createLogger("PgAnalyticsStore");
+  return _log;
+}
 
 const MAX_LATENCY_SAMPLES = 1000;
 
@@ -711,7 +721,7 @@ export class PgAnalyticsStore implements AnalyticsStore {
     );
     const deletedCount = result.rowCount ?? 0;
     if (deletedCount > 0) {
-      log.info("Pruned old request logs", { deletedCount, retentionDays });
+      log().info("Pruned old request logs", { deletedCount, retentionDays });
     }
     return { deletedCount };
   }

--- a/src/infrastructure/persistence/sidecar-factory.ts
+++ b/src/infrastructure/persistence/sidecar-factory.ts
@@ -8,15 +8,21 @@
  *   - SQLite (default): the original synchronous better-sqlite3 stores,
  *     behavior-identical to the prior implementation.
  *
- * The dialect-specific modules are loaded with a lazy `require()` so that `pg`
- * is only pulled in on the Postgres path and `better-sqlite3` only on the
- * SQLite path — neither driver is loaded for the backend not in use. A
- * synchronous accessor is required because `AppLogger.write()` is a synchronous
- * fire-and-forget call, so an `await import()` is not an option here.
+ * The dialect-specific modules are pulled in with STATIC top-level imports so
+ * the references are statically linked and survive Next.js standalone bundling.
+ * The prior implementation lazily `require()`d these modules, but that interop
+ * does NOT survive standalone bundling — the named export resolved to
+ * `undefined`, producing `TypeError: PgLogStore is not a constructor` at
+ * runtime (bug pcm7). Static imports are bundler-safe.
  *
- * This mirrors the existing lazy-require convention in this codebase
- * (`src/lib/dynamic-fs.ts`, `src/lib/preferences.ts`), which uses the same
- * single-line `no-require-imports` directive for exactly this purpose.
+ * Importing both dialect modules on either path is safe:
+ *   - The native drivers (`pg`, `better-sqlite3`) are externalized via
+ *     `serverExternalPackages` in next.config, so they are not bundled.
+ *   - None of these store modules open a DB connection at import time — the PG
+ *     stores only construct an in-memory write buffer and lazily get the pool on
+ *     first flush; the SQLite stores lazily open their DB on first use. A
+ *     synchronous accessor is required because `AppLogger.write()` is a
+ *     synchronous fire-and-forget call, so an `await import()` is not an option.
  *
  * Both stores are process-wide singletons.
  */
@@ -24,6 +30,10 @@
 import { isPostgres } from "@/db/is-postgres";
 import type { LogRepository } from "@/application/ports/LogRepository";
 import type { AnalyticsStore } from "@/application/ports/AnalyticsStore";
+import { PgLogStore } from "./pg/PgLogStore";
+import { PgAnalyticsStore } from "./pg/PgAnalyticsStore";
+import { getLogRepositoryInstance } from "./repositories/BetterSqliteLogRepository";
+import { SqliteAnalyticsStore } from "@/infrastructure/analytics/SqliteAnalyticsStore";
 
 let _logStore: LogRepository | null = null;
 let _analyticsStore: AnalyticsStore | null = null;
@@ -31,30 +41,16 @@ let _analyticsStore: AnalyticsStore | null = null;
 export function getLogStore(): LogRepository {
   if (_logStore) return _logStore;
 
-  if (isPostgres()) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const mod = require("./pg/PgLogStore") as typeof import("./pg/PgLogStore");
-    _logStore = new mod.PgLogStore();
-  } else {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const mod = require("./repositories/BetterSqliteLogRepository") as typeof import("./repositories/BetterSqliteLogRepository");
-    _logStore = mod.getLogRepositoryInstance();
-  }
+  _logStore = isPostgres() ? new PgLogStore() : getLogRepositoryInstance();
   return _logStore;
 }
 
 export function getAnalyticsStore(): AnalyticsStore {
   if (_analyticsStore) return _analyticsStore;
 
-  if (isPostgres()) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const mod = require("./pg/PgAnalyticsStore") as typeof import("./pg/PgAnalyticsStore");
-    _analyticsStore = new mod.PgAnalyticsStore();
-  } else {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const mod = require("@/infrastructure/analytics/SqliteAnalyticsStore") as typeof import("@/infrastructure/analytics/SqliteAnalyticsStore");
-    _analyticsStore = new mod.SqliteAnalyticsStore();
-  }
+  _analyticsStore = isPostgres()
+    ? new PgAnalyticsStore()
+    : new SqliteAnalyticsStore();
   return _analyticsStore;
 }
 


### PR DESCRIPTION
## Summary

Fixes **`remote-dev-pcm7`** — on the PostgreSQL path, instances logged `TypeError: PgLogStore is not a constructor` and could not persist logs/analytics to PG. Also adds the PostgreSQL migration tooling used for the `rdv.joyful.house` k3s cutover.

## The bug (pcm7)

`src/infrastructure/persistence/sidecar-factory.ts` loaded the dialect-specific log/analytics stores via dynamic `require("./pg/PgLogStore")` etc. That interop **does not survive the Next.js standalone bundle** — the named export resolves to `undefined`, so `new mod.PgLogStore()` throws. Effect: PG-backed instances silently failed to write logs/analytics (app + `readyz` were unaffected, so it went unnoticed until the homelab migration). It wasn't caught earlier because the Unit-11 tests imported the stores **directly**, not through the bundled-require path.

## Fix

- **Static imports** in `sidecar-factory.ts` (statically linked → bundler-safe). `pg`/`better-sqlite3` stay external via `serverExternalPackages`, and none of the stores open a DB connection at import, so importing both impls on either path is safe. Removes the `eslint-disable @typescript-eslint/no-require-imports` lines.
- The static imports surfaced a **latent import cycle** (`AppLogger` → `sidecar-factory` → `Pg/SqliteAnalyticsStore` → `createLogger`, evaluated before `AppLogger` finished exporting it). Broke it by making the module logger **lazy** in `PgAnalyticsStore` and `SqliteAnalyticsStore` (the `createLogger` import stays static; only the call is deferred to first use).
- Regression test (`sidecar-factory.test.ts`) asserting the factory returns the correct impl per `DATABASE_URL`.

## Migration tooling (used for the rdv.joyful.house cutover)

- `scripts/dump-main-sql.ts` — instance SQLite → Postgres INSERT SQL (type-aware via the schema-def kinds, incl. epoch-seconds tables), applied via `kubectl exec psql`.
- `apps/supervisor/scripts/migrate-supervisor-to-postgres.ts` — Drizzle round-trip copy of the supervisor registry (FK checks deferred via `session_replication_role`).
- `apps/supervisor/scripts/dump-supervisor-sql.ts` — supervisor SQLite → Postgres INSERT SQL.
- `db:*` package.json scripts for the above.

## Verification

- `bun run typecheck` (root + `apps/supervisor`): 0 errors
- `bun run lint`: 0 errors, 0 new warnings (no leftover unused-disable)
- `bun run test:run`: 1676 passed (incl. the new regression test)
- `bun run build`: succeeds (the standalone bundle that exhibited the bug)
- **Bundled smoke (the real test):** booted `node .next/standalone/server.js` against a throwaway `postgres:alpine`, hit the app — **no "is not a constructor"**, and `logs.log_entry` rows were written by `PgLogStore` end-to-end.

## Deploy note

This makes PG-backed logging/analytics work in the built image. To take effect on `rdv.joyful.house`, rebuild the platform image (Forgejo "Build remote-dev platform") from this branch / after merge and roll the instances. Related follow-up `remote-dev-snap` (instance terminal-server startup race on fresh PG boot) is **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
