### PR TITLE
fix(migration): call undici fetch directly in peerFetch so the dispatcher is honored

### DIFF
--- a/src/lib/peer-fetch.test.ts
+++ b/src/lib/peer-fetch.test.ts
@@ -43,14 +43,18 @@ function makePeer(overrides: Partial<PeerTarget> = {}): PeerTarget {
  * A fetch double that records its args and returns a canned Response. The
  * recorded init is widened to expose the optional `dispatcher` (undici-only,
  * not on the DOM RequestInit) — the mock simply ignores it, like real tests do.
+ * It is typed to peerFetch's `fetchImpl` shape (a `string` URL + dispatcher-
+ * bearing init) rather than the global `fetch`, since peerFetch now defaults to
+ * undici's fetch and the global signature no longer matches the parameter.
  */
 type RecordedInit = (RequestInit & { dispatcher?: unknown }) | undefined;
+type FetchDouble = (url: string, init?: RecordedInit) => Promise<Response>;
 function fakeFetch(response = new Response("{}", { status: 200 })) {
   const calls: { url: string; init?: RecordedInit }[] = [];
-  const impl = (async (url: string | URL | Request, init?: RecordedInit) => {
+  const impl = (async (url: string, init?: RecordedInit) => {
     calls.push({ url: String(url), init });
     return response;
-  }) as unknown as typeof fetch;
+  }) as FetchDouble;
   return { impl, calls };
 }
 

--- a/src/lib/peer-fetch.ts
+++ b/src/lib/peer-fetch.ts
@@ -30,7 +30,7 @@
 import { Resolver } from "node:dns";
 import type { LookupFunction } from "node:net";
 
-import { Agent, type Dispatcher } from "undici";
+import { Agent, fetch as undiciFetch, type Dispatcher } from "undici";
 
 import { decrypt } from "@/lib/encryption";
 import { createLogger } from "@/lib/logger";
@@ -120,6 +120,21 @@ function getPublicDnsAgent(): Agent {
   return publicDnsAgent;
 }
 
+/**
+ * The minimal fetch signature peerFetch calls — a `string` URL plus an `init`
+ * that carries the undici-only `dispatcher` option (our public-DNS resolver for
+ * CF-fronted peers), returning a lib.dom `Response` (what {@link readPeerJson}
+ * consumes). Both undici's `fetch` and the global `fetch` are structurally
+ * compatible with this at the call boundary; the one genuine impedance mismatch
+ * (undici's distinct `Response`/`RequestInfo` nominal types) is absorbed by a
+ * single cast on the default value below. Injectable so tests can supply a
+ * double.
+ */
+type FetchLike = (
+  url: string,
+  init?: RequestInit & { dispatcher?: Dispatcher },
+) => Promise<Response>;
+
 /** The subset of a peer_instance row peerFetch needs. */
 export interface PeerTarget {
   id: string;
@@ -150,7 +165,14 @@ export async function peerFetch(
   peer: PeerTarget,
   path: string,
   init: RequestInit = {},
-  fetchImpl: typeof fetch = fetch,
+  // Default to undici's `fetch`, not the global. Next.js patches
+  // `globalThis.fetch` for its data cache and that patched fetch silently
+  // DROPS the undici-only `dispatcher` option — so our public-DNS resolver for
+  // CF-fronted peers would never apply and egress would hit the blocked LAN IP.
+  // Calling undici directly honors the dispatcher AND bypasses Next's
+  // fetch-cache (we never want server-to-server migration calls cached).
+  // `fetchImpl` stays injectable so tests can supply a double.
+  fetchImpl: FetchLike = undiciFetch as unknown as FetchLike,
 ): Promise<Response> {
   const label = peer.name?.trim() || peer.id;
 

--- a/src/services/peer-instance-service.ts
+++ b/src/services/peer-instance-service.ts
@@ -245,6 +245,9 @@ export async function verifyPeer(
     log.warn("Peer capabilities fetch failed", {
       peerId: id,
       error: String(error),
+      // undici hides the real network error (ECONNREFUSED, ENOTFOUND, TLS …)
+      // in error.cause; without this the log only shows "TypeError: fetch failed".
+      cause: String((error as { cause?: unknown })?.cause ?? ""),
     });
     throw error instanceof Error
       ? error


### PR DESCRIPTION
Follow-up to #422 (`remote-dev-6n4u`). #422 attached an undici `dispatcher` (public DNS for CF-fronted peers) but `peerFetch` used the **global `fetch`**, which Next.js patches for its data cache and which silently **drops the undici `dispatcher` option** — so the custom resolver never applied and egress still hit the blocked LAN IP.

**Fix:** `peerFetch` now uses undici's `fetch` directly (also correctly bypasses Next's fetch-cache for server-to-server calls). Verified out-of-band that undici `fetch` + the same Agent/dispatcher reaches the peer over Cloudflare's public edge (HTTP 401 — app admits past the edge). Also logs `error.cause` in `verifyPeer` (undici hides the real network error there).

## Validation
- `bun run typecheck` exit 0 · `bun run lint` 0 errors · `peer-fetch.test.ts` 16/16

Refs remote-dev-6n4u

🤖 Generated with [Claude Code](https://claude.com/claude-code)