### PR TITLE
fix(beads): data correctness — blocked status, active-blocker semantics, dolt-unavailable state (remote-dev-y19x)

### DIFF
--- a/src/app/api/beads/[id]/comments/route.ts
+++ b/src/app/api/beads/[id]/comments/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse } from "@/lib/api";
 import { getIssueComments, getIssueEvents } from "@/services/beads-service";
 import { validateProjectPath } from "@/lib/beads-auth";
+import { isDoltUnavailable } from "@/lib/beads-db";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { createLogger } from "@/lib/logger";
@@ -38,13 +39,14 @@ export const GET = withApiAuth(async (request, { userId, params }) => {
     const comments = await getIssueComments(resolved, id);
     return NextResponse.json(comments);
   } catch (err) {
-    const msg = String(err);
     // Dolt server not running is expected — return empty rather than 500
-    if (msg.includes("ECONNREFUSED") || msg.includes("ETIMEDOUT")) {
-      log.debug("Dolt server not reachable, returning empty comments", { error: msg });
-      return NextResponse.json(includeEvents ? { comments: [], events: [] } : []);
+    if (isDoltUnavailable(err)) {
+      log.debug("Dolt server not reachable, returning empty comments", { error: String(err) });
+      return NextResponse.json(
+        includeEvents ? { comments: [], events: [], unavailable: true } : []
+      );
     }
-    log.error("getIssueComments failed", { error: msg });
+    log.error("getIssueComments failed", { error: String(err) });
     return errorResponse(err instanceof Error ? err.message : "Unknown error", 500);
   }
 });

--- a/src/app/api/beads/[id]/route.ts
+++ b/src/app/api/beads/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse } from "@/lib/api";
 import { getIssue } from "@/services/beads-service";
 import { validateProjectPath } from "@/lib/beads-auth";
+import { isDoltUnavailable } from "@/lib/beads-db";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { createLogger } from "@/lib/logger";
@@ -29,13 +30,15 @@ export const GET = withApiAuth(async (request, { userId, params }) => {
     if (!issue) return errorResponse("Issue not found", 404);
     return NextResponse.json(issue);
   } catch (err) {
-    const msg = String(err);
     // Dolt server not running is expected — the issue is simply unavailable
-    if (msg.includes("ECONNREFUSED") || msg.includes("ETIMEDOUT")) {
-      log.debug("Dolt server not reachable, treating issue as not found", { error: msg });
-      return errorResponse("Issue not found", 404);
+    if (isDoltUnavailable(err)) {
+      log.debug("Dolt server not reachable, treating issue as not found", { error: String(err) });
+      return NextResponse.json(
+        { error: "Issue not found", unavailable: true },
+        { status: 404 }
+      );
     }
-    log.error("getIssue failed", { error: msg });
+    log.error("getIssue failed", { error: String(err) });
     return errorResponse(err instanceof Error ? err.message : "Unknown error", 500);
   }
 });

--- a/src/app/api/beads/route.ts
+++ b/src/app/api/beads/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse } from "@/lib/api";
 import { getIssues } from "@/services/beads-service";
 import { validateProjectPath } from "@/lib/beads-auth";
+import { isDoltUnavailable } from "@/lib/beads-db";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { createLogger } from "@/lib/logger";
@@ -9,7 +10,7 @@ import type { BeadsStatus, BeadsIssueType } from "@/types/beads";
 
 const log = createLogger("api/beads");
 
-const VALID_STATUSES = new Set(["open", "in_progress", "closed", "deferred"]);
+const VALID_STATUSES = new Set(["open", "in_progress", "blocked", "closed", "deferred"]);
 const VALID_TYPES = new Set(["task", "bug", "feature", "epic", "chore", "message"]);
 
 export const GET = withApiAuth(async (request, { userId }) => {
@@ -51,13 +52,12 @@ export const GET = withApiAuth(async (request, { userId }) => {
 
     return NextResponse.json({ initialized: true, issues });
   } catch (err) {
-    const msg = String(err);
-    // Dolt server not running is expected — return empty rather than 500
-    if (msg.includes("ECONNREFUSED") || msg.includes("ETIMEDOUT")) {
-      log.debug("Dolt server not reachable, returning empty issues", { error: msg });
-      return NextResponse.json({ initialized: true, issues: [] });
+    // Dolt server not running is expected — flag it rather than 500
+    if (isDoltUnavailable(err)) {
+      log.debug("Dolt server not reachable, returning unavailable", { error: String(err) });
+      return NextResponse.json({ initialized: true, unavailable: true, issues: [] });
     }
-    log.error("getIssues failed", { error: msg });
+    log.error("getIssues failed", { error: String(err) });
     return errorResponse(err instanceof Error ? err.message : "Unknown error", 500);
   }
 });

--- a/src/app/api/beads/stats/route.ts
+++ b/src/app/api/beads/stats/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { withApiAuth, errorResponse } from "@/lib/api";
 import { getStats } from "@/services/beads-service";
 import { validateProjectPath } from "@/lib/beads-auth";
+import { isDoltUnavailable } from "@/lib/beads-db";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { createLogger } from "@/lib/logger";
@@ -42,13 +43,12 @@ export const GET = withApiAuth(async (request, { userId }) => {
     const stats = await getStats(resolved);
     return NextResponse.json(stats);
   } catch (err) {
-    const msg = String(err);
-    // Dolt server not running is expected — return empty rather than 500
-    if (msg.includes("ECONNREFUSED") || msg.includes("ETIMEDOUT")) {
-      log.debug("Dolt server not reachable, returning empty stats", { error: msg });
-      return NextResponse.json(EMPTY_STATS);
+    // Dolt server not running is expected — flag it rather than 500
+    if (isDoltUnavailable(err)) {
+      log.debug("Dolt server not reachable, returning empty stats", { error: String(err) });
+      return NextResponse.json({ ...EMPTY_STATS, unavailable: true });
     }
-    log.error("getStats failed", { error: msg });
+    log.error("getStats failed", { error: String(err) });
     return errorResponse(err instanceof Error ? err.message : "Unknown error", 500);
   }
 });

--- a/src/components/beads/BeadsSidebar.tsx
+++ b/src/components/beads/BeadsSidebar.tsx
@@ -421,12 +421,17 @@ export function BeadsSidebar({
   const epicProgressById = useMemo(() => {
     const map = new Map<string, { closed: number; total: number }>();
     for (const issue of issues) {
-      if (issue.issueType !== "epic" || issue.children.length === 0) continue;
+      if (issue.issueType !== "epic") continue;
+      // Dedupe by child id — the same pair can be linked via both 'child-of'
+      // and 'parent-child' rows (bd renamed the type in 1.0.5), and the dep
+      // loader keys its dedupe on type, so both rows survive.
+      const childIds = new Set(issue.children.map((child) => child.issueId));
+      if (childIds.size === 0) continue;
       let closedCount = 0;
-      for (const child of issue.children) {
-        if (issueMap.get(child.issueId)?.status === "closed") closedCount++;
+      for (const childId of childIds) {
+        if (issueMap.get(childId)?.status === "closed") closedCount++;
       }
-      map.set(issue.id, { closed: closedCount, total: issue.children.length });
+      map.set(issue.id, { closed: closedCount, total: childIds.size });
     }
     return map;
   }, [issues, issueMap]);

--- a/src/components/beads/BeadsSidebar.tsx
+++ b/src/components/beads/BeadsSidebar.tsx
@@ -17,12 +17,13 @@ import {
   RefreshCw,
   Circle,
   GitBranch,
+  Layers,
   PanelRightClose,
   PanelRightOpen,
-  Loader2,
   ArrowLeft,
   Clock,
   CircleOff,
+  ServerOff,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -32,15 +33,14 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import type {
-  BeadsIssue,
-} from "@/types/beads";
+import { hasActiveBlockers, type BeadsIssue } from "@/types/beads";
 import { BeadsIssueDetail } from "./BeadsIssueDetail";
 import {
   PRIORITY_COLORS,
   ISSUE_TYPE_ICONS,
   ISSUE_TYPE_COLORS,
   STATUS_COLORS,
+  DEP_CHIP_COLOR,
   shortenId,
 } from "./beads-constants";
 import { CheckSquare } from "lucide-react";
@@ -124,9 +124,11 @@ function SectionHeader({
 interface BeadsIssueRowProps {
   issue: BeadsIssue;
   onSelect: (issue: BeadsIssue) => void;
+  /** Child completion progress for epic rows ({closed, total}). */
+  epicProgress?: { closed: number; total: number };
 }
 
-function BeadsIssueRow({ issue, onSelect }: BeadsIssueRowProps) {
+function BeadsIssueRow({ issue, onSelect, epicProgress }: BeadsIssueRowProps) {
   const TypeIcon = ISSUE_TYPE_ICONS[issue.issueType] ?? CheckSquare;
   const typeColor = ISSUE_TYPE_COLORS[issue.issueType] ?? "text-muted-foreground";
   const priorityColor = PRIORITY_COLORS[issue.priority] ?? "bg-gray-500";
@@ -190,15 +192,23 @@ function BeadsIssueRow({ issue, onSelect }: BeadsIssueRowProps) {
             {depCount > 0 && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span className="flex items-center gap-0.5 text-[10px] text-orange-400">
+                  <span className={cn("flex items-center gap-0.5 text-[10px]", DEP_CHIP_COLOR)}>
                     <GitBranch className="w-2.5 h-2.5" />
                     {depCount}
                   </span>
                 </TooltipTrigger>
                 <TooltipContent side="top">
-                  {issue.dependencies.length} blocking, {issue.dependents.length} dependent
+                  Blocked by {issue.dependencies.length} · blocks {issue.dependents.length}
                 </TooltipContent>
               </Tooltip>
+            )}
+
+            {/* Epic child progress */}
+            {epicProgress && (
+              <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded">
+                <Layers className="w-2.5 h-2.5" />
+                {epicProgress.closed}/{epicProgress.total}
+              </span>
             )}
 
             {/* Labels (first 2) */}
@@ -234,7 +244,7 @@ export function BeadsSidebar({
   onScheduleTargetConsumed,
 }: BeadsSidebarProps) {
   const {
-    issues, stats, loading, error, initialized, projectPath, refreshIssues,
+    issues, stats, loading, error, initialized, unavailable, projectPath, refreshIssues,
     beadsSidebarCollapsed: dbCollapsed,
     beadsSidebarWidth: dbWidth,
     beadsSectionExpanded: dbSectionExpanded,
@@ -250,8 +260,9 @@ export function BeadsSidebar({
   const [collapsed, setCollapsed] = useState(dbCollapsed);
   const [width, setWidth] = useState(dbWidth);
 
-  // Selected issue for detail view (declared early so switchTab can reference it)
-  const [selectedIssue, setSelectedIssue] = useState<BeadsIssue | null>(null);
+  // Selected issue id for detail view (declared early so switchTab can reference it).
+  // Storing the id (not an object snapshot) keeps the detail pane live across refreshes.
+  const [selectedIssueId, setSelectedIssueId] = useState<string | null>(null);
 
   // Active tab state — seeded with SSR-safe default, hydrated from localStorage on mount.
   const [activeTab, setActiveTab] = useState<SidebarTab>("beads");
@@ -300,7 +311,7 @@ export function BeadsSidebar({
     setActiveTab(tab);
     setStoredTab(tab);
     // Clear issue detail when switching away from beads
-    if (tab !== "beads") setSelectedIssue(null);
+    if (tab !== "beads") setSelectedIssueId(null);
   }, []);
 
   // Auto-switch to schedules tab when a schedule target arrives
@@ -360,30 +371,65 @@ export function BeadsSidebar({
           inProgress.push(issue);
         } else if (
           issue.status === "open" &&
-          issue.dependencies.length === 0
+          !hasActiveBlockers(issue)
         ) {
-          // Ready = open with no blocking dependencies
+          // Ready = open with no still-active blocking dependencies
           ready.push(issue);
         } else {
-          // Open with blocking deps, or deferred
+          // Open with active blockers, stored 'blocked' status, or deferred
           open.push(issue);
         }
       }
+
+      // Most recently closed first; issues without a closedAt sort last.
+      const closedSorted = [...closed].sort((a, b) => {
+        if (a.closedAt && b.closedAt) return b.closedAt.getTime() - a.closedAt.getTime();
+        if (a.closedAt) return -1;
+        if (b.closedAt) return 1;
+        return 0;
+      });
 
       return {
         readyIssues: ready,
         inProgressIssues: inProgress,
         openIssues: open,
-        closedIssues: closed,
+        closedIssues: closedSorted,
       };
     }, [issues]);
 
+  // All non-closed issues (Ready + In Progress + Open buckets)
   const openCount = stats
-    ? (stats.open + stats.inProgress + stats.deferred)
+    ? (stats.total - stats.closed)
     : (readyIssues.length + openIssues.length + inProgressIssues.length);
 
   // O(1) lookup map for navigating to issues by ID
   const issueMap = useMemo(() => new Map(issues.map(i => [i.id, i])), [issues]);
+
+  // Derive the selected issue from the live list so the detail pane never
+  // shows a stale snapshot; if the issue is pruned, this returns null and the
+  // sidebar falls back to the list view.
+  const selectedIssue = useMemo(
+    () => (selectedIssueId ? issueMap.get(selectedIssueId) ?? null : null),
+    [selectedIssueId, issueMap]
+  );
+
+  const handleSelectIssue = useCallback((issue: BeadsIssue) => {
+    setSelectedIssueId(issue.id);
+  }, []);
+
+  // Child completion progress for epic rows
+  const epicProgressById = useMemo(() => {
+    const map = new Map<string, { closed: number; total: number }>();
+    for (const issue of issues) {
+      if (issue.issueType !== "epic" || issue.children.length === 0) continue;
+      let closedCount = 0;
+      for (const child of issue.children) {
+        if (issueMap.get(child.issueId)?.status === "closed") closedCount++;
+      }
+      map.set(issue.id, { closed: closedCount, total: issue.children.length });
+    }
+    return map;
+  }, [issues, issueMap]);
 
   // Listen for collapse state changes (cross-tab sync)
   useEffect(() => {
@@ -453,9 +499,8 @@ export function BeadsSidebar({
   // Navigate to a different issue from the detail view (e.g. clicking a dependency)
   const handleNavigateToIssue = useCallback(
     (issueId: string) => {
-      const target = issueMap.get(issueId);
-      if (target) {
-        setSelectedIssue(target);
+      if (issueMap.has(issueId)) {
+        setSelectedIssueId(issueId);
       }
     },
     [issueMap]
@@ -577,7 +622,7 @@ export function BeadsSidebar({
       <div className="flex items-center gap-2 px-3 h-10 shrink-0 border-b border-border">
         {selectedIssue && activeTab === "beads" ? (
           <button
-            onClick={() => setSelectedIssue(null)}
+            onClick={() => setSelectedIssueId(null)}
             className="text-muted-foreground hover:text-foreground transition-colors"
           >
             <ArrowLeft className="w-4 h-4" />
@@ -698,6 +743,27 @@ export function BeadsSidebar({
                   to get started
                 </p>
               </div>
+            ) : initialized && unavailable ? (
+              /* Dolt server unreachable */
+              <div className="flex flex-col items-center justify-center px-4 py-8 gap-2">
+                <ServerOff className="w-5 h-5 text-muted-foreground" />
+                <p className="text-xs text-muted-foreground text-center">
+                  bd&apos;s dolt server isn&apos;t reachable
+                </p>
+                <p className="text-[11px] text-muted-foreground text-center">
+                  Issues can&apos;t be loaded right now. Start bd in this
+                  project, then retry.
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-xs mt-2"
+                  onClick={() => refreshIssues()}
+                >
+                  <RefreshCw className="w-3 h-3 mr-1.5" />
+                  Retry
+                </Button>
+              </div>
             ) : issues.length === 0 && !loading ? (
               /* Empty state */
               <div className="flex items-center justify-center px-4 py-8">
@@ -730,7 +796,8 @@ export function BeadsSidebar({
                           <BeadsIssueRow
                             key={issue.id}
                             issue={issue}
-                            onSelect={setSelectedIssue}
+                            onSelect={handleSelectIssue}
+                            epicProgress={epicProgressById.get(issue.id)}
                           />
                         ))
                       )}
@@ -762,7 +829,8 @@ export function BeadsSidebar({
                           <BeadsIssueRow
                             key={issue.id}
                             issue={issue}
-                            onSelect={setSelectedIssue}
+                            onSelect={handleSelectIssue}
+                            epicProgress={epicProgressById.get(issue.id)}
                           />
                         ))
                       )}
@@ -791,7 +859,8 @@ export function BeadsSidebar({
                           <BeadsIssueRow
                             key={issue.id}
                             issue={issue}
-                            onSelect={setSelectedIssue}
+                            onSelect={handleSelectIssue}
+                            epicProgress={epicProgressById.get(issue.id)}
                           />
                         ))
                       )}
@@ -820,7 +889,8 @@ export function BeadsSidebar({
                           <BeadsIssueRow
                             key={issue.id}
                             issue={issue}
-                            onSelect={setSelectedIssue}
+                            onSelect={handleSelectIssue}
+                            epicProgress={epicProgressById.get(issue.id)}
                           />
                         ))
                       )}
@@ -831,13 +901,6 @@ export function BeadsSidebar({
             )}
           </div>
         </ScrollArea>
-      )}
-
-      {/* Loading overlay */}
-      {loading && issues.length > 0 && (
-        <div className="absolute inset-0 bg-card/50 flex items-center justify-center pointer-events-none">
-          <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
-        </div>
       )}
     </div>
   );

--- a/src/components/beads/beads-constants.ts
+++ b/src/components/beads/beads-constants.ts
@@ -49,6 +49,7 @@ export const ISSUE_TYPE_COLORS: Record<BeadsIssueType, string> = {
 export const STATUS_COLORS: Record<BeadsStatus, string> = {
   open: "text-muted-foreground",
   in_progress: "text-chart-2",
+  blocked: "text-orange-600 dark:text-orange-400",
   closed: "text-green-500",
   deferred: "text-muted-foreground/50",
 };
@@ -56,9 +57,13 @@ export const STATUS_COLORS: Record<BeadsStatus, string> = {
 export const STATUS_BADGE_STYLES: Record<BeadsStatus, string> = {
   open: "bg-muted text-muted-foreground",
   in_progress: "bg-chart-2/20 text-chart-2",
+  blocked: "bg-orange-400/20 text-orange-600 dark:text-orange-400",
   closed: "bg-green-500/20 text-green-500",
   deferred: "bg-muted text-muted-foreground/50",
 };
+
+/** Color for the dependency-count chip on issue rows. */
+export const DEP_CHIP_COLOR = "text-orange-600 dark:text-orange-400";
 
 /** Truncate a beads issue ID for display. */
 export function shortenId(id: string, maxLen = 12): string {

--- a/src/contexts/BeadsContext.tsx
+++ b/src/contexts/BeadsContext.tsx
@@ -10,8 +10,11 @@ import {
   useMemo,
   type ReactNode,
 } from "react";
-import type { BeadsIssue, BeadsStats } from "@/types/beads";
-import type { BeadsSectionExpandDefaults } from "@/types/preferences";
+import { hasActiveBlockers, type BeadsIssue, type BeadsStats } from "@/types/beads";
+import {
+  BEADS_SECTION_EXPAND_DEFAULTS,
+  type BeadsSectionExpandDefaults,
+} from "@/types/preferences";
 import { usePreferencesContext } from "./PreferencesContext";
 
 import { apiFetch } from "@/lib/api-fetch";
@@ -60,6 +63,8 @@ interface BeadsContextValue {
   error: string | null;
   /** Whether beads is initialized in the current project (.beads dir exists) */
   initialized: boolean;
+  /** Whether bd's dolt server was unreachable on the last load */
+  unavailable: boolean;
   /** The resolved project path used for queries */
   projectPath: string | null;
   /** Refresh issues from the API */
@@ -95,18 +100,12 @@ interface BeadsProviderProps {
   children: ReactNode;
 }
 
-const DEFAULT_SECTION_EXPANDED: BeadsSectionExpandDefaults = {
-  ready: true,
-  inProgress: true,
-  open: true,
-  closed: false,
-};
-
 export function BeadsProvider({ children }: BeadsProviderProps) {
   const [issues, setIssues] = useState<BeadsIssue[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [initialized, setInitialized] = useState(false);
+  const [unavailable, setUnavailable] = useState(false);
 
   const { currentPreferences, userSettings } = usePreferencesContext();
   const projectPath = currentPreferences.defaultWorkingDirectory || null;
@@ -116,7 +115,7 @@ export function BeadsProvider({ children }: BeadsProviderProps) {
   const beadsSidebarCollapsed = userSettings?.beadsSidebarCollapsed ?? true;
   const beadsSidebarWidth = userSettings?.beadsSidebarWidth ?? 320;
   const beadsClosedRetentionDays = userSettings?.beadsClosedRetentionDays ?? 7;
-  const beadsSectionExpanded = userSettings?.beadsSectionExpanded ?? DEFAULT_SECTION_EXPANDED;
+  const beadsSectionExpanded = userSettings?.beadsSectionExpanded ?? BEADS_SECTION_EXPAND_DEFAULTS;
 
   const abortRef = useRef<AbortController | null>(null);
 
@@ -125,12 +124,19 @@ export function BeadsProvider({ children }: BeadsProviderProps) {
     if (issues.length === 0) return null;
     const stats = { total: issues.length, open: 0, inProgress: 0, closed: 0, blocked: 0, ready: 0, deferred: 0 };
     for (const issue of issues) {
+      const activelyBlocked = hasActiveBlockers(issue);
       if (issue.status === "closed") stats.closed++;
       else if (issue.status === "in_progress") stats.inProgress++;
       else if (issue.status === "deferred") stats.deferred++;
-      else if (issue.status === "open" && issue.dependencies.length === 0) { stats.open++; stats.ready++; }
-      else stats.open++;
-      if (issue.dependencies.length > 0 && issue.status !== "closed") stats.blocked++;
+      else if (issue.status === "open") {
+        stats.open++;
+        // ready = open with no still-active blocking dependency
+        if (!activelyBlocked) stats.ready++;
+      }
+      // blocked = non-closed with stored 'blocked' status or an active blocker
+      if (issue.status !== "closed" && (issue.status === "blocked" || activelyBlocked)) {
+        stats.blocked++;
+      }
     }
     return stats;
   }, [issues]);
@@ -141,6 +147,7 @@ export function BeadsProvider({ children }: BeadsProviderProps) {
     if (!projectPath) {
       setIssues([]);
       setInitialized(false);
+      setUnavailable(false);
       return;
     }
 
@@ -166,15 +173,17 @@ export function BeadsProvider({ children }: BeadsProviderProps) {
 
       const data = await issuesRes.json();
 
-      // New response format: { initialized, issues }
+      // New response format: { initialized, unavailable?, issues }
       if (data && typeof data === "object" && "initialized" in data) {
         setInitialized(data.initialized);
+        setUnavailable(data.unavailable === true);
         setIssues(
           Array.isArray(data.issues) ? data.issues.map(hydrateIssue) : []
         );
       } else {
         // Legacy fallback: plain array response
         setInitialized(true);
+        setUnavailable(false);
         setIssues(
           Array.isArray(data) ? data.map(hydrateIssue) : []
         );
@@ -236,6 +245,7 @@ export function BeadsProvider({ children }: BeadsProviderProps) {
       loading,
       error,
       initialized,
+      unavailable,
       projectPath,
       refreshIssues,
       debouncedRefresh,
@@ -245,7 +255,7 @@ export function BeadsProvider({ children }: BeadsProviderProps) {
       beadsSectionExpanded,
       userSettingsLoaded,
     }),
-    [issues, computedStats, loading, error, initialized, projectPath, refreshIssues, debouncedRefresh,
+    [issues, computedStats, loading, error, initialized, unavailable, projectPath, refreshIssues, debouncedRefresh,
      beadsSidebarCollapsed, beadsSidebarWidth, beadsClosedRetentionDays, beadsSectionExpanded, userSettingsLoaded]
   );
 

--- a/src/contexts/BeadsContext.tsx
+++ b/src/contexts/BeadsContext.tsx
@@ -191,6 +191,9 @@ export function BeadsProvider({ children }: BeadsProviderProps) {
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
       setError(err instanceof Error ? err.message : "Unknown error");
+      // A real error supersedes any stale dolt-unavailable flag from a prior
+      // load — the two states must never be shown together.
+      setUnavailable(false);
     } finally {
       // Only clear loading if this controller wasn't aborted by a newer request
       if (!controller.signal.aborted) {

--- a/src/lib/beads-db.ts
+++ b/src/lib/beads-db.ts
@@ -88,3 +88,39 @@ export async function isBeadsAvailable(projectPath: string): Promise<boolean> {
     return false;
   }
 }
+
+/** Error codes that mean the dolt server itself is unreachable. */
+const UNAVAILABLE_CODES: ReadonlySet<string> = new Set([
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+]);
+
+/**
+ * True when an error indicates bd's dolt server is unreachable (not running /
+ * connection refused / DNS failure) rather than a genuine query failure.
+ * Walks `code`, the `cause` chain, and `AggregateError.errors`, with a
+ * message-text fallback for errors that don't carry a code.
+ */
+export function isDoltUnavailable(err: unknown): boolean {
+  const seen = new Set<unknown>();
+  const stack: unknown[] = [err];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === null || typeof current !== "object" || seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === "string" && UNAVAILABLE_CODES.has(code)) return true;
+    const cause = (current as { cause?: unknown }).cause;
+    if (cause) stack.push(cause);
+    if (current instanceof AggregateError) stack.push(...current.errors);
+  }
+  // Fallback: match the message text for errors that don't expose a code.
+  const msg = String(err);
+  for (const code of UNAVAILABLE_CODES) {
+    if (msg.includes(code)) return true;
+  }
+  return false;
+}

--- a/src/services/__tests__/beads-service.test.ts
+++ b/src/services/__tests__/beads-service.test.ts
@@ -1,14 +1,65 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   classifyDependency,
   groupDependencies,
+  getIssue,
+  getIssues,
+  getStats,
   BLOCKING_DEP_TYPES,
   STRUCTURAL_DEP_TYPES,
 } from "../beads-service";
-import type { BeadsDependency } from "@/types/beads";
+import { hasActiveBlockers, type BeadsDependency } from "@/types/beads";
+
+// Mock the dolt query layer so getIssues/getIssue/getStats are deterministic.
+type QueryCall = { sql: string; params: (string | number | null)[] };
+const queryCalls: QueryCall[] = [];
+let queryDispatch: (sql: string, params: (string | number | null)[]) => unknown[] = () => [];
+
+vi.mock("@/lib/beads-db", () => ({
+  beadsQuery: vi.fn(
+    async (_path: string, sql: string, params: (string | number | null)[] = []) => {
+      queryCalls.push({ sql, params });
+      return queryDispatch(sql, params);
+    }
+  ),
+}));
 
 function dep(issueId: string, dependsOnId: string, type: string): BeadsDependency {
   return { issueId, dependsOnId, type, createdAt: new Date(0), createdBy: "" };
+}
+
+/** Minimal dolt `issues` row for the service mappers. */
+function issueRow(overrides: { id: string; status?: string; issue_type?: string; closed_at?: Date | null }) {
+  return {
+    id: overrides.id,
+    title: overrides.id,
+    description: null,
+    design: null,
+    acceptance_criteria: null,
+    notes: null,
+    status: overrides.status ?? "open",
+    priority: 2,
+    issue_type: overrides.issue_type ?? "task",
+    assignee: null,
+    owner: null,
+    created_at: new Date(0),
+    created_by: null,
+    updated_at: new Date(0),
+    closed_at: overrides.closed_at ?? null,
+    close_reason: null,
+    metadata: null,
+  };
+}
+
+/** Minimal dolt `dependencies` row. */
+function depRow(issueId: string, dependsOnId: string, type: string) {
+  return {
+    issue_id: issueId,
+    depends_on_issue_id: dependsOnId,
+    type,
+    created_at: new Date(0),
+    created_by: null,
+  };
 }
 
 describe("classifyDependency", () => {
@@ -122,5 +173,225 @@ describe("groupDependencies", () => {
 
     // children keyed by epic
     expect(result.children.get("epic")).toHaveLength(1);
+  });
+});
+
+describe("getStats", () => {
+  beforeEach(() => {
+    queryCalls.length = 0;
+    queryDispatch = () => [];
+  });
+
+  it("computes ready via dedicated SQL and blocked from status + active blockers", async () => {
+    queryDispatch = (sql) => {
+      if (sql.includes("GROUP BY status")) {
+        return [
+          { status: "open", cnt: 5 },
+          { status: "in_progress", cnt: 2 },
+          { status: "blocked", cnt: 3 },
+          { status: "closed", cnt: 4 },
+          { status: "deferred", cnt: 1 },
+        ];
+      }
+      // Check NOT EXISTS (ready) before EXISTS (blocked) — both contain "EXISTS".
+      if (sql.includes("NOT EXISTS")) return [{ cnt: 2 }];
+      if (sql.includes("EXISTS")) return [{ cnt: 6 }];
+      return [];
+    };
+
+    const stats = await getStats("/proj");
+
+    // total = sum of all status counts, including stored 'blocked' rows
+    expect(stats.total).toBe(15);
+    // open = literal status='open' count only
+    expect(stats.open).toBe(5);
+    expect(stats.inProgress).toBe(2);
+    expect(stats.closed).toBe(4);
+    expect(stats.deferred).toBe(1);
+    // ready comes straight from the dedicated query, NOT open - blocked
+    expect(stats.ready).toBe(2);
+    expect(stats.blocked).toBe(6);
+    expect(stats.ready).not.toBe(Math.max(0, stats.open - stats.blocked));
+  });
+
+  it("ready SQL counts open issues without an active (non-closed) blocker", async () => {
+    await getStats("/proj");
+
+    const readyCall = queryCalls.find((c) => c.sql.includes("NOT EXISTS"));
+    expect(readyCall).toBeDefined();
+    expect(readyCall!.sql).toContain("i.status = 'open'");
+    expect(readyCall!.sql).toContain("b.status != 'closed'");
+    expect(readyCall!.params).toEqual([...BLOCKING_DEP_TYPES]);
+  });
+
+  it("blocked SQL counts non-closed issues with stored blocked status OR an active blocker", async () => {
+    await getStats("/proj");
+
+    const blockedCall = queryCalls.find((c) => c.sql.includes("i.status = 'blocked'"));
+    expect(blockedCall).toBeDefined();
+    expect(blockedCall!.sql).toContain("COUNT(DISTINCT i.id)");
+    expect(blockedCall!.sql).toContain("i.status != 'closed'");
+    expect(blockedCall!.sql).toContain("b.status != 'closed'");
+    expect(blockedCall!.params).toEqual([...BLOCKING_DEP_TYPES]);
+  });
+
+  it("returns zeroed stats for an empty database", async () => {
+    const stats = await getStats("/proj");
+    expect(stats).toEqual({
+      total: 0,
+      open: 0,
+      inProgress: 0,
+      closed: 0,
+      blocked: 0,
+      ready: 0,
+      deferred: 0,
+    });
+  });
+});
+
+describe("getIssues epic-children retention", () => {
+  beforeEach(() => {
+    queryCalls.length = 0;
+    queryDispatch = () => [];
+  });
+
+  it("applies the default retention predicate to the epic-children fetch", async () => {
+    queryDispatch = (sql) => {
+      if (sql.startsWith("SELECT * FROM issues WHERE (")) {
+        return [issueRow({ id: "epic-1", issue_type: "epic" })];
+      }
+      if (sql.includes("FROM dependencies WHERE type IN")) {
+        return [depRow("child-1", "epic-1", "parent-child")];
+      }
+      // Child fetch returns nothing — the child closed outside the window.
+      return [];
+    };
+
+    const issues = await getIssues("/proj");
+
+    const childCall = queryCalls.find((c) =>
+      c.sql.startsWith("SELECT * FROM issues WHERE id IN")
+    );
+    expect(childCall).toBeDefined();
+    expect(childCall!.sql).toContain(
+      "AND (status != 'closed' OR closed_at >= ? OR issue_type = 'epic')"
+    );
+    // params = child id + retention cutoff (same cutoff as the main query)
+    const mainCall = queryCalls[0];
+    expect(childCall!.params).toEqual(["child-1", mainCall.params[0]]);
+
+    // Ancient closed child stays excluded
+    expect(issues.map((i) => i.id)).toEqual(["epic-1"]);
+  });
+
+  it("keeps the explicit status filter (no retention predicate) when status is set", async () => {
+    queryDispatch = (sql) => {
+      if (sql.startsWith("SELECT * FROM issues WHERE status = ?")) {
+        return [issueRow({ id: "epic-1", issue_type: "epic", status: "closed" })];
+      }
+      if (sql.includes("FROM dependencies WHERE type IN")) {
+        return [depRow("child-1", "epic-1", "parent-child")];
+      }
+      return [];
+    };
+
+    await getIssues("/proj", { status: "closed" });
+
+    const childCall = queryCalls.find((c) =>
+      c.sql.startsWith("SELECT * FROM issues WHERE id IN")
+    );
+    expect(childCall).toBeDefined();
+    expect(childCall!.sql).toContain("AND status = ?");
+    expect(childCall!.sql).not.toContain("closed_at >= ?");
+    expect(childCall!.params).toEqual(["child-1", "closed"]);
+  });
+});
+
+describe("getIssues dependsOnStatus population", () => {
+  beforeEach(() => {
+    queryCalls.length = 0;
+    queryDispatch = () => [];
+  });
+
+  it("populates dependsOnStatus from in-set issues and a lookup for out-of-set blockers", async () => {
+    queryDispatch = (sql) => {
+      if (sql.startsWith("SELECT * FROM issues WHERE (")) {
+        return [
+          issueRow({ id: "a" }),
+          issueRow({ id: "b" }),
+          issueRow({ id: "d" }),
+        ];
+      }
+      if (sql.includes("FROM dependencies WHERE issue_id IN")) {
+        return [
+          depRow("a", "b", "blocks"),
+          depRow("a", "c", "blocks"),
+          depRow("d", "c", "blocks"),
+        ];
+      }
+      if (sql.startsWith("SELECT id, status FROM issues WHERE id IN")) {
+        // "c" closed long ago — outside the fetched set
+        return [{ id: "c", status: "closed" }];
+      }
+      return [];
+    };
+
+    const issues = await getIssues("/proj");
+    const byId = new Map(issues.map((i) => [i.id, i]));
+
+    // Out-of-set blocker statuses are fetched exactly once for the missing ids
+    const statusCall = queryCalls.find((c) =>
+      c.sql.startsWith("SELECT id, status FROM issues WHERE id IN")
+    );
+    expect(statusCall).toBeDefined();
+    expect(statusCall!.params).toEqual(["c"]);
+
+    const a = byId.get("a")!;
+    expect(a.dependencies).toHaveLength(2);
+    const aDepB = a.dependencies.find((depLink) => depLink.dependsOnId === "b")!;
+    const aDepC = a.dependencies.find((depLink) => depLink.dependsOnId === "c")!;
+    expect(aDepB.dependsOnStatus).toBe("open"); // in-set blocker
+    expect(aDepC.dependsOnStatus).toBe("closed"); // looked-up blocker
+
+    // dependents links carry the target's status too
+    const b = byId.get("b")!;
+    expect(b.dependents).toHaveLength(1);
+    expect(b.dependents[0].dependsOnStatus).toBe("open");
+
+    // Core correctness: stale dep rows with a closed blocker do NOT block
+    const d = byId.get("d")!;
+    expect(d.dependencies).toHaveLength(1);
+    expect(d.dependencies[0].dependsOnStatus).toBe("closed");
+    expect(hasActiveBlockers(d)).toBe(false);
+    expect(hasActiveBlockers(a)).toBe(true);
+  });
+});
+
+describe("getIssue dependsOnStatus population", () => {
+  beforeEach(() => {
+    queryCalls.length = 0;
+    queryDispatch = () => [];
+  });
+
+  it("resolves out-of-set blocker statuses for a single issue", async () => {
+    queryDispatch = (sql) => {
+      if (sql.startsWith("SELECT * FROM issues WHERE id = ?")) {
+        return [issueRow({ id: "a" })];
+      }
+      if (sql.includes("FROM dependencies WHERE issue_id = ?")) {
+        return [depRow("a", "c", "blocks")];
+      }
+      if (sql.startsWith("SELECT id, status FROM issues WHERE id IN")) {
+        return [{ id: "c", status: "closed" }];
+      }
+      return [];
+    };
+
+    const issue = await getIssue("/proj", "a");
+
+    expect(issue).not.toBeNull();
+    expect(issue!.dependencies).toHaveLength(1);
+    expect(issue!.dependencies[0].dependsOnStatus).toBe("closed");
+    expect(hasActiveBlockers(issue!)).toBe(false);
   });
 });

--- a/src/services/beads-service.ts
+++ b/src/services/beads-service.ts
@@ -138,6 +138,14 @@ interface StatusCountRow extends RowDataPacket {
   cnt: number;
 }
 
+interface IssueStatusRow extends RowDataPacket {
+  id: string;
+  status: string;
+}
+
+/** Max placeholders per IN (...) clause — dolt chokes on very large prepared statements. */
+const CHUNK_SIZE = 50;
+
 // ----- Mappers -----
 
 function mapIssue(
@@ -178,7 +186,10 @@ function mapIssue(
   };
 }
 
-function mapDependency(row: DependencyRow): BeadsDependency {
+function mapDependency(
+  row: DependencyRow,
+  statusById: Map<string, BeadsStatus>
+): BeadsDependency {
   return {
     issueId: row.issue_id,
     // Callers exclude null-target (wisp/external) rows before mapping, so depends_on_issue_id is effectively set here; ?? "" only satisfies the string type.
@@ -186,7 +197,37 @@ function mapDependency(row: DependencyRow): BeadsDependency {
     type: row.type,
     createdAt: row.created_at,
     createdBy: row.created_by ?? "",
+    dependsOnStatus: statusById.get(row.depends_on_issue_id ?? "") ?? null,
   };
+}
+
+/**
+ * Fill `known` with the statuses of every dependency target not already in the
+ * map (e.g. blockers closed long enough ago to fall outside the fetched set),
+ * so active-blocker semantics can distinguish live blockers from closed ones.
+ */
+async function resolveDependsOnStatuses(
+  projectPath: string,
+  deps: DependencyRow[],
+  known: Map<string, BeadsStatus>
+): Promise<void> {
+  const missing = [
+    ...new Set(
+      deps
+        .map((d) => d.depends_on_issue_id)
+        .filter((id): id is string => id !== null && id !== "" && !known.has(id))
+    ),
+  ];
+  for (let i = 0; i < missing.length; i += CHUNK_SIZE) {
+    const chunk = missing.slice(i, i + CHUNK_SIZE);
+    const ph = chunk.map(() => "?").join(",");
+    const rows = await beadsQuery<IssueStatusRow>(
+      projectPath,
+      `SELECT id, status FROM issues WHERE id IN (${ph})`,
+      chunk
+    );
+    for (const r of rows) known.set(r.id, r.status as BeadsStatus);
+  }
 }
 
 function mapComment(row: CommentRow): BeadsComment {
@@ -280,6 +321,11 @@ export async function getIssues(
       if (opts?.status) {
         childSql += ` AND status = ?`;
         childParams.push(opts.status);
+      } else {
+        // Same retention predicate as the default query above — without it,
+        // closed children outside the retention window reappear forever.
+        childSql += ` AND (status != 'closed' OR closed_at >= ? OR issue_type = 'epic')`;
+        childParams.push(cutoff);
       }
       if (opts?.issueType) {
         childSql += ` AND issue_type = ?`;
@@ -300,7 +346,6 @@ export async function getIssues(
 
   // Batch-load labels and dependencies in chunks to avoid dolt choking on
   // large IN (...) clauses with hundreds of prepared-statement placeholders.
-  const CHUNK_SIZE = 50;
   const labels: LabelRow[] = [];
   const deps: DependencyRow[] = [];
   const seenDepKeys = new Set<string>();
@@ -339,10 +384,18 @@ export async function getIssues(
     labelMap.set(l.issue_id, arr);
   }
 
+  // Resolve blocker statuses: issues already in the fetched set are known;
+  // any dependency target outside the set (e.g. long-closed blockers) is
+  // looked up so active-blocker semantics stay correct.
+  const statusById = new Map<string, BeadsStatus>(
+    issues.map((i) => [i.id, i.status as BeadsStatus])
+  );
+  await resolveDependsOnStatuses(projectPath, deps, statusById);
+
   // Group dependencies by semantic class
   const mappedDeps = deps
     .filter((d) => d.depends_on_issue_id)
-    .map(mapDependency);
+    .map((d) => mapDependency(d, statusById));
   const { dependencies, dependents, parents, children } = groupDependencies(mappedDeps);
 
   return issues.map((row) =>
@@ -383,9 +436,14 @@ export async function getIssue(
     ),
   ]);
 
+  const statusById = new Map<string, BeadsStatus>([
+    [row.id, row.status as BeadsStatus],
+  ]);
+  await resolveDependsOnStatuses(projectPath, deps, statusById);
+
   const mappedDeps = deps
     .filter((d) => d.depends_on_issue_id)
-    .map(mapDependency);
+    .map((d) => mapDependency(d, statusById));
   const grouped = groupDependencies(mappedDeps);
 
   return mapIssue(
@@ -423,19 +481,37 @@ export async function getIssueEvents(
 }
 
 export async function getStats(projectPath: string): Promise<BeadsStats> {
-  const [statusCounts, blockedCount] = await Promise.all([
+  const blockingTypesPh = [...BLOCKING_DEP_TYPES].map(() => "?").join(",");
+  // Subquery: does issue `i` have a blocking dep whose blocker is still active?
+  const activeBlockerExists = `EXISTS (
+    SELECT 1 FROM dependencies d
+    JOIN issues b ON b.id = d.depends_on_issue_id
+    WHERE d.issue_id = i.id
+      AND d.type IN (${blockingTypesPh})
+      AND b.status != 'closed'
+  )`;
+
+  const [statusCounts, blockedCount, readyCount] = await Promise.all([
     beadsQuery<StatusCountRow>(
       projectPath,
       `SELECT status, COUNT(*) as cnt FROM issues GROUP BY status`
     ),
+    // blocked = non-closed AND (stored 'blocked' status OR active blocking dep)
     beadsQuery<CountRow>(
       projectPath,
-      `SELECT COUNT(DISTINCT d.issue_id) as cnt
-       FROM dependencies d
-       JOIN issues blocked ON blocked.id = d.issue_id
-       JOIN issues blocker ON blocker.id = d.depends_on_issue_id
-       WHERE blocked.status != 'closed' AND blocker.status != 'closed'
-         AND d.type IN (${[...BLOCKING_DEP_TYPES].map(() => "?").join(",")})`,
+      `SELECT COUNT(DISTINCT i.id) as cnt
+       FROM issues i
+       WHERE i.status != 'closed'
+         AND (i.status = 'blocked' OR ${activeBlockerExists})`,
+      [...BLOCKING_DEP_TYPES]
+    ),
+    // ready = open AND no active blocking dep (computed directly, not by subtraction)
+    beadsQuery<CountRow>(
+      projectPath,
+      `SELECT COUNT(*) as cnt
+       FROM issues i
+       WHERE i.status = 'open'
+         AND NOT ${activeBlockerExists}`,
       [...BLOCKING_DEP_TYPES]
     ),
   ]);
@@ -447,20 +523,13 @@ export async function getStats(projectPath: string): Promise<BeadsStats> {
     total += row.cnt;
   }
 
-  const blocked = blockedCount[0]?.cnt ?? 0;
-  const open = counts["open"] ?? 0;
-  const inProgress = counts["in_progress"] ?? 0;
-
-  // "ready" = open issues that are NOT blocked
-  const ready = Math.max(0, open - blocked);
-
   return {
     total,
-    open,
-    inProgress,
+    open: counts["open"] ?? 0,
+    inProgress: counts["in_progress"] ?? 0,
     closed: counts["closed"] ?? 0,
-    blocked,
-    ready,
+    blocked: blockedCount[0]?.cnt ?? 0,
+    ready: readyCount[0]?.cnt ?? 0,
     deferred: counts["deferred"] ?? 0,
   };
 }

--- a/src/types/__tests__/beads.test.ts
+++ b/src/types/__tests__/beads.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import {
+  isActiveBlocker,
+  hasActiveBlockers,
+  type BeadsDependency,
+  type BeadsIssue,
+  type BeadsStatus,
+} from "../beads";
+
+function dep(dependsOnStatus?: BeadsStatus | null): BeadsDependency {
+  return {
+    issueId: "a",
+    dependsOnId: "b",
+    type: "blocks",
+    createdAt: new Date(0),
+    createdBy: "",
+    ...(dependsOnStatus !== undefined ? { dependsOnStatus } : {}),
+  };
+}
+
+function issue(dependencies: BeadsDependency[]): BeadsIssue {
+  return {
+    id: "a",
+    title: "a",
+    description: "",
+    status: "open",
+    priority: 2,
+    issueType: "task",
+    assignee: null,
+    owner: null,
+    createdAt: new Date(0),
+    createdBy: null,
+    updatedAt: new Date(0),
+    closedAt: null,
+    closeReason: null,
+    design: "",
+    acceptanceCriteria: "",
+    notes: "",
+    metadata: {},
+    labels: [],
+    dependencies,
+    dependents: [],
+    parents: [],
+    children: [],
+  };
+}
+
+describe("isActiveBlocker", () => {
+  it("treats a closed blocker as inactive", () => {
+    expect(isActiveBlocker(dep("closed"))).toBe(false);
+  });
+
+  it("treats open / in_progress / blocked / deferred blockers as active", () => {
+    expect(isActiveBlocker(dep("open"))).toBe(true);
+    expect(isActiveBlocker(dep("in_progress"))).toBe(true);
+    expect(isActiveBlocker(dep("blocked"))).toBe(true);
+    expect(isActiveBlocker(dep("deferred"))).toBe(true);
+  });
+
+  it("treats an unknown blocker status as active (conservative)", () => {
+    expect(isActiveBlocker(dep())).toBe(true);
+    expect(isActiveBlocker(dep(null))).toBe(true);
+  });
+});
+
+describe("hasActiveBlockers", () => {
+  it("returns false for an issue with no blocking deps", () => {
+    expect(hasActiveBlockers(issue([]))).toBe(false);
+  });
+
+  it("returns false when every blocker is closed (stale dep rows)", () => {
+    expect(hasActiveBlockers(issue([dep("closed"), dep("closed")]))).toBe(false);
+  });
+
+  it("returns true when at least one blocker is still active", () => {
+    expect(hasActiveBlockers(issue([dep("closed"), dep("open")]))).toBe(true);
+  });
+
+  it("returns true when a blocker status is unknown", () => {
+    expect(hasActiveBlockers(issue([dep()]))).toBe(true);
+  });
+});

--- a/src/types/beads.ts
+++ b/src/types/beads.ts
@@ -32,7 +32,7 @@ export interface BeadsIssue {
   children: BeadsDependency[];
 }
 
-export type BeadsStatus = "open" | "in_progress" | "closed" | "deferred";
+export type BeadsStatus = "open" | "in_progress" | "blocked" | "closed" | "deferred";
 export type BeadsIssueType = "task" | "bug" | "feature" | "epic" | "chore" | "message";
 
 export interface BeadsDependency {
@@ -41,6 +41,26 @@ export interface BeadsDependency {
   type: string;
   createdAt: Date;
   createdBy: string;
+  /**
+   * Status of the blocker issue (dependsOnId) at fetch time, when known.
+   * Optional/additive so consumers that don't need it compile unchanged.
+   */
+  dependsOnStatus?: BeadsStatus | null;
+}
+
+/**
+ * Whether a blocking dependency still gates its issue. The `dependencies`
+ * dolt table keeps rows after the blocker closes, so a dep only counts as
+ * blocking while the blocker issue is still active (non-closed).
+ */
+export function isActiveBlocker(dep: BeadsDependency): boolean {
+  // Unknown blocker status is treated as active (conservative).
+  return dep.dependsOnStatus !== "closed";
+}
+
+/** Whether an issue has at least one still-active blocking dependency. */
+export function hasActiveBlockers(issue: BeadsIssue): boolean {
+  return issue.dependencies.some(isActiveBlocker);
 }
 
 export interface BeadsComment {


### PR DESCRIPTION
## Summary
- Recognize bd's stored `blocked` status end-to-end (types, badge styles, API filter) — previously unstyled and miscounted as open (remote-dev-y19x)
- Ready/blocked now match `bd ready`: a blocking dep only counts while its blocker is non-closed (`dependsOnStatus` populated by the service; `isActiveBlocker`/`hasActiveBlockers` helpers); identical definitions in client stats, sidebar buckets, and `getStats` SQL (ready via NOT EXISTS, not subtraction)
- Epic-children augmentation honors the closed-retention window (old closed children no longer pile up in the Closed section forever)
- Dolt-server-down is now a distinct `unavailable` state with a Retry UI — the sidebar no longer claims "No issues. Run bd create" when the DB is simply unreachable; detection via error codes (`isDoltUnavailable`), not message strings
- Sidebar UX: removed the full-sidebar loading overlay that flashed over the Schedules tab on every WS-driven refresh; issue detail selection is id-derived so the pane live-updates instead of showing stale snapshots; Closed sorted by close time; epic rows show child progress; dep tooltip reads "Blocked by N · blocks M"

Part of the 2026-06-09 bd-integration bugbash (plan: docs/claude/plans/2026-06-09-polish-bugbash-bd-visual.md).

## Test plan
- New: active-blocker helper unit tests; getStats SQL behavior (incl. ready-not-by-subtraction); epic-child retention predicate (both paths); dependsOnStatus population with the stale-closed-blocker regression case
- `bun run typecheck` / `bun run lint` / full `bun run test:run` green (2381 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)