### PR TITLE
chore(ci): bump GitHub actions to Node-24 runtimes (remote-dev-hjmc)

### DIFF
--- a/.github/workflows/dev-env-image.yml
+++ b/.github/workflows/dev-env-image.yml
@@ -41,13 +41,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build dev-env image (Node 24, load to local daemon)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -42,14 +42,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
 
       - name: Cache pub
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.pub-cache
@@ -82,7 +82,7 @@ jobs:
         run: flutter build appbundle --release
 
       - name: Upload App Bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: remote-dev-${{ github.ref_name }}.aab
           path: mobile/build/app/outputs/bundle/release/app-release.aab
@@ -93,14 +93,14 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
 
       - name: Cache pub
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.pub-cache
@@ -108,7 +108,7 @@ jobs:
           key: pub-${{ runner.os }}-${{ hashFiles('mobile/pubspec.lock') }}
 
       - name: Cache CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             mobile/ios/Pods
@@ -146,7 +146,7 @@ jobs:
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
 
       - name: Upload IPA artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: remote-dev-${{ github.ref_name }}.ipa
           path: mobile/build/ios/ipa/*.ipa

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,12 @@ jobs:
             node_modules/node-pty/
             node_modules/better-sqlite3/
             node_modules/@libsql/
+          # `.next/` is a hidden (dot-prefixed) directory; upload-artifact
+          # excludes hidden paths by default (since v4.4), which would silently
+          # drop the entire Next.js build from the artifact. Safe here: CI builds
+          # from a clean checkout (no stray secret dotfiles) and the artifact is
+          # same-repo with 1-day retention.
+          include-hidden-files: true
           retention-days: 1
 
   # ─── Build rdv CLI + pack tarball per platform ────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
     name: Build Web App
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -38,7 +38,7 @@ jobs:
         run: bun run terminal:build
 
       - name: Upload web build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: web-build
           path: |
@@ -80,14 +80,14 @@ jobs:
             rust-target: x86_64-apple-darwin
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Download web build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: web-build
 
@@ -123,7 +123,7 @@ jobs:
             --rdv-binary crates/rdv/target/${{ matrix.rust-target }}/release/rdv
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.platform }}
           path: dist/*.tar.gz
@@ -135,10 +135,10 @@ jobs:
     needs: [build-release]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: release-*
           path: dist

--- a/.github/workflows/supervisor-router-e2e.yml
+++ b/.github/workflows/supervisor-router-e2e.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Free up disk space (runner has too little for 3 images)
         run: |
@@ -70,7 +70,7 @@ jobs:
           echo "Disk after cleanup:"; df -h /
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -89,7 +89,7 @@ jobs:
       # SCOPED GHA cache so they don't evict one another.
 
       - name: Build router image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./apps/supervisor-router/Dockerfile
@@ -100,7 +100,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=router
 
       - name: Build supervisor image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./apps/supervisor/Dockerfile
@@ -111,7 +111,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=supervisor
 
       - name: Build instance (dev-env) image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
## Summary
- Bump every third-party GitHub Action across `.github/workflows/` to its current major that runs on the **Node 24** runtime (GitHub forces Node 24 as default 2026-06-16 and removes Node 20 on 2026-09-16): checkout v4→v6, build-push-action v6→v7, upload-artifact v4→v7, cache v4→v5, setup-buildx v3→v4, setup-node v4→v6, download-artifact v4→v8. `oven-sh/setup-bun@v2` (already node24), `subosito/flutter-action@v2` + `dtolnay/rust-toolchain@stable` (composite) unchanged.
- Every new ref's runtime was verified by reading `action.yml` at the tag (`using: node24` / `composite`); release-note breaking changes audited against our actual usage (details in commit body).
- **Fix from adversarial review:** `release.yml`'s `web-build` artifact uploads `.next/standalone|static/` — hidden (dot-prefixed) paths that upload-artifact has silently EXCLUDED by default since v4.4, so the downstream release pack was missing the entire Next.js build. Added `include-hidden-files: true` (safe: clean CI checkout, same-repo artifact, 1-day retention). Audited the other three upload steps — none use hidden paths.

## Key decisions
- Preferred plain major tags (`@vN`) per repo convention over SHA pins.
- download-artifact v8's `digest-mismatch: error` default is safe (artifacts produced+consumed in the same run); setup-node v6 cache-narrowing irrelevant (no `cache:` input used); checkout v6 credential relocation irrelevant (no step relies on persisted git creds — `gh release create` uses explicit `GH_TOKEN`).
- No self-hosted runners affected (all jobs on GitHub-hosted labels).

## Test plan
- YAML parse validation of all 5 workflow files (bun + `yaml` package) — clean.
- Workflows-only diff: app code untouched, so app gates (typecheck/lint/test/build) are unaffected by construction.
- Real verification happens on next workflow executions (deploy.yml untouched; release/mobile/e2e workflows exercise the bumps on their next runs).

## Review chain
Codex adversarial review: 1 High (hidden-file artifact exclusion) → fixed in 6afd4235; all other bumps explicitly checked clean (input contracts, artifact compat, cache-key reuse, runner labels).

Closes remote-dev-hjmc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)