### PR TITLE
fix(sessions): derive effectiveAgentProvider from merged provider resolution (remote-dev-u02r)

### DIFF
--- a/src/services/__tests__/session-service-provider-resolution.test.ts
+++ b/src/services/__tests__/session-service-provider-resolution.test.ts
@@ -1,0 +1,292 @@
+// @vitest-environment node
+/**
+ * [remote-dev-u02r] Provider-resolution contract for createSession.
+ *
+ * Bug: when a client OMITS `agentProvider` for an agent/loop session and the
+ * resolved folder/user default is non-claude (e.g. "codex"), the session
+ * actually launches codex (the plugin command is built from the *merged*
+ * provider) and the DB row records codex — but everything keyed off the old
+ * `effectiveAgentProvider` (which read the RAW `input.agentProvider`) recorded
+ * "claude": the durable resume binding `provider`, the model-proxy
+ * `providerScope`, and the claude-defaults env gate. A terminal-server restart
+ * would then try to resume a codex conversation with the claude CLI.
+ *
+ * These tests drive `createSessionWithDedupFlag` end-to-end with the real
+ * terminal-type plugins + real resume-binding builder, mocking only the I/O
+ * boundaries (db / tmux / worktree / github / preferences / profile / api-key
+ * / container / proxy-token). We then assert the *recorded* provider — the DB
+ * `agentProvider` column, the persisted `resumeBinding.provider`, and the
+ * proxy-token `providerScope` — all follow the MERGED resolution, not the raw
+ * (absent) input.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/** Captured payload from the single `db.insert(...).values(...)` write. */
+let insertedValues: Record<string, unknown> | null = null;
+/** Captured options passed to the mocked `issueProxyToken`. */
+let proxyTokenOpts: { providerScope?: string[] } | null = null;
+
+/**
+ * Resolved preferences returned by the mocked preferences-service. Tests mutate
+ * `defaultAgentProvider` before importing the service to exercise the merge.
+ */
+const resolvedPreferences: {
+  defaultAgentProvider?: string;
+  defaultWorkingDirectory?: string;
+  agentProviderSettings?: Record<string, unknown>;
+} = {};
+
+/**
+ * Install all the I/O-boundary mocks. Called inside each test AFTER
+ * `vi.resetModules()` so the dynamically-imported session-service binds to
+ * these doubles. Only the external surface is faked — the terminal-type plugin
+ * registry and the resume-binding builder run for real.
+ */
+function installMocks() {
+  insertedValues = null;
+  proxyTokenOpts = null;
+
+  // --- Database: dedup SELECTs return empty, INSERT echoes the row back. ---
+  const insertChain = {
+    values: (vals: Record<string, unknown>) => {
+      insertedValues = vals;
+      return {
+        // `.returning()` resolves to the inserted row (id + values) so
+        // mapDbSessionToSession has a complete record to map.
+        returning: () =>
+          Promise.resolve([
+            {
+              ...fullRow(vals),
+            },
+          ]),
+      };
+    },
+  };
+  vi.doMock("@/db", () => ({
+    db: {
+      query: {
+        terminalSessions: {
+          // No existing scope-keyed row, and tabOrder lookup → empty.
+          findMany: vi.fn().mockResolvedValue([]),
+          findFirst: vi.fn().mockResolvedValue(null),
+        },
+      },
+      insert: vi.fn(() => insertChain),
+      delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    },
+  }));
+  // drizzle-orm helpers are only used to build where-clauses we never inspect.
+  vi.doMock("drizzle-orm", () => ({
+    eq: vi.fn(),
+    and: vi.fn(),
+    asc: vi.fn(),
+    desc: vi.fn(),
+    inArray: vi.fn(),
+  }));
+  vi.doMock("@/db/schema", () => ({
+    terminalSessions: {
+      userId: "userId",
+      terminalType: "terminalType",
+      scopeKey: "scopeKey",
+      status: "status",
+      tabOrder: "tabOrder",
+      lastActivityAt: "lastActivityAt",
+    },
+    githubRepositories: {},
+    apiKeys: { userId: "userId", name: "name" },
+  }));
+
+  // --- tmux: record nothing, just succeed. ---
+  vi.doMock("@/services/tmux-service", () => ({
+    generateSessionName: (id: string) => `rdv-${id}`,
+    createSession: vi.fn().mockResolvedValue(undefined),
+    setSessionEnvironment: vi.fn().mockResolvedValue(undefined),
+    setHook: vi.fn().mockResolvedValue(undefined),
+    killSession: vi.fn().mockResolvedValue(undefined),
+    TmuxServiceError: class TmuxServiceError extends Error {},
+  }));
+
+  // --- worktree / github: not exercised by these (no createWorktree) inputs. ---
+  vi.doMock("@/services/worktree-service", () => ({
+    isGitRepo: vi.fn().mockResolvedValue(false),
+    createWorktree: vi.fn(),
+    removeWorktree: vi.fn().mockResolvedValue(undefined),
+  }));
+  vi.doMock("@/services/github-service", () => ({}));
+
+  // --- preferences: agent default provider comes from here. ---
+  vi.doMock("@/services/preferences-service", () => ({
+    getResolvedPreferences: vi.fn().mockResolvedValue(resolvedPreferences),
+    getFolderPreferences: vi.fn().mockResolvedValue(null),
+    getEnvironmentForSession: vi.fn().mockResolvedValue({}),
+    getFolderGitIdentity: vi.fn().mockResolvedValue({ env: {} }),
+  }));
+
+  // --- profile: no profile selected. installAgentHooks / validateAgentHooks
+  // run only on the claude path (ensureAgentConfig), so stub them too. ---
+  vi.doMock("@/services/agent-profile-service", () => ({
+    getProfile: vi.fn().mockResolvedValue(undefined),
+    getProfileEnvironment: vi.fn().mockResolvedValue(undefined),
+    installAgentHooks: vi.fn().mockResolvedValue(undefined),
+    validateAgentHooks: vi.fn().mockResolvedValue({ valid: true }),
+  }));
+
+  // --- api keys: agent runtime mints one; return a stub. ---
+  vi.doMock("@/services/api-key-service", () => ({
+    createApiKey: vi.fn().mockResolvedValue({ key: "rdv_test_key" }),
+  }));
+
+  // --- DI container: git-credential + github-account env. No bound account →
+  // the GitHubAccountEnvironment.create branch is never reached. ---
+  vi.doMock("@/infrastructure/container", () => ({
+    githubAccountRepository: {
+      findByProject: vi.fn().mockResolvedValue(null),
+      findDefault: vi.fn().mockResolvedValue(null),
+      getAccessToken: vi.fn().mockResolvedValue(null),
+    },
+    gitCredentialManager: {
+      buildSessionEnv: vi
+        .fn()
+        .mockResolvedValue({ toRecord: () => ({ GIT_TERMINAL_PROMPT: "0" }) }),
+    },
+  }));
+
+  // --- model-proxy token: capture the providerScope it's minted with. ---
+  vi.doMock("@/services/model-proxy-token-service", () => ({
+    issueProxyToken: vi.fn(async (opts: { providerScope?: string[] }) => {
+      proxyTokenOpts = opts;
+      return { token: "mp_test_token" };
+    }),
+  }));
+}
+
+/** Build a complete terminalSessions row by layering insert values over defaults. */
+function fullRow(over: Record<string, unknown>): Record<string, unknown> {
+  const now = new Date();
+  return {
+    id: "123e4567-e89b-12d3-a456-426614174000",
+    userId: "u1",
+    name: "Agent",
+    tmuxSessionName: "rdv-123e4567-e89b-12d3-a456-426614174000",
+    status: "active",
+    projectPath: "/p",
+    githubRepoId: null,
+    worktreeBranch: null,
+    worktreeType: null,
+    projectId: "folder-1",
+    profileId: null,
+    terminalType: "agent",
+    agentProvider: "claude",
+    agentExitState: "running",
+    agentExitCode: null,
+    agentExitedAt: null,
+    agentRestartCount: 0,
+    agentActivityStatus: null,
+    typeMetadata: null,
+    scopeKey: null,
+    parentSessionId: null,
+    pinned: false,
+    tabOrder: 0,
+    lastActivityAt: now,
+    createdAt: now,
+    updatedAt: now,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  // Default: folder/user preference default provider is codex (non-claude).
+  resolvedPreferences.defaultAgentProvider = "codex";
+  resolvedPreferences.defaultWorkingDirectory = "/p";
+  resolvedPreferences.agentProviderSettings = {};
+  installMocks();
+  // Enable the model-proxy so providerScopeFor(effectiveAgentProvider) runs.
+  process.env.RDV_MODEL_PROXY_ENABLED = "1";
+});
+
+afterEach(() => {
+  delete process.env.RDV_MODEL_PROXY_ENABLED;
+  vi.unstubAllEnvs();
+});
+
+describe("createSession provider resolution (remote-dev-u02r)", () => {
+  it("records the MERGED provider (codex) when input omits agentProvider for an agent session", async () => {
+    const { createSessionWithDedupFlag } = await import(
+      "@/services/session-service"
+    );
+
+    const { session } = await createSessionWithDedupFlag("u1", {
+      projectId: "folder-1",
+      name: "Agent",
+      terminalType: "agent",
+      // agentProvider intentionally OMITTED — folder default ("codex") applies.
+      autoLaunchAgent: true,
+    });
+
+    // DB row: agentProvider column follows the merged resolution.
+    expect(insertedValues).not.toBeNull();
+    expect(insertedValues!.agentProvider).toBe("codex");
+
+    // Durable resume binding: provider must be codex, NOT the old "claude".
+    // (Bug 1: a claude binding here would resume a codex chat with claude.)
+    const meta = JSON.parse(insertedValues!.typeMetadata as string) as {
+      resumeBinding?: { provider?: string };
+    };
+    expect(meta.resumeBinding?.provider).toBe("codex");
+
+    // Model-proxy scope: minted for openai (codex), not anthropic (claude).
+    expect(proxyTokenOpts).not.toBeNull();
+    expect(proxyTokenOpts!.providerScope).toEqual(["openai"]);
+
+    // Sanity: the mapped session surfaces the merged provider too.
+    expect(session.agentProvider).toBe("codex");
+  });
+
+  it("still records claude when neither input nor preference default is set", async () => {
+    // No preference default → merge falls back to "claude".
+    resolvedPreferences.defaultAgentProvider = undefined;
+    installMocks();
+
+    const { createSessionWithDedupFlag } = await import(
+      "@/services/session-service"
+    );
+
+    await createSessionWithDedupFlag("u1", {
+      projectId: "folder-1",
+      name: "Agent",
+      terminalType: "agent",
+      autoLaunchAgent: true,
+    });
+
+    expect(insertedValues!.agentProvider).toBe("claude");
+    const meta = JSON.parse(insertedValues!.typeMetadata as string) as {
+      resumeBinding?: { provider?: string };
+    };
+    expect(meta.resumeBinding?.provider).toBe("claude");
+    expect(proxyTokenOpts!.providerScope).toEqual(["anthropic"]);
+  });
+
+  it("honors an explicit input provider over the preference default", async () => {
+    // Folder default is codex (from beforeEach), but the client explicitly
+    // requests gemini — explicit input must win (OVERRIDE semantics).
+    const { createSessionWithDedupFlag } = await import(
+      "@/services/session-service"
+    );
+
+    await createSessionWithDedupFlag("u1", {
+      projectId: "folder-1",
+      name: "Agent",
+      terminalType: "agent",
+      agentProvider: "gemini",
+      autoLaunchAgent: true,
+    });
+
+    expect(insertedValues!.agentProvider).toBe("gemini");
+    const meta = JSON.parse(insertedValues!.typeMetadata as string) as {
+      resumeBinding?: { provider?: string };
+    };
+    expect(meta.resumeBinding?.provider).toBe("gemini");
+    expect(proxyTokenOpts!.providerScope).toEqual(["gemini"]);
+  });
+});

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -243,17 +243,7 @@ export async function createSessionWithDedupFlag(
     }
   }
 
-  // Build a partial session stub for the plugin to introspect if needed.
   const isAgentTerminal = terminalType === "agent" || terminalType === "loop";
-  const pluginSessionStub: Partial<TerminalSession> = {
-    id: sessionId,
-    userId,
-    name: input.name,
-    projectId: input.projectId,
-    profileId: input.profileId ?? null,
-    terminalType,
-    agentProvider: isAgentTerminal ? (input.agentProvider ?? "claude") : null,
-  };
 
   // Pre-resolve folder/user preferences so we can layer in per-provider
   // agentProviderSettings below. The legacy folder-level `startupCommand`
@@ -302,6 +292,22 @@ export async function createSessionWithDedupFlag(
         input.allowDangerousFlags ?? effectiveSettings.allowDangerous ?? false;
     }
   }
+
+  // Build a partial session stub for the plugin to introspect if needed.
+  // Constructed AFTER the merge so the provider exposed to server plugins
+  // matches what actually launches — `mergedAgentProvider` (input → folder/user
+  // default → "claude"), not the raw (possibly absent) `input.agentProvider`.
+  // The stub's only consumer is `plugin.createSession(pluginInput, …)` below,
+  // which runs after this point. (remote-dev-u02r, codex finding 2)
+  const pluginSessionStub: Partial<TerminalSession> = {
+    id: sessionId,
+    userId,
+    name: input.name,
+    projectId: input.projectId,
+    profileId: input.profileId ?? null,
+    terminalType,
+    agentProvider: isAgentTerminal ? (mergedAgentProvider ?? "claude") : null,
+  };
 
   // Pass to the plugin via a mutated input copy so agent-style plugins see
   // the merged provider/flags/allowDangerous. Non-agent plugins ignore the
@@ -944,6 +950,16 @@ export async function createSessionWithDedupFlag(
         // worktree the loser may have created. Currently unreachable in
         // practice (createWorktree sessions don't combine with scopeKey dedup),
         // but hardened to stay correct if they ever do. (remote-dev-u02r)
+        //
+        // SAFETY (codex finding 1): in a `scopeKey + createWorktree` race, the
+        // loser can be handed the WINNER's worktree path — `createBranchWithWorktree`
+        // in worktree-service reuses an existing valid worktree when `git worktree
+        // add` fails and the target path is already a git repo (see "If the target
+        // path already exists as a valid git worktree, reuse it", ~line 466-471).
+        // Force-removing that path would destroy the winner's ACTIVE worktree, so
+        // skip removal when the winner row already points at the same path. The
+        // session row stores the working path in `projectPath` (DB insert:
+        // `projectPath: workingPath ?? null`).
         const raceCleanup: Promise<void>[] = [
           TmuxService.killSession(tmuxSessionName).catch(() => {
             log.error("Failed to clean up orphaned tmux after race", {
@@ -951,7 +967,12 @@ export async function createSessionWithDedupFlag(
             });
           }),
         ];
-        if (createdWorktree && repoPath && workingPath) {
+        if (
+          createdWorktree &&
+          repoPath &&
+          workingPath &&
+          existingAfterRace[0].projectPath !== workingPath
+        ) {
           raceCleanup.push(
             WorktreeService.removeWorktree(repoPath, workingPath, true)
               .then(() => {}) // Discard result to match Promise<void> type

--- a/src/services/session-service.ts
+++ b/src/services/session-service.ts
@@ -559,13 +559,28 @@ export async function createSessionWithDedupFlag(
   // hooks into `~/.claude/settings.json`) from leaking into SSH sessions.
   const emitsExitEvents =
     TerminalTypeServerRegistry.get(terminalType)?.emitsExitEvents ?? false;
+  // First clause uses `mergedAgentProvider` for consistency with
+  // `effectiveAgentProvider` below. This is semantically identical to reading
+  // `input.agentProvider` here: for agent/loop the `terminalType` clauses
+  // already force `true`, and for every other terminal type
+  // `mergedAgentProvider === input.agentProvider` (it's only reassigned inside
+  // the agent/loop merge branch).
   const isAgentRuntime =
-    (input.agentProvider && input.agentProvider !== "none" && input.autoLaunchAgent) ||
+    (mergedAgentProvider && mergedAgentProvider !== "none" && input.autoLaunchAgent) ||
     input.terminalType === "agent" ||
     input.terminalType === "loop";
   const isAgentSession = isAgentRuntime || emitsExitEvents;
-  const effectiveAgentProvider = input.agentProvider && input.agentProvider !== "none"
-    ? input.agentProvider
+  // Derive the effective provider from the MERGED resolution, not raw
+  // `input.agentProvider`. For agent/loop sessions where the client omitted a
+  // provider, `mergedAgentProvider` folded in the folder/user default (→ "claude"
+  // as last resort), which is the provider that actually launches (plugin
+  // command) and is written to the DB row. Keying the durable resume binding,
+  // model-proxy scope, and claude-defaults gate off this — rather than off the
+  // raw input — keeps "what we recorded" in sync with "what we launched". For
+  // non-agent/loop types `mergedAgentProvider === input.agentProvider`, so this
+  // is semantics-preserving there. (remote-dev-u02r)
+  const effectiveAgentProvider = mergedAgentProvider && mergedAgentProvider !== "none"
+    ? mergedAgentProvider
     : "claude"; // Default matches DB default on line ~350
 
   // RDV env vars for agent hook callbacks (session ID + terminal server address)
@@ -923,12 +938,31 @@ export async function createSessionWithDedupFlag(
           scopeKey: input.scopeKey,
         });
         // Clean up the tmux/worktree resources we allocated for the
-        // losing-side INSERT — the winner already owns its own.
-        await TmuxService.killSession(tmuxSessionName).catch(() => {
-          log.error("Failed to clean up orphaned tmux after race", {
-            tmuxSessionName,
-          });
-        });
+        // losing-side INSERT — the winner already owns its own. Mirrors the
+        // generic cleanup block below (same guard + .catch + log.error, run
+        // concurrently) so the race-recovery return path doesn't leak a
+        // worktree the loser may have created. Currently unreachable in
+        // practice (createWorktree sessions don't combine with scopeKey dedup),
+        // but hardened to stay correct if they ever do. (remote-dev-u02r)
+        const raceCleanup: Promise<void>[] = [
+          TmuxService.killSession(tmuxSessionName).catch(() => {
+            log.error("Failed to clean up orphaned tmux after race", {
+              tmuxSessionName,
+            });
+          }),
+        ];
+        if (createdWorktree && repoPath && workingPath) {
+          raceCleanup.push(
+            WorktreeService.removeWorktree(repoPath, workingPath, true)
+              .then(() => {}) // Discard result to match Promise<void> type
+              .catch(() => {
+                log.error("Failed to clean up orphaned worktree after race", {
+                  worktreePath: workingPath,
+                });
+              })
+          );
+        }
+        await Promise.all(raceCleanup);
         return {
           session: mapDbSessionToSession(existingAfterRace[0]),
           reused: true,


### PR DESCRIPTION
## Summary
- `effectiveAgentProvider` in `createSessionWithDedupFlag` used raw `input.agentProvider`, diverging from the merged resolution (`input → folder default → user default → "claude"`) that the plugin launch command and the DB row use. When a client omitted `agentProvider` and the resolved default was non-claude (e.g. codex), the session launched codex and the DB said codex — but the durable resume binding, model-proxy `providerScope`, claude-defaults env gate, and debug log all recorded "claude". A terminal-server restart would then try to resume a codex conversation with the claude CLI. Now derived from `mergedAgentProvider` (semantics-preserving for non-agent/loop types, where merged ≡ input). `pluginSessionStub` construction moved after the merge for the same consistency (codex finding).
- Hardening: the scope-key INSERT-race recovery branch now also cleans up an orphaned loser-side worktree (matching the generic catch block) — guarded so it can NEVER remove the winner's worktree: worktree-service reuses an existing valid worktree path on retry, so the loser can hold the winner's path; removal is skipped when the winner row's `projectPath` equals the loser's `workingPath` (codex High).

## Key decisions
- Minimal swap to `mergedAgentProvider`; "none"-handling and the DB write untouched. The `isAgentRuntime` first clause also swapped — semantically identical in all reachable combinations (agent/loop forced true by terminalType clauses; merged ≡ input elsewhere).
- The generic catch block's identical reuse exposure is pre-existing and deliberately untouched.

## Test plan
- New `src/services/__tests__/session-service-provider-resolution.test.ts`: real plugin registry + real resume-binding builder over mocked I/O; asserts DB row + `resumeBinding.provider` + proxy scope follow merged resolution (omitted input + codex default; no defaults → claude; explicit gemini overrides codex default). Verified to FAIL on revert of the fix.
- Full suite: 2277 passed. `bun run build` clean. Typecheck/lint clean.

## Review chain
Codex adversarial review: 1 High (race cleanup could delete the winner's REUSED worktree — fixed with the projectPath guard), 1 Low (plugin stub provider — fixed by post-merge construction); explicitly checked clean: non-agent/loop regression surface, explicit-"none" semantics, isAgentRuntime clause equivalence, test pins the bug.

Closes remote-dev-u02r.

🤖 Generated with [Claude Code](https://claude.com/claude-code)