### PR TITLE
fix(migration): land migrated working tree on persistent RDV_DATA_DIR, not ephemeral $HOME

### DIFF
--- a/src/services/migration-import-files.test.ts
+++ b/src/services/migration-import-files.test.ts
@@ -14,7 +14,6 @@ import { promisify } from "node:util";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { eq } from "drizzle-orm";
 
@@ -54,6 +53,7 @@ import {
   type ImportBookkeeping,
 } from "./migration-import-service";
 import { users, profileGitIdentities, agentProfiles, migrationImports } from "@/db/schema";
+import { getProjectsDir } from "@/lib/paths";
 import type {
   ArchiveManifestEntry,
   BundleManifest,
@@ -282,8 +282,9 @@ describe("MigrationImportService file phase", () => {
     const { import: finalized, conflicts } = await finalizeImport(DEST_USER, JOB_ID);
     expect(finalized.status).toBe("completed");
 
-    // Working tree extracted to the REWRITTEN destination (~/projects/filesapp).
-    const destDir = join(homedir(), "projects", "filesapp");
+    // Working tree extracted to the REWRITTEN destination: the persistent
+    // projects root, getProjectsDir() = <RDV_DATA_DIR>/projects/filesapp.
+    const destDir = join(getProjectsDir(), "filesapp");
     expect(readFileSync(join(destDir, "hello.txt"), "utf8")).toBe(
       "hello from the source\n",
     );
@@ -434,7 +435,7 @@ describe("MigrationImportService file phase", () => {
     await pushChunks(tree);
 
     // The destination working dir already has user files in it.
-    const destDir = join(homedir(), "projects", "filesapp");
+    const destDir = join(getProjectsDir(), "filesapp");
     mkdirSync(destDir, { recursive: true });
     writeFileSync(join(destDir, "precious.txt"), "do not clobber");
 

--- a/src/services/migration-import-service.test.ts
+++ b/src/services/migration-import-service.test.ts
@@ -10,10 +10,11 @@
  * dialect module — see migration-test-db.ts), `@/db` mocked to point at it.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { existsSync } from "node:fs";
-import { homedir } from "node:os";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { and, eq } from "drizzle-orm";
+import { getProjectsDir } from "@/lib/paths";
 
 // Deterministic encryption key for the re-encryption round-trip assertions.
 process.env.AUTH_SECRET = "migration-import-test-secret";
@@ -387,14 +388,15 @@ describe("MigrationImportService", () => {
       .where(eq(triggerConfigs.projectId, SRC_PROJECT));
     expect(trigger.enabled).toBe(false);
 
-    // Working directory rewritten to this host's ~/projects/<basename>.
+    // Working directory rewritten to this host's persistent projects root
+    // (getProjectsDir() = <RDV_DATA_DIR>/projects/<basename>), NOT ephemeral $HOME.
     const [pref] = await handle.db
       .select()
       .from(nodePreferences)
       .where(
         and(eq(nodePreferences.ownerId, SRC_PROJECT), eq(nodePreferences.userId, DEST_USER)),
       );
-    const expectedDir = join(homedir(), "projects", "myapp");
+    const expectedDir = join(getProjectsDir(), "myapp");
     expect(pref.defaultWorkingDirectory).toBe(expectedDir);
     expect(pref.localRepoPath).toBe(expectedDir);
 
@@ -477,7 +479,7 @@ describe("MigrationImportService", () => {
   });
 
   it("suffixes the working directory when another project already uses it", async () => {
-    const contested = join(homedir(), "projects", "myapp");
+    const contested = join(getProjectsDir(), "myapp");
     await handle.db.insert(nodePreferences).values({
       id: "other-pref",
       ownerId: "other-project",
@@ -499,7 +501,48 @@ describe("MigrationImportService", () => {
           eq(nodePreferences.userId, DEST_USER),
         ),
       );
-    expect(pref.defaultWorkingDirectory).toBe(join(homedir(), "projects", "myapp-2"));
+    expect(pref.defaultWorkingDirectory).toBe(join(getProjectsDir(), "myapp-2"));
+  });
+
+  it("lands the working dir under the persistent RDV_DATA_DIR projects root, not $HOME", async () => {
+    // On a Shape-B (k8s) instance homedir()=/home/rdv is EPHEMERAL overlay
+    // storage wiped on every pod roll, while the persistent PVC is RDV_DATA_DIR.
+    // Point RDV_DATA_DIR at a dir OUTSIDE $HOME so the two roots can't coincide.
+    const persistentDir = mkdtempSync(join(tmpdir(), "rdv-persistent-"));
+    process.env.RDV_DATA_DIR = persistentDir;
+    try {
+      const result = await initAndImport();
+
+      const [pref] = await handle.db
+        .select()
+        .from(nodePreferences)
+        .where(
+          and(
+            eq(nodePreferences.ownerId, result.importedProjectId),
+            eq(nodePreferences.userId, DEST_USER),
+          ),
+        );
+      const projectsRoot = join(persistentDir, "projects");
+      expect(getProjectsDir()).toBe(projectsRoot);
+      expect(pref.defaultWorkingDirectory).toBe(join(projectsRoot, "myapp"));
+      expect(pref.defaultWorkingDirectory?.startsWith(`${projectsRoot}/`)).toBe(true);
+      expect(pref.localRepoPath).toBe(join(projectsRoot, "myapp"));
+      // Crucially: NOT rooted on ephemeral $HOME.
+      expect(pref.defaultWorkingDirectory?.startsWith(join(homedir(), "projects"))).toBe(
+        false,
+      );
+
+      // The stage-2 path map points at the persistent root too.
+      const row = await getImport(DEST_USER, JOB_ID);
+      const bookkeeping = JSON.parse(row!.optionsJson) as ImportBookkeeping;
+      expect(bookkeeping.pathMap?.["/Users/alice/dev/myapp"]).toBe(
+        join(projectsRoot, "myapp"),
+      );
+    } finally {
+      // Restore the per-test data dir (afterEach deletes RDV_DATA_DIR anyway).
+      process.env.RDV_DATA_DIR = handle.dir;
+      rmSync(persistentDir, { recursive: true, force: true });
+    }
   });
 
   it("upserts node preferences on (ownerId, ownerType, userId)", async () => {

--- a/src/services/migration-import-service.ts
+++ b/src/services/migration-import-service.ts
@@ -14,13 +14,13 @@
  *   directory itself is materialized by the stage-2 file transfer).
  * - all other child rows: fresh uuids, with in-bundle references
  *   (group→channel, message threads, task dependency edges) remapped.
- * - working directories: rewritten to `~/projects/<basename>` on this host;
- *   the source→destination path map is recorded for stage-2 extraction.
+ * - working directories: rewritten to `<RDV_DATA_DIR>/projects/<basename>` on
+ *   this host (the persistent projects root, `getProjectsDir()`); the
+ *   source→destination path map is recorded for stage-2 extraction.
  */
 import { createHash, randomUUID } from "node:crypto";
 import { createReadStream, createWriteStream, existsSync } from "node:fs";
 import { pipeline } from "node:stream/promises";
-import { homedir } from "node:os";
 import { basename, dirname } from "node:path";
 import {
   copyFile,
@@ -59,7 +59,7 @@ import {
   migrationImports,
 } from "@/db/schema";
 import { encrypt } from "@/lib/encryption";
-import { getMigrationStagingDir, getProfilesDir } from "@/lib/paths";
+import { getMigrationStagingDir, getProfilesDir, getProjectsDir } from "@/lib/paths";
 import { runtimeJoin as join } from "@/lib/dynamic-fs";
 import {
   ARCHIVE_NAMES,
@@ -436,7 +436,8 @@ export async function receiveChunk(
 
 /**
  * Rewrite a source working-directory path to this host:
- * `~/projects/<basename>`, suffixing `-2`/`-3`/… when another project's
+ * `<RDV_DATA_DIR>/projects/<basename>` (the persistent projects root,
+ * `getProjectsDir()`), suffixing `-2`/`-3`/… when another project's
  * preferences already reference the candidate. `usedInRun` covers paths
  * assigned earlier in the same import.
  */
@@ -449,8 +450,7 @@ async function rewriteWorkingDir(
   const base = basename(sourcePath.replace(/\/+$/, "")) || "project";
   for (let attempt = 1; attempt < 100; attempt++) {
     const candidate = join(
-      homedir(),
-      "projects",
+      getProjectsDir(),
       attempt === 1 ? base : `${base}-${attempt}`,
     );
     if (usedInRun.has(candidate)) continue;
@@ -470,7 +470,7 @@ async function rewriteWorkingDir(
     }
   }
   // Pathological collision space — fall back to a unique suffix.
-  const fallback = join(homedir(), "projects", `${base}-${randomUUID().slice(0, 8)}`);
+  const fallback = join(getProjectsDir(), `${base}-${randomUUID().slice(0, 8)}`);
   usedInRun.add(fallback);
   return fallback;
 }
@@ -681,10 +681,10 @@ export async function importDb(
         let localRepoPath: string | null = null;
         if (pref.localRepoPath) {
           // Reuse the mapping when the repo path matches the working dir;
-          // otherwise rewrite it to its own ~/projects/<basename>.
+          // otherwise rewrite it to its own getProjectsDir()/<basename>.
           localRepoPath =
             pathMap[pref.localRepoPath] ??
-            join(homedir(), "projects", basename(pref.localRepoPath.replace(/\/+$/, "")));
+            join(getProjectsDir(), basename(pref.localRepoPath.replace(/\/+$/, "")));
           pathMap[pref.localRepoPath] = localRepoPath;
         }
         const values = {


### PR DESCRIPTION
## Problem (P1, `remote-dev-uyfl`)

Migrated projects' sessions open in `\$HOME` (`/home/rdv`) instead of the project directory. Surfaced live on `rdv.joyful.house/homelab`.

**Root cause:** `migration-import-service.ts`'s `rewriteWorkingDir()` computed the destination working-tree path as `join(homedir(), "projects", …)`. On a Shape-B (k8s) instance, `homedir()` = `/home/rdv` is **ephemeral overlay storage** (wiped on every pod roll), while the persistent NFS PVC is `RDV_DATA_DIR` = `/var/lib/rdv`, already surfaced by the app as `getProjectsDir()` (= `\${RDV_DATA_DIR}/projects`) and used by the directory picker, fresh projects, and sibling worktrees. The migration ignored it, so the working tree was extracted to ephemeral storage, recorded as the project's `defaultWorkingDirectory`, then **destroyed on the next image roll**. Session creation then ran `tmux new-session -c <gone-dir>`, which silently falls back to `\$HOME`.

## Fix

Use the app's canonical persistent projects root (`getProjectsDir()`) instead of `homedir()/projects` in all three rewrite spots (working dir, fallback, `localRepoPath`). Strictly better on every deployment shape — migrated trees now persist, matching fresh projects.

## Validation
- `bun run typecheck` — exit 0
- `bun run lint` — 0 errors
- `bun run test:run` (migration import/files/service) — 34/34 pass, incl. a new test asserting the dest working dir lands under `getProjectsDir()` (driven by `RDV_DATA_DIR`) and **not** under `\$HOME`

## Follow-up (separate, deeper — `remote-dev-u6p3`)
`\$HOME` itself is ephemeral on instances, so agent settings (`~/.claude`, `~/.codex`, `~/.gemini`) + agent session-resume history are also wiped on every roll. Needs a deploy/image fix (persist `\$HOME` on the PVC or point the agent config-dir env vars at it). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)