### PR TITLE
feat(docker): bake bd (beads) + dolt CLIs into the dev-env instance image (remote-dev-vpap)

### DIFF
--- a/.github/workflows/dev-env-image.yml
+++ b/.github/workflows/dev-env-image.yml
@@ -3,8 +3,9 @@
 # Build + smoke the "golden dev-env" Docker image (root Dockerfile, epic
 # remote-dev-oyej.7) on Node 24 BEFORE it is ever tagged/pushed. The runtime
 # stage bakes all 5 agent CLIs (claude, codex, gemini, opencode + best-effort
-# `agy`) plus sudo/apt; this workflow proves the image actually builds under CI
-# (network + Node-24 ABI) and that the 5-agent smoke gate passes.
+# `agy`) plus the beads stack (`bd` + `dolt`, remote-dev-vpap) and sudo/apt;
+# this workflow proves the image actually builds under CI (network + Node-24
+# ABI) and that the agent-CLI + bd/dolt smoke gate passes.
 #
 # SCOPE: build into the LOCAL daemon (`--load`) and smoke-test only. This
 # workflow deliberately does NOT push or tag any registry image — tagging/push
@@ -62,11 +63,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Smoke test — Node 24 + agent CLIs present
+      - name: Smoke test — Node 24 + agent CLIs + bd/dolt present
         timeout-minutes: 5
-        # Assert Node is v24 and the 4 hard-gated agent CLIs resolve on PATH.
-        # antigravity (`agy`) is BEST-EFFORT (its installer 404s) — intentionally
-        # NOT asserted here, mirroring the Dockerfile's build-time smoke gate. A
+        # Assert Node is v24 and the 4 hard-gated agent CLIs plus the beads
+        # stack (`bd` + `dolt`, remote-dev-vpap) resolve on PATH. antigravity
+        # (`agy`) is BEST-EFFORT (its installer 404s) — intentionally NOT
+        # asserted here, mirroring the Dockerfile's build-time smoke gate. A
         # non-zero exit from this command fails the job.
         #
         # `--entrypoint sh`: the image's entrypoint (docker/entrypoint.sh) starts
@@ -81,7 +83,9 @@ jobs:
               && command -v claude \
               && command -v codex \
               && command -v gemini \
-              && command -v opencode
+              && command -v opencode \
+              && command -v bd \
+              && command -v dolt
           '
 
       - name: Smoke test — RDV_IMAGE_FLAVOR is dev-env

--- a/Dockerfile
+++ b/Dockerfile
@@ -277,14 +277,34 @@ RUN set -eu; \
            fi \
     ) || echo "WARN: antigravity 'agy' install unavailable (installer URL 404); skipping — entrypoint auto-update will retry on a live box"
 
-# Build-time smoke check: fail the build if an agent CLI is missing from PATH so
-# a broken install surfaces here, not when an agent session can't find its CLI.
-# We check resolvability only (`command -v`) — NOT `<agent> --version`, which can
-# require auth/network and would make the build flaky. `agy` is intentionally
-# EXCLUDED: its installer is currently unavailable (see above), so gating on it
-# would fail every build.
+# Beads (`bd`) issue tracker + Dolt SQL CLI (remote-dev-vpap). Agents track
+# work with `bd`, and the app's beads sidebar reads the project's bd/dolt
+# stack — both binaries were MISSING on live instance pods (`command -v bd
+# dolt` → empty), so the sidebar could never connect. Bake them onto the
+# system PATH like the agent CLIs above. Both official installers fetch the
+# LATEST GitHub release (auto-updating per the global Docker policy, like the
+# npm + curl installs above) and derive the arch from `uname -m` internally
+# (amd64 + arm64), so nothing is hardcoded per-platform. This layer runs as
+# root (before `USER rdv`), so /usr/local/bin is writable and the dolt
+# installer's root requirement is satisfied:
+#   - beads installer (repo moved steveyegge→gastownhall; this is the README's
+#     documented URL): checksum-verifies the release asset against the
+#     release's checksums.txt, installs /usr/local/bin/bd + a `beads` symlink.
+#   - dolt installer: installs /usr/local/bin/dolt. bd manages
+#     `dolt sql-server` per-project; the binary just needs to be on PATH.
+# A silent installer failure (e.g. transient network → empty pipe into bash)
+# is caught by the `command -v bd` / `command -v dolt` smoke gate below.
+RUN curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash \
+    && curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash
+
+# Build-time smoke check: fail the build if an agent CLI (or the bd/dolt beads
+# stack) is missing from PATH so a broken install surfaces here, not when an
+# agent session can't find its CLI. We check resolvability only (`command -v`)
+# — NOT `<tool> --version`, which can require auth/network and would make the
+# build flaky. `agy` is intentionally EXCLUDED: its installer is currently
+# unavailable (see above), so gating on it would fail every build.
 RUN command -v claude && command -v codex && command -v gemini \
-    && command -v opencode
+    && command -v opencode && command -v bd && command -v dolt
 
 # [oyej] Golden dev-env image flavor (epic remote-dev-oyej.7). The runtime stage
 # above ALREADY bakes all 5 agent CLIs + sudo/apt + gh; this build-arg just lets


### PR DESCRIPTION
## Summary
Homelab instances (rdv-dev/rdv-demo) can never show beads issues: `command -v bd dolt` → both missing in the image, so the project-local `dolt sql-server` the beads sidebar reads can never exist. Bakes both CLIs into the runtime stage (root layer, before `USER rdv`):

- beads installer (repo moved steveyegge→gastownhall; README's documented URL) — checksum-verified release asset, arch from `uname -m`
- dolt official installer — `/usr/local/bin/dolt`

Build-time smoke gate and the dev-env-image CI smoke both extended to assert `bd` + `dolt` resolve (a silent installer failure can't slip through).

## Test plan
- Real build + smoke green via workflow_dispatch on this branch: https://github.com/btli/remote-dev/actions/runs/27263791767
- Post-merge: Forgejo */15 build → tpb5 auto-roll ships it to rdv-dev/rdv-demo; verify `command -v bd dolt` in-pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)