### PR TITLE
fix(mobile): register FCM token for OIDC (cookie-auth) workspaces, not just API-key

### DIFF
--- a/mobile/lib/infrastructure/push/push_token_registrar.dart
+++ b/mobile/lib/infrastructure/push/push_token_registrar.dart
@@ -21,8 +21,11 @@ import '../auth/mobile_credentials.dart';
 /// Host/Workspace store rather than the legacy per-server store. For each
 /// workspace it builds a [RemoteDevClient.forWorkspace] (origin + basePath +
 /// per-workspace API key + host-wide CF cookie) and POSTs the token to
-/// `/api/notifications/push-token`. Workspaces with no stored API key are
-/// skipped (they were never signed into).
+/// `/api/notifications/push-token`. Workspaces with no stored API key AND no
+/// session cookies are skipped (they were never signed into). OIDC workspaces
+/// authenticate by cookie and have no API key, so a stored auth cookie is just
+/// as valid a "signed-in" signal as an API key — the client built by
+/// [clientFactory] cookie-authenticates the POST either way.
 ///
 /// Background-POST constraint: the workspace clients are constructed with NO
 /// interactive refresh, so a token POST against a workspace with a stale CF
@@ -44,8 +47,8 @@ class PushTokenRegistrar {
   /// store the registrar used pre-migration.
   final HostWorkspaceStore store;
 
-  /// Reads the per-workspace API key (to decide whether a workspace was ever
-  /// signed into) before building a client for it.
+  /// Reads the per-workspace API key and/or auth cookies (to decide whether a
+  /// workspace was ever signed into) before building a client for it.
   final MobileCredentialsStore credentials;
 
   /// Builds an [ApiClientPort] for a (host, workspace) pair. Production wires
@@ -74,16 +77,20 @@ class PushTokenRegistrar {
     return true;
   }
 
-  /// POST the token to every saved workspace that has a stored API key.
-  /// Per-workspace failures (and unresolvable hosts) don't block the others.
+  /// POST the token to every saved workspace that has a stored API key OR
+  /// stored session cookies. Per-workspace failures (and unresolvable hosts)
+  /// don't block the others.
   Future<void> registerWithAll(String token) async {
     final workspaces = await store.loadWorkspaces();
     final platform = Platform.isIOS ? 'ios' : 'android';
     for (final ws in workspaces) {
       try {
-        // Never signed into this workspace → nothing to register against.
+        // Never signed into this workspace (no API key AND no session cookies)
+        // → nothing to register against. OIDC workspaces authenticate by cookie
+        // and have no API key; the clientFactory still cookie-auths the POST.
         final apiKey = await credentials.getWorkspaceApiKey(ws.id);
-        if (apiKey == null || apiKey.isEmpty) continue;
+        final cookies = await credentials.getWorkspaceAuthCookies(ws.id);
+        if ((apiKey == null || apiKey.isEmpty) && cookies.isEmpty) continue;
 
         final host = await store.loadHost(ws.hostId);
         if (host == null) continue;
@@ -104,9 +111,10 @@ class PushTokenRegistrar {
   }
 
   /// DELETE the token from a single workspace (used on sign-out /
-  /// delete-workspace). Best-effort: a missing workspace, missing API key, or
-  /// network failure is swallowed (logged) so the caller's delete/sign-out is
-  /// never blocked.
+  /// delete-workspace). Best-effort: a missing workspace, a workspace that was
+  /// never signed into (no API key AND no session cookies), or a network
+  /// failure is swallowed (logged) so the caller's delete/sign-out is never
+  /// blocked.
   Future<void> unregisterWorkspace(String workspaceId) async {
     final token = await push.getToken();
     if (token == null) return;
@@ -124,8 +132,12 @@ class PushTokenRegistrar {
     }
     if (target == null) return;
 
+    // Never signed into this workspace (no API key AND no session cookies) →
+    // nothing to unregister against. OIDC workspaces authenticate by cookie and
+    // have no API key; the clientFactory still cookie-auths the DELETE.
     final apiKey = await credentials.getWorkspaceApiKey(target.id);
-    if (apiKey == null || apiKey.isEmpty) return;
+    final cookies = await credentials.getWorkspaceAuthCookies(target.id);
+    if ((apiKey == null || apiKey.isEmpty) && cookies.isEmpty) return;
 
     final host = await store.loadHost(target.hostId);
     if (host == null) return;

--- a/mobile/test/infrastructure/push/push_token_registrar_test.dart
+++ b/mobile/test/infrastructure/push/push_token_registrar_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:remote_dev/application/ports/api_client_port.dart';
 import 'package:remote_dev/application/ports/host_workspace_store.dart';
 import 'package:remote_dev/application/ports/push_port.dart';
+import 'package:remote_dev/domain/auth_cookie.dart';
 import 'package:remote_dev/domain/host_config.dart';
 import 'package:remote_dev/domain/workspace_config.dart';
 import 'package:remote_dev/infrastructure/auth/mobile_credentials.dart';
@@ -37,6 +38,11 @@ void main() {
     credentials = _MockCredentials();
     refresh = StreamController<String>.broadcast();
     when(() => push.onTokenRefresh).thenAnswer((_) => refresh.stream);
+    // Default: no session cookies for any workspace. Cookie-only (OIDC) tests
+    // override this per-workspace. API-key tests rely on this default so the
+    // registrar's "API key OR cookies" gate sees only the API key.
+    when(() => credentials.getWorkspaceAuthCookies(any()))
+        .thenAnswer((_) async => const <AuthCookie>[]);
   });
 
   tearDown(() async {
@@ -142,6 +148,75 @@ void main() {
 
     // Only the signed-in workspace (b) is registered; a is skipped.
     verifyPosted(clientB);
+  });
+
+  test(
+      'registerWithAll POSTs to a cookie-only (OIDC) workspace with no API key',
+      () async {
+    final clientA = _MockClient();
+    when(() => clientA.post(any(), body: any(named: 'body')))
+        .thenAnswer((_) async => null);
+
+    final h = host('h1');
+    // OIDC workspace: no API key, but a stored session cookie.
+    final wsA = ws('a', hostId: 'h1', slug: 'dev', basePath: '/dev');
+    when(store.loadWorkspaces).thenAnswer((_) async => [wsA]);
+    when(() => store.loadHost('h1')).thenAnswer((_) async => h);
+    when(() => credentials.getWorkspaceApiKey('a'))
+        .thenAnswer((_) async => null);
+    when(() => credentials.getWorkspaceAuthCookies('a')).thenAnswer(
+      (_) async => const [
+        AuthCookie(name: '__session', value: 'sess-jwt', path: '/'),
+      ],
+    );
+
+    final registrar = PushTokenRegistrar(
+      push: push,
+      store: store,
+      credentials: credentials,
+      clientFactory: (_, __) => clientA,
+      deviceId: 'dev-1',
+    );
+
+    await registrar.registerWithAll('tok-1');
+
+    // The cookie-only workspace IS registered: the clientFactory cookie-auths
+    // the POST even though no API key exists.
+    final captured = verify(
+      () => clientA.post(_pushTokenPath, body: captureAny(named: 'body')),
+    ).captured.single as Map<String, dynamic>;
+    expect(captured['token'], 'tok-1');
+    expect(captured['deviceId'], 'dev-1');
+  });
+
+  test(
+      'registerWithAll skips a workspace with neither API key nor cookies',
+      () async {
+    final clientA = _MockClient();
+    when(() => clientA.post(any(), body: any(named: 'body')))
+        .thenAnswer((_) async => null);
+
+    final h = host('h1');
+    final wsA = ws('a', hostId: 'h1');
+    when(store.loadWorkspaces).thenAnswer((_) async => [wsA]);
+    when(() => store.loadHost('h1')).thenAnswer((_) async => h);
+    when(() => credentials.getWorkspaceApiKey('a'))
+        .thenAnswer((_) async => null);
+    when(() => credentials.getWorkspaceAuthCookies('a'))
+        .thenAnswer((_) async => const <AuthCookie>[]);
+
+    final registrar = PushTokenRegistrar(
+      push: push,
+      store: store,
+      credentials: credentials,
+      clientFactory: (_, __) => clientA,
+      deviceId: 'dev-1',
+    );
+
+    await registrar.registerWithAll('tok-1');
+
+    // Never signed in (no API key AND no cookies) → no POST.
+    verifyNever(() => clientA.post(any(), body: any(named: 'body')));
   });
 
   test('per-workspace failure does not block subsequent workspaces', () async {
@@ -277,6 +352,41 @@ void main() {
     await registrar.unregisterWorkspace('a');
 
     verifyNever(() => clientA.delete(any(), body: any(named: 'body')));
+  });
+
+  test('unregisterWorkspace DELETEs from a cookie-only (OIDC) workspace',
+      () async {
+    final clientA = _MockClient();
+    when(() => clientA.delete(any(), body: any(named: 'body')))
+        .thenAnswer((_) async {});
+    when(() => push.getToken()).thenAnswer((_) async => 'tok-1');
+
+    final h = host('h1');
+    when(store.loadWorkspaces).thenAnswer((_) async => [ws('a', hostId: 'h1')]);
+    when(() => store.loadHost('h1')).thenAnswer((_) async => h);
+    // OIDC workspace: no API key, but a stored session cookie.
+    when(() => credentials.getWorkspaceApiKey('a'))
+        .thenAnswer((_) async => null);
+    when(() => credentials.getWorkspaceAuthCookies('a')).thenAnswer(
+      (_) async => const [
+        AuthCookie(name: '__session', value: 'sess-jwt', path: '/'),
+      ],
+    );
+
+    final registrar = PushTokenRegistrar(
+      push: push,
+      store: store,
+      credentials: credentials,
+      clientFactory: (_, __) => clientA,
+      deviceId: 'dev-1',
+    );
+
+    await registrar.unregisterWorkspace('a');
+
+    final captured = verify(
+      () => clientA.delete(_pushTokenPath, body: captureAny(named: 'body')),
+    ).captured.single as Map<String, dynamic>;
+    expect(captured['token'], 'tok-1');
   });
 
   test('start returns false when push.initialize fails', () async {


### PR DESCRIPTION
PushTokenRegistrar skipped any workspace with no stored API key — OIDC workspaces auth by session cookie and have none, so rdv.joyful.house never uploaded its FCM token → no push. Gate now accepts apiKey OR getWorkspaceAuthCookies in registerWithAll + unregisterWorkspace; the clientFactory already cookie-auths the POST and the route is withApiAuth. Part of remote-dev-wnl4. flutter analyze clean; 25 push tests green. Needs APK rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)