### PR TITLE
fix(sidebar): show the project tree when there are projects/groups but zero sessions

### DIFF
--- a/src/components/session/Sidebar.tsx
+++ b/src/components/session/Sidebar.tsx
@@ -32,6 +32,7 @@ import { usePortContext } from "@/contexts/PortContext";
 import { usePreferencesContext } from "@/contexts/PreferencesContext";
 import { useSessionMCP, useSessionMCPAutoLoad } from "@/contexts/SessionMCPContext";
 import { useSessionContext } from "@/contexts/SessionContext";
+import { useProjectTree } from "@/contexts/ProjectTreeContext";
 import { MCPServersSection } from "@/components/mcp";
 import { FilesSection } from "./FilesSection";
 import {
@@ -258,6 +259,12 @@ export function Sidebar({
   // Pulled from SessionContext (same source ProjectTreeSidebar uses) so the
   // collapsed rail can color agent icons by their real-time activity status.
   const { getAgentActivityStatus } = useSessionContext();
+  // Project/group counts decide whether the expanded sidebar shows the
+  // bare "No sessions" quick-start or the full tree. We must NOT hide the
+  // tree just because there are zero terminal sessions — a migrated
+  // instance (sessions never migrate) or a user who closed every session
+  // still has projects/groups to show. Same source ProjectTreeSidebar uses.
+  const { groups: projectTreeGroups, projects: projectTreeProjects } = useProjectTree();
 
   // Resize handlers
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
@@ -301,6 +308,15 @@ export function Sidebar({
   const { mcpSupported } = useSessionMCP();
 
   const activeSessions = sessions.filter((s) => s.status !== "closed");
+
+  // Show the first-run quick-start ONLY when the instance is truly empty for
+  // this user (no sessions AND no projects AND no groups). Otherwise render
+  // the project tree even with zero sessions. (P1: tree was hidden whenever
+  // activeSessions was empty — invisible projects on every migrated instance.)
+  const hasAnyTreeContent =
+    activeSessions.length > 0 ||
+    projectTreeProjects.length > 0 ||
+    projectTreeGroups.length > 0;
 
   // Empty the trash permanently. Used by the right-click affordance on the
   // footer Trash button; see remote-dev-mtv7.7.
@@ -616,7 +632,7 @@ export function Sidebar({
                 })}
               </div>
             )
-          ) : activeSessions.length === 0 ? (
+          ) : !hasAnyTreeContent ? (
             <div className="text-center py-8 px-2">
               <Terminal className="w-6 h-6 mx-auto text-muted-foreground mb-2" />
               <p className="text-xs text-muted-foreground mb-2">No sessions</p>

--- a/src/components/session/__tests__/sidebar-collapsed.test.tsx
+++ b/src/components/session/__tests__/sidebar-collapsed.test.tsx
@@ -50,6 +50,13 @@ vi.mock("@/contexts/SessionContext", () => ({
   }),
 }));
 
+// Sidebar reads the project/group counts from useProjectTree() to decide
+// whether the expanded body shows the tree or the empty state. The collapsed
+// rail never branches on it, but the hook still runs, so it must be mocked.
+vi.mock("@/contexts/ProjectTreeContext", () => ({
+  useProjectTree: () => ({ groups: [], projects: [] }),
+}));
+
 // ProjectTreeSidebar is heavy (consumes many contexts) and is never rendered
 // in collapsed mode anyway. Stub it out so we don't have to mock the world.
 vi.mock("../ProjectTreeSidebar", () => ({

--- a/src/components/session/__tests__/sidebar-empty-state.test.tsx
+++ b/src/components/session/__tests__/sidebar-empty-state.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Sidebar expanded-mode empty-state tests (P1: tree hidden with zero sessions).
+ *
+ * The expanded sidebar used to gate the project/group tree behind
+ * `activeSessions.length === 0`, rendering the "No sessions" quick-start
+ * INSTEAD of <ProjectTreeSidebar> whenever there were no open terminal
+ * sessions. That hid every project and group on freshly-migrated instances
+ * (terminal sessions never migrate) and for any user who closed all sessions.
+ *
+ * These tests verify the tree now renders whenever the user has any projects
+ * OR groups OR active sessions, and the bare quick-start only shows when the
+ * instance is truly empty for the user.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import type { TerminalSession } from "@/types/session";
+
+// Override the global PortContext mock from tests/setup.ts so Sidebar's call
+// to `activePorts.size` works. We don't need a real provider tree for this
+// component — every context it reads is mocked below.
+vi.mock("@/contexts/PortContext", () => ({
+  usePortContext: () => ({
+    allocations: [],
+    activePorts: new Set<number>(),
+  }),
+  usePortContextOptional: () => null,
+  PortProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@/contexts/ProfileContext", () => ({
+  useProfileContext: () => ({ profileCount: 0 }),
+}));
+
+vi.mock("@/contexts/PreferencesContext", () => ({
+  usePreferencesContext: () => ({
+    getNodePreferences: () => null,
+  }),
+}));
+
+vi.mock("@/contexts/SessionMCPContext", () => ({
+  useSessionMCP: () => ({ mcpSupported: false }),
+  useSessionMCPAutoLoad: () => undefined,
+}));
+
+vi.mock("@/contexts/SessionContext", () => ({
+  useSessionContext: () => ({
+    getAgentActivityStatus: () => "idle",
+  }),
+}));
+
+// Drive the project/group counts per test. Sidebar reads these (same source
+// ProjectTreeSidebar consumes) to decide between the tree and the empty state.
+let mockGroups: Array<{ id: string }> = [];
+let mockProjects: Array<{ id: string }> = [];
+vi.mock("@/contexts/ProjectTreeContext", () => ({
+  useProjectTree: () => ({ groups: mockGroups, projects: mockProjects }),
+}));
+
+// ProjectTreeSidebar is heavy (consumes many contexts). Stub it out so we can
+// simply assert presence/absence of the tree without mocking the world.
+vi.mock("../ProjectTreeSidebar", () => ({
+  ProjectTreeSidebar: () => <div data-testid="project-tree-sidebar" />,
+}));
+
+// FilesSection / MCPServersSection are conditionally rendered; stubbing keeps
+// the test focused on the body branch under test.
+vi.mock("../FilesSection", () => ({
+  FilesSection: () => null,
+}));
+
+vi.mock("@/components/mcp", () => ({
+  MCPServersSection: () => null,
+}));
+
+import { Sidebar } from "../Sidebar";
+
+function makeSession(overrides: Partial<TerminalSession> = {}): TerminalSession {
+  const now = new Date();
+  return {
+    id: "session-1",
+    userId: "user-1",
+    name: "My Shell",
+    tmuxSessionName: "rdv-session-1",
+    projectPath: null,
+    githubRepoId: null,
+    worktreeBranch: null,
+    worktreeType: null,
+    projectId: "project-1",
+    profileId: null,
+    terminalType: "shell" as TerminalSession["terminalType"],
+    agentProvider: null,
+    agentExitState: null,
+    agentExitCode: null,
+    agentExitedAt: null,
+    agentRestartCount: 0,
+    agentActivityStatus: null,
+    agentActivityStatusAt: null,
+    typeMetadata: null,
+    scopeKey: null,
+    parentSessionId: null,
+    status: "active",
+    pinned: false,
+    tabOrder: 0,
+    lastActivityAt: now,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function renderExpandedSidebar(opts: { sessions?: TerminalSession[] } = {}) {
+  return render(
+    <Sidebar
+      sessions={opts.sessions ?? []}
+      activeSessionId={null}
+      activeProjectId={null}
+      collapsed={false}
+      onCollapsedChange={vi.fn()}
+      projectHasRepo={() => false}
+      getFolderRepoStats={() => null}
+      onSessionClick={vi.fn()}
+      onSessionClose={vi.fn()}
+      onSessionRename={vi.fn()}
+      onSessionTogglePin={vi.fn()}
+      onSessionMove={vi.fn()}
+      onSessionReorder={vi.fn()}
+      onNewSession={vi.fn()}
+      onQuickNewSession={vi.fn()}
+      onNewAgent={vi.fn()}
+      onNewAgentWithProvider={vi.fn()}
+      onOpenAgentSettings={vi.fn()}
+      onProjectSettings={vi.fn()}
+      onProjectNewSession={vi.fn()}
+      onProjectNewAgent={vi.fn()}
+      onProjectNewAgentWithProvider={vi.fn()}
+      onProjectResumeClaudeSession={vi.fn()}
+      onProjectAdvancedSession={vi.fn()}
+      onProjectNewWorktree={vi.fn()}
+      onProjectNewSshSession={vi.fn()}
+      onProjectOpenSshSettings={vi.fn()}
+      onProjectOpenSecrets={vi.fn()}
+      onNewSshSession={vi.fn()}
+      onOpenSshSettings={vi.fn()}
+      trashCount={0}
+      onTrashOpen={vi.fn()}
+    />
+  );
+}
+
+describe("Sidebar expanded empty state (project tree visibility)", () => {
+  beforeEach(() => {
+    cleanup();
+    mockGroups = [];
+    mockProjects = [];
+  });
+
+  it("renders the project tree when projects exist but there are no active sessions", () => {
+    mockProjects = [{ id: "p1" }];
+    renderExpandedSidebar({ sessions: [] });
+    expect(screen.getByTestId("project-tree-sidebar")).toBeInTheDocument();
+    expect(screen.queryByText(/No sessions/i)).toBeNull();
+  });
+
+  it("renders the project tree when only groups exist and there are no active sessions", () => {
+    mockGroups = [{ id: "g1" }];
+    renderExpandedSidebar({ sessions: [] });
+    expect(screen.getByTestId("project-tree-sidebar")).toBeInTheDocument();
+    expect(screen.queryByText(/No sessions/i)).toBeNull();
+  });
+
+  it("renders the project tree when active sessions exist", () => {
+    // Counts are empty; an active session alone should still surface the tree.
+    renderExpandedSidebar({ sessions: [makeSession()] });
+    expect(screen.getByTestId("project-tree-sidebar")).toBeInTheDocument();
+    expect(screen.queryByText(/No sessions/i)).toBeNull();
+  });
+
+  it("shows the quick-start empty state only when truly empty", () => {
+    renderExpandedSidebar({ sessions: [] });
+    // No sessions AND no projects AND no groups → the bare quick-start.
+    expect(screen.getByText(/No sessions/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("project-tree-sidebar")).toBeNull();
+    // The create affordances must remain available in the empty state.
+    expect(
+      screen.getByRole("button", { name: /New Session/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Advanced options/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
A user with projects/groups but **no open terminal sessions** saw an empty 'No sessions' card and the **entire project tree was hidden** — `Sidebar.tsx` gated `<ProjectTreeSidebar>` behind `activeSessions.length === 0`. This hits **every migrated instance** (terminal sessions never migrate) and anyone who closes all sessions.

Verified live on rdv.joyful.house/homelab after the homelab migration: the browser's session calls return all projects/groups (HTTP 200, incl. the migrated `homelab`), no console errors — but the tree component never mounted.

## Fix
Render `<ProjectTreeSidebar>` whenever there are projects OR groups OR active sessions; show the bare quick-start only when truly empty:
```
const hasAnyTreeContent =
  activeSessions.length > 0 || projectTreeProjects.length > 0 || projectTreeGroups.length > 0;
```
Counts come from the same `useProjectTree()` context the tree consumes (Sidebar is inside `ProjectTreeProvider`). Collapsed branch unchanged (it never renders the tree; create affordance is in its always-present header). Quick-start's New Session / Advanced options preserved.

## Test plan
New `sidebar-empty-state.test.tsx` (4 cases: projects-no-sessions, groups-no-sessions, with-sessions, truly-empty). typecheck 0, lint 0 src, **2501 passed**, build compiles.

Found in the homelab migration bugbash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)