### PR TITLE
fix(mobile): cache WebView target Future to stop blank-state flash on rebuild (remote-dev-9c5j)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Mobile session view no longer flashes the "No active server configured" blank state on keyboard/layout rebuilds — the WebView target Future is now resolved once and cached instead of rebuilt every frame (remote-dev-9c5j).
 - Sidebar session status: replaced the redundant needs-attention dot with a glow on the status icon (driven by both live status and unread actionable/error notifications; the row's accessible name now also announces "waiting for input"/"error" so the colour-only glow isn't the sole signal), and stopped showing stale "running"/green status after the tab regains focus or the WebSocket reconnects (the in-memory status cache now reconciles from the DB on every refresh; refresh also fires on window focus; the terminal server replays in-memory status indicators/progress on reattach). (remote-dev-f9y9)
 - Mobile biometric lock now auto-presents the OS biometric/device-credential prompt the moment the lock screen appears, instead of requiring a tap on "Authenticate"; the button remains as a manual-retry fallback after a cancel/failure. (remote-dev-u8sq)
 - Mobile push: the FCM token registrar now retries failed workspace registrations on connectivity-restored, app-resume, and a bounded backoff timer instead of silently giving up at launch (e.g. when the app starts behind the screensaver and Doze blocks the network). (remote-dev-0ir2)

--- a/mobile/lib/presentation/router/app_router.dart
+++ b/mobile/lib/presentation/router/app_router.dart
@@ -287,18 +287,27 @@ class AppRouter {
         ),
         GoRoute(
           path: '/home/session/:id',
-          builder: (context, state) => SessionViewScreen(
-            sessionId: state.pathParameters['id']!,
-            // Pre-resolved summary when navigation carries one (Sessions
-            // list / freshly-created session). Notification/deep-link
-            // cold-starts pass no extra, so the screen resolves the name
-            // from the sessions list instead. Guard the cast: GoRouter may
-            // hand back arbitrary extras (e.g. a ServerConfig from an
-            // unrelated push) so only accept a SessionSummary.
-            initialSummary: state.extra is SessionSummary
-                ? state.extra! as SessionSummary
-                : null,
-          ),
+          builder: (context, state) {
+            final id = state.pathParameters['id']!;
+            // Key by session id so the screen REMOUNTS whenever the session
+            // changes. SessionViewScreen + _Webview cache per-session state in
+            // initState (resolved name, resolved WebView target); without a key a
+            // future context.go(...) or route restoration could reuse this element
+            // across sessions and leave those caches stale (remote-dev-9c5j).
+            return SessionViewScreen(
+              key: ValueKey('session-$id'),
+              sessionId: id,
+              // Pre-resolved summary when navigation carries one (Sessions
+              // list / freshly-created session). Notification/deep-link
+              // cold-starts pass no extra, so the screen resolves the name
+              // from the sessions list instead. Guard the cast: GoRouter may
+              // hand back arbitrary extras (e.g. a ServerConfig from an
+              // unrelated push) so only accept a SessionSummary.
+              initialSummary: state.extra is SessionSummary
+                  ? state.extra! as SessionSummary
+                  : null,
+            );
+          },
         ),
         GoRoute(
           path: '/home/channel/:id',

--- a/mobile/lib/presentation/screens/session_view/session_view_screen.dart
+++ b/mobile/lib/presentation/screens/session_view/session_view_screen.dart
@@ -451,19 +451,47 @@ class _SessionViewScreenState extends ConsumerState<SessionViewScreen> {
   }
 }
 
-class _Webview extends ConsumerWidget {
+class _Webview extends ConsumerStatefulWidget {
   const _Webview({required this.sessionId, required this.onWebViewCreated});
 
   final String sessionId;
   final void Function(InAppWebViewController) onWebViewCreated;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_Webview> createState() => _WebviewState();
+}
+
+class _WebviewState extends ConsumerState<_Webview> {
+  /// The resolved WebView target, computed exactly ONCE in [initState] and
+  /// cached. Resolving in `build()` would create a fresh Future every frame,
+  /// so any cosmetic parent rebuild (e.g. a keyboard-inset change recomputing
+  /// `webViewHeight`) would restart the [FutureBuilder] from
+  /// `ConnectionState.waiting` — briefly flashing the blank 'No active server
+  /// configured.' state and re-running the cookie-seeding side effect. The
+  /// target depends only on the active workspace, and this view is pinned to
+  /// its session for its lifetime, so caching once is correct.
+  late final Future<_WebviewTarget?> _targetFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _targetFuture = _resolveTarget();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return FutureBuilder<_WebviewTarget?>(
-      future: _resolveTarget(ref),
+      future: _targetFuture,
       builder: (context, snap) {
+        // Still resolving: show a neutral dark placeholder, NOT the error
+        // text. Distinguishing waiting from a genuine null target is what
+        // stops the blank-state flash during the first async resolve.
+        if (snap.connectionState == ConnectionState.waiting) {
+          return const ColoredBox(color: Color(0xFF1A1B26));
+        }
         final target = snap.data;
         if (target == null) {
+          // Resolution is done and yielded no server — genuinely unconfigured.
           return const ColoredBox(
             color: Color(0xFF1A1B26),
             child: Center(
@@ -480,7 +508,7 @@ class _Webview extends ConsumerWidget {
         final origin = target.origin;
         final basePath = target.basePath;
         final urls = WorkspaceUrls(origin.toString(), basePath);
-        final url = Uri.parse(urls.web('/m/session/$sessionId'));
+        final url = Uri.parse(urls.web('/m/session/${widget.sessionId}'));
         return WebViewFactory().build(
           initialUrl: url,
           policy: NavigationPolicy(
@@ -498,7 +526,7 @@ class _Webview extends ConsumerWidget {
             // See bd remote-dev-pmhg.
             unawaited(_openExternal(uri));
           },
-          onWebViewCreated: onWebViewCreated,
+          onWebViewCreated: widget.onWebViewCreated,
           // Diagnostic logging (bd remote-dev-l4q6 Bug 4). Without an on-
           // device repro of the blank-screen / submit-does-nothing bug we
           // surface page-load + console output to `flutter logs` so the
@@ -519,7 +547,7 @@ class _Webview extends ConsumerWidget {
   /// with the persisted CF JWT before the WebView mounts. Seeding failures
   /// are swallowed so they don't block the WebView (the WebView will hit a
   /// CF Access challenge instead, and the user re-auths via /reauth).
-  Future<_WebviewTarget?> _resolveTarget(WidgetRef ref) async {
+  Future<_WebviewTarget?> _resolveTarget() async {
     final conn = await ref.read(activeWorkspaceProvider.future);
     if (conn == null) return null;
     // The WebView loads `<origin><basePath>/m/session/<id>`. The cookie is


### PR DESCRIPTION
## Summary

Fixes **remote-dev-9c5j**: the mobile session view briefly flashed the **"No active server configured."** blank state on any cosmetic rebuild (e.g. a keyboard-inset change), and redundantly re-ran cookie-seeding every frame.

`_Webview` was a `ConsumerWidget` whose `build()` passed `FutureBuilder(future: _resolveTarget(ref))` — a **new Future every rebuild** — so `FutureBuilder` kept restarting from `ConnectionState.waiting`/`null`.

### Commits
1. **`fix`** — convert `_Webview` to a `ConsumerStatefulWidget`; resolve the target **once** in `initState` and cache it in `late final _targetFuture`; `build()` uses the cached future so cosmetic rebuilds reuse the completed snapshot (no flash). Also distinguishes `ConnectionState.waiting` (neutral dark placeholder) from a genuine done+null (the error text), so the legitimate first-load no longer shows misleading text.
2. **`harden`** — key the `/home/session/:id` route by `sessionId` so `SessionViewScreen` remounts on any session change under **any** navigation method (incl. a future `context.go(...)` / state restoration), keeping the per-session `initState` caches (WebView target *and* resolved name) correct by construction. (Surfaced by the codex adversarial review as a non-blocking future-proofing.)

## Key decisions
- Caching once is correct because every current session navigation remounts the screen (`_openSwitcher` invalidates `activeWorkspaceProvider` then `pushReplacement`s; sessions-list uses `push`). The route-key commit removes the reliance on that convention.
- Cookie-seeding intentionally drops from every-rebuild to once per mount (verified no ordering/behavior change otherwise).

## Test plan
- `flutter analyze` on both changed files → **No issues found**.
- `flutter test` **not** run — known `_dyld_start` hang of the Flutter test runner on the build host (environment issue, not code).
- `tsc --noEmit` clean; web lint unchanged (mobile-only diff touches zero `src/` files, so the web build/deploy is unaffected).
- Adversarial review by codex (go_router 14.8.1 + Riverpod 2.6.1 source-checked): no production-blocking defect; the one hardening suggestion is included as commit 2.

Mobile-only — lands on `master` to ride the next APK rebuild (the device-gated `qnp9` tail); this fix itself needs no device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)