### PR TITLE
fix(ci): bypass server entrypoint in dev-env image smoke checks (remote-dev-i0le)

### DIFF
--- a/.github/workflows/dev-env-image.yml
+++ b/.github/workflows/dev-env-image.yml
@@ -68,8 +68,15 @@ jobs:
         # antigravity (`agy`) is BEST-EFFORT (its installer 404s) — intentionally
         # NOT asserted here, mirroring the Dockerfile's build-time smoke gate. A
         # non-zero exit from this command fails the job.
+        #
+        # `--entrypoint sh`: the image's entrypoint (docker/entrypoint.sh) starts
+        # the instance servers (terminal server + Next.js + background
+        # auto-update) and IGNORES the CMD, so a plain `docker run … sh -lc …`
+        # boots the servers (which run forever) instead of running the checks and
+        # the step times out. Override the entrypoint to assert image *contents*
+        # without booting the servers.
         run: |
-          docker run --rm rdv-dev-env:ci sh -lc '
+          docker run --rm --entrypoint sh rdv-dev-env:ci -lc '
             node --version | grep -q "^v24" \
               && command -v claude \
               && command -v codex \
@@ -80,4 +87,4 @@ jobs:
       - name: Smoke test — RDV_IMAGE_FLAVOR is dev-env
         timeout-minutes: 5
         run: |
-          docker run --rm rdv-dev-env:ci sh -lc '[ "$RDV_IMAGE_FLAVOR" = "dev-env" ]'
+          docker run --rm --entrypoint sh rdv-dev-env:ci -lc '[ "$RDV_IMAGE_FLAVOR" = "dev-env" ]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The `dev-env-image` CI smoke checks now bypass the image's server entrypoint (`docker run --entrypoint sh …`) so they actually assert Node v24 + the agent CLIs on PATH instead of booting the instance servers and timing out. (remote-dev-i0le)
 - The `Supervisor Router E2E` CI workflow now frees ~20–30 GB of preinstalled runner toolchains before building its three images — `ubuntu-latest`'s ~14 GB of free space was exhausted by the heavy dev-env instance image (`no space left on device`). (remote-dev-6vqr)
 - **Dev-Env Image CI green again** — the `dev-env-image` workflow built with `NODE_VERSION=24` (Debian bookworm, glibc 2.36), which fails the image's own `rdv` glibc gate (needs GLIBC_2.39); pinned to `24-trixie-slim` (still Node 24) to match the Dockerfile default and the supervisor-router-e2e workflow. (remote-dev-i0le)
 - Mobile session view no longer flashes the "No active server configured" blank state on keyboard/layout rebuilds — the WebView target Future is now resolved once and cached instead of rebuilt every frame (remote-dev-9c5j).


### PR DESCRIPTION
## Summary
Second fix for **remote-dev-i0le**. The first fix (`NODE_VERSION=24-trixie-slim`, #386) repaired the dev-env image **build** (the original failure was the Dockerfile `RUN rdv --version` glibc gate). That revealed a second bug: the workflow's smoke steps **timed out after 5 min** (run `27037749791`).

Root cause: `docker run --rm rdv-dev-env:ci sh -lc '<checks>'` — the image ENTRYPOINT (`docker/entrypoint.sh`) starts the terminal + Next.js servers and **ignores the CMD** (no `exec "$@"`), so the container boots the instance servers (which run forever) instead of running the checks → timeout (CI log shows `▲ Next.js … Ready`, then hang).

Fix: run both smoke steps with **`--entrypoint sh`** to assert image *contents* (Node v24 + the agent CLIs on PATH + `RDV_IMAGE_FLAVOR`) without booting the servers.

## Test plan
- YAML parses; both smoke `docker run` lines now use `--entrypoint sh … -lc`.
- Merging re-triggers `Dev-Env Image CI` (this workflow file is in its `push` paths) — the run going green is the validation. Closes i0le when green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)