### PR TITLE
fix(beads): detail-pane error states, refresh, date guard, a11y (remote-dev-ougb)

### DIFF
--- a/src/components/beads/BeadsDependencyTree.tsx
+++ b/src/components/beads/BeadsDependencyTree.tsx
@@ -67,11 +67,12 @@ function DependencyNode({
       <div
         className="flex items-center gap-1.5 py-0.5 text-[11px] text-muted-foreground/50"
         style={{ paddingLeft: `${depth * 12 + 8}px` }}
+        title="Not in the loaded issue set — usually closed beyond the retention window"
       >
         <span className="font-mono text-[10px]">
           {shortenId(issueId)}
         </span>
-        <span>(not found)</span>
+        <span>(not loaded)</span>
       </div>
     );
   }
@@ -104,6 +105,8 @@ function DependencyNode({
         {hasChildren ? (
           <button
             onClick={() => setExpanded(!expanded)}
+            aria-expanded={expanded}
+            aria-label={expanded ? "Collapse" : "Expand"}
             className="shrink-0 text-muted-foreground hover:text-foreground"
           >
             {expanded ? (

--- a/src/components/beads/BeadsIssueDetail.tsx
+++ b/src/components/beads/BeadsIssueDetail.tsx
@@ -17,6 +17,7 @@ import {
   ChevronDown,
   ChevronRight,
   MessageSquare,
+  RefreshCw,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -38,6 +39,7 @@ import { CheckSquare } from "lucide-react";
 
 import { apiFetch } from "@/lib/api-fetch";
 function formatDate(date: Date): string {
+  if (!date || isNaN(date.getTime())) return "unknown";
   return date.toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
@@ -86,6 +88,9 @@ export function BeadsIssueDetail({
   const [comments, setComments] = useState<BeadsComment[]>([]);
   const [events, setEvents] = useState<BeadsEvent[]>([]);
   const [loadingDetails, setLoadingDetails] = useState(false);
+  const [detailsError, setDetailsError] = useState(false);
+  // Bumping this re-runs the fetch effect (retry / manual refresh)
+  const [reloadCounter, setReloadCounter] = useState(0);
 
   // Section collapse state
   const [descriptionExpanded, setDescriptionExpanded] = useState(true);
@@ -99,6 +104,7 @@ export function BeadsIssueDetail({
 
     async function fetchDetails() {
       setLoadingDetails(true);
+      setDetailsError(false);
       try {
         const res = await apiFetch(
           `/api/beads/${encodeURIComponent(issue.id)}/comments?includeEvents=true&projectPath=${encodeURIComponent(projectPath)}`
@@ -116,12 +122,14 @@ export function BeadsIssueDetail({
           } else {
             setComments([]);
             setEvents([]);
+            setDetailsError(true);
           }
         }
       } catch {
         if (!cancelled) {
           setComments([]);
           setEvents([]);
+          setDetailsError(true);
         }
       } finally {
         if (!cancelled) setLoadingDetails(false);
@@ -132,7 +140,7 @@ export function BeadsIssueDetail({
     return () => {
       cancelled = true;
     };
-  }, [issue.id, projectPath]);
+  }, [issue.id, projectPath, reloadCounter]);
 
   const hasDeps = issue.dependencies.length > 0 || issue.dependents.length > 0 || issue.parents.length > 0 || issue.children.length > 0;
 
@@ -212,6 +220,7 @@ export function BeadsIssueDetail({
         <div>
           <button
             onClick={() => setDescriptionExpanded(!descriptionExpanded)}
+            aria-expanded={descriptionExpanded}
             className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors w-full"
           >
             {descriptionExpanded ? (
@@ -302,6 +311,7 @@ export function BeadsIssueDetail({
             <div>
               <button
                 onClick={() => setDepsExpanded(!depsExpanded)}
+                aria-expanded={depsExpanded}
                 className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors w-full"
               >
                 {depsExpanded ? (
@@ -332,23 +342,36 @@ export function BeadsIssueDetail({
         <>
           <Separator />
           <div>
-            <button
-              onClick={() => setCommentsExpanded(!commentsExpanded)}
-              className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors w-full"
-            >
-              {commentsExpanded ? (
-                <ChevronDown className="w-3 h-3" />
-              ) : (
-                <ChevronRight className="w-3 h-3" />
-              )}
-              <MessageSquare className="w-3 h-3" />
-              Comments
-              {comments.length > 0 && (
-                <span className="ml-auto text-[10px] bg-muted px-1.5 py-0.5 rounded">
-                  {comments.length}
-                </span>
-              )}
-            </button>
+            <div className="flex items-center gap-1.5">
+              <button
+                onClick={() => setCommentsExpanded(!commentsExpanded)}
+                aria-expanded={commentsExpanded}
+                className="flex-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {commentsExpanded ? (
+                  <ChevronDown className="w-3 h-3" />
+                ) : (
+                  <ChevronRight className="w-3 h-3" />
+                )}
+                <MessageSquare className="w-3 h-3" />
+                Comments
+                {comments.length > 0 && (
+                  <span className="ml-auto text-[10px] bg-muted px-1.5 py-0.5 rounded">
+                    {comments.length}
+                  </span>
+                )}
+              </button>
+              <button
+                onClick={() => setReloadCounter((c) => c + 1)}
+                disabled={loadingDetails}
+                aria-label="Refresh comments"
+                className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <RefreshCw
+                  className={cn("w-3 h-3", loadingDetails && "animate-spin")}
+                />
+              </button>
+            </div>
             {commentsExpanded && (
               <div className="mt-1.5 space-y-2 pl-2">
                 {loadingDetails ? (
@@ -357,6 +380,18 @@ export function BeadsIssueDetail({
                     <span className="text-[11px] text-muted-foreground">
                       Loading...
                     </span>
+                  </div>
+                ) : detailsError ? (
+                  <div className="flex items-center gap-2">
+                    <p className="text-[11px] text-destructive py-1">
+                      Failed to load
+                    </p>
+                    <button
+                      onClick={() => setReloadCounter((c) => c + 1)}
+                      className="text-[11px] text-muted-foreground hover:text-foreground underline transition-colors"
+                    >
+                      Retry
+                    </button>
                   </div>
                 ) : comments.length === 0 ? (
                   <p className="text-[11px] text-muted-foreground italic py-1">
@@ -390,6 +425,7 @@ export function BeadsIssueDetail({
           <div>
             <button
               onClick={() => setAuditExpanded(!auditExpanded)}
+              aria-expanded={auditExpanded}
               className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors w-full"
             >
               {auditExpanded ? (
@@ -413,6 +449,18 @@ export function BeadsIssueDetail({
                     <span className="text-[11px] text-muted-foreground">
                       Loading...
                     </span>
+                  </div>
+                ) : detailsError ? (
+                  <div className="flex items-center gap-2">
+                    <p className="text-[11px] text-destructive py-1">
+                      Failed to load
+                    </p>
+                    <button
+                      onClick={() => setReloadCounter((c) => c + 1)}
+                      className="text-[11px] text-muted-foreground hover:text-foreground underline transition-colors"
+                    >
+                      Retry
+                    </button>
                   </div>
                 ) : events.length === 0 ? (
                   <p className="text-[11px] text-muted-foreground italic py-1">

--- a/src/components/beads/BeadsIssueDetail.tsx
+++ b/src/components/beads/BeadsIssueDetail.tsx
@@ -365,7 +365,7 @@ export function BeadsIssueDetail({
                 onClick={() => setReloadCounter((c) => c + 1)}
                 disabled={loadingDetails}
                 aria-label="Refresh comments"
-                className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+                className="shrink-0 text-muted-foreground hover:text-foreground transition-colors disabled:pointer-events-none"
               >
                 <RefreshCw
                   className={cn("w-3 h-3", loadingDetails && "animate-spin")}

--- a/src/components/beads/__tests__/BeadsDependencyTree.test.tsx
+++ b/src/components/beads/__tests__/BeadsDependencyTree.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { BeadsIssue, BeadsDependency } from "@/types/beads";
+
+import { BeadsDependencyTree } from "../BeadsDependencyTree";
+
+function makeDep(issueId: string, dependsOnId: string): BeadsDependency {
+  return {
+    issueId,
+    dependsOnId,
+    type: "blocks",
+    createdAt: new Date("2026-06-01T12:00:00Z"),
+    createdBy: "alice",
+  };
+}
+
+function makeIssue(
+  id: string,
+  title: string,
+  overrides: Partial<BeadsIssue> = {}
+): BeadsIssue {
+  return {
+    id,
+    title,
+    description: "",
+    status: "open",
+    priority: 2,
+    issueType: "task",
+    assignee: null,
+    owner: null,
+    createdAt: new Date("2026-06-01T12:00:00Z"),
+    createdBy: null,
+    updatedAt: new Date("2026-06-01T12:00:00Z"),
+    closedAt: null,
+    closeReason: null,
+    design: "",
+    acceptanceCriteria: "",
+    notes: "",
+    metadata: {},
+    labels: [],
+    dependencies: [],
+    dependents: [],
+    parents: [],
+    children: [],
+    ...overrides,
+  };
+}
+
+describe("BeadsDependencyTree", () => {
+  it("labels nodes missing from the loaded set as '(not loaded)' with an explanatory title", () => {
+    const root = makeIssue("rd-root", "Root issue", {
+      dependencies: [makeDep("rd-root", "rd-missing")],
+    });
+
+    render(
+      <BeadsDependencyTree
+        issue={root}
+        allIssues={[root]}
+        onNavigateToIssue={vi.fn()}
+      />
+    );
+
+    const label = screen.getByText("(not loaded)");
+    expect(label).toBeInTheDocument();
+    expect(label.closest("div")).toHaveAttribute(
+      "title",
+      "Not in the loaded issue set — usually closed beyond the retention window"
+    );
+    expect(screen.queryByText("(not found)")).not.toBeInTheDocument();
+  });
+
+  it("exposes aria-expanded and aria-label on the expand/collapse chevron", () => {
+    const grandchild = makeIssue("rd-c", "Issue C");
+    const child = makeIssue("rd-b", "Issue B", {
+      dependencies: [makeDep("rd-b", "rd-c")],
+    });
+    const root = makeIssue("rd-root", "Root issue", {
+      dependencies: [makeDep("rd-root", "rd-b")],
+    });
+
+    render(
+      <BeadsDependencyTree
+        issue={root}
+        allIssues={[root, child, grandchild]}
+        onNavigateToIssue={vi.fn()}
+      />
+    );
+
+    // Expanded by default at depth 0 → grandchild visible
+    expect(screen.getByText("Issue C")).toBeInTheDocument();
+
+    const chevron = screen.getByRole("button", { name: "Collapse" });
+    expect(chevron).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(chevron);
+
+    const collapsed = screen.getByRole("button", { name: "Expand" });
+    expect(collapsed).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Issue C")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/beads/__tests__/BeadsIssueDetail.test.tsx
+++ b/src/components/beads/__tests__/BeadsIssueDetail.test.tsx
@@ -118,6 +118,41 @@ describe("BeadsIssueDetail", () => {
     await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(2));
   });
 
+  it("shows loading (not a stale error) during an in-flight retry, with refresh disabled and spinning", async () => {
+    apiFetch.mockResolvedValueOnce(errorResponse());
+    renderDetail(makeIssue());
+
+    await waitFor(() =>
+      expect(screen.getByText("Failed to load")).toBeInTheDocument()
+    );
+
+    let resolveFetch!: (value: Response) => void;
+    apiFetch.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    // While the refetch is in flight: loading indicator replaces the error,
+    // and the refresh affordance is disabled + spinning.
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(screen.queryByText("Failed to load")).not.toBeInTheDocument();
+    const refresh = screen.getByRole("button", { name: "Refresh comments" });
+    expect(refresh).toBeDisabled();
+    expect(refresh.querySelector("svg")).toHaveClass("animate-spin");
+
+    resolveFetch(jsonResponse({ comments: [], events: [] }));
+
+    await waitFor(() =>
+      expect(screen.getByText("No comments")).toBeInTheDocument()
+    );
+    expect(refresh).toBeEnabled();
+    expect(refresh.querySelector("svg")).not.toHaveClass("animate-spin");
+  });
+
   it("renders 'unknown' instead of 'Invalid Date' for invalid dates", async () => {
     apiFetch.mockResolvedValue(jsonResponse({ comments: [], events: [] }));
     renderDetail(makeIssue({ createdAt: new Date("not-a-date") }));

--- a/src/components/beads/__tests__/BeadsIssueDetail.test.tsx
+++ b/src/components/beads/__tests__/BeadsIssueDetail.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BeadsIssue } from "@/types/beads";
+
+const apiFetch = vi.fn();
+vi.mock("@/lib/api-fetch", () => ({
+  apiFetch: (...args: unknown[]) => apiFetch(...args),
+}));
+
+import { BeadsIssueDetail } from "../BeadsIssueDetail";
+
+function jsonResponse(body: unknown) {
+  return { ok: true, json: async () => body } as unknown as Response;
+}
+
+function errorResponse() {
+  return { ok: false, status: 500, json: async () => ({}) } as unknown as Response;
+}
+
+function makeIssue(overrides: Partial<BeadsIssue> = {}): BeadsIssue {
+  return {
+    id: "rd-test1",
+    title: "Test issue",
+    description: "",
+    status: "open",
+    priority: 2,
+    issueType: "task",
+    assignee: null,
+    owner: null,
+    createdAt: new Date("2026-06-01T12:00:00Z"),
+    createdBy: null,
+    updatedAt: new Date("2026-06-01T12:00:00Z"),
+    closedAt: null,
+    closeReason: null,
+    design: "",
+    acceptanceCriteria: "",
+    notes: "",
+    metadata: {},
+    labels: [],
+    dependencies: [],
+    dependents: [],
+    parents: [],
+    children: [],
+    ...overrides,
+  };
+}
+
+function renderDetail(issue: BeadsIssue) {
+  return render(
+    <BeadsIssueDetail
+      issue={issue}
+      allIssues={[issue]}
+      projectPath="/tmp/project"
+      onNavigateToIssue={vi.fn()}
+    />
+  );
+}
+
+describe("BeadsIssueDetail", () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+  });
+
+  it("shows an error state with retry when the details fetch fails, and retry refetches", async () => {
+    apiFetch.mockResolvedValueOnce(errorResponse());
+    renderDetail(makeIssue());
+
+    await waitFor(() =>
+      expect(screen.getByText("Failed to load")).toBeInTheDocument()
+    );
+
+    apiFetch.mockResolvedValueOnce(
+      jsonResponse({
+        comments: [
+          {
+            id: "c1",
+            issueId: "rd-test1",
+            author: "alice",
+            text: "hello from a comment",
+            createdAt: "2026-06-02T10:00:00Z",
+          },
+        ],
+        events: [],
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("hello from a comment")).toBeInTheDocument()
+    );
+    expect(apiFetch).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText("Failed to load")).not.toBeInTheDocument();
+  });
+
+  it("shows the error state in the audit trail section too", async () => {
+    apiFetch.mockResolvedValue(errorResponse());
+    renderDetail(makeIssue());
+
+    await waitFor(() =>
+      expect(screen.getByText("Failed to load")).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^audit trail/i }));
+    expect(screen.getAllByText("Failed to load")).toHaveLength(2);
+  });
+
+  it("refetches comments via the refresh button", async () => {
+    apiFetch.mockResolvedValue(jsonResponse({ comments: [], events: [] }));
+    renderDetail(makeIssue());
+
+    await waitFor(() =>
+      expect(screen.getByText("No comments")).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh comments" }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(2));
+  });
+
+  it("renders 'unknown' instead of 'Invalid Date' for invalid dates", async () => {
+    apiFetch.mockResolvedValue(jsonResponse({ comments: [], events: [] }));
+    renderDetail(makeIssue({ createdAt: new Date("not-a-date") }));
+
+    expect(screen.getByText("Created unknown")).toBeInTheDocument();
+    expect(screen.queryByText(/Invalid Date/)).not.toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByText("No comments")).toBeInTheDocument()
+    );
+  });
+
+  it("exposes aria-expanded on every section toggle", async () => {
+    apiFetch.mockResolvedValue(jsonResponse({ comments: [], events: [] }));
+    renderDetail(
+      makeIssue({
+        dependencies: [
+          {
+            issueId: "rd-test1",
+            dependsOnId: "rd-dep1",
+            type: "blocks",
+            createdAt: new Date("2026-06-01T12:00:00Z"),
+            createdBy: "alice",
+          },
+        ],
+      })
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("No comments")).toBeInTheDocument()
+    );
+
+    const description = screen.getByRole("button", { name: "Description" });
+    expect(description).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(description);
+    expect(description).toHaveAttribute("aria-expanded", "false");
+
+    expect(
+      screen.getByRole("button", { name: /^dependencies/i })
+    ).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: /^comments/i })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+    expect(
+      screen.getByRole("button", { name: /^audit trail/i })
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+});


### PR DESCRIPTION
## Summary
- Comment/audit fetch failures now show an inline "Failed to load" + Retry instead of silently rendering "No comments" (remote-dev-ougb)
- Comments section gains a refresh affordance (RefreshCw, spins while loading); header restructured so toggle + refresh are sibling buttons (no nested-button HTML)
- `formatDate` guards invalid dates ("unknown" instead of literal "Invalid Date")
- `aria-expanded` on all detail section toggles; dependency-tree chevrons get `aria-expanded`/`aria-label`
- Dependency-tree nodes outside the loaded set read "(not loaded)" with a tooltip explaining retention pruning (was a misleading "(not found)")

Part of the 2026-06-09 bd-integration bugbash (plan: docs/claude/plans/2026-06-09-polish-bugbash-bd-visual.md).

## Test plan
- New unit tests: error+retry refetch, audit-trail error state, refresh refetch, in-flight retry state (loading replaces error; refresh disabled+spinning), invalid-date guard, aria-expanded coverage, not-loaded label, chevron a11y/collapse
- `bun run typecheck` / `bun run lint` / `bunx vitest run src/components/beads` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)