### PR TITLE
fix(migration): unlink read-only targets before overwriting in agent-settings extract

### DIFF
--- a/src/services/migration-import-files.test.ts
+++ b/src/services/migration-import-files.test.ts
@@ -328,6 +328,42 @@ describe("MigrationImportService file phase", () => {
     expect(verify.ok).toBe(true);
   });
 
+  it("overwrites a READ-ONLY existing agent-settings file without EACCES", async () => {
+    // Agent settings can contain git repos (e.g. .claude/skills) whose
+    // .git/objects/** are mode 0444; a re-migration / baked ~/.claude leaves
+    // read-only targets in place. copyFile over a read-only file throws EACCES
+    // — finalize must unlink first and land the new content cleanly.
+    write("content_ro/file.txt", "tree");
+    const tree = await makeArchive("working-tree", join(fixtureRoot, "content_ro"), 1);
+
+    write("ascontent_ro/agent-settings/claude/settings.json", '{"new":true}');
+    const settings = await makeArchive("agent-settings", join(fixtureRoot, "ascontent_ro"), 1);
+
+    // Pre-existing READ-ONLY host file at the same dest path.
+    const dest = join(process.env.HOME!, ".claude/settings.json");
+    write("home/.claude/settings.json", '{"old":true}');
+    const { chmodSync } = await import("node:fs");
+    chmodSync(dest, 0o444);
+
+    try {
+      await initWithArchives([tree.entry, settings.entry]);
+      await pushChunks(tree);
+      await pushChunks(settings);
+
+      const { import: finalized, conflicts } = await finalizeImport(DEST_USER, JOB_ID);
+      expect(finalized.status).toBe("completed");
+      // The read-only target was replaced with the incoming content.
+      expect(readFileSync(dest, "utf8")).toBe('{"new":true}');
+      expect(
+        conflicts.some(
+          (c) => c.type === "file_overwritten" && c.detail === dest,
+        ),
+      ).toBe(true);
+    } finally {
+      if (existsSync(dest)) chmodSync(dest, 0o644);
+    }
+  });
+
   it("rejects a chunk whose sha256 does not match (tmp cleaned)", async () => {
     write("content2/file.txt", "data");
     const tree = await makeArchive("working-tree", join(fixtureRoot, "content2"), 1);

--- a/src/services/migration-import-service.ts
+++ b/src/services/migration-import-service.ts
@@ -1347,6 +1347,11 @@ async function extractAgentSettings(
       if (existsSync(destPath)) {
         overwrittenTotal++;
         if (overwritten.length < OVERWRITE_LIST_CAP) overwritten.push(destPath);
+        // copyFile fails with EACCES when the existing target is read-only
+        // (git object files are mode 0444; agent settings can contain git
+        // repos like .claude/skills). Unlink first — rm needs only parent-dir
+        // write, so it succeeds on read-only files — then copyFile writes fresh.
+        await rm(destPath, { force: true });
       }
       await mkdir(dirname(destPath), { recursive: true });
       await copyFile(join(providerRoot, rel), destPath);


### PR DESCRIPTION
## `remote-dev-2qqt` — finalize EACCES on read-only agent-settings overwrite

Found by a real E2E migration test. After the transfer fully succeeded over the public CF path (db_done + files_done), **finalize 500'd**:
```
EACCES: permission denied, copyfile … → /var/lib/rdv/home/.claude/skills/.git/objects/00/5515f5cb…
```
`extractAgentSettings` `copyFile`s curated settings over the destination's existing files; git object files are **read-only (0444)** (`.claude/skills` is a git repo), so `copyFile` can't overwrite them. Bites any re-migration or any destination with pre-existing `~/.claude`.

**Fix:** unlink the existing target (`rm(destPath,{force:true})`) before `copyFile` — `rm` needs only parent-dir write, so it works on read-only files. `extractProfiles` untouched (copies into fresh per-id dirs).

## Validation
- `bun run typecheck` exit 0 · `bun run lint` 0 errors · 23/23 tests, incl. a new test that reproduces the EACCES without the fix and passes with it (read-only dest file + finalize).

Destination-side change — requires an instance image roll.

Fixes remote-dev-2qqt

🤖 Generated with [Claude Code](https://claude.com/claude-code)