### PR TITLE
ci: adopt Forgejo-side buildx registry-mirror fixes (mirror reconciliation)

### DIFF
--- a/.github/workflows/dev-env-image.yml
+++ b/.github/workflows/dev-env-image.yml
@@ -46,6 +46,13 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          # Mirror docker.io → mirror.gcr.io: the shared-WAN-IP runners 429 on
+          # anonymous Docker Hub pulls; the docker-container buildx driver ignores
+          # the DinD daemon mirror, so set the buildkit mirror here too.
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
 
       - name: Build dev-env image (Node 24, load to local daemon)
         uses: docker/build-push-action@v7

--- a/.github/workflows/supervisor-router-e2e.yml
+++ b/.github/workflows/supervisor-router-e2e.yml
@@ -71,6 +71,13 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          # Mirror docker.io → mirror.gcr.io: the shared-WAN-IP runners 429 on
+          # anonymous Docker Hub pulls; the docker-container buildx driver ignores
+          # the DinD daemon mirror, so set the buildkit mirror here too.
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
Reconciles the diverged Forgejo mirror (`git.joyful.house/joyfulhouse/remote-dev`).

Two commits were made directly on the Forgejo side on Jun 13 and never reached GitHub, diverging the mirror and making every deploy's mirror-push step fail since. This cherry-picks them onto GitHub master (original authorship/messages preserved):

- `supervisor-router-e2e.yml`: buildkit `docker.io → mirror.gcr.io` mirror (shared-WAN-IP runners 429 on anonymous Docker Hub pulls; the docker-container buildx driver ignores the DinD daemon mirror)
- `dev-env-image.yml`: same fix

After merge, the Forgejo mirror will be force-aligned to GitHub master (its two unique commits are preserved here, plus an archive branch on the Forgejo side).

CI-only YAML change — no runtime code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)