### PR TITLE
fix(beads): epic progress chip counts retention-pruned children as closed (remote-dev-xgif)

### DIFF
--- a/src/components/beads/BeadsSidebar.tsx
+++ b/src/components/beads/BeadsSidebar.tsx
@@ -33,7 +33,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { hasActiveBlockers, type BeadsIssue } from "@/types/beads";
+import {
+  hasActiveBlockers,
+  type BeadsDependency,
+  type BeadsIssue,
+} from "@/types/beads";
 import { BeadsIssueDetail } from "./BeadsIssueDetail";
 import {
   PRIORITY_COLORS,
@@ -84,6 +88,32 @@ function getStoredTab(): SidebarTab {
 
 function setStoredTab(val: SidebarTab) {
   localStorage.setItem("beads-sidebar-tab", val);
+}
+
+/**
+ * Child completion progress for an epic ({closed, total}).
+ *
+ * Dedupes by child id — the same pair can be linked via both 'child-of' and
+ * 'parent-child' rows (bd renamed the type in 1.0.5), and the dep loader keys
+ * its dedupe on type, so both rows survive.
+ *
+ * A child link whose target is NOT in `issueMap` counts as closed: the
+ * beads-service epic-children augmentation always loads non-closed children
+ * (`status != 'closed' OR closed_at >= cutoff OR issue_type = 'epic'`), so a
+ * not-loaded child can only be a retention-pruned closed issue.
+ */
+export function computeEpicProgress(
+  children: BeadsDependency[],
+  issueMap: Map<string, BeadsIssue>
+): { closed: number; total: number } {
+  const childIds = new Set(children.map((child) => child.issueId));
+  let closed = 0;
+  for (const childId of childIds) {
+    const target = issueMap.get(childId);
+    // Not loaded ⇒ retention-pruned closed (non-closed children always load).
+    if (!target || target.status === "closed") closed++;
+  }
+  return { closed, total: childIds.size };
 }
 
 interface SectionHeaderProps {
@@ -422,16 +452,9 @@ export function BeadsSidebar({
     const map = new Map<string, { closed: number; total: number }>();
     for (const issue of issues) {
       if (issue.issueType !== "epic") continue;
-      // Dedupe by child id — the same pair can be linked via both 'child-of'
-      // and 'parent-child' rows (bd renamed the type in 1.0.5), and the dep
-      // loader keys its dedupe on type, so both rows survive.
-      const childIds = new Set(issue.children.map((child) => child.issueId));
-      if (childIds.size === 0) continue;
-      let closedCount = 0;
-      for (const childId of childIds) {
-        if (issueMap.get(childId)?.status === "closed") closedCount++;
-      }
-      map.set(issue.id, { closed: closedCount, total: childIds.size });
+      const progress = computeEpicProgress(issue.children, issueMap);
+      if (progress.total === 0) continue;
+      map.set(issue.id, progress);
     }
     return map;
   }, [issues, issueMap]);

--- a/src/components/beads/__tests__/BeadsSidebar.test.ts
+++ b/src/components/beads/__tests__/BeadsSidebar.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import type { BeadsDependency, BeadsIssue } from "@/types/beads";
+
+import { computeEpicProgress } from "../BeadsSidebar";
+
+function makeIssue(overrides: Partial<BeadsIssue> = {}): BeadsIssue {
+  return {
+    id: "rd-child1",
+    title: "Child issue",
+    description: "",
+    status: "open",
+    priority: 2,
+    issueType: "task",
+    assignee: null,
+    owner: null,
+    createdAt: new Date("2026-06-01T12:00:00Z"),
+    createdBy: null,
+    updatedAt: new Date("2026-06-01T12:00:00Z"),
+    closedAt: null,
+    closeReason: null,
+    design: "",
+    acceptanceCriteria: "",
+    notes: "",
+    metadata: {},
+    labels: [],
+    dependencies: [],
+    dependents: [],
+    parents: [],
+    children: [],
+    ...overrides,
+  };
+}
+
+/** A structural child link as it appears in an epic's `children` array. */
+function makeChildLink(
+  childId: string,
+  type: string = "parent-child"
+): BeadsDependency {
+  return {
+    issueId: childId,
+    dependsOnId: "rd-epic1",
+    type,
+    createdAt: new Date("2026-06-01T12:00:00Z"),
+    createdBy: "bd",
+  };
+}
+
+function toMap(issues: BeadsIssue[]): Map<string, BeadsIssue> {
+  return new Map(issues.map((i) => [i.id, i]));
+}
+
+describe("computeEpicProgress", () => {
+  it("returns zero progress for an epic with no child links", () => {
+    expect(computeEpicProgress([], toMap([]))).toEqual({ closed: 0, total: 0 });
+  });
+
+  it("dedupes duplicate child-of + parent-child links for the same child", () => {
+    const children = [
+      makeChildLink("rd-a", "parent-child"),
+      makeChildLink("rd-a", "child-of"),
+      makeChildLink("rd-b", "parent-child"),
+    ];
+    const issueMap = toMap([
+      makeIssue({ id: "rd-a", status: "closed" }),
+      makeIssue({ id: "rd-b", status: "open" }),
+    ]);
+
+    expect(computeEpicProgress(children, issueMap)).toEqual({
+      closed: 1,
+      total: 2,
+    });
+  });
+
+  it("counts loaded-closed children but not loaded-open ones", () => {
+    const children = [
+      makeChildLink("rd-closed"),
+      makeChildLink("rd-open"),
+      makeChildLink("rd-wip"),
+    ];
+    const issueMap = toMap([
+      makeIssue({ id: "rd-closed", status: "closed" }),
+      makeIssue({ id: "rd-open", status: "open" }),
+      makeIssue({ id: "rd-wip", status: "in_progress" }),
+    ]);
+
+    expect(computeEpicProgress(children, issueMap)).toEqual({
+      closed: 1,
+      total: 3,
+    });
+  });
+
+  it("counts children missing from issueMap as closed (retention-pruned)", () => {
+    // The epic-children augmentation always loads non-closed children, so a
+    // not-loaded child can only be a retention-pruned closed issue.
+    const children = [
+      makeChildLink("rd-pruned1"),
+      makeChildLink("rd-pruned2"),
+      makeChildLink("rd-open"),
+    ];
+    const issueMap = toMap([makeIssue({ id: "rd-open", status: "open" })]);
+
+    expect(computeEpicProgress(children, issueMap)).toEqual({
+      closed: 2,
+      total: 3,
+    });
+  });
+
+  it("combines loaded-closed, open, and pruned-closed children (jvcx repro)", () => {
+    // 7 loaded-closed + 2 open + 8 pruned-closed = 15/17 complete; the chip
+    // previously rendered 7/17 because pruned children never counted.
+    const loadedClosed = Array.from({ length: 7 }, (_, i) =>
+      makeIssue({ id: `rd-closed${i}`, status: "closed" })
+    );
+    const open = Array.from({ length: 2 }, (_, i) =>
+      makeIssue({ id: `rd-open${i}`, status: "open" })
+    );
+    const children = [
+      ...loadedClosed.map((issue) => makeChildLink(issue.id)),
+      ...open.map((issue) => makeChildLink(issue.id)),
+      ...Array.from({ length: 8 }, (_, i) => makeChildLink(`rd-pruned${i}`)),
+    ];
+
+    expect(
+      computeEpicProgress(children, toMap([...loadedClosed, ...open]))
+    ).toEqual({ closed: 15, total: 17 });
+  });
+});


### PR DESCRIPTION
## Summary
Found verifying PR #407 in the live app: epic remote-dev-jvcx showed **7/17** while \`bd show\` says **15/17 complete**. The chip's total counts all child links, but closed only counted children present in the loaded issue map — children closed beyond the retention window are deliberately not loaded (y19x), so they never counted as closed.

Fix: a child link whose target is not loaded can only be a retention-pruned closed issue (the epic-children augmentation always loads non-closed children), so count not-loaded children as closed. Extracted \`computeEpicProgress\` as an exported pure helper with the inference documented.

## Test plan
- 5 new pure-helper tests incl. the exact live repro (7 loaded-closed + 2 open + 8 pruned → 15/17), dedupe across child-of/parent-child, open/in_progress not counted
- typecheck / lint / \`bunx vitest run src/components/beads\` green (13/13)
- Will re-verify the live sidebar shows 15/17 post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)