### PR TITLE
fix(ci): free runner disk before the supervisor-router-e2e 3-image build (remote-dev-6vqr)

### DIFF
--- a/.github/workflows/supervisor-router-e2e.yml
+++ b/.github/workflows/supervisor-router-e2e.yml
@@ -57,6 +57,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Free up disk space (runner has too little for 3 images)
+        run: |
+          echo "Disk before cleanup:"; df -h /
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc /usr/local/.ghcup || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          sudo rm -rf /usr/local/share/boost || true
+          sudo rm -rf "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+          sudo docker image prune --all --force || true
+          echo "Disk after cleanup:"; df -h /
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The `Supervisor Router E2E` CI workflow now frees ~20–30 GB of preinstalled runner toolchains before building its three images — `ubuntu-latest`'s ~14 GB of free space was exhausted by the heavy dev-env instance image (`no space left on device`). (remote-dev-6vqr)
 - **Dev-Env Image CI green again** — the `dev-env-image` workflow built with `NODE_VERSION=24` (Debian bookworm, glibc 2.36), which fails the image's own `rdv` glibc gate (needs GLIBC_2.39); pinned to `24-trixie-slim` (still Node 24) to match the Dockerfile default and the supervisor-router-e2e workflow. (remote-dev-i0le)
 - Mobile session view no longer flashes the "No active server configured" blank state on keyboard/layout rebuilds — the WebView target Future is now resolved once and cached instead of rebuilt every frame (remote-dev-9c5j).
 - Sidebar session status: replaced the redundant needs-attention dot with a glow on the status icon (driven by both live status and unread actionable/error notifications; the row's accessible name now also announces "waiting for input"/"error" so the colour-only glow isn't the sole signal), and stopped showing stale "running"/green status after the tab regains focus or the WebSocket reconnects (the in-memory status cache now reconciles from the DB on every refresh; refresh also fires on window focus; the terminal server replays in-memory status indicators/progress on reattach). (remote-dev-f9y9)


### PR DESCRIPTION
## Summary
Fixes **remote-dev-6vqr**: the `Supervisor Router E2E` guard (PR #385 / jvcx.11) failed its first real CI run (run `27037483304`) with **`no space left on device`** — router + supervisor images built, then the heavy dev-env instance image (5 agent CLIs) exhausted `ubuntu-latest`'s ~14 GB. The smoke **logic** is correct (PASS 15/15 locally); only the runner needed more disk.

Adds a dependency-free **"Free up disk space"** step after checkout / before the builds: removes preinstalled `.NET`/Android/GHC/CodeQL/toolcache (~20–30 GB) + `docker image prune`, each `|| true`-guarded with `df -h` before/after. No build/smoke/trigger steps changed.

## Test plan
- YAML parses (PyYAML); the new step is correctly placed (index 1, between checkout and Buildx).
- Merging re-triggers `Supervisor Router E2E` (this workflow file is in its own `push` paths) — the run going green (all 3 images build + the smoke passes) is the validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)