### PR TITLE
feat(supervisor): provision FCM (project id + service-account) into instances for push

### DIFF
--- a/apps/supervisor/src/controller/__tests__/reconciler.test.ts
+++ b/apps/supervisor/src/controller/__tests__/reconciler.test.ts
@@ -143,6 +143,8 @@ afterEach(() => {
   delete process.env.SUPERVISOR_INSTANCE_IMAGE_PULL_DOCKERCONFIGJSON;
   delete process.env.SUPERVISOR_INSTANCE_NODE_SELECTOR;
   delete process.env.SUPERVISOR_INSTANCE_BASELINE_PACKAGES;
+  delete process.env.SUPERVISOR_INSTANCE_FCM_PROJECT_ID;
+  delete process.env.SUPERVISOR_INSTANCE_FCM_SERVICE_ACCOUNT_JSON;
   setNodeEnv(ORIGINAL_NODE_ENV);
   vi.clearAllMocks();
 });
@@ -999,6 +1001,44 @@ describe("readProvisionEnv — provision baseline (remote-dev-uobt)", () => {
     expect(() => readProvisionEnv()).toThrow(
       /SUPERVISOR_INSTANCE_BASELINE_PACKAGES is not valid JSON/,
     );
+  });
+});
+
+describe("readProvisionEnv — FCM (remote-dev-wnl4)", () => {
+  const PROJECT_ID = "my-firebase-project";
+  const SA_JSON = '{"type":"service_account","project_id":"my-firebase-project"}';
+
+  beforeEach(() => {
+    process.env.SUPERVISOR_INSTANCE_IMAGE = "ghcr.io/x@sha256:abc";
+    process.env.SUPERVISOR_INSTANCE_HOST = "dev.example.com";
+    setNodeEnv("development");
+  });
+
+  it("populates fcm only when BOTH project id + service-account JSON are set", () => {
+    process.env.SUPERVISOR_INSTANCE_FCM_PROJECT_ID = PROJECT_ID;
+    process.env.SUPERVISOR_INSTANCE_FCM_SERVICE_ACCOUNT_JSON = SA_JSON;
+    expect(readProvisionEnv().fcm).toEqual({
+      projectId: PROJECT_ID,
+      serviceAccountJson: SA_JSON,
+    });
+  });
+
+  it("fcm undefined when only the project id is set", () => {
+    process.env.SUPERVISOR_INSTANCE_FCM_PROJECT_ID = PROJECT_ID;
+    delete process.env.SUPERVISOR_INSTANCE_FCM_SERVICE_ACCOUNT_JSON;
+    expect(readProvisionEnv().fcm).toBeUndefined();
+  });
+
+  it("fcm undefined when only the service-account JSON is set", () => {
+    delete process.env.SUPERVISOR_INSTANCE_FCM_PROJECT_ID;
+    process.env.SUPERVISOR_INSTANCE_FCM_SERVICE_ACCOUNT_JSON = SA_JSON;
+    expect(readProvisionEnv().fcm).toBeUndefined();
+  });
+
+  it("fcm undefined when neither is set", () => {
+    delete process.env.SUPERVISOR_INSTANCE_FCM_PROJECT_ID;
+    delete process.env.SUPERVISOR_INSTANCE_FCM_SERVICE_ACCOUNT_JSON;
+    expect(readProvisionEnv().fcm).toBeUndefined();
   });
 });
 

--- a/apps/supervisor/src/controller/reconciler.ts
+++ b/apps/supervisor/src/controller/reconciler.ts
@@ -229,6 +229,7 @@ export function readProvisionEnv(): {
   cfAccess: { team: string; aud: string };
   github?: { clientId: string; clientSecret: string };
   oidc?: { issuer: string; clientId: string; clientSecret: string; name: string };
+  fcm?: { projectId: string; serviceAccountJson: string };
   imagePullSecret?: { name: string; dockerConfigJson?: string };
   nodeSelector?: Record<string, string>;
   provisionBaseline?: string;
@@ -280,6 +281,23 @@ export function readProvisionEnv(): {
         }
       : undefined;
 
+  // Optional Firebase/FCM creds injected so provisioned instances can SEND FCM
+  // push (remote-dev-wnl4). The instance's container.ts enables FcmPushGateway
+  // only when BOTH FCM_PROJECT_ID and FCM_SERVICE_ACCOUNT_PATH are set, so this
+  // is ALL-OR-NOTHING (mirrors the OIDC gate above): present ONLY when BOTH
+  // SUPERVISOR_INSTANCE_FCM_PROJECT_ID and ..._FCM_SERVICE_ACCOUNT_JSON are set;
+  // when either is missing, no FCM is injected. The service-account JSON is a
+  // SECRET — never logged (it becomes a mounted Secret file in the instance).
+  const fcm =
+    process.env.SUPERVISOR_INSTANCE_FCM_PROJECT_ID &&
+    process.env.SUPERVISOR_INSTANCE_FCM_SERVICE_ACCOUNT_JSON
+      ? {
+          projectId: process.env.SUPERVISOR_INSTANCE_FCM_PROJECT_ID,
+          serviceAccountJson:
+            process.env.SUPERVISOR_INSTANCE_FCM_SERVICE_ACCOUNT_JSON,
+        }
+      : undefined;
+
   // Optional image-pull credential for PRIVATE instance images (remote-dev-2xhg).
   // The dockerconfigjson is a SECRET — never logged. A dockerconfigjson with no
   // name can be neither created nor referenced, so that combination throws loud.
@@ -314,6 +332,7 @@ export function readProvisionEnv(): {
     cfAccess: { team, aud },
     github,
     oidc,
+    fcm,
     imagePullSecret,
     nodeSelector,
     provisionBaseline,
@@ -430,6 +449,7 @@ function buildProvisionOptions(row: InstanceRow): ProvisionOptions {
     cfAccess: env.cfAccess,
     github: env.github,
     oidc: env.oidc,
+    fcm: env.fcm,
     imagePullSecret: env.imagePullSecret,
     nodeSelector: env.nodeSelector,
     provisionBaseline: env.provisionBaseline,

--- a/apps/supervisor/src/lib/__tests__/provisioner-builders.test.ts
+++ b/apps/supervisor/src/lib/__tests__/provisioner-builders.test.ts
@@ -5,6 +5,7 @@ import {
   buildSharedSecret,
   buildAuthSecret,
   buildDbSecret,
+  buildFcmSecret,
   buildImagePullSecret,
   buildService,
   buildStatefulSet,
@@ -13,6 +14,7 @@ import {
   buildInstanceEnv,
   authSecretName,
   dbSecretName,
+  fcmSecretName,
   MANAGED_BY,
   SERVICE_NAME,
   SHARED_SECRET_NAME,
@@ -22,6 +24,8 @@ import {
   DATA_DIR,
   INSPECT_DIR,
   INSPECTOR_ROLE,
+  FCM_SERVICE_ACCOUNT_MOUNT_DIR,
+  FCM_SERVICE_ACCOUNT_MOUNT_PATH,
 } from "@/lib/provisioner-builders";
 
 const SLUG = "alpha";
@@ -118,6 +122,27 @@ describe("buildDbSecret (Postgres dual-backend, Unit 8)", () => {
     expect(s.stringData?.DATABASE_URL).toBe(
       "postgresql://rdv_alpha:p%40ss%3Aw%2Ford%3F@pooler.cnpg.svc:5432/rdv_alpha",
     );
+  });
+});
+
+describe("buildFcmSecret (FCM push provisioning, remote-dev-wnl4)", () => {
+  it("is an Opaque Secret named rdv-<slug>-fcm in the instance namespace with instance labels", () => {
+    const s = buildFcmSecret(SLUG, { serviceAccountJson: '{"type":"service_account"}' });
+    expect(s.type).toBe("Opaque");
+    expect(s.metadata?.name).toBe(fcmSecretName(SLUG));
+    expect(s.metadata?.name).toBe("rdv-alpha-fcm");
+    expect(s.metadata?.namespace).toBe("rdv-alpha");
+    expect(s.metadata?.labels?.["managed-by"]).toBe(MANAGED_BY);
+    expect(s.metadata?.labels?.["rdv.io/slug"]).toBe(SLUG);
+  });
+
+  it("stores the service-account JSON verbatim under the service-account.json key", () => {
+    const json =
+      '{"type":"service_account","project_id":"my-fb","private_key":"-----BEGIN-----"}';
+    const s = buildFcmSecret(SLUG, { serviceAccountJson: json });
+    expect(s.stringData?.["service-account.json"]).toBe(json);
+    // No other keys leak in.
+    expect(Object.keys(s.stringData ?? {})).toEqual(["service-account.json"]);
   });
 });
 
@@ -218,6 +243,28 @@ describe("buildInstanceEnv", () => {
     expect(env.AUTH_TRUST_HOST).toBe("true");
     // The client SECRET must NOT leak into the non-secret env.
     expect(env.OIDC_CLIENT_SECRET).toBeUndefined();
+  });
+
+  it("omits FCM env unless fcm is provided (remote-dev-wnl4)", () => {
+    const env = buildInstanceEnv(SLUG, { host: "dev.example.com" });
+    expect(env.FCM_PROJECT_ID).toBeUndefined();
+    expect(env.FCM_SERVICE_ACCOUNT_PATH).toBeUndefined();
+  });
+
+  it("sets FCM_PROJECT_ID + FCM_SERVICE_ACCOUNT_PATH only when fcm is set (remote-dev-wnl4)", () => {
+    const env = buildInstanceEnv(SLUG, {
+      host: "dev.example.com",
+      fcm: {
+        projectId: "my-firebase-project",
+        serviceAccountJson: '{"type":"service_account"}',
+      },
+    });
+    expect(env.FCM_PROJECT_ID).toBe("my-firebase-project");
+    // The PATH is the in-container mount location (non-secret); the JSON itself
+    // must NEVER appear in the non-secret env.
+    expect(env.FCM_SERVICE_ACCOUNT_PATH).toBe(FCM_SERVICE_ACCOUNT_MOUNT_PATH);
+    expect(env.FCM_SERVICE_ACCOUNT_PATH).toBe("/etc/rdv-fcm/service-account.json");
+    expect(JSON.stringify(env)).not.toContain("service_account");
   });
 
   it("omits RDV_PROVISION_BASELINE unless a baseline is provided (remote-dev-uobt)", () => {
@@ -344,6 +391,35 @@ describe("buildStatefulSet", () => {
     expect(databaseUrl?.valueFrom?.secretKeyRef?.name).toBe(dbSecretName(SLUG));
     expect(databaseUrl?.valueFrom?.secretKeyRef?.name).toBe("rdv-alpha-db");
     expect(databaseUrl?.valueFrom?.secretKeyRef?.key).toBe("DATABASE_URL");
+  });
+
+  it("adds the fcm volume + read-only mount ONLY when withFcm (remote-dev-wnl4)", () => {
+    // Default options (top-of-describe `sts`) have no FCM → no fcm volume/mount,
+    // and (since the data volume rides in volumeClaimTemplates) NO pod `volumes`.
+    expect(container?.volumeMounts?.find((m) => m.name === "fcm")).toBeUndefined();
+    expect(sts.spec?.template.spec?.volumes).toBeUndefined();
+
+    const withFcm = buildStatefulSet(SLUG, {
+      image: "img",
+      env: buildInstanceEnv(SLUG, { host: "h" }),
+      volumeClaimTemplate: PVC,
+      withFcm: true,
+    });
+    const fcmContainer = withFcm.spec?.template.spec?.containers[0];
+    // Read-only volumeMount at the DIRECTORY so service-account.json lands at
+    // FCM_SERVICE_ACCOUNT_PATH.
+    const fcmMount = fcmContainer?.volumeMounts?.find((m) => m.name === "fcm");
+    expect(fcmMount?.mountPath).toBe(FCM_SERVICE_ACCOUNT_MOUNT_DIR);
+    expect(fcmMount?.mountPath).toBe("/etc/rdv-fcm");
+    expect(fcmMount?.readOnly).toBe(true);
+    // The data mount is still present.
+    expect(fcmContainer?.volumeMounts?.find((m) => m.name === "data")?.mountPath).toBe(
+      DATA_DIR,
+    );
+    // Pod-level fcm volume sources the rdv-<slug>-fcm Secret.
+    const fcmVolume = withFcm.spec?.template.spec?.volumes?.find((v) => v.name === "fcm");
+    expect(fcmVolume?.secret?.secretName).toBe(fcmSecretName(SLUG));
+    expect(fcmVolume?.secret?.secretName).toBe("rdv-alpha-fcm");
   });
 
   it("mounts the data volume at /var/lib/rdv and includes the volumeClaimTemplate", () => {

--- a/apps/supervisor/src/lib/__tests__/provisioner-service.test.ts
+++ b/apps/supervisor/src/lib/__tests__/provisioner-service.test.ts
@@ -264,6 +264,82 @@ describe("provisionInstance — provision baseline (remote-dev-uobt)", () => {
   });
 });
 
+describe("provisionInstance — FCM push provisioning (remote-dev-wnl4)", () => {
+  it("with fcm creates the rdv-<slug>-fcm Secret (before the Service) AND the STS mounts it", async () => {
+    const { clients, order } = makeClients();
+    await provisionInstance(
+      row(),
+      {
+        ...OPTS,
+        fcm: {
+          projectId: "my-firebase-project",
+          serviceAccountJson: '{"type":"service_account"}',
+        },
+      },
+      clients,
+    );
+    // The FCM Secret is created after the auth secret and BEFORE the Service.
+    expect(order).toEqual([
+      "namespace",
+      "secret:rdv-shared",
+      "secret:rdv-alpha",
+      "secret:rdv-alpha-fcm",
+      "service",
+      "statefulset",
+    ]);
+    // The created FCM Secret carries the service-account JSON under the right key.
+    const fcmSecret = (clients.core.createNamespacedSecret as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c[0].body)
+      .find((b: { metadata?: { name?: string } }) => b.metadata?.name === "rdv-alpha-fcm");
+    expect(fcmSecret.type).toBe("Opaque");
+    expect(fcmSecret.stringData["service-account.json"]).toBe('{"type":"service_account"}');
+
+    // The STS injects FCM_PROJECT_ID + FCM_SERVICE_ACCOUNT_PATH and mounts the vol.
+    const stsBody = (clients.apps.createNamespacedStatefulSet as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0].body;
+    const env: Array<{ name: string; value?: string }> =
+      stsBody.spec.template.spec.containers[0].env;
+    expect(env.find((e) => e.name === "FCM_PROJECT_ID")?.value).toBe("my-firebase-project");
+    expect(env.find((e) => e.name === "FCM_SERVICE_ACCOUNT_PATH")?.value).toBe(
+      "/etc/rdv-fcm/service-account.json",
+    );
+    const fcmMount = stsBody.spec.template.spec.containers[0].volumeMounts.find(
+      (m: { name: string }) => m.name === "fcm",
+    );
+    expect(fcmMount.mountPath).toBe("/etc/rdv-fcm");
+    expect(fcmMount.readOnly).toBe(true);
+    const fcmVol = stsBody.spec.template.spec.volumes.find(
+      (v: { name: string }) => v.name === "fcm",
+    );
+    expect(fcmVol.secret.secretName).toBe("rdv-alpha-fcm");
+  });
+
+  it("back-compat: no fcm → no FCM Secret, no FCM env, no fcm volume/mount", async () => {
+    const { clients, order } = makeClients();
+    await provisionInstance(row(), OPTS, clients);
+    expect(order).toEqual([
+      "namespace",
+      "secret:rdv-shared",
+      "secret:rdv-alpha",
+      "service",
+      "statefulset",
+    ]);
+    expect(order).not.toContain("secret:rdv-alpha-fcm");
+    const stsBody = (clients.apps.createNamespacedStatefulSet as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0].body;
+    const env: Array<{ name: string }> = stsBody.spec.template.spec.containers[0].env;
+    expect(env.find((e) => e.name === "FCM_PROJECT_ID")).toBeUndefined();
+    expect(env.find((e) => e.name === "FCM_SERVICE_ACCOUNT_PATH")).toBeUndefined();
+    // No pod volumes at all (data rides in volumeClaimTemplates).
+    expect(stsBody.spec.template.spec.volumes).toBeUndefined();
+    expect(
+      stsBody.spec.template.spec.containers[0].volumeMounts.find(
+        (m: { name: string }) => m.name === "fcm",
+      ),
+    ).toBeUndefined();
+  });
+});
+
 describe("provisionInstance — Postgres dual-backend (Unit 8)", () => {
   const CNPG_ENV = {
     CNPG_CLUSTER_NAME: "rdv-pg",

--- a/apps/supervisor/src/lib/provisioner-builders.ts
+++ b/apps/supervisor/src/lib/provisioner-builders.ts
@@ -49,6 +49,17 @@ export const DATA_DIR = "/var/lib/rdv";
 /** Read-only mount point the inspector Job mounts the data PVC at (§ storage browser). */
 export const INSPECT_DIR = "/inspect";
 
+/**
+ * Directory the per-instance FCM service-account Secret is mounted into, and the
+ * absolute path the file lands at inside the container. The DIRECTORY is the
+ * volumeMount target (so the secret's single `service-account.json` key becomes
+ * the file `/etc/rdv-fcm/service-account.json`); the FILE path is injected as the
+ * non-secret env `FCM_SERVICE_ACCOUNT_PATH` so the instance's container.ts enables
+ * FcmPushGateway (it reads FCM_PROJECT_ID + FCM_SERVICE_ACCOUNT_PATH).
+ */
+export const FCM_SERVICE_ACCOUNT_MOUNT_DIR = "/etc/rdv-fcm";
+export const FCM_SERVICE_ACCOUNT_MOUNT_PATH = `${FCM_SERVICE_ACCOUNT_MOUNT_DIR}/service-account.json`;
+
 /** StatefulSet termination grace (matches the app's graceful tmux shutdown). */
 const TERMINATION_GRACE_SECONDS = 30;
 
@@ -64,6 +75,15 @@ export function authSecretName(slug: string): string {
  */
 export function dbSecretName(slug: string): string {
   return `rdv-${slug}-db`;
+}
+
+/**
+ * Per-instance FCM service-account secret name (`rdv-<slug>-fcm`). Created only
+ * when the supervisor is configured to inject FCM credentials; the StatefulSet
+ * mounts it (read-only) at {@link FCM_SERVICE_ACCOUNT_MOUNT_DIR} when `withFcm`.
+ */
+export function fcmSecretName(slug: string): string {
+  return `rdv-${slug}-fcm`;
 }
 
 /** Labels shared by all objects for an instance. */
@@ -192,6 +212,34 @@ export function buildDbSecret(
 }
 
 /**
+ * V1Secret `rdv-<slug>-fcm` — the per-instance Firebase/FCM service-account JSON,
+ * so the instance can SEND FCM push (the app's container.ts enables FcmPushGateway
+ * only when BOTH FCM_PROJECT_ID and FCM_SERVICE_ACCOUNT_PATH are set). The JSON is
+ * stored under the single key `service-account.json`; the StatefulSet mounts it
+ * read-only at {@link FCM_SERVICE_ACCOUNT_MOUNT_DIR} so the file lands at
+ * {@link FCM_SERVICE_ACCOUNT_MOUNT_PATH}. Created ONLY when the supervisor is
+ * configured with FCM creds (else no FCM Secret / mount / env at all).
+ *
+ * SECURITY: callers MUST NOT log the returned object or `opts.serviceAccountJson`.
+ */
+export function buildFcmSecret(
+  slug: string,
+  opts: { serviceAccountJson: string },
+): V1Secret {
+  return {
+    metadata: {
+      name: fcmSecretName(slug),
+      namespace: namespaceForSlug(slug),
+      labels: instanceLabels(slug),
+    },
+    type: "Opaque",
+    stringData: {
+      "service-account.json": opts.serviceAccountJson,
+    },
+  };
+}
+
+/**
  * V1Secret of `type: kubernetes.io/dockerconfigjson` — a per-instance image-pull
  * credential for PRIVATE instance images (spec §15 B2; remote-dev-2xhg). Created
  * in the instance namespace and referenced from the pod's `imagePullSecrets` so a
@@ -266,6 +314,15 @@ export function buildService(slug: string): V1Service {
  * (a JSON manifest string) is injected as RDV_PROVISION_BASELINE (remote-dev-uobt)
  * so the instance entrypoint can merge it with the per-instance PVC manifest at
  * boot. Spread in ONLY when set so existing callers/tests stay byte-identical.
+ *
+ * When `opts.fcm` is set, the NON-SECRET FCM config is injected so the instance
+ * can SEND FCM push: FCM_PROJECT_ID (the Firebase project id) and
+ * FCM_SERVICE_ACCOUNT_PATH (the in-container path the FCM service-account Secret
+ * is mounted at — itself non-secret, just a mount location). The service-account
+ * JSON is NOT here — it is a mounted Secret file (see {@link buildFcmSecret} /
+ * the `withFcm` volume in {@link buildStatefulSet}). The instance's container.ts
+ * enables FcmPushGateway only when BOTH vars are set. Added ONLY when set so
+ * existing callers/tests stay byte-identical.
  */
 export function buildInstanceEnv(
   slug: string,
@@ -273,6 +330,7 @@ export function buildInstanceEnv(
     host: string;
     oidc?: { issuer: string; clientId: string; name: string };
     provisionBaseline?: string;
+    fcm?: { projectId: string; serviceAccountJson: string };
   },
 ): Record<string, string> {
   const env: Record<string, string> = {
@@ -295,6 +353,12 @@ export function buildInstanceEnv(
   }
   if (opts.provisionBaseline) {
     env.RDV_PROVISION_BASELINE = opts.provisionBaseline;
+  }
+  if (opts.fcm) {
+    env.FCM_PROJECT_ID = opts.fcm.projectId;
+    // The service-account JSON is a mounted Secret file; this is just where it
+    // lands inside the container (non-secret mount path).
+    env.FCM_SERVICE_ACCOUNT_PATH = FCM_SERVICE_ACCOUNT_MOUNT_PATH;
   }
   return env;
 }
@@ -344,6 +408,15 @@ export interface BuildStatefulSetOptions {
    * sqlite.db). The non-secret env is unchanged — DATABASE_URL is secret-backed.
    */
   withDatabase?: boolean;
+  /**
+   * Mount the per-instance FCM service-account Secret (`rdv-<slug>-fcm`) read-only
+   * at {@link FCM_SERVICE_ACCOUNT_MOUNT_DIR} so the instance can SEND FCM push.
+   * Set from `!!opts.fcm` by the caller (mirrors how `withOidc` is plumbed). The
+   * non-secret FCM env (FCM_PROJECT_ID / FCM_SERVICE_ACCOUNT_PATH) rides in `env`
+   * via buildInstanceEnv; the service-account JSON is the mounted Secret file.
+   * Omitted when unset, preserving current output for non-FCM instances.
+   */
+  withFcm?: boolean;
   /**
    * Name of an image-pull Secret in the instance namespace, referenced in the
    * pod's `imagePullSecrets` (private-registry instance images; remote-dev-2xhg).
@@ -458,9 +531,38 @@ export function buildStatefulSet(
                 timeoutSeconds: 3,
                 failureThreshold: 3,
               },
-              volumeMounts: [{ name: "data", mountPath: DATA_DIR }],
+              volumeMounts: [
+                { name: "data", mountPath: DATA_DIR },
+                // FCM service-account Secret mounted read-only at the DIRECTORY so
+                // the `service-account.json` key lands at FCM_SERVICE_ACCOUNT_PATH.
+                // Spread in ONLY when withFcm so non-FCM specs are byte-identical.
+                // readOnlyRootFilesystem allows this — it's its own mount, not the
+                // root fs.
+                ...(opts.withFcm
+                  ? [
+                      {
+                        name: "fcm",
+                        mountPath: FCM_SERVICE_ACCOUNT_MOUNT_DIR,
+                        readOnly: true,
+                      },
+                    ]
+                  : []),
+              ],
             },
           ],
+          // Pod-level volumes (the `data` volume comes from volumeClaimTemplates).
+          // The FCM secret volume is added ONLY when withFcm, so the spec is
+          // unchanged (no `volumes` field at all) for non-FCM instances.
+          ...(opts.withFcm
+            ? {
+                volumes: [
+                  {
+                    name: "fcm",
+                    secret: { secretName: fcmSecretName(slug) },
+                  },
+                ],
+              }
+            : {}),
         },
       },
       volumeClaimTemplates: [opts.volumeClaimTemplate],

--- a/apps/supervisor/src/lib/provisioner-service.ts
+++ b/apps/supervisor/src/lib/provisioner-service.ts
@@ -29,6 +29,7 @@ import {
   buildSharedSecret,
   buildAuthSecret,
   buildDbSecret,
+  buildFcmSecret,
   buildImagePullSecret,
   buildService,
   buildStatefulSet,
@@ -69,6 +70,7 @@ export type ProvisioningStage =
   | "shared-secret"
   | "auth-secret"
   | "db-secret"
+  | "fcm-secret"
   | "service"
   | "statefulset";
 
@@ -172,6 +174,13 @@ export interface ProvisionOptions {
    * clientSecret is secret-backed. SECURITY: never log `clientSecret`.
    */
   oidc?: { issuer: string; clientId: string; clientSecret: string; name: string };
+  /**
+   * Optional Firebase/FCM creds so the instance can SEND FCM push. `projectId`
+   * rides in the non-secret env (FCM_PROJECT_ID); `serviceAccountJson` is mounted
+   * as a Secret file (FCM_SERVICE_ACCOUNT_PATH points at it). All-or-nothing:
+   * present only when BOTH are configured. SECURITY: never log `serviceAccountJson`.
+   */
+  fcm?: { projectId: string; serviceAccountJson: string };
   /**
    * Optional image-pull credential for PRIVATE instance images (remote-dev-2xhg).
    * When `name` is set it is referenced in the StatefulSet's `imagePullSecrets`;
@@ -341,6 +350,23 @@ export async function provisionInstance(
       );
     }
 
+    // 3c. Per-instance FCM service-account Secret (`rdv-<slug>-fcm`) — ONLY when
+    //     the supervisor is configured with FCM creds (opts.fcm set). Lets the
+    //     instance SEND FCM push (the StatefulSet mounts it via `withFcm`; the
+    //     non-secret FCM env rides in buildInstanceEnv). All-or-nothing: when
+    //     unset, no FCM Secret/mount/env at all (back-compat).
+    //     SECURITY: never log the built Secret / serviceAccountJson.
+    if (opts.fcm) {
+      await createStep("fcm-secret", () =>
+        core.createNamespacedSecret({
+          namespace,
+          body: buildFcmSecret(slug, {
+            serviceAccountJson: opts.fcm!.serviceAccountJson,
+          }),
+        }),
+      );
+    }
+
     // 4. Governing Service `rdv`.
     await createStep("service", () =>
       core.createNamespacedService({ namespace, body: buildService(slug) }),
@@ -353,6 +379,9 @@ export async function provisionInstance(
         ? { issuer: opts.oidc.issuer, clientId: opts.oidc.clientId, name: opts.oidc.name }
         : undefined,
       provisionBaseline: opts.provisionBaseline,
+      // FCM: non-secret projectId + the mount path ride in env; the JSON is a
+      // mounted Secret file (created above, mounted via withFcm below).
+      fcm: opts.fcm,
     });
     await createStep("statefulset", () =>
       apps.createNamespacedStatefulSet({
@@ -363,6 +392,8 @@ export async function provisionInstance(
           volumeClaimTemplate: toVolumeClaimTemplate(opts.storage),
           withGithub: Boolean(opts.github),
           withOidc: Boolean(opts.oidc),
+          // FCM: mount the `rdv-<slug>-fcm` Secret read-only when FCM is set.
+          withFcm: Boolean(opts.fcm),
           // Postgres dual-backend (Unit 8): DATABASE_URL from `rdv-<slug>-db`.
           withDatabase,
           // Referenced whenever the name is set — even without a dockerConfigJson


### PR DESCRIPTION
Mirrors the OIDC injection: reads optional SUPERVISOR_INSTANCE_FCM_PROJECT_ID + SUPERVISOR_INSTANCE_FCM_SERVICE_ACCOUNT_JSON, creates a per-instance `rdv-<slug>-fcm` Secret (key service-account.json), and injects FCM_PROJECT_ID + FCM_SERVICE_ACCOUNT_PATH env + a read-only volume mount at /etc/rdv-fcm into the instance StatefulSet. All-or-nothing; absent FCM env → spec byte-identical (verified). Enables FcmPushGateway on instances so rdv.joyful.house can send push. Part of remote-dev-wnl4. 472 supervisor tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)