### PR TITLE
fix(mobile): derive terminal WS URL from forwarded host so /m/session works behind the router

### DIFF
--- a/src/app/m/session/[id]/page.tsx
+++ b/src/app/m/session/[id]/page.tsx
@@ -47,7 +47,7 @@ import { AppearanceProvider } from "@/contexts/AppearanceContext";
 import { NotificationProvider } from "@/contexts/NotificationContext";
 import { PreferencesProvider } from "@/contexts/PreferencesContext";
 import { EmbeddedSessionView } from "@/components/mobile/embed/EmbeddedSessionView";
-import { resolveTerminalWsUrlFromHost } from "@/lib/terminal-ws-url";
+import { resolveTerminalWsUrlFromHeaders } from "@/lib/terminal-ws-url";
 import { BASE_PATH } from "@/lib/base-path";
 
 interface PageProps {
@@ -66,24 +66,23 @@ export default async function MobileSessionPage({ params }: PageProps) {
   });
   if (!row) notFound();
 
-  // Resolve WS URL from the request host so the WebView talks back to
-  // the same Remote Dev origin it loaded the page from. Uses the shared
-  // resolver so the mobile WebView and the desktop client agree on the
-  // URL shape (notably `wss://host{basePath}/ws` for Cloudflare-tunneled
-  // prod, not a direct hit on the terminal-server port).
+  // Resolve WS URL so the WebView talks back to the same Remote Dev origin
+  // it loaded the page from. Uses the shared resolver so the mobile WebView
+  // and the desktop client agree on the URL shape (notably
+  // `wss://host{basePath}/ws` for Cloudflare-tunneled prod, not a direct hit
+  // on the terminal-server port).
   //
   // basePath: server-side, the resolver has no `window.__RDV_BASE_PATH__`
   // to read from, so we pass the validated BASE_PATH constant explicitly.
   // Without this, multi-instance deployments under `/alpha` would point
   // the embed WebSocket at `/ws` and be rejected by the upgrade gate.
+  //
+  // Behind the supervisor-router the inbound `Host` is the INTERNAL upstream
+  // (`rdv.<ns>.svc.cluster.local:6001`); derive the WS URL from the
+  // edge-forwarded host (same precedence as the proxy) so the WebView connects
+  // back to the public origin (e.g. wss://rdv.joyful.house/<slug>/ws).
   const h = await headers();
-  const host = h.get("host") ?? "localhost";
-  const protocol = h.get("x-forwarded-proto") ?? "http";
-  const wsUrl = resolveTerminalWsUrlFromHost({
-    host,
-    protocol,
-    basePath: BASE_PATH,
-  });
+  const wsUrl = resolveTerminalWsUrlFromHeaders((name) => h.get(name), BASE_PATH);
 
   // Provider order mirrors `src/app/page.tsx` and `/m/channel/[id]`:
   // PreferencesProvider is the outermost context-bearing wrapper; the

--- a/src/lib/__tests__/terminal-ws-url.test.ts
+++ b/src/lib/__tests__/terminal-ws-url.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
-import { resolveTerminalWsUrlFromHost } from "@/lib/terminal-ws-url";
+import { resolveTerminalWsUrlFromHeaders, resolveTerminalWsUrlFromHost } from "@/lib/terminal-ws-url";
 
 describe("resolveTerminalWsUrlFromHost", () => {
   const originalEnv = process.env.NEXT_PUBLIC_TERMINAL_PORT;
@@ -111,5 +111,63 @@ describe("resolveTerminalWsUrlFromHost", () => {
         protocol: "http",
       }),
     ).toBe("ws://localhost:3001/ws");
+  });
+});
+
+/**
+ * Tests for the header-driven `resolveTerminalWsUrlFromHeaders`, used by the
+ * `/m/session/[id]` Server Component. Behind the supervisor-router the raw
+ * `Host` header is the INTERNAL cluster upstream
+ * (`rdv.<ns>.svc.cluster.local:6001`), so the WS URL must be derived from the
+ * edge-forwarded host (`x-forwarded-host` → `host`) — the same precedence the
+ * proxy uses for redirects — or the WebView connects to an unreachable address.
+ */
+describe("resolveTerminalWsUrlFromHeaders", () => {
+  const originalEnv = process.env.NEXT_PUBLIC_TERMINAL_PORT;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_TERMINAL_PORT = "6002";
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_TERMINAL_PORT;
+    } else {
+      process.env.NEXT_PUBLIC_TERMINAL_PORT = originalEnv;
+    }
+  });
+
+  /** Build a case-insensitive header getter from a plain record. */
+  function makeGetHeader(headers: Record<string, string>): (name: string) => string | undefined {
+    const lower = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+    return (name: string) => lower.get(name.toLowerCase());
+  }
+
+  it("prefers x-forwarded-host over the internal Host (supervisor-router) → wss://public/dev/ws", () => {
+    const getHeader = makeGetHeader({
+      "x-forwarded-host": "rdv.joyful.house",
+      "x-forwarded-proto": "https",
+      host: "rdv.rdv-dev.svc.cluster.local:6001",
+    });
+    expect(resolveTerminalWsUrlFromHeaders(getHeader, "/dev")).toBe("wss://rdv.joyful.house/dev/ws");
+  });
+
+  it("uses the first value of a comma-separated forwarded chain", () => {
+    const getHeader = makeGetHeader({
+      "x-forwarded-host": "rdv.joyful.house, internal",
+      "x-forwarded-proto": "https",
+      host: "rdv.rdv-dev.svc.cluster.local:6001",
+    });
+    expect(resolveTerminalWsUrlFromHeaders(getHeader, "/dev")).toBe("wss://rdv.joyful.house/dev/ws");
+  });
+
+  it("falls back to Host and defaults a non-loopback host to wss", () => {
+    const getHeader = makeGetHeader({ host: "rdv.example.com" });
+    expect(resolveTerminalWsUrlFromHeaders(getHeader, "")).toBe("wss://rdv.example.com/ws");
+  });
+
+  it("treats a localhost host as loopback → ws://localhost:port/ws", () => {
+    const getHeader = makeGetHeader({ host: "localhost:6001", "x-forwarded-proto": "http" });
+    expect(resolveTerminalWsUrlFromHeaders(getHeader, "")).toBe("ws://localhost:6002/ws");
   });
 });

--- a/src/lib/terminal-ws-url.ts
+++ b/src/lib/terminal-ws-url.ts
@@ -18,6 +18,8 @@
  * (`"https"`); the trailing colon is normalized away.
  */
 
+import { resolveExternalOrigin } from "@/lib/request-origin";
+
 export function resolveTerminalWsUrlFromHost(input: {
   protocol: string;
   host: string;
@@ -47,6 +49,28 @@ export function resolveTerminalWsUrlFromHost(input: {
   }
   const wsProtocol = normalizedProto === "https" ? "wss:" : "ws:";
   return `${wsProtocol}//${hostname}${port ? `:${port}` : ""}${prefix}/ws`;
+}
+
+/**
+ * Server-side terminal WS URL resolver that derives the EXTERNAL host/scheme
+ * from edge-forwarded headers (`x-forwarded-host` → `host`, `x-forwarded-proto`),
+ * mirroring `resolveExternalOrigin` / the proxy. Behind the supervisor-router the
+ * raw `Host` header is the internal cluster upstream
+ * (`rdv.<ns>.svc.cluster.local:6001`); using it would point the WebView at an
+ * unreachable address. Use this (not the raw `host`) from server components that
+ * pass a `wsUrl` into a client embed.
+ */
+export function resolveTerminalWsUrlFromHeaders(
+  getHeader: (name: string) => string | null | undefined,
+  basePath: string,
+): string {
+  const origin = resolveExternalOrigin(getHeader, "http://localhost");
+  const url = new URL(origin);
+  return resolveTerminalWsUrlFromHost({
+    host: url.host, // includes :port if present
+    protocol: url.protocol, // "https:"/"http:" — resolveTerminalWsUrlFromHost strips the colon
+    basePath,
+  });
 }
 
 function splitHost(host: string): [string, string | undefined] {


### PR DESCRIPTION
## Summary

The Flutter mobile terminal reconnect-looped ("WebSocket error" / "Reconnecting 1/5") on **multi-instance basePath** deployments (e.g. rdv.joyful.house/dev, /demo), while single-instance (dev.bryanli.net) and desktop browsers worked.

**Root cause:** `src/app/m/session/[id]/page.tsx` built the terminal WebSocket URL **server-side** from the raw `Host` header. Behind the supervisor-router the inbound `Host` is the INTERNAL Kubernetes upstream (`rdv.<ns>.svc.cluster.local:6001`), so the embed computed `wss://rdv.rdv-dev.svc.cluster.local:6001/dev/ws` — unreachable from the device.

Confirmed on-device via CDP: token fetch returned 200 and a **manual** `new WebSocket('wss://rdv.joyful.house/dev/ws?token=…')` inside the same WebView attached cleanly; only the app's server-derived `wsUrl` was wrong (extracted `wss://rdv.rdv-dev.svc.cluster.local:6001/dev/ws` from the RSC payload). Desktop works because it derives the WS URL client-side from `window.location`; single-instance works because nothing rewrites `Host`.

**Fix:** derive the external host/scheme with the same `x-forwarded-host` → `host` precedence the proxy already uses (`resolveExternalOrigin`). Added `resolveTerminalWsUrlFromHeaders(getHeader, basePath)` to `src/lib/terminal-ws-url.ts` (composes `resolveExternalOrigin` + the existing host resolver) so any server-side caller is correct; `/m/session` now uses it.

## Test plan
- New unit tests: forwarded host beats internal Host → `wss://rdv.joyful.house/dev/ws`; comma-chain uses first hop; no-forwarded falls back to `host` (wss for non-loopback); localhost → `ws://localhost…`.
- typecheck, lint, **build exit 0**, `bun run test:run` 2146 passed.

Fixes remote-dev-g6cs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)