### PR TITLE
feat(deploy): schema drift guard — fail the deploy if db:push leaves the live schema drifted

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "db:migrate-github-accounts": "bun run scripts/migrate-github-accounts.ts",
     "db:backfill-user-emails": "bun run scripts/backfill-user-emails.ts",
     "db:verify-backfills": "bun run scripts/verify-backfills.ts",
+    "db:check-drift": "bun run scripts/check-schema-drift.ts",
     "db:migrate-profile-gitconfigs": "bun run scripts/migrate-profile-gitconfigs.ts",
     "db:migrate-channels": "tsx src/db/migrations/migrate-channels.ts",
     "db:migrate-agent-provider": "bun run scripts/migrate-agent-provider.ts",

--- a/scripts/check-schema-drift.ts
+++ b/scripts/check-schema-drift.ts
@@ -1,0 +1,318 @@
+#!/usr/bin/env bun
+/**
+ * CLI entry: detect SQLite SCHEMA DRIFT between schema.ts and the live DB
+ * (remote-dev-9qni).
+ *
+ * Invoked by `scripts/deploy.ts` immediately AFTER `bun run db:push`, mirroring
+ * the existing `db:verify-backfills` abort-on-fail guard. Exits NON-ZERO if the
+ * live SQLite schema does not match what schema.ts expects, so the deploy aborts
+ * loudly instead of going green with a silently-drifted schema.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `db:push` is `drizzle-kit push`, which runs non-interactively in the deploy.
+ * When a schema change is DATA-LOSS (e.g. adding a NOT NULL column with only an
+ * app-level default to a table that already has rows), drizzle-kit SKIPS that
+ * statement and exits 0 — leaving the live schema silently drifted from
+ * schema.ts. This already broke prod once: `notification_event` lost
+ * severity/coalesce_key/count/meta/updated_at → notifications/push died, yet the
+ * deploy went green. This guard turns that silent drift into a LOUD failure. It
+ * does NOT change the push strategy.
+ *
+ * HOW IT WORKS
+ * ------------
+ *  1. Skip on Postgres (the PG schema is applied via the drizzle/pg
+ *     migrate-on-boot path, not db:push) — same gate as deploy.ts's db:push.
+ *  2. Build the EXPECTED schema by running `drizzle-kit push` into a fresh, EMPTY
+ *     temp RDV_DATA_DIR. An empty DB has no rows, so push applies the FULL
+ *     schema.ts with no data-loss prompts/skips — that temp DB is the ground
+ *     truth for "what schema.ts wants".
+ *  3. Column-diff every expected table against the LIVE DB (opened readonly).
+ *     Any missing table, missing/extra column, or changed type/notnull → drift.
+ *  4. Any drift → print a namespaced report and exit 1. Else exit 0.
+ *
+ * Runs from the deploy-src worktree (origin/master code) but inspects the SAME
+ * live DB the server serves, because the DB target resolves purely from env
+ * (DATABASE_URL > RDV_DATA_DIR/sqlite.db > ~/.remote-dev/sqlite.db), not cwd.
+ *
+ * Run manually with: bun run db:check-drift
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "libsql";
+import { getDatabasePath } from "../src/lib/paths";
+import { shouldRunSqlitePush } from "./deploy-lib";
+
+/** A single column's drift-relevant shape, sourced from `PRAGMA table_info`. */
+export interface ColumnInfo {
+  name: string;
+  /** SQLite declared type, e.g. "TEXT", "INTEGER" (may be "" for typeless). */
+  type: string;
+  /** 1 if NOT NULL, 0 otherwise (PRAGMA's `notnull` flag). */
+  notnull: number;
+}
+
+/** A table and the columns it declares. */
+export interface TableCols {
+  table: string;
+  columns: ColumnInfo[];
+}
+
+/** One table's worth of differences between expected and live. */
+export interface TableDrift {
+  table: string;
+  /** Table exists in expected schema.ts but is absent in the live DB. */
+  missingTable: boolean;
+  /** Columns expected but absent in the live DB. */
+  missingColumns: string[];
+  /** Columns present live but not in expected schema.ts. */
+  extraColumns: string[];
+  /** Columns present in both but whose type/notnull differs. */
+  changedColumns: Array<{
+    column: string;
+    expected: { type: string; notnull: number };
+    live: { type: string; notnull: number };
+  }>;
+}
+
+export interface DriftReport {
+  hasDrift: boolean;
+  tables: TableDrift[];
+}
+
+/** Tables that are noise — not part of the app schema. */
+function isIgnoredTable(name: string): boolean {
+  return name.startsWith("sqlite_") || name === "__drizzle_migrations";
+}
+
+/**
+ * Pure column-level diff of an EXPECTED schema (from schema.ts) against the LIVE
+ * schema. For every expected table: a missing table, a missing/extra column, or
+ * a column whose type or notnull flag differs is recorded as drift. Extra LIVE
+ * tables (present live, absent in expected) are intentionally ignored — db:push
+ * never DROPs, so leftover tables are not a deploy-breaking drift and would only
+ * produce false alarms for renamed/retired tables.
+ *
+ * Exported and dependency-free so the diff contract is unit-tested without
+ * spawning drizzle-kit or opening any real database.
+ */
+export function diffSchemas(
+  expected: TableCols[],
+  live: TableCols[],
+): DriftReport {
+  const liveByTable = new Map<string, Map<string, ColumnInfo>>();
+  for (const t of live) {
+    liveByTable.set(t.table, new Map(t.columns.map((c) => [c.name, c])));
+  }
+
+  const tables: TableDrift[] = [];
+
+  for (const exp of expected) {
+    const liveCols = liveByTable.get(exp.table);
+    if (!liveCols) {
+      tables.push({
+        table: exp.table,
+        missingTable: true,
+        missingColumns: exp.columns.map((c) => c.name),
+        extraColumns: [],
+        changedColumns: [],
+      });
+      continue;
+    }
+
+    const expByName = new Map(exp.columns.map((c) => [c.name, c]));
+    const missingColumns: string[] = [];
+    const changedColumns: TableDrift["changedColumns"] = [];
+
+    for (const ec of exp.columns) {
+      const lc = liveCols.get(ec.name);
+      if (!lc) {
+        missingColumns.push(ec.name);
+        continue;
+      }
+      if (lc.type !== ec.type || lc.notnull !== ec.notnull) {
+        changedColumns.push({
+          column: ec.name,
+          expected: { type: ec.type, notnull: ec.notnull },
+          live: { type: lc.type, notnull: lc.notnull },
+        });
+      }
+    }
+
+    const extraColumns: string[] = [];
+    for (const lc of liveCols.values()) {
+      if (!expByName.has(lc.name)) extraColumns.push(lc.name);
+    }
+
+    if (
+      missingColumns.length > 0 ||
+      extraColumns.length > 0 ||
+      changedColumns.length > 0
+    ) {
+      tables.push({
+        table: exp.table,
+        missingTable: false,
+        missingColumns,
+        extraColumns,
+        changedColumns,
+      });
+    }
+  }
+
+  return { hasDrift: tables.length > 0, tables };
+}
+
+/** Read the app tables + columns from a SQLite file (readonly). */
+function readSchema(dbFile: string, readonly: boolean): TableCols[] {
+  const db = new Database(dbFile, { readonly });
+  try {
+    const tableRows = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+      .all() as Array<{ name: string }>;
+
+    const result: TableCols[] = [];
+    for (const { name } of tableRows) {
+      if (isIgnoredTable(name)) continue;
+      // PRAGMA table_info → { cid, name, type, notnull, dflt_value, pk }.
+      const cols = db.prepare(`PRAGMA table_info('${name}')`).all() as Array<{
+        name: string;
+        type: string;
+        notnull: number;
+      }>;
+      result.push({
+        table: name,
+        columns: cols.map((c) => ({
+          name: c.name,
+          type: c.type,
+          notnull: c.notnull,
+        })),
+      });
+    }
+    return result;
+  } finally {
+    db.close();
+  }
+}
+
+/** Build the EXPECTED schema DB by pushing schema.ts into an empty temp dir. */
+function buildExpectedSchema(tmpDir: string): string {
+  // Empty DB ⇒ no rows ⇒ no data-loss prompts ⇒ db:push applies ALL of
+  // schema.ts. cwd is process.cwd() (deploy runs this from DEPLOY_SRC), so
+  // drizzle.config.ts resolves schema.ts relative to the built tree.
+  const result = spawnSync(
+    "bun",
+    ["--env-file=/dev/null", "x", "drizzle-kit", "push", "--config=drizzle.config.ts"],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, RDV_DATA_DIR: tmpDir, DATABASE_URL: "" },
+      encoding: "utf8",
+    },
+  );
+
+  if (result.status !== 0) {
+    console.error(
+      "[schema-drift] FAILED to build expected schema (drizzle-kit push into temp dir).",
+    );
+    if (result.stderr) console.error(result.stderr.trim());
+    if (result.stdout) console.error(result.stdout.trim());
+    // Can't verify → fail closed.
+    process.exit(1);
+  }
+
+  const expectedDb = join(tmpDir, "sqlite.db");
+  if (!existsSync(expectedDb)) {
+    console.error(
+      `[schema-drift] FAILED: expected schema DB was not created at ${expectedDb}`,
+    );
+    process.exit(1);
+  }
+  return expectedDb;
+}
+
+/** Print a human-readable, namespaced drift report (one block per table). */
+function printReport(report: DriftReport): void {
+  console.error(
+    "[schema-drift] SCHEMA DRIFT DETECTED — the live SQLite schema does not " +
+      "match schema.ts (db:push likely SKIPPED a data-loss change):",
+  );
+  for (const t of report.tables) {
+    if (t.missingTable) {
+      console.error(`[schema-drift]   table '${t.table}': MISSING from live DB`);
+      continue;
+    }
+    const parts: string[] = [];
+    if (t.missingColumns.length > 0) {
+      parts.push(`missing columns: ${t.missingColumns.join(", ")}`);
+    }
+    if (t.extraColumns.length > 0) {
+      parts.push(`unexpected columns: ${t.extraColumns.join(", ")}`);
+    }
+    for (const c of t.changedColumns) {
+      parts.push(
+        `column '${c.column}' changed ` +
+          `(expected type=${c.expected.type || "''"} notnull=${c.expected.notnull}, ` +
+          `live type=${c.live.type || "''"} notnull=${c.live.notnull})`,
+      );
+    }
+    console.error(`[schema-drift]   table '${t.table}': ${parts.join("; ")}`);
+  }
+}
+
+function main(): void {
+  // 1. Postgres uses migrate-on-boot, not db:push — nothing for this guard to do.
+  //    Reuse the exact predicate deploy.ts gates db:push behind.
+  if (!shouldRunSqlitePush(process.env.DATABASE_URL)) {
+    console.log(
+      "[schema-drift] DATABASE_URL is Postgres — drift guard is SQLite-only " +
+        "(PG schema is applied via migrate-on-boot); skipping.",
+    );
+    process.exit(0);
+  }
+
+  const liveDb = getDatabasePath();
+  if (!existsSync(liveDb)) {
+    // No live DB yet (fresh install): db:push just created it from schema.ts, so
+    // there is nothing to drift from. Treat as in-sync.
+    console.log(
+      `[schema-drift] live DB not found at ${liveDb} (fresh install); nothing to verify.`,
+    );
+    process.exit(0);
+  }
+
+  const tmpDir = mkdtempSync(join(tmpdir(), "rdv-schema-expected-"));
+  try {
+    const expectedDb = buildExpectedSchema(tmpDir);
+    const expected = readSchema(expectedDb, true);
+    if (expected.length === 0) {
+      console.error(
+        "[schema-drift] FAILED: expected schema has 0 tables — refusing to verify.",
+      );
+      process.exit(1);
+    }
+
+    const live = readSchema(liveDb, /* readonly */ true);
+    const report = diffSchemas(expected, live);
+
+    if (report.hasDrift) {
+      printReport(report);
+      process.exit(1);
+    }
+
+    console.log(
+      `[schema-drift] schema in sync (${expected.length} tables verified).`,
+    );
+    process.exit(0);
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// Only run the CLI when executed directly (bun run scripts/check-schema-drift.ts),
+// NOT when imported — tests import `diffSchemas` and must not trigger the live
+// drift check or its process.exit. `import.meta.main` is true only for the entry
+// module under both bun (the deploy runtime) and Node 24+ (the vitest runtime).
+if (import.meta.main) {
+  main();
+}

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -937,6 +937,24 @@ function runMigration(): boolean {
     return false;
   }
 
+  // Schema drift guard (remote-dev-9qni): db:push silently SKIPS data-loss
+  // changes (e.g. adding a NOT NULL column to a populated table) and exits 0,
+  // leaving the live schema drifted from schema.ts — which already broke prod
+  // (notification_event lost columns → notifications/push dead). Verify the live
+  // SQLite schema matches schema.ts and ABORT the deploy loudly on any drift,
+  // rather than going green with a broken schema. SQLite-only (PG: migrate-on-boot).
+  if (shouldRunSqlitePush(process.env.DATABASE_URL) && !runCommand(
+    ["bun", "run", "db:check-drift"],
+    DEPLOY_SRC,
+    "schema drift verification",
+  )) {
+    logError(
+      "Schema drift verification FAILED — db:push left the live schema out of sync " +
+        "with schema.ts (a data-loss change was likely skipped). Aborting deploy.",
+    );
+    return false;
+  }
+
   // Backfill github_account_metadata for any OAuth accounts missing metadata
   runCommand(
     ["bun", "run", "db:migrate-github-accounts"],

--- a/tests/check-schema-drift.test.ts
+++ b/tests/check-schema-drift.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import {
+  diffSchemas,
+  type ColumnInfo,
+  type TableCols,
+} from "../scripts/check-schema-drift";
+
+/** Helper: build a column with sensible defaults. */
+function col(
+  name: string,
+  type = "TEXT",
+  notnull = 0,
+): ColumnInfo {
+  return { name, type, notnull };
+}
+
+/** A representative two-table schema used as the "expected" side. */
+function expectedSchema(): TableCols[] {
+  return [
+    {
+      table: "notification_event",
+      columns: [
+        col("id", "TEXT", 1),
+        col("severity", "TEXT", 1),
+        col("coalesce_key", "TEXT", 0),
+        col("count", "INTEGER", 1),
+        col("meta", "TEXT", 0),
+        col("updated_at", "INTEGER", 1),
+      ],
+    },
+    {
+      table: "users",
+      columns: [col("id", "TEXT", 1), col("email", "TEXT", 0)],
+    },
+  ];
+}
+
+describe("diffSchemas", () => {
+  it("reports NO drift when expected and live are identical", () => {
+    const expected = expectedSchema();
+    // Deep-clone so identity differences can't accidentally pass the test.
+    const live: TableCols[] = JSON.parse(JSON.stringify(expected));
+
+    const report = diffSchemas(expected, live);
+
+    expect(report.hasDrift).toBe(false);
+    expect(report.tables).toHaveLength(0);
+  });
+
+  it("detects a MISSING COLUMN (the notification_event regression)", () => {
+    const expected = expectedSchema();
+    const live: TableCols[] = JSON.parse(JSON.stringify(expected));
+    // Live notification_event lost severity + updated_at (the real drift).
+    live[0].columns = live[0].columns.filter(
+      (c) => c.name !== "severity" && c.name !== "updated_at",
+    );
+
+    const report = diffSchemas(expected, live);
+
+    expect(report.hasDrift).toBe(true);
+    const drift = report.tables.find((t) => t.table === "notification_event");
+    expect(drift).toBeDefined();
+    expect(drift?.missingTable).toBe(false);
+    expect(drift?.missingColumns.sort()).toEqual(["severity", "updated_at"]);
+    expect(drift?.extraColumns).toEqual([]);
+    expect(drift?.changedColumns).toEqual([]);
+  });
+
+  it("detects an EXTRA column present live but not in schema.ts", () => {
+    const expected = expectedSchema();
+    const live: TableCols[] = JSON.parse(JSON.stringify(expected));
+    live[1].columns.push(col("legacy_flag", "INTEGER", 0));
+
+    const report = diffSchemas(expected, live);
+
+    expect(report.hasDrift).toBe(true);
+    const drift = report.tables.find((t) => t.table === "users");
+    expect(drift?.extraColumns).toEqual(["legacy_flag"]);
+    expect(drift?.missingColumns).toEqual([]);
+  });
+
+  it("detects a NOTNULL change on an existing column", () => {
+    const expected = expectedSchema();
+    const live: TableCols[] = JSON.parse(JSON.stringify(expected));
+    // Live made users.email NOT NULL while schema.ts has it nullable.
+    const email = live[1].columns.find((c) => c.name === "email")!;
+    email.notnull = 1;
+
+    const report = diffSchemas(expected, live);
+
+    expect(report.hasDrift).toBe(true);
+    const drift = report.tables.find((t) => t.table === "users");
+    expect(drift?.changedColumns).toEqual([
+      {
+        column: "email",
+        expected: { type: "TEXT", notnull: 0 },
+        live: { type: "TEXT", notnull: 1 },
+      },
+    ]);
+  });
+
+  it("detects a TYPE change on an existing column", () => {
+    const expected = expectedSchema();
+    const live: TableCols[] = JSON.parse(JSON.stringify(expected));
+    const count = live[0].columns.find((c) => c.name === "count")!;
+    count.type = "TEXT"; // schema.ts wants INTEGER
+
+    const report = diffSchemas(expected, live);
+
+    expect(report.hasDrift).toBe(true);
+    const drift = report.tables.find((t) => t.table === "notification_event");
+    expect(drift?.changedColumns).toEqual([
+      {
+        column: "count",
+        expected: { type: "INTEGER", notnull: 1 },
+        live: { type: "TEXT", notnull: 1 },
+      },
+    ]);
+  });
+
+  it("detects a MISSING TABLE (table in schema.ts absent from live)", () => {
+    const expected = expectedSchema();
+    // Live is missing the users table entirely.
+    const live: TableCols[] = [
+      JSON.parse(JSON.stringify(expected[0])) as TableCols,
+    ];
+
+    const report = diffSchemas(expected, live);
+
+    expect(report.hasDrift).toBe(true);
+    const drift = report.tables.find((t) => t.table === "users");
+    expect(drift?.missingTable).toBe(true);
+    expect(drift?.missingColumns.sort()).toEqual(["email", "id"]);
+  });
+
+  it("ignores EXTRA live tables (db:push never drops; not deploy-breaking)", () => {
+    const expected = expectedSchema();
+    const live: TableCols[] = JSON.parse(JSON.stringify(expected));
+    live.push({ table: "retired_table", columns: [col("x", "TEXT", 0)] });
+
+    const report = diffSchemas(expected, live);
+
+    expect(report.hasDrift).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`db:push` (`drizzle-kit push`) runs non-interactively in the deploy and **silently skips data-loss schema changes** (e.g. adding a NOT NULL column to a populated table), exiting 0 — leaving the live schema drifted from `schema.ts`. This already broke prod: `notification_event` lost `severity/coalesce_key/count/meta/updated_at`, so notifications + push died while the deploy went green.

This adds a guard that turns silent drift into a **loud deploy failure** (it does NOT change the push strategy):

- `scripts/check-schema-drift.ts` — builds the EXPECTED schema by pushing `schema.ts` into a fresh empty temp `RDV_DATA_DIR` (empty DB → no data-loss skips → full schema), then column-diffs every expected table against the live DB (readonly). Missing table / missing-or-extra column / changed type|notnull → exit 1.
- Wired into `scripts/deploy.ts` `runMigration()` right after `db:push`, mirroring the existing `db:verify-backfills` abort-on-fail guard. SQLite-only (Postgres uses migrate-on-boot).
- `package.json`: `db:check-drift`.

## Test plan
- Unit: `tests/check-schema-drift.test.ts` — 7 cases on the pure `diffSchemas` (identical, missing column [the notification_event regression], extra column, notnull/type change, missing table, ignore-extra-live-tables).
- End-to-end sanity: empty live → exit 1 (74 missing tables); drop `notification_event.severity` → exit 1 (`missing columns: severity`); live==expected → exit 0.
- typecheck, lint, **build exit 0**, full suite green.

Follow-up to the `db:push` silent-data-loss-skip class (root-cause P0 still tracks switching to versioned migrations). Closes remote-dev-9qni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)