### PR TITLE
fix(instance): persist $HOME on the PVC + drop AppleDouble files from migration tars

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -37,6 +37,28 @@ export TMUX_TMPDIR="${RDV_DATA_DIR}/tmux"
 mkdir -p "$TMUX_TMPDIR"
 
 # ──────────────────────────────────────────────────────────────────────────
+# Persistent HOME (remote-dev-u6p3)
+#
+# $HOME (/home/rdv) is the EPHEMERAL container layer: agent CLIs keep their
+# config + credentials (~/.claude, ~/.claude.json, ~/.codex, ~/.gemini,
+# ~/.config/opencode) and Claude resume history (~/.claude/projects) under
+# $HOME, so every pod roll wipes agent logins. Relocate HOME onto the PVC so
+# it survives restarts. Seed it ONCE from the image's baked /home/rdv skeleton
+# (.bashrc/.profile + any baked defaults); thereafter the PVC copy is
+# authoritative (an existing dir is left untouched, preserving accumulated
+# agent state). Exported BEFORE the servers start, so both servers and every
+# child PTY (agent session) inherit it — see getCleanEnvironment() in
+# src/server/terminal.ts; the agent-profile env never overrides HOME. This
+# keeps node os.homedir(), the migration's agentSettingsDirs(), and the agent
+# CLIs all resolving to the same persistent location.
+export HOME="${RDV_DATA_DIR}/home"
+if [ ! -d "$HOME" ]; then
+    mkdir -p "$HOME"
+    # Best-effort skeleton seed; never fail the boot if the source is sparse.
+    cp -a /home/rdv/. "$HOME/" 2>/dev/null || true
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
 # Persistent package prefixes (remote-dev-uobt)
 #
 # Anything an agent installs at runtime normally lands on the EPHEMERAL container

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -47,7 +47,10 @@ export async function execFile(
   args: string[] = [],
   options?: {
     cwd?: string;
-    env?: NodeJS.ProcessEnv;
+    // Partial: merged as an OVERRIDE over a clean copy of process.env (see
+    // getCleanProcessEnv), so callers pass only the vars they want to set and
+    // need not re-supply required keys like NODE_ENV.
+    env?: Partial<NodeJS.ProcessEnv>;
     timeout?: number;
   }
 ): Promise<ExecResult> {
@@ -100,7 +103,10 @@ export async function execFileNoThrow(
   args: string[] = [],
   options?: {
     cwd?: string;
-    env?: NodeJS.ProcessEnv;
+    // Partial: merged as an OVERRIDE over a clean copy of process.env (see
+    // getCleanProcessEnv), so callers pass only the vars they want to set and
+    // need not re-supply required keys like NODE_ENV.
+    env?: Partial<NodeJS.ProcessEnv>;
     timeout?: number;
   }
 ): Promise<ExecResult> {
@@ -140,7 +146,10 @@ export function execFileCapped(
   args: string[] = [],
   options?: {
     cwd?: string;
-    env?: NodeJS.ProcessEnv;
+    // Partial: merged as an OVERRIDE over a clean copy of process.env (see
+    // getCleanProcessEnv), so callers pass only the vars they want to set and
+    // need not re-supply required keys like NODE_ENV.
+    env?: Partial<NodeJS.ProcessEnv>;
     timeout?: number;
     maxBytes?: number;
   }
@@ -222,7 +231,9 @@ export function spawnProcess(
   args: string[],
   options?: {
     cwd?: string;
-    env?: NodeJS.ProcessEnv;
+    // Partial: merged as an OVERRIDE over a clean copy of process.env (see
+    // getCleanProcessEnv), so callers pass only the vars they want to set.
+    env?: Partial<NodeJS.ProcessEnv>;
     onStdout?: (data: string) => void;
     onStderr?: (data: string) => void;
   }

--- a/src/services/migration-file-service.test.ts
+++ b/src/services/migration-file-service.test.ts
@@ -42,6 +42,7 @@ import {
   sha256File,
   sizePreview,
 } from "./migration-file-service";
+import * as exec from "@/lib/exec";
 import { CHUNK_SIZE_BYTES, type MigrationOptions } from "@/lib/migration-bundle";
 import { users, projects, nodePreferences, agentProfiles, projectProfileLinks } from "@/db/schema";
 
@@ -137,6 +138,27 @@ describe("MigrationFileService", () => {
     // readArchiveChunk(0) returns the whole (single-chunk) archive.
     const chunk = await readArchiveChunk(built.archivePaths["working-tree"]!, 0);
     expect(chunk.length).toBe(entry.sizeBytes);
+  });
+
+  it("tar invocations set COPYFILE_DISABLE=1 (no macOS AppleDouble ._* files)", async () => {
+    write("tree/src/index.ts", "code");
+    // Spy on the real execFile but delegate through to it, so the archive is
+    // still produced and we can inspect the options tar was invoked with.
+    const spy = vi.spyOn(exec, "execFile");
+
+    await buildArchives({
+      jobId: "job-copyfile",
+      workingDir: join(fixtureRoot, "tree"),
+      options: { ...OPTIONS, includeAgentSettings: false },
+      profiles: [],
+    });
+
+    const tarCalls = spy.mock.calls.filter(([command]) => command === "tar");
+    expect(tarCalls.length).toBeGreaterThan(0);
+    for (const [, , options] of tarCalls) {
+      expect(options?.env?.COPYFILE_DISABLE).toBe("1");
+    }
+    spy.mockRestore();
   });
 
   it("profiles archive excludes .cache always and .ssh unless includeSshKeys", async () => {

--- a/src/services/migration-file-service.ts
+++ b/src/services/migration-file-service.ts
@@ -146,7 +146,13 @@ async function tarCreate(
   await execFile(
     "tar",
     ["-czf", outFile, ...tarExcludeArgs(excludePatterns), "-C", cwd, "."],
-    { timeout: 10 * 60 * 1000 },
+    {
+      timeout: 10 * 60 * 1000,
+      // COPYFILE_DISABLE stops macOS bsdtar from emitting AppleDouble `._*`
+      // sidecar files that extract as junk on the Linux destination
+      // (remote-dev-awwu). No-op on GNU tar / Linux.
+      env: { COPYFILE_DISABLE: "1" },
+    },
   );
 }
 


### PR DESCRIPTION
Two P2 migration follow-ups.

## `remote-dev-u6p3` — instance `\$HOME` is ephemeral → agent logins wiped on every roll
On Shape-B k8s instances only `RDV_DATA_DIR=/var/lib/rdv` (NFS PVC) persists; `\$HOME=/home/rdv` is overlay storage wiped on every pod roll. Agent CLIs keep config/creds + Claude resume history under `\$HOME` (`~/.claude`, `~/.claude.json`, `~/.codex`, `~/.gemini`, `~/.config/opencode`, `~/.claude/projects`), so every roll forced re-login. **Fix:** relocate `HOME` to `\$RDV_DATA_DIR/home` in `docker/entrypoint.sh` (seeded once from the baked skeleton; existing dir left untouched). Exported before the servers start, so both servers and every child PTY inherit it — keeping `os.homedir()`, the migration's `agentSettingsDirs()`, and the agent CLIs all on the PVC. The deeper sibling of the working-dir fix (#417).

## `remote-dev-awwu` — migration tars ship macOS AppleDouble `._*` files
macOS bsdtar emitted `._*` resource-fork sidecars that extracted as junk (`._.git`, `._ansible`, …) on Linux destinations. **Fix:** `COPYFILE_DISABLE=1` on the migration `tarCreate` (no-op on GNU tar).

Also widened `@/lib/exec`'s `env?` option from `NodeJS.ProcessEnv` to `Partial<NodeJS.ProcessEnv>` (it's merged as an override over a clean base, so a partial is the accurate type — lets callers set one var without re-supplying `NODE_ENV`).

## Validation
- `bun run typecheck` exit 0 · `bun run lint` 0 errors · `migration-file-service.test.ts` 9/9 (incl. new test asserting every tar call sets `COPYFILE_DISABLE=1`) · `bash -n docker/entrypoint.sh` clean

Fixes remote-dev-u6p3, remote-dev-awwu

🤖 Generated with [Claude Code](https://claude.com/claude-code)