### PR TITLE
fix(ci): build dev-env image with NODE_VERSION=24-trixie-slim to clear the glibc gate (remote-dev-i0le)

### DIFF
--- a/.github/workflows/dev-env-image.yml
+++ b/.github/workflows/dev-env-image.yml
@@ -11,11 +11,13 @@
 # is a SEPARATE, later step (a future release workflow or a manual
 # `docker buildx ... --push`) that should run ONLY after this gate is green.
 #
-# NODE_VERSION: passed as `24` per the task. The Dockerfile's production default
-# is the more specific `24-trixie-slim` tag (Node 24 ABI 137 + Debian trixie
-# glibc 2.41 — see the Dockerfile header); `24` here pins the same Node MAJOR for
-# the smoke assertion while exercising the full multi-stage build + agent-CLI
-# install path.
+# NODE_VERSION: pinned to `24-trixie-slim` — still Node 24, just the Debian
+# *trixie* codename rather than the default `24` (Debian *bookworm*, glibc 2.36).
+# The image's own runtime smoke gate runs `rdv --version`, and the Rust `rdv`
+# binary is compiled against trixie's glibc, so a bookworm runtime fails the gate
+# with "GLIBC_2.39 not found". `24-trixie-slim` (Node 24 ABI 137 + Debian trixie
+# glibc 2.41 — see the Dockerfile header) clears it, mirroring the Dockerfile's
+# production default and `.github/workflows/supervisor-router-e2e.yml`.
 
 name: Dev-Env Image CI
 
@@ -55,7 +57,7 @@ jobs:
           push: false
           tags: rdv-dev-env:ci
           build-args: |
-            NODE_VERSION=24
+            NODE_VERSION=24-trixie-slim
             RDV_IMAGE_FLAVOR=dev-env
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dev-Env Image CI green again** — the `dev-env-image` workflow built with `NODE_VERSION=24` (Debian bookworm, glibc 2.36), which fails the image's own `rdv` glibc gate (needs GLIBC_2.39); pinned to `24-trixie-slim` (still Node 24) to match the Dockerfile default and the supervisor-router-e2e workflow. (remote-dev-i0le)
 - Mobile session view no longer flashes the "No active server configured" blank state on keyboard/layout rebuilds — the WebView target Future is now resolved once and cached instead of rebuilt every frame (remote-dev-9c5j).
 - Sidebar session status: replaced the redundant needs-attention dot with a glow on the status icon (driven by both live status and unread actionable/error notifications; the row's accessible name now also announces "waiting for input"/"error" so the colour-only glow isn't the sole signal), and stopped showing stale "running"/green status after the tab regains focus or the WebSocket reconnects (the in-memory status cache now reconciles from the DB on every refresh; refresh also fires on window focus; the terminal server replays in-memory status indicators/progress on reattach). (remote-dev-f9y9)
 - Mobile biometric lock now auto-presents the OS biometric/device-credential prompt the moment the lock screen appears, instead of requiring a tap on "Authenticate"; the button remains as a manual-retry fallback after a cancel/failure. (remote-dev-u8sq)


### PR DESCRIPTION
## Summary
Fixes **remote-dev-i0le**: the `Dev-Env Image CI` workflow has been **red on master** (latest run `26976819926`, 2026-06-04). It passed build-arg `NODE_VERSION=24` (Debian *bookworm*, glibc 2.36), which fails the image's own runtime `rdv --version` glibc gate (the Rust `rdv` is compiled against Debian *trixie* glibc → `GLIBC_2.39 not found`).

Pins to `NODE_VERSION=24-trixie-slim` — **still Node 24**, just the trixie codename the runtime needs — matching the Dockerfile default (`ARG NODE_VERSION=24-trixie-slim`) and `.github/workflows/supervisor-router-e2e.yml`. The `node --version | grep ^v24` smoke assertion stays valid.

## Test plan
- Workflow YAML parses clean (PyYAML + Ruby Psych); no leftover bare `NODE_VERSION=24`.
- Merging this triggers `Dev-Env Image CI` (its `push` paths include this workflow file) — the run going green is the validation.

Surfaced during the codex review of #385 (remote-dev-jvcx.11), which independently confirmed `24-trixie-slim` is the correct value for the glibc gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)