### PR TITLE
fix(terminal): terminal resize-on-focus race — unified reconciliation coordinator (remote-dev-ah7q)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Terminal view not resizing on focus** — terminal sizing now flows through a single reconciliation coordinator with panel-aware focus signals, convergent tmux sizing, and deferred primary promotion across desktop and mobile clients. (remote-dev-ah7q)
 - **"Sync" after a Claude login did nothing** (remote-dev-n4x4.8) — `syncAccountFromCredentials()` read `<profileConfigDir>/.claude/.credentials.json`, but Claude Code writes credentials to the macOS Keychain under a service name derived from `CLAUDE_CONFIG_DIR`, so that file never exists (`find ~/.remote-dev/profiles -name .credentials.json` returns nothing) even when the profile *is* logged in. The read returned null, sync reported `loggedIn: false`, the completion callback never fired, and the button was silently dead — it had never worked on macOS with a current CLI. Identity is now read from `claude auth status --json` executed under the account's own env; credential files are never parsed. The stale `prepareFileBasedLogin()` hack (seeding an empty `.credentials.json` to force file-based creds, which also put refresh tokens in plaintext on disk) is deleted, along with `claude-login-service`, `POST|GET /api/profiles/:id/claude-login`, and the hardcoded `credentialMode: "file"` column.
 
 ### Removed

--- a/docs/claude/plans/2026-08-02-terminal-resize-reconciliation.md
+++ b/docs/claude/plans/2026-08-02-terminal-resize-reconciliation.md
@@ -1,0 +1,373 @@
+# Terminal Resize Reconciliation — Implementation Plan (v2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Per repo CLAUDE.md, all implementation happens in a git worktree (`./scripts/worktree-warm.sh` after creation).
+
+**bd issue:** `remote-dev-ah7q` (P1 epic)
+**RCA:** Joint investigation 2026-08-02 (Claude Fable 5 + Codex gpt-5.6-sol xhigh).
+**Review log:** v1 reviewed by Codex gpt-5.6-sol xhigh (verdict: needs-rework, 2 blockers / 8 majors / 3 minors). All 13 findings verified against the repo and incorporated below (v2). Key corrections: `visible` must thread through the **plugin client adapters** (not the unused `TerminalTypeRenderer`); tmux reassertion must be **forced on focus** (applied-size cache alone re-creates RC-F); `fit()` must report success (FitAddon silently no-ops); initial reconcile must be awaitable before `connect()`; focus-signal state must be panel-aware and socket-independent; promotion-defer needs identity-conditional bookkeeping; test env is **happy-dom**.
+
+**Goal:** Terminal grid, PTY size, and tmux window size converge to the visible terminal's container size on every focus/reveal — eliminating the "stale size until manual window resize" race class.
+
+**Architecture:** Replace the scattered, edge-triggered fit calls in `Terminal.tsx` with a single per-terminal **ResizeReconciler** (plain TS class, React-free, unit-testable) that owns all fitting, re-checks visibility after every async boundary, verifies fit success, commits its dedupe cache only after a verified visible fit, and queues desired dimensions for replay when the socket is closed. Add an explicit `visible` prop threaded from the two UI surfaces that hide terminals without unmounting (chat/terminal view toggle, Loop drawer) **through the plugin client adapters**. Introduce a **desired-focus-state** model so `client_focus`/`client_blur` reflect panel visibility and survive reconnects. On the server, make tmux sizing **convergent**: per-session desired/applied size with latest-wins serialization, forced reassertion on focus (even when already primary), and identity-conditional deferred promotion instead of silent cooldown drops.
+
+**Tech Stack:** TypeScript, React 19, xterm.js `@xterm/addon-fit` (`proposeDimensions()` + `fit()`), Vitest (**happy-dom**), Node `ws` terminal server, tmux.
+
+## Global Constraints
+
+- **No new dependencies.**
+- **Server logging:** `createLogger` only — never `console.*` in server code (repo CLAUDE.md).
+- **WS protocol compatibility:** existing message types (`resize`, `client_focus`, `client_blur`, `primary_changed`) keep their shapes; additions are optional fields only. Old clients keep working against the new server and vice versa. One documented compatibility exception: initial-URL dimension clamping (see T4 Step 3, finding #12).
+- **Mobile bridge contract preserved:** `TerminalRef.refit()` (rdv-bridge v4) keeps its public behavior. Verified unaffected paths: `TerminalWithKeyboard.refit()` forwards directly (`TerminalWithKeyboard.tsx:191`), `EmbeddedSessionView.tsx:403` exposes it; `RecordingPlayer.tsx` owns a separate xterm/FitAddon lifecycle; `PortAllocationsTab` contains no Terminal.
+- **Existing guard values preserved:** container minima 100×80 px, grid minima 10×3, settle stability 2 frames / max 10 frames, server resize coalesce 50 ms, promotion cooldown 1000 ms.
+- **Quality gates before merge:** `bun run lint && bun run typecheck && bun run test:run`.
+
+---
+
+## Root causes this plan must close (from the RCA)
+
+| # | Root cause | Evidence | Closed by task |
+|---|-----------|----------|----------------|
+| RC-A | ResizeObserver commits `lastWidth/lastHeight` *before* the 16 ms-debounced fit runs; hide-during-debounce loses the fit and an identical re-show is suppressed forever | `Terminal.tsx:1299-1304` | T1, T2 |
+| RC-B | `settleAndFit` guards are entry-only (TOCTOU): a terminal hidden mid-settle is still fitted, corrupting local xterm to 2×1 (FitAddon clamps zero boxes) | `Terminal.tsx:60-70`, `FitAddon.ts:84` | T1 |
+| RC-C | Chat↔terminal toggle and Loop drawer hide terminals via CSS with **no** refit trigger and no `isActive` change | `SessionManager.tsx:2377`, `TerminalDrawer.tsx:78` | T3 |
+| RC-D | `ws.onopen` and `initAndConnect` fit unguarded (can fit hidden / after 30 failed frames); URL accepts 2×1 initial dims that later resize validation rejects | `Terminal.tsx:879, 1158`, `terminal.ts:3040` | T2, T5 |
+| RC-E | Activation before async init completes is lost (null refs, no post-init replay) | `Terminal.tsx:365, 1452` | T2 |
+| RC-F | Server resize dedupe compares against `connection.lastCols`, not tmux's actual size; `client_focus` no-ops when already primary → externally-resized tmux is unrepairable | `terminal.ts:3350, 686` | T4 (forced reassert) |
+| RC-G | 1 s promotion-cooldown denial is silent with no retry; client focus dedupe never re-sends → wrong client keeps tmux sizing indefinitely | `terminal.ts:691`, `Terminal.tsx:1194` | T4, T2 (focus-state), T3 |
+| RC-H | `tmux resize-window` calls are unawaited/unserialized (stale command can land last) | `terminal.ts:650` | T4 |
+| RC-I | Resize computed while WS closed is discarded, not queued for replay on open | `Terminal.tsx:72` | T1, T2 |
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/components/terminal/resize-reconciler.ts` | Create | React-free reconciliation coordinator: epoch/generation settle loop, visibility gating, verified fits, commit-after-success cache, desired-dims queue |
+| `src/components/terminal/resize-reconciler.test.ts` | Create | Unit tests for every client-side RCA interleaving + no-op-fit + dispose/epoch |
+| `src/components/terminal/Terminal.tsx` | Modify | Delete `settleAndFit` + direct fit paths; instantiate reconciler; add `visible` prop; desired-focus-state; wire all triggers to `reconciler.request()` |
+| `src/components/terminal/TerminalWithKeyboard.tsx` | Modify | Thread `visible` prop (interface `:70-93`, pass-through `:269`) |
+| `src/types/terminal-type.ts` | Modify | Add `visible?: boolean` to `TerminalRenderProps` (`:321` area; inherited by `TerminalTypeClientComponentProps`, `terminal-type-client.ts:50`) |
+| `src/lib/terminal-plugins/plugins/shell-plugin-client.tsx` | Modify | Forward `visible` (explicit destructure at `:34` currently drops unknown props) |
+| `src/lib/terminal-plugins/plugins/agent-plugin-client.tsx` | Modify | Forward `visible` |
+| `src/lib/terminal-plugins/plugins/ssh-plugin-client.tsx` (and any other client adapter rendering TerminalWithKeyboard — grep `plugins/*-plugin-client.tsx`) | Modify | Forward `visible` |
+| `src/lib/terminal-plugins/plugins/loop-agent-plugin-client.tsx` | Modify | Forward `visible` as `parentVisible` to LoopChatPane |
+| `src/components/session/SessionManager.tsx` | Modify | Pass `visible={effectiveActiveView === "terminal"}` at the PluginComponent render (`:2413`) |
+| `src/components/loop/LoopChatPane.tsx` | Modify | Accept `parentVisible?: boolean`; pass `visible={parentVisible !== false && terminalVisible}` to its Terminal (`:323`) |
+| `src/server/tmux-size-controller.ts` | Create | Per-session desired/applied tmux size, latest-wins serialized `resize-window`, `force` reassertion, per-session epoch |
+| `src/server/__tests__/tmux-size-controller.test.ts` | Create | Unit tests with injected exec (repo convention: server tests live in `__tests__/`) |
+| `src/server/__tests__/promotion-defer.test.ts` | Create | Fake-timer tests for deferred promotion orderings |
+| `src/server/terminal.ts` | Modify | Use controller; promotion defer (identity-conditional); already-primary forced re-assert; clamp initial URL dims; extract promotion/pending logic into testable helpers |
+| `src/components/terminal/Terminal.refit.test.tsx` | Modify | Assert real reconciler behavior (v1 test used `scrollToBottom` as a proxy and a zero-size container, `:297`) |
+
+**Note (review finding #2):** `TerminalTypeRenderer.tsx` is NOT on the active render path — SessionManager dispatches through the plugin registry (`SessionManager.tsx:86` comment, `:2410`). Do not route the fix through it.
+
+---
+
+## Design: the reconciler contract
+
+```ts
+// src/components/terminal/resize-reconciler.ts
+export type ReconcileReason =
+  | "panel-visible" | "page-visible" | "window-focus" | "window-resize"
+  | "visual-viewport" | "resize-observer" | "font-change" | "socket-open"
+  | "post-init" | "active" | "refit" | "dpr-change";
+
+export interface FitResult { cols: number; rows: number; }
+
+export interface ReconcilerHost {
+  getContainer(): HTMLElement | null;
+  /** Verified fit (finding #5): call fitAddon.proposeDimensions(); if null or
+   *  below minima, return null WITHOUT fitting. Otherwise fit() and return the
+   *  resulting terminal cols/rows, which must equal the proposal (else null).
+   *  A null return means "fit did not happen" — never commit on null. */
+  fitVerified(): FitResult | null;
+  isPageVisible(): boolean;    // !document.hidden
+  isPanelVisible(): boolean;   // latest `visible` prop value (latest-value ref)
+  getWebSocket(): WebSocket | null;
+  onDimensions?(cols: number, rows: number): void;
+  raf(cb: () => void): number; // injectable for deterministic tests
+  caf(id: number): void;
+}
+
+export class ResizeReconciler {
+  constructor(host: ReconcilerHost, opts?: Partial<ReconcilerLimits>);
+  /** Any trigger. Coalesces; latest generation wins. Never fits while hidden —
+   *  a request while hidden is REMEMBERED and replayed on the next reveal. */
+  request(reason: ReconcileReason): void;
+  /** Awaitable one-shot reconcile for the pre-connect path (finding #7).
+   *  Resolves with the verified dims, or null if hidden/invalid at completion.
+   *  Runs through the same generation machinery as request(). */
+  reconcileOnce(reason: ReconcileReason): Promise<FitResult | null>;
+  /** From the `visible` prop effect. `false` aborts in-flight work AND
+   *  invalidates the committed rect so the next reveal always reconciles.
+   *  `true` always requests. */
+  notifyPanelVisibility(visible: boolean): void;
+  /** ResizeObserver feed. Debounce lives here; the observed rect is only
+   *  COMMITTED (for dedupe) after a verified visible fit. */
+  observeRect(width: number, height: number): void;
+  /** ws.onopen. Socket identity REQUIRED (finding #6): no-op if `socket` is
+   *  not the host's current socket. Replays desired dims if present, then
+   *  requests "socket-open" (covers the no-desired-dims-yet case). */
+  notifySocketOpen(socket: WebSocket): void;
+  getDesiredDims(): FitResult | null;
+  /** Increments the internal epoch, cancels all rAF/debounce work, and makes
+   *  every public method a permanent no-op (finding #6 / StrictMode). */
+  dispose(): void;
+}
+```
+
+**Invariant:** *when a terminal is active, initialized, connected, and measurably visible, DOM box == xterm grid == connection desired dims == PTY size == primary tmux window size, at the latest generation.*
+
+Implementation rules:
+
+1. **Visibility re-checked after every rAF boundary** — before each measurement and before the fit. Failure aborts the generation and sets `pendingWhileHidden = true`; it never falls through to a fit (RC-B).
+2. **Rect dedupe cache committed only after a verified visible fit** (`fitVerified()` non-null, ≥10×3). `notifyPanelVisibility(false)` clears the cache unconditionally (RC-A).
+3. **Desired dims persist.** Socket not OPEN at send time → store dims; `notifySocketOpen(socket)` replays them (RC-I).
+4. **Every entry point is a request.** No caller invokes fit directly (RC-D, RC-E).
+5. **Epoch discipline (finding #6):** every async continuation captures the epoch at scheduling time and self-cancels if it differs at execution time. A disposed instance can never mutate state or call host methods.
+
+## Design: desired focus state (finding #3)
+
+`Terminal.tsx` maintains a single derived focus intent, independent of socket readiness:
+
+```
+desiredFocus = panelVisible && !document.hidden && (windowFocused || xtermTextareaFocused)
+```
+
+- All existing signal sources (window focus/blur `Terminal.tsx:1254-1263`, visibilitychange `:1233`, textarea focus/blur `:1219`, the new `visible` prop) update the derived state; a single `syncFocusToServer()` sends `client_focus`/`client_blur` only when the derived state *changes* (replaces the raw `lastSentFocusStateRef` dedupe at `:1194`).
+- State survives sockets: `ws.onopen` flushes the **current derived state** (replacing the `document.hasFocus()`-only reconstruction at `:865-872`) *before* the reconciler's dim replay, so promotion precedes resize.
+- **A hidden panel never sends `client_focus`** — closes the "closed Loop drawer reclaims primary on window focus" hole and the hidden-`ws.onopen` hole (RC-C/RC-G interaction).
+- If the socket is not OPEN when the state changes, the state is simply retained; the next `onopen` flush delivers it (no lost blur/focus).
+- `refit()` keeps its force semantics: it re-sends the current state unconditionally (clears the "unchanged" suppression), preserving the rdv-bridge contract.
+
+## Design: server tmux-size controller (finding #1 amended)
+
+```ts
+// src/server/tmux-size-controller.ts
+export interface TmuxExec {
+  (args: string[], cb: (err: Error | null) => void): void; // wraps execFile("tmux", ...)
+}
+
+export class TmuxSizeController {
+  constructor(exec: TmuxExec, log: Logger);
+  /** Latest-wins serialized resize. `force: true` bypasses the applied-size
+   *  dedupe and always issues resize-window (used on focus/promotion —
+   *  tmux may have been resized externally; our applied cache is NOT ground
+   *  truth). Ordinary resize-message traffic uses the dedupe. */
+  requestResize(sessionId: string, tmuxSessionName: string, cols: number, rows: number, opts?: { force?: boolean }): void;
+  /** Called ONLY when the tmux session is confirmed gone (session kill path)
+   *  — NEVER on transient WS disconnect (finding #9; matches the existing
+   *  preserve-state cleanup at terminal.ts:772). Bumps the session epoch so
+   *  outstanding exec callbacks cannot mutate replacement state. */
+  clearSession(sessionId: string): void;
+  getAppliedSize(sessionId: string): { cols: number; rows: number } | null;
+}
+```
+
+`terminal.ts` integration:
+- All three `runTmuxResize` call sites (promotion `:701`, disconnect handoff `:807`, resize handler `:3366`) go through the controller; delete `runTmuxResize` (RC-H).
+- **Resize handler:** keep the 50 ms coalesce and PTY-resize skip-if-unchanged; **always** call `requestResize(...)` (non-forced) when primary — the controller's applied-size compare makes converged calls free.
+- **`tryPromoteToPrimary`:** on *any* accepted `client_focus` — including the `currentPrimary === connectionId` early-return path (`:686`) — call `requestResize(..., { force: true })` with the connection's latest dims. This is the RC-F closure: focus always reasserts tmux size regardless of every cache.
+- **Deferred promotion (finding #4, identity-conditional):**
+  - On cooldown denial: `sessionPendingPromotion.set(sessionId, connectionId)`; arm/re-arm ONE timer per session for the cooldown remainder.
+  - Timer fire: re-read the map; promote only if the mapped candidate (a) is still the mapped candidate, (b) exists in `connections`, (c) has an OPEN socket, and (d) `isVisible === true`. Otherwise drop silently.
+  - `client_blur`: clear pending **only if** the blurring connection is the mapped candidate.
+  - Disconnect cleanup: clear pending **only if** the disconnecting connection is the mapped candidate; cancel the timer only when clearing.
+  - Successful promotion (any path): clear pending + cancel timer.
+- **Initial URL dims (`:3040`, finding #12):** clamp positive-but-small (`0 < cols < 10 || 0 < rows < 3`) up to 10×3; use the 80×24 default only for absent/NaN/nonpositive values. Documented compatibility exception: an old client requesting 9×2 now gets 10×3 (previously honored) — strictly closer to its request than v1's 80×24 clamp.
+- **Session kill path only:** `tmuxSize.clearSession(sessionId)` where tmux is destroyed (DELETE/kill), not in `cleanupConnection`.
+
+---
+
+### Task T1: ResizeReconciler core + unit tests
+
+**Files:**
+- Create: `src/components/terminal/resize-reconciler.ts`
+- Test: `src/components/terminal/resize-reconciler.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (leaf module; DOM types only).
+- Produces: `ResizeReconciler`, `ReconcilerHost`, `ReconcileReason`, `FitResult` exactly as in the Design section. Constants exported: `SETTLE_MIN_WIDTH = 100`, `SETTLE_MIN_HEIGHT = 80`, `MIN_COLS = 10`, `MIN_ROWS = 3`, `SETTLE_STABLE_FRAMES = 2`, `SETTLE_MAX_FRAMES = 10`, `OBSERVER_DEBOUNCE_MS = 16` (moved from `Terminal.tsx:19-24`; Terminal imports them afterward).
+
+- [ ] **Step 1: Write failing tests.** Harness (finding #11): `FakeHost` with a manually-pumped rAF queue whose `pumpUntilIdle()` alternates one rAF callback with a microtask flush (`await Promise.resolve()`) until both the queue AND the reconciler's work state are idle — a purely synchronous drain can observe an empty queue between async continuations. Mutable `rect`/`panelVisible`/`pageVisible`; `fitVerified()` spy computing grid from rect with fake 8×16 cells, with a switchable **no-op mode** returning `null` while leaving the old grid in place; fake WS recording frames with settable `readyState` and distinct object identities for the stale-socket test. Cover at minimum:
+
+```ts
+it("RC-A: rect observed then hidden before debounce — re-show at same size still fits", async () => {
+  host.rect = { width: 800, height: 480 };
+  r.observeRect(800, 480);            // debounce armed, NOT committed
+  r.notifyPanelVisibility(false);      // aborts + clears committed cache
+  await vi.advanceTimersByTimeAsync(20);
+  expect(host.fitCalls).toBe(0);       // never fit hidden
+  r.notifyPanelVisibility(true);       // same 800×480 — must STILL reconcile
+  await host.pumpUntilIdle();
+  expect(host.sentResizes.at(-1)).toEqual({ type: "resize", cols: 100, rows: 30 });
+});
+
+it("RC-B: hide mid-settle aborts without fitting; reveal replays", async () => {
+  r.request("window-resize");
+  await host.pump(1);                  // inside the settle loop
+  r.notifyPanelVisibility(false);
+  await host.pumpUntilIdle();
+  expect(host.fitCalls).toBe(0);
+  r.notifyPanelVisibility(true);       // pendingWhileHidden must replay
+  await host.pumpUntilIdle();
+  expect(host.fitCalls).toBeGreaterThan(0);
+});
+
+it("RC-I: socket closed at send time — dims queued and replayed on open", async () => {
+  host.ws.readyState = WebSocket.CONNECTING;
+  r.request("active");
+  await host.pumpUntilIdle();
+  expect(host.sentResizes).toHaveLength(0);
+  expect(r.getDesiredDims()).toEqual({ cols: 100, rows: 30 });
+  host.ws.readyState = WebSocket.OPEN;
+  r.notifySocketOpen(host.ws);
+  expect(host.sentResizes.at(-1)).toEqual({ type: "resize", cols: 100, rows: 30 });
+});
+
+it("finding #5: no-op fit (fitVerified null) commits nothing and sends nothing", async () => {
+  host.fitNoopMode = true;             // grid stays 80×24, fitVerified() → null
+  r.observeRect(800, 480);
+  await host.pumpUntilIdle();
+  expect(host.sentResizes).toHaveLength(0);
+  expect(r.getDesiredDims()).toBeNull();
+  host.fitNoopMode = false;            // same rect must NOT be suppressed now
+  r.request("window-focus");
+  await host.pumpUntilIdle();
+  expect(host.sentResizes.at(-1)).toEqual({ type: "resize", cols: 100, rows: 30 });
+});
+
+it("finding #6: stale socket identity — notifySocketOpen(oldWs) is a no-op", async () => {
+  const oldWs = host.ws;
+  host.ws = new FakeWS();              // reconnect happened
+  r.notifySocketOpen(oldWs);
+  expect(host.ws.sent).toHaveLength(0);
+});
+
+it("finding #6: dispose cancels in-flight work; all methods no-op after", async () => {
+  r.request("active");
+  await host.pump(1);
+  r.dispose();
+  await host.pumpUntilIdle();
+  expect(host.fitCalls).toBe(0);
+  r.request("active"); r.notifyPanelVisibility(true);
+  await host.pumpUntilIdle();
+  expect(host.fitCalls).toBe(0);
+});
+
+it("reconcileOnce resolves with verified dims (pre-connect path)", async () => {
+  const p = r.reconcileOnce("post-init");
+  await host.pumpUntilIdle();
+  expect(await p).toEqual({ cols: 100, rows: 30 });
+});
+
+it("supersede: a newer request cancels an older in-flight generation", ...);
+it("never sends grids below 10×3 and does not commit them", ...);
+it("request while page hidden (document.hidden) is deferred, not dropped", ...);
+```
+
+- [ ] **Step 2: Run tests, verify they fail** (`bun run test:run -- resize-reconciler`).
+- [ ] **Step 3: Implement** per Design rules 1-5. Port the settle-loop shape from `settleAndFit` (`Terminal.tsx:35-83`) with per-frame guard re-checks, abort-to-pending, verified fits, and epochs.
+- [ ] **Step 4: Run tests, verify pass.**
+- [ ] **Step 5: Commit** (`feat(terminal): add ResizeReconciler coordinator (remote-dev-ah7q)`).
+
+### Task T2: Wire Terminal.tsx onto the reconciler + desired focus state
+
+**Files:**
+- Modify: `src/components/terminal/Terminal.tsx`
+- Test: `src/components/terminal/Terminal.refit.test.tsx` (update), `src/components/terminal/Terminal.fontRace.test.tsx` (keep green)
+
+**Interfaces:**
+- Consumes: T1's exports.
+- Produces: `TerminalProps.visible?: boolean` (default `true`); `TerminalRef.refit()` behavior preserved; internal `reconcilerRef`, `visibleRef` (latest-value), `desiredFocus` derivation + `syncFocusToServer()`.
+
+- [ ] **Step 1: Write failing tests** — extend `Terminal.refit.test.tsx`: (a) mount with `visible={false}`, flip to `true`, assert a reconcile ran (spy on ws resize frame — NOT the v1 `scrollToBottom` proxy; give the container a stubbed non-zero `getBoundingClientRect`/`offsetParent` since happy-dom does no layout); (b) StrictMode mount/unmount/remount produces exactly one live reconciler and no post-dispose host calls; (c) `visible={false}` + window focus event sends NO `client_focus` frame.
+- [ ] **Step 2: Replace all fit paths.** Construct the reconciler in the init effect once refs exist (host `fitVerified()` implements the proposeDimensions/verify contract; `isPanelVisible()` reads `visibleRef`). Convert: `initAndConnect` final `fit()` (`:1158`) → `const dims = await reconciler.reconcileOnce("post-init")` **before** `connect()` so the WS URL carries fitted dims (finding #7); if null (hidden at mount), proceed to `connect()` with xterm defaults and rely on the reveal-path reconcile — document this accepted reflow. `ws.onopen` rAF fit (`:879`) → `syncFocusToServer(flush)` then `reconciler.notifySocketOpen(ws)`. Font effect rAF fit (`:1421`) → `request("font-change")` (retain the existing `document.fonts.load`/`fonts.ready` ordering at `:1110`, finding #13). `isActive` effect (`:1461`) → `request("active")`. Window resize/focus, visualViewport, visibilitychange → `request(...)`. DPR listener (`:622-640`) → after `clearTextureAtlas()`, also `request("dpr-change")` (finding #13). ResizeObserver body → `reconciler.observeRect(w, h)` (delete local cache + timeout). Delete `settleAndFit` + module constants (import from T1). Cleanup path calls `reconciler.dispose()`; async init closures capture their own reconciler instance and self-cancel if superseded (finding #6; note current cleanup-before-async-assignment hazard at `:1341`).
+- [ ] **Step 3: Desired focus state (finding #3).** Implement the derivation + `syncFocusToServer()` per the Design section, replacing `lastSentFocusStateRef` raw dedupe (`:1194`) and the `ws.onopen` `document.hasFocus()` reconstruction (`:865`). All senders route through it; hidden panel ⇒ never `client_focus`. `refit()` = force-flush current state + `request("refit")` + `scrollToBottom()`.
+- [ ] **Step 4: Preserve keyboard focus on activation (finding #8).** The `isActive` path keeps its focus side effect: after the reconcile settles (or immediately if reconcile skipped), call `terminal.focus()` gated by `isActive && visible && !document.hidden && !mobileMode`. Add an activation-before-init test asserting both the post-init resize AND the focus call happen.
+- [ ] **Step 5: Run the full terminal test files** (`bun run test:run -- src/components/terminal`). Fix regressions.
+- [ ] **Step 6: Commit** (`refactor(terminal): route all resize triggers through ResizeReconciler; panel-aware focus state (remote-dev-ah7q)`).
+
+### Task T3: Thread `visible` through the plugin adapters (finding #2)
+
+**Files:**
+- Modify: `src/types/terminal-type.ts:321` area (`visible?: boolean` on `TerminalRenderProps`), `src/components/terminal/TerminalWithKeyboard.tsx` (interface + pass-through `:269`), `src/lib/terminal-plugins/plugins/shell-plugin-client.tsx:34` area, `agent-plugin-client.tsx`, `ssh-plugin-client.tsx` (+ any other `*-plugin-client.tsx` that renders TerminalWithKeyboard — enumerate via `grep -l TerminalWithKeyboard src/lib/terminal-plugins/plugins/`), `loop-agent-plugin-client.tsx` (forward as `parentVisible`), `src/components/session/SessionManager.tsx:2413` (`visible={effectiveActiveView === "terminal"}`), `src/components/loop/LoopChatPane.tsx` (accept `parentVisible?: boolean`; Terminal gets `visible={parentVisible !== false && terminalVisible}`).
+- Test: co-located component test (happy-dom) rendering each plugin component with `visible={false}` and asserting the underlying Terminal received it (finding #10 — the adapters' explicit destructuring means a dropped prop still typechecks; only a render test catches it).
+
+**Interfaces:**
+- Consumes: `TerminalProps.visible` from T2.
+- Produces: `visible?: boolean` across `TerminalRenderProps` → plugin adapters → `TerminalWithKeyboardProps` → Terminal; `LoopChatPaneProps.parentVisible?: boolean`. Omitted ⇒ `true` everywhere (all other call sites unchanged: mobile embed views and `PortAllocationsTab` render unhidden today).
+
+- [ ] **Step 1:** Write the failing propagation tests (one per adapter + the Loop combined-visibility case: `parentVisible=false` must yield `visible=false` even with the drawer open).
+- [ ] **Step 2:** Add the prop through the chain; do NOT touch `TerminalTypeRenderer.tsx` (not on the render path — `SessionManager.tsx:86`).
+- [ ] **Step 3:** `bun run typecheck` + tests green.
+- [ ] **Step 4:** Manual verification (`bun run dev`): chat↔terminal toggle and Loop drawer open/close refit with unchanged container size; window-resize while hidden reconciles on return; a closed Loop drawer no longer sends `client_focus` on window focus.
+- [ ] **Step 5: Commit** (`feat(terminal): explicit visible prop through plugin adapters + loop drawer (remote-dev-ah7q)`).
+
+### Task T4: Server convergence — TmuxSizeController, forced reassert, identity-conditional promotion defer
+
+**Files:**
+- Create: `src/server/tmux-size-controller.ts`, `src/server/__tests__/tmux-size-controller.test.ts`, `src/server/__tests__/promotion-defer.test.ts`
+- Modify: `src/server/terminal.ts` (`:650-706`, `:807`, `:3325-3383`, `:3040`, session-kill cleanup)
+
+**Interfaces:**
+- Consumes: nothing from client tasks (independently mergeable).
+- Produces: `TmuxSizeController` per Design; module singleton `const tmuxSize = new TmuxSizeController(execTmux, log)`. Promotion/pending logic extracted into exported helpers so `promotion-defer.test.ts` can drive them with fake timers (repo convention: `src/server/__tests__/`).
+
+- [ ] **Step 1: Write failing controller tests:**
+
+```ts
+it("RC-H: latest-wins — resize completing after a newer request re-runs with newest size", () => {
+  ctl.requestResize("s1", "rdv-s1", 100, 30);
+  ctl.requestResize("s1", "rdv-s1", 120, 40);      // arrives while busy
+  exec.completeNext();                              // 100×30 done
+  expect(exec.calls.at(-1)!.args).toContain("120"); // pump re-ran with latest
+  exec.completeNext();
+  expect(ctl.getAppliedSize("s1")).toEqual({ cols: 120, rows: 40 });
+});
+it("finding #1: force bypasses applied-size dedupe — equal-to-applied forced request still execs", () => {
+  ctl.requestResize("s1", "rdv-s1", 100, 30); exec.completeNext();
+  ctl.requestResize("s1", "rdv-s1", 100, 30);            // non-forced: no-op
+  expect(exec.calls).toHaveLength(1);
+  ctl.requestResize("s1", "rdv-s1", 100, 30, { force: true }); // focus path
+  expect(exec.calls).toHaveLength(2);
+});
+it("finding #9: clearSession during in-flight exec — stale callback cannot mutate recreated state", () => {
+  ctl.requestResize("s1", "rdv-s1", 100, 30);      // in flight
+  ctl.clearSession("s1");
+  ctl.requestResize("s1", "rdv-s1", 120, 40);      // session recreated
+  exec.completeNext();                              // OLD callback fires
+  expect(ctl.getAppliedSize("s1")).not.toEqual({ cols: 100, rows: 30 });
+});
+it("failed exec does not mark size applied (retries on next request)", ...);
+```
+
+- [ ] **Step 2: Write failing promotion-defer tests** (fake timers, finding #4): denied→timer fires→promotes only if candidate still mapped + OPEN + visible; denied→blur clears pending (candidate identity match) → timer no-ops; candidate replaced by C, B disconnects → C's pending survives; successful promotion cancels timer; already-primary focus triggers forced reassert.
+- [ ] **Step 3: Implement + integrate** per the Design section (forced reassert on all accepted `client_focus` incl. already-primary; controller at all three resize sites; initial-dim clamp small→10×3 / invalid→80×24 with tests for 2×1, 9×2, 10×3; `clearSession` on tmux-kill only).
+- [ ] **Step 4:** `bun run test:run -- src/server` + `bun run typecheck`.
+- [ ] **Step 5: Commit** (`fix(terminal-server): convergent tmux sizing + deferred promotion (remote-dev-ah7q)`).
+
+### Task T5: End-to-end regression sweep + cleanup
+
+**Files:**
+- Modify: `src/components/terminal/Terminal.refit.test.tsx` (final pass), `CHANGELOG.md` (`[Unreleased] > Fixed`)
+
+- [ ] **Step 1:** Full gates: `bun run lint && bun run typecheck && bun run test:run`.
+- [ ] **Step 2:** Manual race checklist (each a confirmed RCA interleaving): (a) chat→terminal same-size return; (b) window-resize while in chat view, then return; (c) rapid focus bounce between two browser windows on the same session (<1 s apart) — both converge within ~1.5 s; (d) `tmux attach -t rdv-<id>` from a real terminal at a different size, detach, click the web terminal — tmux re-converges on focus (this is the forced-reassert proof, finding #1); (e) Loop drawer open after background window resize; (f) font-size change while in chat view, then return; (g) closed Loop drawer + window focus → no primary steal (finding #3).
+- [ ] **Step 3:** Update CHANGELOG, close checklist on `remote-dev-ah7q`, ship via `/ship`.
+
+---
+
+## Explicitly out of scope (file follow-up bd issues if wanted)
+
+- Passing `visible` from mobile embed views (`EmbeddedSessionView`, `MobileSessionView`) — the native shell already drives lifecycle via `refit()` (rdv-bridge v4), and those views render unhidden.
+- Browser-level (Playwright/CDP) automation of the race checklist — the reconciler/controller unit tests cover the interleavings deterministically.
+- Reworking the `isActive`-only remount model in SessionManager.
+- An actual-tmux-size probe (`display-message #{window_width}`) as an alternative to forced reassert — forced reassert on focus is simpler and idempotent; revisit only if resize-window churn shows up in practice.
+
+## Self-review notes
+
+- Every RCA root cause (RC-A…RC-I) and every Codex v1 review finding (#1-#13) maps to a task; findings #1/#2 (blockers) are closed by T4's `force` + T3's adapter threading respectively.
+- Constants defined once in T1, imported by T2.
+- T4 is independently deployable before/after T1-T3 (protocol unchanged; the initial-dim clamp is the one documented compat exception); T2 depends on T1; T3 depends on T2.

--- a/src/components/loop/LoopChatPane.tsx
+++ b/src/components/loop/LoopChatPane.tsx
@@ -43,6 +43,7 @@ interface LoopChatPaneProps {
   scrollback?: number;
   tmuxHistoryLimit?: number;
   isActive?: boolean;
+  parentVisible?: boolean;
   environmentVars?: Record<string, string> | null;
   onAgentActivityStatus?: (sessionId: string, status: string) => void;
   onBeadsIssuesUpdated?: (sessionId: string) => void;
@@ -76,6 +77,7 @@ export function LoopChatPane({
   scrollback = 10000,
   tmuxHistoryLimit = 50000,
   isActive = false,
+  parentVisible = true,
   environmentVars,
   onAgentActivityStatus,
   onBeadsIssuesUpdated,
@@ -332,6 +334,7 @@ export function LoopChatPane({
             scrollback={scrollback}
             tmuxHistoryLimit={tmuxHistoryLimit}
             isActive={isActive}
+            visible={parentVisible !== false && terminalVisible}
             environmentVars={environmentVars}
             terminalType="agent"
             onStatusChange={handleStatusChange}

--- a/src/components/session/SessionManager.tsx
+++ b/src/components/session/SessionManager.tsx
@@ -2424,6 +2424,7 @@ export function SessionManager({ isGitHubConnected = false }: SessionManagerProp
                           notificationsEnabled={notificationsEnabled}
                           isRecording={isRecording}
                           isActive={session.id === activeSessionId}
+                          visible={effectiveActiveView === "terminal"}
                           environmentVars={getEnvironmentWithSecrets(folderId)}
                           onOutput={isRecording ? recordOutput : undefined}
                           onDimensionsChange={isRecording ? updateDimensions : undefined}

--- a/src/components/terminal/Terminal.refit.test.tsx
+++ b/src/components/terminal/Terminal.refit.test.tsx
@@ -725,6 +725,132 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
     }
   });
 
+  it("keeps its mounted clientInstanceId and reasserts across a same-session effect restart", async () => {
+    const Terminal = await getTerminal();
+    const view = render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:1"
+        terminalType="shell"
+        visible
+      />,
+    );
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
+    });
+    const firstSocket = wsInstances.at(-1)!;
+    const clientInstanceId = new URL(firstSocket.url).searchParams.get(
+      "clientInstanceId",
+    );
+
+    view.rerender(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:2"
+        terminalType="shell"
+        visible
+      />,
+    );
+
+    await waitFor(() => {
+      expect(wsInstances.at(-1)).not.toBe(firstSocket);
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
+    });
+    const replacement = wsInstances.at(-1)!;
+    expect(new URL(replacement.url).searchParams.get("clientInstanceId")).toBe(
+      clientInstanceId,
+    );
+    expect(
+      replacement.sent
+        .map((frame) => JSON.parse(frame) as { type: string; reassert?: boolean })
+        .find((frame) => frame.type === "client_focus"),
+    ).toEqual({ type: "client_focus", reassert: true });
+  });
+
+  it("keeps its mounted clientInstanceId but flushes genuine focus for a new session", async () => {
+    const Terminal = await getTerminal();
+    const view = render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:1"
+        terminalType="shell"
+        visible
+      />,
+    );
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
+    });
+    const firstSocket = wsInstances.at(-1)!;
+    const clientInstanceId = new URL(firstSocket.url).searchParams.get(
+      "clientInstanceId",
+    );
+
+    view.rerender(
+      <Terminal
+        sessionId="s2"
+        tmuxSessionName="rdv-s2"
+        wsUrl="ws://localhost:1"
+        terminalType="shell"
+        visible
+      />,
+    );
+
+    await waitFor(() => {
+      expect(wsInstances.at(-1)).not.toBe(firstSocket);
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
+    });
+    const replacement = wsInstances.at(-1)!;
+    expect(new URL(replacement.url).searchParams.get("clientInstanceId")).toBe(
+      clientInstanceId,
+    );
+    expect(
+      replacement.sent
+        .map((frame) => JSON.parse(frame) as { type: string; reassert?: boolean })
+        .find((frame) => frame.type === "client_focus"),
+    ).toEqual({ type: "client_focus" });
+  });
+
+  it("clears stale textarea focus before a same-session effect restart", async () => {
+    const Terminal = await getTerminal();
+    const view = render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:1"
+        terminalType="shell"
+        visible
+      />,
+    );
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
+    });
+    const firstSocket = wsInstances.at(-1)!;
+    documentHasFocus = false;
+    act(() => {
+      xtermInstances.at(-1)?.textarea.dispatchEvent(new Event("focus"));
+    });
+
+    view.rerender(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:2"
+        terminalType="shell"
+        visible
+      />,
+    );
+
+    await waitFor(() => {
+      expect(wsInstances.at(-1)).not.toBe(firstSocket);
+      expect(wsInstances.at(-1)?.sent.length).toBeGreaterThan(0);
+    });
+    expect(wsInstances.at(-1)?.sentTypes()).toContain("client_blur");
+    expect(wsInstances.at(-1)?.sentTypes()).not.toContain("client_focus");
+  });
+
   it("forces client_focus and a resize reconciliation while derived focus is blurred", async () => {
     const Terminal = await getTerminal();
     const ref = createRef<TerminalRef>();

--- a/src/components/terminal/Terminal.refit.test.tsx
+++ b/src/components/terminal/Terminal.refit.test.tsx
@@ -15,11 +15,10 @@
  * disabled and the native shell owns the keyboard, so focusing here would
  * steal the keyboard context.
  *
- * This test asserts that calling `ref.refit()` drives the terminal's
- * scrollToBottom (an observable proxy for the refit pipeline running), that
- * it forces a fresh `client_focus` frame past the client-side dedupe before
- * the resize (Codex Fix 1 — the dedupe-trap on lifecycle edges), and that it
- * is a safe no-op before the terminal has finished initializing.
+ * These tests assert that calling `ref.refit()` issues a real reconciler
+ * request and resize frame, scrolls to the bottom, forces a fresh
+ * `client_focus` frame even while the derived state is blurred, and remains a
+ * safe no-op before the terminal has finished initializing.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render, cleanup, waitFor } from "@testing-library/react";
@@ -28,7 +27,11 @@ import { createRef, StrictMode } from "react";
 import type { TerminalRef } from "./Terminal";
 
 const reconcilerState = vi.hoisted(() => ({
-  instances: [] as Array<{ wasDisposed: boolean; callsAfterDispose: number }>,
+  instances: [] as Array<{
+    wasDisposed: boolean;
+    callsAfterDispose: number;
+    requests: string[];
+  }>,
 }));
 
 vi.mock("./resize-reconciler", async (importOriginal) => {
@@ -36,6 +39,7 @@ vi.mock("./resize-reconciler", async (importOriginal) => {
   class TrackingResizeReconciler extends actual.ResizeReconciler {
     wasDisposed = false;
     callsAfterDispose = 0;
+    requests: string[] = [];
 
     constructor(
       ...args: ConstructorParameters<typeof actual.ResizeReconciler>
@@ -46,6 +50,7 @@ vi.mock("./resize-reconciler", async (importOriginal) => {
 
     request(reason: Parameters<typeof actual.ResizeReconciler.prototype.request>[0]) {
       if (this.wasDisposed) this.callsAfterDispose++;
+      this.requests.push(reason);
       return super.request(reason);
     }
 
@@ -75,6 +80,8 @@ const fitAddonInstances: Array<{
 // opens synchronously-ish (onopen fired on a microtask) and captures every
 // JSON frame the component sends.
 const wsInstances: MockWebSocket[] = [];
+let blurBeforeSocketOpen = false;
+let documentHasFocus = true;
 class MockWebSocket {
   static readonly CONNECTING = 0;
   static readonly OPEN = 1;
@@ -93,7 +100,10 @@ class MockWebSocket {
   constructor(public url: string) {
     wsInstances.push(this);
     // Fire onopen on a microtask so the component's onopen handler runs.
-    queueMicrotask(() => this.onopen?.());
+    queueMicrotask(() => {
+      if (blurBeforeSocketOpen) documentHasFocus = false;
+      this.onopen?.();
+    });
   }
   send(data: string) {
     this.sent.push(data);
@@ -248,6 +258,7 @@ vi.mock("@/hooks/useNotifications", () => ({
 const originalFetch = globalThis.fetch;
 const originalWebSocket = globalThis.WebSocket;
 let rectSpy: ReturnType<typeof vi.spyOn>;
+let hasFocusSpy: ReturnType<typeof vi.spyOn>;
 beforeEach(() => {
   // Token endpoint succeeds so connect() proceeds to open a WebSocket; any
   // other URL resolves benignly. The focus-frame test needs a live socket.
@@ -267,6 +278,11 @@ beforeEach(() => {
     } as Response);
   }) as unknown as typeof fetch;
   globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+  blurBeforeSocketOpen = false;
+  documentHasFocus = true;
+  hasFocusSpy = vi
+    .spyOn(document, "hasFocus")
+    .mockImplementation(() => documentHasFocus);
   rectSpy = vi
     .spyOn(HTMLElement.prototype, "getBoundingClientRect")
     .mockReturnValue({
@@ -291,6 +307,7 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.fetch = originalFetch;
   globalThis.WebSocket = originalWebSocket;
+  hasFocusSpy.mockRestore();
   rectSpy.mockRestore();
   xtermInstances.length = 0;
   fitAddonInstances.length = 0;
@@ -427,6 +444,65 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
     });
 
     expect(ws.sentTypes()).toContain("client_focus");
+  });
+
+  it("flushes live document focus state when the socket opens", async () => {
+    const Terminal = await getTerminal();
+    blurBeforeSocketOpen = true;
+
+    render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        visible
+      />,
+    );
+
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_blur");
+    });
+    expect(wsInstances.at(-1)?.sentTypes()).not.toContain("client_focus");
+  });
+
+  it("forces client_focus and a resize reconciliation while derived focus is blurred", async () => {
+    const Terminal = await getTerminal();
+    const ref = createRef<TerminalRef>();
+
+    render(
+      <Terminal
+        ref={ref}
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        visible
+      />,
+    );
+
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("resize");
+    });
+    const ws = wsInstances.at(-1)!;
+    documentHasFocus = false;
+    act(() => window.dispatchEvent(new Event("blur")));
+    expect(ws.sentTypes()).toContain("client_blur");
+
+    ws.sent.length = 0;
+    const reconciler = reconcilerState.instances.find(
+      (instance) => !instance.wasDisposed,
+    )!;
+    reconciler.requests.length = 0;
+    act(() => ref.current?.refit());
+
+    expect(ws.sentTypes()).toContain("client_focus");
+    expect(reconciler.requests).toContain("refit");
+    await waitFor(() => expect(ws.sentTypes()).toContain("resize"));
+
+    ws.sent.length = 0;
+    act(() => window.dispatchEvent(new Event("blur")));
+    expect(ws.sentTypes()).toContain("client_blur");
   });
 
   it("reconciles and sends dimensions when a hidden panel becomes visible", async () => {

--- a/src/components/terminal/Terminal.refit.test.tsx
+++ b/src/components/terminal/Terminal.refit.test.tsx
@@ -769,6 +769,64 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
     ).toEqual({ type: "client_focus", reassert: true });
   });
 
+  it("preserves a pending genuine focus across a same-session effect restart", async () => {
+    const Terminal = await getTerminal();
+    const view = render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:1"
+        terminalType="shell"
+        visible
+      />,
+    );
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
+    });
+    const firstSocket = wsInstances.at(-1)!;
+    documentHasFocus = false;
+    act(() => window.dispatchEvent(new Event("blur")));
+
+    autoOpenSockets = false;
+    view.rerender(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:2"
+        terminalType="shell"
+        visible
+      />,
+    );
+    await waitFor(() => {
+      expect(wsInstances.at(-1)).not.toBe(firstSocket);
+      expect(wsInstances.at(-1)?.readyState).toBe(MockWebSocket.CONNECTING);
+    });
+    const connectingSocket = wsInstances.at(-1)!;
+
+    documentHasFocus = true;
+    act(() => window.dispatchEvent(new Event("focus")));
+    view.rerender(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:3"
+        terminalType="shell"
+        visible
+      />,
+    );
+    await waitFor(() => {
+      expect(wsInstances.at(-1)).not.toBe(connectingSocket);
+      expect(wsInstances.at(-1)?.readyState).toBe(MockWebSocket.CONNECTING);
+    });
+
+    const replacement = wsInstances.at(-1)!;
+    act(() => replacement.open());
+    const focusFrame = replacement.sent
+      .map((frame) => JSON.parse(frame) as { type: string; reassert?: boolean })
+      .find((frame) => frame.type === "client_focus");
+    expect(focusFrame).toEqual({ type: "client_focus" });
+  });
+
   it("keeps its mounted clientInstanceId but flushes genuine focus for a new session", async () => {
     const Terminal = await getTerminal();
     const view = render(

--- a/src/components/terminal/Terminal.refit.test.tsx
+++ b/src/components/terminal/Terminal.refit.test.tsx
@@ -769,6 +769,59 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
     ).toEqual({ type: "client_focus", reassert: true });
   });
 
+  it("flushes genuine focus when returning from chat during the restart import gap", async () => {
+    const Terminal = await getTerminal();
+    const view = render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:1"
+        terminalType="shell"
+        visible
+      />,
+    );
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
+    });
+    const firstSocket = wsInstances.at(-1)!;
+
+    view.rerender(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:1"
+        terminalType="shell"
+        visible={false}
+      />,
+    );
+    await waitFor(() => {
+      expect(firstSocket.sentTypes()).toContain("client_blur");
+    });
+
+    autoOpenSockets = false;
+    view.rerender(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:2"
+        terminalType="shell"
+        visible
+      />,
+    );
+    await waitFor(() => {
+      expect(wsInstances.at(-1)).not.toBe(firstSocket);
+      expect(wsInstances.at(-1)?.readyState).toBe(MockWebSocket.CONNECTING);
+    });
+
+    const replacement = wsInstances.at(-1)!;
+    act(() => replacement.open());
+    expect(
+      replacement.sent
+        .map((frame) => JSON.parse(frame) as { type: string; reassert?: boolean })
+        .find((frame) => frame.type === "client_focus"),
+    ).toEqual({ type: "client_focus" });
+  });
+
   it("preserves a pending genuine focus across a same-session effect restart", async () => {
     const Terminal = await getTerminal();
     const view = render(

--- a/src/components/terminal/Terminal.refit.test.tsx
+++ b/src/components/terminal/Terminal.refit.test.tsx
@@ -70,7 +70,7 @@ const fitAddonInstances: Array<{
 
 // ── Recording WebSocket mock ──────────────────────────────────────────────
 // The focus-frame assertion needs an OPEN socket that records sent frames.
-// Terminal.tsx's sendFocusSignal only sends when ws.readyState === OPEN, so a
+// Terminal.tsx only sends a focus signal when ws.readyState === OPEN, so a
 // plain 401 (no socket) wouldn't exercise the dedupe path. This minimal mock
 // opens synchronously-ish (onopen fired on a microtask) and captures every
 // JSON frame the component sends.
@@ -361,9 +361,9 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
       ref.current?.refit();
     });
 
-    // refit() calls scrollToBottom directly (the settle+fit half no-ops in a
-    // zero-size jsdom container, but scrollToBottom is unconditional and is a
-    // faithful proxy that the imperative path executed).
+    // refit() calls scrollToBottom directly — an unconditional, synchronous
+    // proxy that the imperative path executed (the reconcile half is async and
+    // is asserted separately).
     expect(xterm.scrollToBottom).toHaveBeenCalledTimes(1);
   });
 

--- a/src/components/terminal/Terminal.refit.test.tsx
+++ b/src/components/terminal/Terminal.refit.test.tsx
@@ -17,8 +17,9 @@
  *
  * These tests assert that calling `ref.refit()` issues a real reconciler
  * request and resize frame, scrolls to the bottom, forces a fresh
- * `client_focus` frame even while the derived state is blurred, and remains a
- * safe no-op before the terminal has finished initializing.
+ * `client_focus` frame even while the derived state is blurred, suppresses that
+ * assertion while the panel/page is hidden, and remains a safe no-op before
+ * the terminal has finished initializing.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render, cleanup, waitFor } from "@testing-library/react";
@@ -466,6 +467,28 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
     expect(wsInstances.at(-1)?.sentTypes()).not.toContain("client_focus");
   });
 
+  it("marks the socket-open focus flush as a recency-neutral reassert", async () => {
+    const Terminal = await getTerminal();
+    render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        visible
+      />,
+    );
+
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
+    });
+    const focusFrame = wsInstances
+      .at(-1)!
+      .sent.map((frame) => JSON.parse(frame) as { type: string; reassert?: boolean })
+      .find((frame) => frame.type === "client_focus");
+    expect(focusFrame).toEqual({ type: "client_focus", reassert: true });
+  });
+
   it("forces client_focus and a resize reconciliation while derived focus is blurred", async () => {
     const Terminal = await getTerminal();
     const ref = createRef<TerminalRef>();
@@ -596,6 +619,34 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
     act(() => window.dispatchEvent(new Event("focus")));
 
     expect(ws.sentTypes()).not.toContain("client_focus");
+  });
+
+  it("refit while the panel is hidden emits no client_focus frame", async () => {
+    const Terminal = await getTerminal();
+    const ref = createRef<TerminalRef>();
+    render(
+      <Terminal
+        ref={ref}
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        visible={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sent.length).toBeGreaterThan(0);
+    });
+    const ws = wsInstances.at(-1)!;
+    ws.sent.length = 0;
+
+    act(() => ref.current?.refit());
+
+    expect(ws.sentTypes()).not.toContain("client_focus");
+    expect(
+      reconcilerState.instances.find((instance) => !instance.wasDisposed)?.requests,
+    ).toContain("refit");
   });
 
   it("replays activation after async initialization with resize and keyboard focus", async () => {

--- a/src/components/terminal/Terminal.refit.test.tsx
+++ b/src/components/terminal/Terminal.refit.test.tsx
@@ -111,6 +111,7 @@ class MockWebSocket {
   }
   close() {
     this.readyState = 3;
+    setTimeout(() => this.onclose?.(), 0);
   }
   serverClose() {
     this.readyState = MockWebSocket.CLOSED;
@@ -528,7 +529,7 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
     }
   });
 
-  it("sends genuine focus on reconnect while this terminal is actively engaged", async () => {
+  it("uses one clientInstanceId and reasserts on a mobile-mode reconnect", async () => {
     const Terminal = await getTerminal();
     render(
       <Terminal
@@ -536,6 +537,7 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
         tmuxSessionName="rdv-s1"
         wsUrl="ws://localhost:0"
         terminalType="shell"
+        mobileMode
         visible
       />,
     );
@@ -544,9 +546,8 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
       expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
     });
     const firstSocket = wsInstances.at(-1)!;
-    act(() => {
-      xtermInstances.at(-1)!.textarea.dispatchEvent(new Event("focus"));
-    });
+    const firstInstanceId = new URL(firstSocket.url).searchParams.get("clientInstanceId");
+    expect(firstInstanceId).toBeTruthy();
 
     vi.useFakeTimers();
     try {
@@ -557,10 +558,13 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
 
       const reconnect = wsInstances.at(-1)!;
       expect(reconnect).not.toBe(firstSocket);
+      expect(new URL(reconnect.url).searchParams.get("clientInstanceId")).toBe(
+        firstInstanceId,
+      );
       const focusFrame = reconnect.sent
         .map((frame) => JSON.parse(frame) as { type: string; reassert?: boolean })
         .find((frame) => frame.type === "client_focus");
-      expect(focusFrame).toEqual({ type: "client_focus" });
+      expect(focusFrame).toEqual({ type: "client_focus", reassert: true });
     } finally {
       vi.useRealTimers();
     }
@@ -673,6 +677,57 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
         0,
       ),
     ).toBe(0);
+  });
+
+  it("ignores an asynchronous close from a superseded StrictMode socket", async () => {
+    const Terminal = await getTerminal();
+    const onStatusChange = vi.fn();
+    const onWebSocketReady = vi.fn();
+    render(
+      <StrictMode>
+        <Terminal
+          sessionId="s1"
+          tmuxSessionName="rdv-s1"
+          wsUrl="ws://localhost:0"
+          terminalType="shell"
+          visible
+          onStatusChange={onStatusChange}
+          onWebSocketReady={onWebSocketReady}
+        />
+      </StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
+    });
+    const firstSocket = wsInstances.at(-1)!;
+
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        firstSocket.serverClose();
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+      const replacement = wsInstances.at(-1)!;
+      expect(replacement).not.toBe(firstSocket);
+      expect(onStatusChange).toHaveBeenLastCalledWith("connected");
+      expect(onWebSocketReady).toHaveBeenLastCalledWith(replacement);
+
+      const socketCount = wsInstances.length;
+      firstSocket.close();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(onStatusChange).toHaveBeenLastCalledWith("connected");
+      expect(onWebSocketReady).toHaveBeenLastCalledWith(replacement);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+      expect(wsInstances).toHaveLength(socketCount);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not send client_focus for a hidden panel on window focus", async () => {

--- a/src/components/terminal/Terminal.refit.test.tsx
+++ b/src/components/terminal/Terminal.refit.test.tsx
@@ -83,6 +83,7 @@ const fitAddonInstances: Array<{
 const wsInstances: MockWebSocket[] = [];
 let blurBeforeSocketOpen = false;
 let documentHasFocus = true;
+let autoOpenSockets = true;
 class MockWebSocket {
   static readonly CONNECTING = 0;
   static readonly OPEN = 1;
@@ -92,7 +93,8 @@ class MockWebSocket {
   readonly OPEN = 1;
   readonly CLOSING = 2;
   readonly CLOSED = 3;
-  readyState = 1; // OPEN immediately so post-open sends land
+  readyState = MockWebSocket.CONNECTING;
+  closeCalls = 0;
   sent: string[] = [];
   onopen: (() => void) | null = null;
   onmessage: ((e: MessageEvent) => void) | null = null;
@@ -102,7 +104,9 @@ class MockWebSocket {
     wsInstances.push(this);
     // Fire onopen on a microtask so the component's onopen handler runs.
     queueMicrotask(() => {
+      if (!autoOpenSockets || this.readyState !== MockWebSocket.CONNECTING) return;
       if (blurBeforeSocketOpen) documentHasFocus = false;
+      this.readyState = MockWebSocket.OPEN;
       this.onopen?.();
     });
   }
@@ -110,8 +114,13 @@ class MockWebSocket {
     this.sent.push(data);
   }
   close() {
+    this.closeCalls++;
     this.readyState = 3;
     setTimeout(() => this.onclose?.(), 0);
+  }
+  open() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
   }
   serverClose() {
     this.readyState = MockWebSocket.CLOSED;
@@ -286,6 +295,7 @@ beforeEach(() => {
   globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
   blurBeforeSocketOpen = false;
   documentHasFocus = true;
+  autoOpenSockets = true;
   hasFocusSpy = vi
     .spyOn(document, "hasFocus")
     .mockImplementation(() => documentHasFocus);
@@ -524,6 +534,151 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
         .map((frame) => JSON.parse(frame) as { type: string; reassert?: boolean })
         .find((frame) => frame.type === "client_focus");
       expect(focusFrame).toEqual({ type: "client_focus", reassert: true });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes genuine focus when focus transitions while the replacement socket connects", async () => {
+    const Terminal = await getTerminal();
+    render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        visible
+      />,
+    );
+
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
+    });
+    const firstSocket = wsInstances.at(-1)!;
+    documentHasFocus = false;
+    act(() => window.dispatchEvent(new Event("blur")));
+    vi.useFakeTimers();
+    try {
+      autoOpenSockets = false;
+      firstSocket.serverClose();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+      const reconnect = wsInstances.at(-1)!;
+      expect(reconnect).not.toBe(firstSocket);
+      expect(reconnect.readyState).toBe(MockWebSocket.CONNECTING);
+
+      documentHasFocus = true;
+      act(() => window.dispatchEvent(new Event("focus")));
+      act(() => reconnect.open());
+
+      const focusFrame = reconnect.sent
+        .map((frame) => JSON.parse(frame) as { type: string; reassert?: boolean })
+        .find((frame) => frame.type === "client_focus");
+      expect(focusFrame).toEqual({ type: "client_focus" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears pending gap focus when the client blurs again before reopen", async () => {
+    const Terminal = await getTerminal();
+    render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        visible
+      />,
+    );
+
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
+    });
+    const firstSocket = wsInstances.at(-1)!;
+    documentHasFocus = false;
+    act(() => window.dispatchEvent(new Event("blur")));
+    vi.useFakeTimers();
+    try {
+      autoOpenSockets = false;
+      firstSocket.serverClose();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+      const reconnect = wsInstances.at(-1)!;
+      documentHasFocus = true;
+      act(() => window.dispatchEvent(new Event("focus")));
+      documentHasFocus = false;
+      act(() => window.dispatchEvent(new Event("blur")));
+      act(() => reconnect.open());
+
+      expect(reconnect.sentTypes()).toContain("client_blur");
+      expect(reconnect.sentTypes()).not.toContain("client_focus");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes a stale socket if it opens after a replacement supersedes it", async () => {
+    autoOpenSockets = false;
+    const Terminal = await getTerminal();
+    const view = render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        visible
+      />,
+    );
+    await waitFor(() => expect(wsInstances.length).toBeGreaterThan(0));
+    const stale = wsInstances.at(-1)!;
+
+    view.rerender(
+      <Terminal
+        sessionId="s2"
+        tmuxSessionName="rdv-s2"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        visible
+      />,
+    );
+    await waitFor(() => expect(wsInstances.length).toBeGreaterThan(1));
+    const closesBeforeStaleOpen = stale.closeCalls;
+
+    act(() => stale.open());
+
+    expect(stale.closeCalls).toBe(closesBeforeStaleOpen + 1);
+  });
+
+  it("does not create a second replacement while a socket is connecting", async () => {
+    const Terminal = await getTerminal();
+    render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        visible
+      />,
+    );
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
+    });
+    const firstSocket = wsInstances.at(-1)!;
+
+    vi.useFakeTimers();
+    try {
+      autoOpenSockets = false;
+      firstSocket.serverClose();
+      firstSocket.onclose?.();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      expect(wsInstances).toHaveLength(2);
+      expect(wsInstances.at(-1)?.readyState).toBe(MockWebSocket.CONNECTING);
     } finally {
       vi.useRealTimers();
     }

--- a/src/components/terminal/Terminal.refit.test.tsx
+++ b/src/components/terminal/Terminal.refit.test.tsx
@@ -23,7 +23,13 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render, cleanup, waitFor } from "@testing-library/react";
-import { createRef, StrictMode } from "react";
+import {
+  createRef,
+  startTransition,
+  StrictMode,
+  Suspense,
+  useState,
+} from "react";
 
 import type { TerminalRef } from "./Terminal";
 
@@ -480,6 +486,58 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
       expect(wsInstances.at(-1)?.sentTypes()).toContain("client_blur");
     });
     expect(wsInstances.at(-1)?.sentTypes()).not.toContain("client_focus");
+  });
+
+  it("uses committed panel visibility when a socket opens during a suspended render", async () => {
+    const Terminal = await getTerminal();
+    autoOpenSockets = false;
+    const neverResolves = new Promise<void>(() => {});
+    let speculativeRenderSeen = false;
+
+    function SuspendOnReveal({ visible }: { visible: boolean }) {
+      if (visible) {
+        speculativeRenderSeen = true;
+        throw neverResolves;
+      }
+      return null;
+    }
+
+    function Harness() {
+      const [visible, setVisible] = useState(false);
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => startTransition(() => setVisible(true))}
+          >
+            Reveal
+          </button>
+          <Suspense fallback={null}>
+            <Terminal
+              sessionId="s1"
+              tmuxSessionName="rdv-s1"
+              wsUrl="ws://localhost:0"
+              terminalType="shell"
+              visible={visible}
+            />
+            <SuspendOnReveal visible={visible} />
+          </Suspense>
+        </>
+      );
+    }
+
+    const view = render(<Harness />);
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.readyState).toBe(MockWebSocket.CONNECTING);
+    });
+    const socket = wsInstances.at(-1)!;
+
+    act(() => view.getByRole("button", { name: "Reveal" }).click());
+    expect(speculativeRenderSeen).toBe(true);
+    act(() => socket.open());
+
+    expect(socket.sentTypes()).toContain("client_blur");
+    expect(socket.sentTypes()).not.toContain("client_focus");
   });
 
   it("sends a genuine focus assertion on the first socket open", async () => {

--- a/src/components/terminal/Terminal.refit.test.tsx
+++ b/src/components/terminal/Terminal.refit.test.tsx
@@ -23,14 +23,49 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render, cleanup, waitFor } from "@testing-library/react";
-import { createRef } from "react";
+import { createRef, StrictMode } from "react";
 
 import type { TerminalRef } from "./Terminal";
+
+const reconcilerState = vi.hoisted(() => ({
+  instances: [] as Array<{ wasDisposed: boolean; callsAfterDispose: number }>,
+}));
+
+vi.mock("./resize-reconciler", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./resize-reconciler")>();
+  class TrackingResizeReconciler extends actual.ResizeReconciler {
+    wasDisposed = false;
+    callsAfterDispose = 0;
+
+    constructor(
+      ...args: ConstructorParameters<typeof actual.ResizeReconciler>
+    ) {
+      super(...args);
+      reconcilerState.instances.push(this);
+    }
+
+    request(reason: Parameters<typeof actual.ResizeReconciler.prototype.request>[0]) {
+      if (this.wasDisposed) this.callsAfterDispose++;
+      return super.request(reason);
+    }
+
+    dispose() {
+      this.wasDisposed = true;
+      super.dispose();
+    }
+  }
+  return { ...actual, ResizeReconciler: TrackingResizeReconciler };
+});
 
 // Capture every XTerm instance so we can assert against its methods + textarea.
 const xtermInstances: Array<{
   scrollToBottom: ReturnType<typeof vi.fn>;
+  focus: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
   textarea: HTMLTextAreaElement;
+}> = [];
+const fitAddonInstances: Array<{
+  fit: ReturnType<typeof vi.fn>;
 }> = [];
 
 // ── Recording WebSocket mock ──────────────────────────────────────────────
@@ -94,7 +129,9 @@ vi.mock("@xterm/xterm", () => {
       this.textarea = document.createElement("textarea");
       xtermInstances.push(this);
     }
-    loadAddon() {}
+    loadAddon(addon: { activate?: (terminal: FakeTerminal) => void }) {
+      addon.activate?.(this);
+    }
     open() {}
     onData() {
       return { dispose: () => {} };
@@ -106,10 +143,10 @@ vi.mock("@xterm/xterm", () => {
       return { dispose: () => {} };
     }
     attachCustomKeyEventHandler() {}
-    focus() {}
+    focus = vi.fn();
     write() {}
     writeln() {}
-    dispose() {}
+    dispose = vi.fn();
     clear() {}
   }
   return { Terminal: FakeTerminal };
@@ -117,9 +154,22 @@ vi.mock("@xterm/xterm", () => {
 
 vi.mock("@xterm/addon-fit", () => ({
   FitAddon: class {
-    activate() {}
+    private terminal: { cols: number; rows: number } | null = null;
+    fit = vi.fn(() => {
+      if (!this.terminal) return;
+      this.terminal.cols = 100;
+      this.terminal.rows = 30;
+    });
+    constructor() {
+      fitAddonInstances.push(this);
+    }
+    activate(terminal: { cols: number; rows: number }) {
+      this.terminal = terminal;
+    }
+    proposeDimensions() {
+      return { cols: 100, rows: 30 };
+    }
     dispose() {}
-    fit() {}
   },
 }));
 
@@ -197,6 +247,7 @@ vi.mock("@/hooks/useNotifications", () => ({
 
 const originalFetch = globalThis.fetch;
 const originalWebSocket = globalThis.WebSocket;
+let rectSpy: ReturnType<typeof vi.spyOn>;
 beforeEach(() => {
   // Token endpoint succeeds so connect() proceeds to open a WebSocket; any
   // other URL resolves benignly. The focus-frame test needs a live socket.
@@ -216,6 +267,19 @@ beforeEach(() => {
     } as Response);
   }) as unknown as typeof fetch;
   globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+  rectSpy = vi
+    .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+    .mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 800,
+      bottom: 480,
+      width: 800,
+      height: 480,
+      toJSON: () => ({}),
+    });
   if (!("fonts" in document)) {
     Object.defineProperty(document, "fonts", {
       configurable: true,
@@ -227,7 +291,10 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.fetch = originalFetch;
   globalThis.WebSocket = originalWebSocket;
+  rectSpy.mockRestore();
   xtermInstances.length = 0;
+  fitAddonInstances.length = 0;
+  reconcilerState.instances.length = 0;
   wsInstances.length = 0;
   cleanup();
 });
@@ -360,5 +427,117 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
     });
 
     expect(ws.sentTypes()).toContain("client_focus");
+  });
+
+  it("reconciles and sends dimensions when a hidden panel becomes visible", async () => {
+    const Terminal = await getTerminal();
+    const view = render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        visible={false}
+      />,
+    );
+
+    await waitFor(() => expect(wsInstances.length).toBeGreaterThan(0));
+    const ws = wsInstances.at(-1)!;
+    ws.sent.length = 0;
+
+    view.rerender(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        visible
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        ws.sent
+          .map((frame) => JSON.parse(frame) as { type: string; cols?: number; rows?: number })
+          .find((frame) => frame.type === "resize"),
+      ).toEqual({ type: "resize", cols: 100, rows: 30 });
+    });
+  });
+
+  it("StrictMode leaves one live terminal and teardown prevents later fits", async () => {
+    const Terminal = await getTerminal();
+    const view = render(
+      <StrictMode>
+        <Terminal
+          sessionId="s1"
+          tmuxSessionName="rdv-s1"
+          wsUrl="ws://localhost:0"
+          terminalType="shell"
+          visible
+        />
+      </StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(
+        reconcilerState.instances.filter((reconciler) => !reconciler.wasDisposed),
+      ).toHaveLength(1);
+    });
+
+    view.unmount();
+    act(() => window.dispatchEvent(new Event("resize")));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(
+      reconcilerState.instances.filter((reconciler) => !reconciler.wasDisposed),
+    ).toHaveLength(0);
+    expect(
+      reconcilerState.instances.reduce(
+        (total, reconciler) => total + reconciler.callsAfterDispose,
+        0,
+      ),
+    ).toBe(0);
+  });
+
+  it("does not send client_focus for a hidden panel on window focus", async () => {
+    const Terminal = await getTerminal();
+    render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        visible={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sent.length).toBeGreaterThan(0);
+    });
+    const ws = wsInstances.at(-1)!;
+    ws.sent.length = 0;
+
+    act(() => window.dispatchEvent(new Event("focus")));
+
+    expect(ws.sentTypes()).not.toContain("client_focus");
+  });
+
+  it("replays activation after async initialization with resize and keyboard focus", async () => {
+    const Terminal = await getTerminal();
+    render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        isActive
+        visible
+      />,
+    );
+
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("resize");
+      expect(xtermInstances.at(-1)?.focus).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/terminal/Terminal.refit.test.tsx
+++ b/src/components/terminal/Terminal.refit.test.tsx
@@ -28,6 +28,7 @@ import {
   startTransition,
   StrictMode,
   Suspense,
+  useLayoutEffect,
   useState,
 } from "react";
 
@@ -535,6 +536,48 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
     act(() => view.getByRole("button", { name: "Reveal" }).click());
     expect(speculativeRenderSeen).toBe(true);
     act(() => socket.open());
+
+    expect(socket.sentTypes()).toContain("client_blur");
+    expect(socket.sentTypes()).not.toContain("client_focus");
+  });
+
+  it("flushes blur when a socket opens after committed hide but before passive effects", async () => {
+    const Terminal = await getTerminal();
+    autoOpenSockets = false;
+
+    function OpenSocketOnCommittedHide({ visible }: { visible: boolean }) {
+      useLayoutEffect(() => {
+        if (!visible) wsInstances.at(-1)?.open();
+      }, [visible]);
+      return null;
+    }
+
+    function Harness() {
+      const [visible, setVisible] = useState(true);
+      return (
+        <>
+          <button type="button" onClick={() => setVisible(false)}>
+            Hide
+          </button>
+          <Terminal
+            sessionId="s1"
+            tmuxSessionName="rdv-s1"
+            wsUrl="ws://localhost:0"
+            terminalType="shell"
+            visible={visible}
+          />
+          <OpenSocketOnCommittedHide visible={visible} />
+        </>
+      );
+    }
+
+    const view = render(<Harness />);
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.readyState).toBe(MockWebSocket.CONNECTING);
+    });
+    const socket = wsInstances.at(-1)!;
+
+    act(() => view.getByRole("button", { name: "Hide" }).click());
 
     expect(socket.sentTypes()).toContain("client_blur");
     expect(socket.sentTypes()).not.toContain("client_focus");

--- a/src/components/terminal/Terminal.refit.test.tsx
+++ b/src/components/terminal/Terminal.refit.test.tsx
@@ -112,6 +112,10 @@ class MockWebSocket {
   close() {
     this.readyState = 3;
   }
+  serverClose() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
   /** Parsed frame `type`s in send order. */
   sentTypes(): string[] {
     return this.sent.map((s) => {
@@ -467,7 +471,7 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
     expect(wsInstances.at(-1)?.sentTypes()).not.toContain("client_focus");
   });
 
-  it("marks the socket-open focus flush as a recency-neutral reassert", async () => {
+  it("sends a genuine focus assertion on the first socket open", async () => {
     const Terminal = await getTerminal();
     render(
       <Terminal
@@ -486,7 +490,80 @@ describe("Terminal.refit (remote-dev-u5q5.2)", () => {
       .at(-1)!
       .sent.map((frame) => JSON.parse(frame) as { type: string; reassert?: boolean })
       .find((frame) => frame.type === "client_focus");
-    expect(focusFrame).toEqual({ type: "client_focus", reassert: true });
+    expect(focusFrame).toEqual({ type: "client_focus" });
+  });
+
+  it("reasserts focus on an unattended reconnect without promoting recency", async () => {
+    const Terminal = await getTerminal();
+    render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        visible
+      />,
+    );
+
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
+    });
+    const firstSocket = wsInstances.at(-1)!;
+
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        firstSocket.serverClose();
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      const reconnect = wsInstances.at(-1)!;
+      expect(reconnect).not.toBe(firstSocket);
+      const focusFrame = reconnect.sent
+        .map((frame) => JSON.parse(frame) as { type: string; reassert?: boolean })
+        .find((frame) => frame.type === "client_focus");
+      expect(focusFrame).toEqual({ type: "client_focus", reassert: true });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("sends genuine focus on reconnect while this terminal is actively engaged", async () => {
+    const Terminal = await getTerminal();
+    render(
+      <Terminal
+        sessionId="s1"
+        tmuxSessionName="rdv-s1"
+        wsUrl="ws://localhost:0"
+        terminalType="shell"
+        visible
+      />,
+    );
+
+    await waitFor(() => {
+      expect(wsInstances.at(-1)?.sentTypes()).toContain("client_focus");
+    });
+    const firstSocket = wsInstances.at(-1)!;
+    act(() => {
+      xtermInstances.at(-1)!.textarea.dispatchEvent(new Event("focus"));
+    });
+
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        firstSocket.serverClose();
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      const reconnect = wsInstances.at(-1)!;
+      expect(reconnect).not.toBe(firstSocket);
+      const focusFrame = reconnect.sent
+        .map((frame) => JSON.parse(frame) as { type: string; reassert?: boolean })
+        .find((frame) => frame.type === "client_focus");
+      expect(focusFrame).toEqual({ type: "client_focus" });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("forces client_focus and a resize reconciliation while derived focus is blurred", async () => {

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -855,7 +855,10 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
           reconnectAttemptsRef.current = 0;
           lastSentFocusStateRef.current = null;
           onWebSocketReadyRef.current?.(ws);
-          syncFocusToServer(true, true);
+          const reassert =
+            hasConnectedBeforeRef.current &&
+            !(textareaFocusedRef.current && document.hasFocus());
+          syncFocusToServer(true, reassert);
           reconciler.notifySocketOpen(ws);
 
           // [remote-dev-d5ci] On a RE-open (not the first connect), dispatch the

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -169,7 +169,9 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   const isActiveRef = useRef(isActive);
   const textareaFocusedRef = useRef(false);
   const lastSentFocusStateRef = useRef<"focus" | "blur" | null>(null);
-  const syncFocusToServerRef = useRef<((force?: boolean) => void) | null>(null);
+  const syncFocusToServerRef = useRef<
+    ((force?: boolean, reassert?: boolean) => void) | null
+  >(null);
   const forceFocusAssertRef = useRef<(() => void) | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -524,17 +526,18 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
         visibleRef.current &&
         !document.hidden &&
         (document.hasFocus() || textareaFocusedRef.current);
-      const syncFocusToServer = (force = false) => {
+      const syncFocusToServer = (force = false, reassert = false) => {
         const socket = wsRef.current;
         const next = getDesiredFocus() ? "focus" : "blur";
         if (!force && lastSentFocusStateRef.current === next) return;
         if (!socket || socket.readyState !== WebSocket.OPEN) return;
         try {
-          socket.send(
-            JSON.stringify({
-              type: next === "focus" ? "client_focus" : "client_blur",
-            }),
-          );
+          const message = next === "focus"
+            ? reassert
+              ? { type: "client_focus", reassert: true }
+              : { type: "client_focus" }
+            : { type: "client_blur" };
+          socket.send(JSON.stringify(message));
           lastSentFocusStateRef.current = next;
         } catch {
           // The desired state remains available for the next socket-open flush.
@@ -542,6 +545,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       };
       syncFocusToServerRef.current = syncFocusToServer;
       const forceFocusAssert = () => {
+        if (!visibleRef.current || document.hidden) return;
         const socket = wsRef.current;
         if (!socket || socket.readyState !== WebSocket.OPEN) return;
         try {
@@ -851,7 +855,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
           reconnectAttemptsRef.current = 0;
           lastSentFocusStateRef.current = null;
           onWebSocketReadyRef.current?.(ws);
-          syncFocusToServer(true);
+          syncFocusToServer(true, true);
           reconciler.notifySocketOpen(ws);
 
           // [remote-dev-d5ci] On a RE-open (not the first connect), dispatch the

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useCallback, useState, forwardRef, useImperativeHandle, useMemo, Activity } from "react";
+import { useEffect, useLayoutEffect, useRef, useCallback, useState, forwardRef, useImperativeHandle, useMemo, Activity } from "react";
 import type { Terminal as XTermType } from "@xterm/xterm";
 import type { FitAddon as FitAddonType } from "@xterm/addon-fit";
 import type { ImageAddon as ImageAddonType } from "@xterm/addon-image";
@@ -202,8 +202,6 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   // sidebar re-seed on reconnect (mirrors useTerminalWebSocket's hasConnectedBefore).
   const hasConnectedBeforeRef = useRef(false);
   const maxReconnectAttempts = 5;
-
-  isActiveRef.current = isActive;
 
   /**
    * Atomically marks session exit as intentional and cancels any pending reconnect.
@@ -1304,8 +1302,12 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
     };
   }, [sessionId, tmuxSessionName, projectPath, wsUrl, updateStatus, terminalType, markIntentionalExit, focusIfPresented]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     visibleRef.current = visible;
+    isActiveRef.current = isActive;
+  }, [visible, isActive]);
+
+  useEffect(() => {
     syncFocusToServerRef.current?.();
     reconcilerRef.current?.notifyPanelVisibility(visible);
   }, [visible]);

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -362,6 +362,15 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
     []
   );
 
+  /** Keyboard focus belongs to this terminal only while it is the active
+   *  session in a presented panel, and never in mobile mode where the native
+   *  shell owns the keyboard. */
+  const focusIfPresented = useCallback(() => {
+    if (!isActiveRef.current || !visibleRef.current) return;
+    if (document.hidden || mobileModeRef.current) return;
+    xtermRef.current?.focus();
+  }, []);
+
   useEffect(() => {
     if (!terminalRef.current || xtermRef.current) return;
 
@@ -375,6 +384,15 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
     // open is a FIRST connect, not a reconnect. (Stays true across reconnect
     // attempts within this same effect run.)
     hasConnectedBeforeRef.current = false;
+
+    const releaseReconciler = (instance: ResizeReconciler | null) => {
+      if (!instance) return;
+      instance.dispose();
+      if (reconcilerRef.current === instance) {
+        reconcilerRef.current = null;
+        syncFocusToServerRef.current = null;
+      }
+    };
 
     // Dynamically import xterm modules (browser-only)
     async function initTerminal() {
@@ -507,10 +525,8 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
         visibleRef.current &&
         !document.hidden &&
         (windowFocusedRef.current || textareaFocusedRef.current);
-      const syncFocusToServer = (
-        force = false,
-        socket = wsRef.current,
-      ) => {
+      const syncFocusToServer = (force = false) => {
+        const socket = wsRef.current;
         const next = getDesiredFocus() ? "focus" : "blur";
         if (!force && lastSentFocusStateRef.current === next) return;
         if (!socket || socket.readyState !== WebSocket.OPEN) return;
@@ -525,8 +541,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
           // The desired state remains available for the next socket-open flush.
         }
       };
-      syncFocusToServerRef.current = (force = false) =>
-        syncFocusToServer(force);
+      syncFocusToServerRef.current = syncFocusToServer;
 
       // Load WebGL renderer for better performance (falls back to DOM renderer)
       try {
@@ -826,7 +841,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
           reconnectAttemptsRef.current = 0;
           lastSentFocusStateRef.current = null;
           onWebSocketReadyRef.current?.(ws);
-          syncFocusToServer(true, ws);
+          syncFocusToServer(true);
           reconciler.notifySocketOpen(ws);
 
           // [remote-dev-d5ci] On a RE-open (not the first connect), dispatch the
@@ -1067,14 +1082,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
         // reveal signal replays reconciliation once the panel is measurable.
         await reconciler.reconcileOnce("post-init");
         if (!mounted || reconcilerRef.current !== reconciler) return;
-        if (
-          isActiveRef.current &&
-          visibleRef.current &&
-          !document.hidden &&
-          !mobileModeRef.current
-        ) {
-          terminal.focus();
-        }
+        focusIfPresented();
         void connect();
       };
 
@@ -1112,18 +1120,10 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       }
 
       const handleVisibilityChange = () => {
+        syncFocusToServer();
         if (!document.hidden) {
-          syncFocusToServer();
           reconciler.request("page-visible");
-          if (
-            isActiveRef.current &&
-            visibleRef.current &&
-            !mobileModeRef.current
-          ) {
-            terminal.focus();
-          }
-        } else {
-          syncFocusToServer();
+          focusIfPresented();
         }
       };
 
@@ -1171,11 +1171,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
 
       // Store cleanup in closure
       return () => {
-        if (reconcilerRef.current === reconciler) {
-          reconcilerRef.current = null;
-          syncFocusToServerRef.current = null;
-        }
-        reconciler.dispose();
+        releaseReconciler(reconciler);
         window.removeEventListener("resize", handleWindowResize);
         document.removeEventListener("visibilitychange", handleVisibilityChange);
         window.removeEventListener("focus", handleWindowFocus);
@@ -1203,11 +1199,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       mounted = false;
       isUnmountingRef.current = true;
       cleanup?.();
-      liveReconciler?.dispose();
-      if (reconcilerRef.current === liveReconciler) {
-        reconcilerRef.current = null;
-        syncFocusToServerRef.current = null;
-      }
+      releaseReconciler(liveReconciler);
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
       }
@@ -1224,7 +1216,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       webglAddonRef.current = null;
       wsRef.current = null;
     };
-  }, [sessionId, tmuxSessionName, projectPath, wsUrl, updateStatus, terminalType, markIntentionalExit]);
+  }, [sessionId, tmuxSessionName, projectPath, wsUrl, updateStatus, terminalType, markIntentionalExit, focusIfPresented]);
 
   useEffect(() => {
     syncFocusToServerRef.current?.();
@@ -1281,24 +1273,16 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   useEffect(() => {
     if (!isActive) return;
     const reconciler = reconcilerRef.current;
-    const terminal = xtermRef.current;
-    if (!reconciler || !terminal) return;
+    if (!reconciler) return;
     let cancelled = false;
     void reconciler.reconcileOnce("active").then(() => {
-      if (
-        !cancelled &&
-        visibleRef.current &&
-        !document.hidden &&
-        !mobileModeRef.current
-      ) {
-        terminal.focus();
-      }
+      if (!cancelled) focusIfPresented();
     });
 
     return () => {
       cancelled = true;
     };
-  }, [isActive, visible]);
+  }, [isActive, visible, focusIfPresented]);
 
   // Update terminal theme when appearance changes
   useEffect(() => {

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -916,9 +916,14 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
           lastSentFocusStateRef.current = null;
           onWebSocketReadyRef.current?.(ws);
           const pendingGenuineFocus = pendingGenuineFocusRef.current;
+          const currentDesiredFocusState = getDesiredFocus() ? "focus" : "blur";
+          const flushAsGenuineFocus =
+            pendingGenuineFocus ||
+            (lastDesiredFocusStateRef.current === "blur" &&
+              currentDesiredFocusState === "focus");
           const focusFlushed = syncFocusToServer(
             true,
-            hasConnectedBeforeRef.current && !pendingGenuineFocus,
+            hasConnectedBeforeRef.current && !flushAsGenuineFocus,
           );
           if (pendingGenuineFocus && focusFlushed) {
             pendingGenuineFocusRef.current = false;

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -14,73 +14,13 @@ import { sendImageToTerminal } from "@/lib/image-upload";
 import { AuthErrorOverlay } from "./AuthErrorOverlay";
 import { createTouchScrollHandlers } from "./touch-scroll";
 import { createTouchInteractions, createTouchModeRef } from "./useTouchInteractions";
+import {
+  MIN_COLS,
+  MIN_ROWS,
+  ResizeReconciler,
+} from "./resize-reconciler";
 
 import { apiFetch } from "@/lib/api-fetch";
-const SETTLE_MIN_WIDTH = 100;
-const SETTLE_MIN_HEIGHT = 80;
-const SETTLE_MIN_COLS = 10;
-const SETTLE_MIN_ROWS = 3;
-const SETTLE_STABLE_FRAMES = 2;
-const SETTLE_MAX_FRAMES = 10;
-
-interface SettleAndFitOptions {
-  container: HTMLDivElement | null;
-  terminal: XTermType | null;
-  fitAddon: FitAddonType | null;
-  ws: WebSocket | null;
-  isCurrent: () => boolean;
-  onDimensions?: (cols: number, rows: number) => void;
-}
-
-async function settleAndFit(opts: SettleAndFitOptions): Promise<void> {
-  const { container, terminal, fitAddon, ws, isCurrent, onDimensions } = opts;
-  if (!container || !terminal || !fitAddon) return;
-  if (typeof document !== "undefined" && document.hidden) return;
-  if (container.offsetParent === null) return;
-
-  const initialRect = container.getBoundingClientRect();
-  if (initialRect.width < SETTLE_MIN_WIDTH || initialRect.height < SETTLE_MIN_HEIGHT) return;
-
-  let lastWidth = 0;
-  let lastHeight = 0;
-  let stableFrames = 0;
-  for (let attempt = 0; attempt < SETTLE_MAX_FRAMES; attempt++) {
-    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-    if (!isCurrent()) return;
-    const rect = container.getBoundingClientRect();
-    if (rect.width < SETTLE_MIN_WIDTH || rect.height < SETTLE_MIN_HEIGHT) continue;
-    if (rect.width === lastWidth && rect.height === lastHeight) {
-      stableFrames++;
-      if (stableFrames >= SETTLE_STABLE_FRAMES) break;
-    } else {
-      stableFrames = 0;
-      lastWidth = rect.width;
-      lastHeight = rect.height;
-    }
-  }
-
-  if (!isCurrent()) return;
-  fitAddon.fit();
-
-  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-  if (!isCurrent()) return;
-  fitAddon.fit();
-
-  if (!isCurrent()) return;
-  if (terminal.cols < SETTLE_MIN_COLS || terminal.rows < SETTLE_MIN_ROWS) return;
-
-  if (ws && ws.readyState === WebSocket.OPEN) {
-    ws.send(
-      JSON.stringify({
-        type: "resize",
-        cols: terminal.cols,
-        rows: terminal.rows,
-      })
-    );
-  }
-  if (!isCurrent()) return;
-  onDimensions?.(terminal.cols, terminal.rows);
-}
 
 export interface TerminalRef {
   focus: () => void;
@@ -116,7 +56,7 @@ export interface TerminalRef {
   toggleSearch: () => void;
 }
 
-interface TerminalProps {
+export interface TerminalProps {
   sessionId: string;
   tmuxSessionName: string;
   sessionName?: string;
@@ -131,6 +71,8 @@ interface TerminalProps {
   notificationsEnabled?: boolean;
   isRecording?: boolean;
   isActive?: boolean;
+  /** Whether the containing panel is currently presented to the user. */
+  visible?: boolean;
   /** Environment variables to inject into new terminal sessions */
   environmentVars?: Record<string, string> | null;
   /** Terminal type for agent exit detection */
@@ -190,6 +132,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   notificationsEnabled = true,
   isRecording = false,
   isActive = false,
+  visible = true,
   environmentVars,
   terminalType = "shell",
   mobileMode = false,
@@ -221,23 +164,15 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   const searchAddonRef = useRef<SearchAddonType | null>(null);
   const webglAddonRef = useRef<WebglAddonType | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
-  // Last focus signal sent to the server, tracked across reconnects so that a
-  // fresh socket starts with a clean baseline (the server's debounce state
-  // resets per-connection on its side too).
-  const lastSentFocusStateRef = useRef<"focus" | "blur" | null>(null);
-  // Points at the init-effect's `handleResize` (settle → fit → ws-resize →
-  // onDimensions) while the terminal is mounted, so the imperative `refit()`
-  // can drive the exact same pipeline the in-page resize listeners use. Set
-  // inside the init effect after `handleResize` is defined; cleared on
-  // teardown so a post-unmount call is a safe no-op (remote-dev-u5q5.2).
-  const handleResizeRef = useRef<(() => void) | null>(null);
-  // Focus-signal sender for the imperative `refit()`, mirroring the
-  // `handleVisibilityChange` intent (tell the server this client is active
-  // so it promotes us as primary before the resize lands). Set alongside
-  // `handleResizeRef` inside the init effect; cleared on teardown.
-  const sendFocusSignalRef = useRef<((next: "focus" | "blur") => void) | null>(
-    null,
+  const reconcilerRef = useRef<ResizeReconciler | null>(null);
+  const visibleRef = useRef(visible);
+  const isActiveRef = useRef(isActive);
+  const windowFocusedRef = useRef(
+    typeof document !== "undefined" && document.hasFocus(),
   );
+  const textareaFocusedRef = useRef(false);
+  const lastSentFocusStateRef = useRef<"focus" | "blur" | null>(null);
+  const syncFocusToServerRef = useRef<((force?: boolean) => void) | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -260,6 +195,9 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   // sidebar re-seed on reconnect (mirrors useTerminalWebSocket's hasConnectedBefore).
   const hasConnectedBeforeRef = useRef(false);
   const maxReconnectAttempts = 5;
+
+  visibleRef.current = visible;
+  isActiveRef.current = isActive;
 
   /**
    * Atomically marks session exit as intentional and cancels any pending reconnect.
@@ -384,35 +322,8 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       xtermRef.current?.scrollToBottom();
     },
     refit: () => {
-      // Mirror handleVisibilityChange's intent for the native-shell resume /
-      // route-pop path, MINUS terminal.focus(): on mobile the terminal runs
-      // in mobileMode (xterm's internal textarea disabled) and the native
-      // shell owns the input bar + keyboard, so calling terminal.focus()
-      // here would steal the keyboard context (collapse / refocus the
-      // wrong field). We only need the grid re-measured and the viewport
-      // pinned to the latest output.
-      //
-      // 1. Re-assert focus so the server promotes this client to primary
-      //    before the resize message from settleAndFit arrives (another
-      //    tmux client may have resized the session while we were
-      //    backgrounded). 2. settle + fit + ws-resize via the init effect's
-      //    handleResize. 3. scrollToBottom so a grid that grew taller shows
-      //    the prompt, matching the visibilitychange handler.
-      //
-      // FORCE the focus signal past the client-side dedupe. `sendFocusSignal`
-      // early-returns when `lastSentFocusStateRef.current === "focus"`, but
-      // refit() exists precisely for lifecycle edges (app resume, route
-      // pop-back) where the page got NO blur/visibilitychange event — so the
-      // last-sent state is STILL "focus" and a plain call would be skipped.
-      // If another client became primary while this view was backgrounded,
-      // the server only resizes tmux for the primary connection, so the
-      // resize from handleResize below would be ignored. Clearing the
-      // baseline first guarantees a fresh `client_focus` frame re-elects this
-      // connection BEFORE the resize lands. The server's own 1s cooldown
-      // still bounds any thrash, so this is safe to force.
-      lastSentFocusStateRef.current = null;
-      sendFocusSignalRef.current?.("focus");
-      handleResizeRef.current?.();
+      syncFocusToServerRef.current?.(true);
+      reconcilerRef.current?.request("refit");
       xtermRef.current?.scrollToBottom();
     },
     setCursorBlink: (blink: boolean) => {
@@ -456,6 +367,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
 
     let terminal: XTermType;
     let fitAddon: FitAddonType;
+    let liveReconciler: ResizeReconciler | null = null;
     let mounted = true;
     isUnmountingRef.current = false;
     intentionalExitRef.current = false;
@@ -555,9 +467,71 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
 
       terminal.open(xtermContainerRef.current ?? terminalRef.current);
 
+      xtermRef.current = terminal;
+      fitAddonRef.current = fitAddon;
+      imageAddonRef.current = imageAddon;
+      searchAddonRef.current = searchAddon;
+
+      const reconciler = new ResizeReconciler({
+        getContainer: () => terminalRef.current,
+        fitVerified: () => {
+          const proposal = fitAddon.proposeDimensions();
+          if (
+            !proposal ||
+            proposal.cols < MIN_COLS ||
+            proposal.rows < MIN_ROWS
+          ) {
+            return null;
+          }
+          fitAddon.fit();
+          if (
+            terminal.cols !== proposal.cols ||
+            terminal.rows !== proposal.rows
+          ) {
+            return null;
+          }
+          return { cols: terminal.cols, rows: terminal.rows };
+        },
+        isPageVisible: () => !document.hidden,
+        isPanelVisible: () => visibleRef.current,
+        getWebSocket: () => wsRef.current,
+        onDimensions: (cols, rows) =>
+          onDimensionsChangeRef.current?.(cols, rows),
+        raf: (cb) => requestAnimationFrame(cb),
+        caf: (id) => cancelAnimationFrame(id),
+      });
+      liveReconciler = reconciler;
+      reconcilerRef.current = reconciler;
+
+      const getDesiredFocus = () =>
+        visibleRef.current &&
+        !document.hidden &&
+        (windowFocusedRef.current || textareaFocusedRef.current);
+      const syncFocusToServer = (
+        force = false,
+        socket = wsRef.current,
+      ) => {
+        const next = getDesiredFocus() ? "focus" : "blur";
+        if (!force && lastSentFocusStateRef.current === next) return;
+        if (!socket || socket.readyState !== WebSocket.OPEN) return;
+        try {
+          socket.send(
+            JSON.stringify({
+              type: next === "focus" ? "client_focus" : "client_blur",
+            }),
+          );
+          lastSentFocusStateRef.current = next;
+        } catch {
+          // The desired state remains available for the next socket-open flush.
+        }
+      };
+      syncFocusToServerRef.current = (force = false) =>
+        syncFocusToServer(force);
+
       // Load WebGL renderer for better performance (falls back to DOM renderer)
       try {
         const { WebglAddon } = await import("@xterm/addon-webgl");
+        if (!mounted || reconcilerRef.current !== reconciler) return;
         let contextLossRecoveryAttempted = false;
 
         // onRemoveTextureAtlasCanvas only fires inside TextureAtlas._mergePages
@@ -629,6 +603,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
           dprMedia = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
           handleDprChange = () => {
             webglAddonRef.current?.clearTextureAtlas();
+            reconciler.request("dpr-change");
             dprMedia?.removeEventListener("change", handleDprChange);
             armDprListener();
           };
@@ -641,6 +616,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       } catch {
         // WebGL not supported — DOM renderer is used automatically
       }
+      if (!mounted || reconcilerRef.current !== reconciler) return;
 
       // Configure the xterm textarea to disable mobile predictive text/autocomplete
       // This helps prevent the duplication issue where mobile keyboards replace
@@ -776,11 +752,6 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       const preventContextMenu = (e: Event) => e.preventDefault();
       terminalRef.current.addEventListener("contextmenu", preventContextMenu);
 
-      xtermRef.current = terminal;
-      fitAddonRef.current = fitAddon;
-      imageAddonRef.current = imageAddon;
-      searchAddonRef.current = searchAddon;
-
       // Post-init reconciliation: if PreferencesContext resolved during the
       // async init window (xterm/addon imports + WebGL load), the font-update
       // effect would have run with the latest fontSize/fontFamily but bailed
@@ -815,6 +786,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
           updateStatus("error");
           return;
         }
+        if (!mounted || reconcilerRef.current !== reconciler) return;
 
         const cols = terminal.cols;
         const rows = terminal.rows;
@@ -845,47 +817,17 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
         ws.onopen = () => {
           // Guard against race condition: if component unmounted during connection,
           // close the WebSocket immediately and don't call any callbacks with stale references
-          if (isUnmountingRef.current) {
+          if (isUnmountingRef.current || wsRef.current !== ws) {
             ws.close();
             return;
           }
 
           updateStatus("connected");
           reconnectAttemptsRef.current = 0;
-          // Reset focus-send debounce baseline so the first signal on this fresh
-          // socket is always sent (the previous socket's state is irrelevant).
           lastSentFocusStateRef.current = null;
           onWebSocketReadyRef.current?.(ws);
-
-          // Re-assert focus state on (re)connect: if this window currently has
-          // focus, the focus listeners won't fire (the window already had it),
-          // so the server would never learn this connection is the active one.
-          // Send the current state proactively before the resize below, so any
-          // server-side primary promotion happens before the resize lands.
-          try {
-            const hasFocus =
-              typeof document !== "undefined" &&
-              document.hasFocus() &&
-              !document.hidden;
-            const focusType = hasFocus ? "client_focus" : "client_blur";
-            ws.send(JSON.stringify({ type: focusType }));
-            lastSentFocusStateRef.current = hasFocus ? "focus" : "blur";
-          } catch {
-            // Best-effort; if document is unavailable (SSR safety) just skip.
-          }
-
-          // Send resize immediately after connection to sync dimensions
-          // The URL params may be stale if container resized during connection
-          requestAnimationFrame(() => {
-            fitAddon.fit();
-            ws.send(
-              JSON.stringify({
-                type: "resize",
-                cols: terminal.cols,
-                rows: terminal.rows,
-              })
-            );
-          });
+          syncFocusToServer(true, ws);
+          reconciler.notifySocketOpen(ws);
 
           // [remote-dev-d5ci] On a RE-open (not the first connect), dispatch the
           // same sidebar-refresh event useTerminalWebSocket fires so SessionManager
@@ -1119,95 +1061,30 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
 
         // Wait for all fonts to be ready
         await document.fonts.ready;
+        if (!mounted || reconcilerRef.current !== reconciler) return;
 
-        // Wait for container dimensions to stabilize
-        // On hard refresh, the layout may take multiple frames to settle
-        const MIN_CONTAINER_WIDTH = 100;
-        const MIN_CONTAINER_HEIGHT = 80;
-        const MAX_WAIT_ATTEMPTS = 30; // ~500ms max wait
-        const STABLE_FRAMES_REQUIRED = 3; // Dimensions must be stable for 3 frames
-
-        let lastWidth = 0;
-        let lastHeight = 0;
-        let stableFrames = 0;
-
-        for (let attempt = 0; attempt < MAX_WAIT_ATTEMPTS; attempt++) {
-          await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-
-          const container = terminalRef.current;
-          if (!container) continue;
-
-          const rect = container.getBoundingClientRect();
-
-          // Check if dimensions are valid and stable
-          if (rect.width >= MIN_CONTAINER_WIDTH && rect.height >= MIN_CONTAINER_HEIGHT) {
-            if (rect.width === lastWidth && rect.height === lastHeight) {
-              stableFrames++;
-              if (stableFrames >= STABLE_FRAMES_REQUIRED) {
-                break; // Container dimensions are stable
-              }
-            } else {
-              // Dimensions changed, reset stability counter
-              stableFrames = 0;
-              lastWidth = rect.width;
-              lastHeight = rect.height;
-            }
-          }
+        // A hidden initial panel connects with xterm's defaults. The explicit
+        // reveal signal replays reconciliation once the panel is measurable.
+        await reconciler.reconcileOnce("post-init");
+        if (!mounted || reconcilerRef.current !== reconciler) return;
+        if (
+          isActiveRef.current &&
+          visibleRef.current &&
+          !document.hidden &&
+          !mobileModeRef.current
+        ) {
+          terminal.focus();
         }
-
-        // Now fit with accurate measurements
-        fitAddon.fit();
-
-        // Connect with correct dimensions
-        connect();
+        void connect();
       };
 
-      initAndConnect();
+      void initAndConnect();
 
       terminal.onData((data) => {
         if (wsRef.current?.readyState === WebSocket.OPEN) {
           wsRef.current.send(JSON.stringify({ type: "input", data }));
         }
       });
-
-      let settleSeq = 0;
-      const handleResize = () => {
-        const mySeq = ++settleSeq;
-        void settleAndFit({
-          container: terminalRef.current,
-          terminal,
-          fitAddon,
-          ws: wsRef.current,
-          isCurrent: () => mySeq === settleSeq,
-          onDimensions: (cols, rows) => onDimensionsChangeRef.current?.(cols, rows),
-        });
-      };
-
-      // Track last focus signal sent to the server to avoid redundant WS chatter
-      // (focus/blur fire frequently — alt-tab, devtools, etc.). The server-side
-      // 1s cooldown handles thrash, but skipping no-op sends is still cheap.
-      // Stored in a ref (declared at component scope) so the baseline survives
-      // initTerminal() but resets when a new socket opens — a closure-local
-      // `let` would persist across reconnects and cause the first focus/blur on
-      // the new socket to be silently dropped if it matched the prior socket's
-      // last-sent value.
-      const sendFocusSignal = (next: "focus" | "blur") => {
-        if (lastSentFocusStateRef.current === next) return;
-        const ws = wsRef.current;
-        if (!ws || ws.readyState !== WebSocket.OPEN) return;
-        try {
-          ws.send(JSON.stringify({ type: next === "focus" ? "client_focus" : "client_blur" }));
-          lastSentFocusStateRef.current = next;
-        } catch {
-          // Ignore send errors — connection might be tearing down
-        }
-      };
-
-      // Expose this terminal's resize + focus-signal closures to the
-      // imperative `refit()` (rdv-bridge, remote-dev-u5q5.2). Cleared in the
-      // cleanup below so a refit after teardown is a no-op.
-      handleResizeRef.current = handleResize;
-      sendFocusSignalRef.current = sendFocusSignal;
 
       // Per-terminal focus signal: window/visibilitychange only fire for
       // coarse browser-level transitions, so they miss clicks between panels
@@ -1216,8 +1093,14 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       // signal the server needs to elect a primary client.
       const xtermTextarea = terminal.textarea;
       if (xtermTextarea) {
-        const onXtermFocus = () => sendFocusSignal("focus");
-        const onXtermBlur = () => sendFocusSignal("blur");
+        const onXtermFocus = () => {
+          textareaFocusedRef.current = true;
+          syncFocusToServer();
+        };
+        const onXtermBlur = () => {
+          textareaFocusedRef.current = false;
+          syncFocusToServer();
+        };
         xtermTextarea.addEventListener("focus", onXtermFocus);
         xtermTextarea.addEventListener("blur", onXtermBlur);
         terminalDisposablesRef.current.push({
@@ -1228,41 +1111,36 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
         });
       }
 
-      // Re-fit when page becomes visible again (returning from background)
-      let visibilityTimeout: ReturnType<typeof setTimeout> | null = null;
       const handleVisibilityChange = () => {
         if (!document.hidden) {
-          // Send focus signal immediately so the server can promote in time for
-          // the resize message that follows from settleAndFit.
-          sendFocusSignal("focus");
-          // Clear any pending timeout to avoid duplicate calls
-          if (visibilityTimeout) {
-            clearTimeout(visibilityTimeout);
-          }
-          // Small delay to let the browser settle after becoming visible
-          visibilityTimeout = setTimeout(() => {
-            visibilityTimeout = null;
-            handleResize();
-            // Focus terminal when page becomes visible
+          syncFocusToServer();
+          reconciler.request("page-visible");
+          if (
+            isActiveRef.current &&
+            visibleRef.current &&
+            !mobileModeRef.current
+          ) {
             terminal.focus();
-          }, 100);
+          }
         } else {
-          sendFocusSignal("blur");
+          syncFocusToServer();
         }
       };
 
       const handleWindowFocus = () => {
-        sendFocusSignal("focus");
-        // Container size may have shifted while unfocused (desktop window
-        // resize, etc.) — settleAndFit on the next frame.
-        requestAnimationFrame(handleResize);
+        windowFocusedRef.current = true;
+        syncFocusToServer();
+        reconciler.request("window-focus");
       };
 
       const handleWindowBlur = () => {
-        sendFocusSignal("blur");
+        windowFocusedRef.current = false;
+        syncFocusToServer();
       };
 
-      window.addEventListener("resize", handleResize);
+      const handleWindowResize = () => reconciler.request("window-resize");
+
+      window.addEventListener("resize", handleWindowResize);
       document.addEventListener("visibilitychange", handleVisibilityChange);
       window.addEventListener("focus", handleWindowFocus);
       window.addEventListener("blur", handleWindowBlur);
@@ -1272,7 +1150,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       // Listening here ensures the terminal re-fits whenever the visible area
       // changes, even if the wrapper's layout height is stable.
       const handleVisualViewportResize = () => {
-        requestAnimationFrame(handleResize);
+        reconciler.request("visual-viewport");
       };
       const visualViewport =
         typeof window.visualViewport !== "undefined" ? window.visualViewport : null;
@@ -1280,29 +1158,10 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
         visualViewport.addEventListener("resize", handleVisualViewportResize);
       }
 
-      // Use ResizeObserver to detect when terminal container becomes visible
-      // This handles the case when switching tabs (hidden -> visible)
-      let lastWidth = 0;
-      let lastHeight = 0;
-      let resizeTimeout: ReturnType<typeof setTimeout> | null = null;
-
       const resizeObserver = new ResizeObserver((entries) => {
         for (const entry of entries) {
           const { width, height } = entry.contentRect;
-          // Only trigger resize when dimensions are above minimum threshold
-          // and actually change to new values
-          if (
-            width >= SETTLE_MIN_WIDTH &&
-            height >= SETTLE_MIN_HEIGHT &&
-            (width !== lastWidth || height !== lastHeight)
-          ) {
-            lastWidth = width;
-            lastHeight = height;
-
-            // Debounce rapid resize events (e.g., during window drag)
-            if (resizeTimeout) clearTimeout(resizeTimeout);
-            resizeTimeout = setTimeout(handleResize, 16); // ~60fps
-          }
+          reconciler.observeRect(width, height);
         }
       });
 
@@ -1312,18 +1171,12 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
 
       // Store cleanup in closure
       return () => {
-        // Drop the refit closures so a post-unmount imperative refit() is a
-        // safe no-op (the xterm instance + ws are torn down below).
-        if (handleResizeRef.current === handleResize) {
-          handleResizeRef.current = null;
+        if (reconcilerRef.current === reconciler) {
+          reconcilerRef.current = null;
+          syncFocusToServerRef.current = null;
         }
-        if (sendFocusSignalRef.current === sendFocusSignal) {
-          sendFocusSignalRef.current = null;
-        }
-        if (visibilityTimeout) {
-          clearTimeout(visibilityTimeout);
-        }
-        window.removeEventListener("resize", handleResize);
+        reconciler.dispose();
+        window.removeEventListener("resize", handleWindowResize);
         document.removeEventListener("visibilitychange", handleVisibilityChange);
         window.removeEventListener("focus", handleWindowFocus);
         window.removeEventListener("blur", handleWindowBlur);
@@ -1332,13 +1185,17 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
         }
         terminalRef.current?.removeEventListener("contextmenu", preventContextMenu);
         resizeObserver.disconnect();
-        if (resizeTimeout) clearTimeout(resizeTimeout);
       };
     }
 
     let cleanup: (() => void) | undefined;
 
-    initTerminal().then((cleanupFn) => {
+    void initTerminal().then((cleanupFn) => {
+      if (!cleanupFn) return;
+      if (!mounted) {
+        cleanupFn();
+        return;
+      }
       cleanup = cleanupFn;
     });
 
@@ -1346,6 +1203,11 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       mounted = false;
       isUnmountingRef.current = true;
       cleanup?.();
+      liveReconciler?.dispose();
+      if (reconcilerRef.current === liveReconciler) {
+        reconcilerRef.current = null;
+        syncFocusToServerRef.current = null;
+      }
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
       }
@@ -1363,6 +1225,11 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       wsRef.current = null;
     };
   }, [sessionId, tmuxSessionName, projectPath, wsUrl, updateStatus, terminalType, markIntentionalExit]);
+
+  useEffect(() => {
+    syncFocusToServerRef.current?.();
+    reconcilerRef.current?.notifyPanelVisibility(visible);
+  }, [visible]);
 
   // Update terminal options when font preferences change
   useEffect(() => {
@@ -1399,46 +1266,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
 
       // Bail out if this effect was superseded by a newer font change
       if (cancelled) return;
-
-      // Apply the same safety checks as handleResize() to prevent
-      // resizing to invalid dimensions when terminal is hidden/backgrounded
-      const container = terminalRef.current;
-      if (!container) return;
-
-      // Skip if page is hidden (browser tab backgrounded)
-      if (document.hidden) return;
-
-      // Skip if container is not visible (display: none)
-      if (container.offsetParent === null) return;
-
-      // Skip if container is too small
-      const MIN_WIDTH = 100;
-      const MIN_HEIGHT = 80;
-      const rect = container.getBoundingClientRect();
-      if (rect.width < MIN_WIDTH || rect.height < MIN_HEIGHT) return;
-
-      // Use requestAnimationFrame to ensure DOM is ready
-      requestAnimationFrame(() => {
-        if (cancelled) return;
-
-        fitAddonRef.current?.fit();
-
-        // Don't send resize for invalid dimensions
-        const MIN_COLS = 10;
-        const MIN_ROWS = 3;
-        if (terminal.cols < MIN_COLS || terminal.rows < MIN_ROWS) return;
-
-        // Send resize to server if connected
-        if (wsRef.current?.readyState === WebSocket.OPEN) {
-          wsRef.current.send(
-            JSON.stringify({
-              type: "resize",
-              cols: terminal.cols,
-              rows: terminal.rows,
-            })
-          );
-        }
-      });
+      reconcilerRef.current?.request("font-change");
     };
 
     loadFontAndFit();
@@ -1452,27 +1280,25 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   // Trigger resize when terminal becomes active (e.g., switching tabs or splits)
   useEffect(() => {
     if (!isActive) return;
-
+    const reconciler = reconcilerRef.current;
     const terminal = xtermRef.current;
-    const fitAddon = fitAddonRef.current;
-    if (!terminal || !fitAddon) return;
-
+    if (!reconciler || !terminal) return;
     let cancelled = false;
-    void settleAndFit({
-      container: terminalRef.current,
-      terminal,
-      fitAddon,
-      ws: wsRef.current,
-      isCurrent: () => !cancelled,
-      onDimensions: (cols, rows) => onDimensionsChangeRef.current?.(cols, rows),
-    }).then(() => {
-      if (!cancelled) terminal.focus();
+    void reconciler.reconcileOnce("active").then(() => {
+      if (
+        !cancelled &&
+        visibleRef.current &&
+        !document.hidden &&
+        !mobileModeRef.current
+      ) {
+        terminal.focus();
+      }
     });
 
     return () => {
       cancelled = true;
     };
-  }, [isActive]);
+  }, [isActive, visible]);
 
   // Update terminal theme when appearance changes
   useEffect(() => {

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -170,6 +170,8 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   const isActiveRef = useRef(isActive);
   const textareaFocusedRef = useRef(false);
   const lastSentFocusStateRef = useRef<"focus" | "blur" | null>(null);
+  const lastDesiredFocusStateRef = useRef<"focus" | "blur" | null>(null);
+  const pendingGenuineFocusRef = useRef(false);
   const syncFocusToServerRef = useRef<
     ((force?: boolean, reassert?: boolean) => void) | null
   >(null);
@@ -387,6 +389,8 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
     // open is a FIRST connect, not a reconnect. (Stays true across reconnect
     // attempts within this same effect run.)
     hasConnectedBeforeRef.current = false;
+    lastDesiredFocusStateRef.current = null;
+    pendingGenuineFocusRef.current = false;
 
     const releaseReconciler = (instance: ResizeReconciler | null) => {
       if (!instance) return;
@@ -532,8 +536,17 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       const syncFocusToServer = (force = false, reassert = false) => {
         const socket = wsRef.current;
         const next = getDesiredFocus() ? "focus" : "blur";
-        if (!force && lastSentFocusStateRef.current === next) return;
-        if (!socket || socket.readyState !== WebSocket.OPEN) return;
+        const previousDesired = lastDesiredFocusStateRef.current;
+        lastDesiredFocusStateRef.current = next;
+        if (!socket || socket.readyState !== WebSocket.OPEN) {
+          if (next === "blur") {
+            pendingGenuineFocusRef.current = false;
+          } else if (previousDesired === "blur") {
+            pendingGenuineFocusRef.current = true;
+          }
+          return false;
+        }
+        if (!force && lastSentFocusStateRef.current === next) return false;
         try {
           const message = next === "focus"
             ? reassert
@@ -542,8 +555,11 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
             : { type: "client_blur" };
           socket.send(JSON.stringify(message));
           lastSentFocusStateRef.current = next;
+          if (next === "blur") pendingGenuineFocusRef.current = false;
+          return true;
         } catch {
           // The desired state remains available for the next socket-open flush.
+          return false;
         }
       };
       syncFocusToServerRef.current = syncFocusToServer;
@@ -798,7 +814,12 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       }
 
       async function connect() {
-        if (wsRef.current?.readyState === WebSocket.OPEN) return;
+        if (
+          wsRef.current?.readyState === WebSocket.OPEN ||
+          wsRef.current?.readyState === WebSocket.CONNECTING
+        ) {
+          return;
+        }
 
         updateStatus("connecting");
 
@@ -819,6 +840,12 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
           return;
         }
         if (!mounted || reconcilerRef.current !== reconciler) return;
+        if (
+          wsRef.current?.readyState === WebSocket.OPEN ||
+          wsRef.current?.readyState === WebSocket.CONNECTING
+        ) {
+          return;
+        }
 
         const cols = terminal.cols;
         const rows = terminal.rows;
@@ -844,13 +871,28 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
           params.set("environmentVars", encodeURIComponent(JSON.stringify(envVars)));
         }
 
+        const oldWs = wsRef.current;
         const ws = new WebSocket(`${wsUrl}?${params.toString()}`);
         wsRef.current = ws;
+        if (oldWs && oldWs !== ws) {
+          try {
+            oldWs.close();
+          } catch {
+            // The replacement remains authoritative even if stale close fails.
+          }
+        }
 
         ws.onopen = () => {
           // Guard against race condition: if component unmounted during connection,
           // close the WebSocket immediately and don't call any callbacks with stale references
-          if (wsRef.current !== ws) return;
+          if (wsRef.current !== ws) {
+            try {
+              ws.close();
+            } catch {
+              // The current socket remains authoritative.
+            }
+            return;
+          }
           if (isUnmountingRef.current) {
             ws.close();
             return;
@@ -860,7 +902,14 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
           reconnectAttemptsRef.current = 0;
           lastSentFocusStateRef.current = null;
           onWebSocketReadyRef.current?.(ws);
-          syncFocusToServer(true, hasConnectedBeforeRef.current);
+          const pendingGenuineFocus = pendingGenuineFocusRef.current;
+          const focusFlushed = syncFocusToServer(
+            true,
+            hasConnectedBeforeRef.current && !pendingGenuineFocus,
+          );
+          if (pendingGenuineFocus && focusFlushed) {
+            pendingGenuineFocusRef.current = false;
+          }
           reconciler.notifySocketOpen(ws);
 
           // [remote-dev-d5ci] On a RE-open (not the first connect), dispatch the

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -203,7 +203,6 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   const hasConnectedBeforeRef = useRef(false);
   const maxReconnectAttempts = 5;
 
-  visibleRef.current = visible;
   isActiveRef.current = isActive;
 
   /**
@@ -1306,6 +1305,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   }, [sessionId, tmuxSessionName, projectPath, wsUrl, updateStatus, terminalType, markIntentionalExit, focusIfPresented]);
 
   useEffect(() => {
+    visibleRef.current = visible;
     syncFocusToServerRef.current?.();
     reconcilerRef.current?.notifyPanelVisibility(visible);
   }, [visible]);

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -399,9 +399,11 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
     previousSessionIdentityRef.current = { sessionId, tmuxSessionName };
     // A same-session effect restart is another reopen of this mounted client,
     // while a different session must begin with a genuine focus assertion.
-    if (isDifferentSession) hasConnectedBeforeRef.current = false;
-    lastDesiredFocusStateRef.current = null;
-    pendingGenuineFocusRef.current = false;
+    if (isDifferentSession) {
+      hasConnectedBeforeRef.current = false;
+      lastDesiredFocusStateRef.current = null;
+      pendingGenuineFocusRef.current = false;
+    }
 
     const releaseReconciler = (instance: ResizeReconciler | null) => {
       if (!instance) return;
@@ -1280,6 +1282,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       releaseReconciler(liveReconciler);
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
       }
       wsRef.current?.close();
       for (const d of terminalDisposablesRef.current) d.dispose();

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -164,6 +164,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   const searchAddonRef = useRef<SearchAddonType | null>(null);
   const webglAddonRef = useRef<WebglAddonType | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
+  const clientInstanceIdRef = useRef<string | null>(null);
   const reconcilerRef = useRef<ResizeReconciler | null>(null);
   const visibleRef = useRef(visible);
   const isActiveRef = useRef(isActive);
@@ -380,6 +381,8 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
     let mounted = true;
     isUnmountingRef.current = false;
     intentionalExitRef.current = false;
+    const clientInstanceId = crypto.randomUUID();
+    clientInstanceIdRef.current = clientInstanceId;
     // [remote-dev-d5ci] Fresh effect run == a new session/socket → the upcoming
     // open is a FIRST connect, not a reconnect. (Stays true across reconnect
     // attempts within this same effect run.)
@@ -829,6 +832,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
           tmuxHistoryLimit: String(tmuxHistoryLimitRef.current),
           // Include terminal type for agent exit detection
           terminalType,
+          clientInstanceId,
         });
         // Include working directory if specified
         if (projectPath) {
@@ -846,7 +850,8 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
         ws.onopen = () => {
           // Guard against race condition: if component unmounted during connection,
           // close the WebSocket immediately and don't call any callbacks with stale references
-          if (isUnmountingRef.current || wsRef.current !== ws) {
+          if (wsRef.current !== ws) return;
+          if (isUnmountingRef.current) {
             ws.close();
             return;
           }
@@ -855,10 +860,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
           reconnectAttemptsRef.current = 0;
           lastSentFocusStateRef.current = null;
           onWebSocketReadyRef.current?.(ws);
-          const reassert =
-            hasConnectedBeforeRef.current &&
-            !(textareaFocusedRef.current && document.hasFocus());
-          syncFocusToServer(true, reassert);
+          syncFocusToServer(true, hasConnectedBeforeRef.current);
           reconciler.notifySocketOpen(ws);
 
           // [remote-dev-d5ci] On a RE-open (not the first connect), dispatch the
@@ -1032,6 +1034,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
         };
 
         ws.onclose = () => {
+          if (wsRef.current !== ws) return;
           if (isUnmountingRef.current) {
             return;
           }
@@ -1230,6 +1233,9 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       searchAddonRef.current = null;
       webglAddonRef.current = null;
       wsRef.current = null;
+      if (clientInstanceIdRef.current === clientInstanceId) {
+        clientInstanceIdRef.current = null;
+      }
     };
   }, [sessionId, tmuxSessionName, projectPath, wsUrl, updateStatus, terminalType, markIntentionalExit, focusIfPresented]);
 

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -167,12 +167,10 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   const reconcilerRef = useRef<ResizeReconciler | null>(null);
   const visibleRef = useRef(visible);
   const isActiveRef = useRef(isActive);
-  const windowFocusedRef = useRef(
-    typeof document !== "undefined" && document.hasFocus(),
-  );
   const textareaFocusedRef = useRef(false);
   const lastSentFocusStateRef = useRef<"focus" | "blur" | null>(null);
   const syncFocusToServerRef = useRef<((force?: boolean) => void) | null>(null);
+  const forceFocusAssertRef = useRef<(() => void) | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -322,7 +320,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       xtermRef.current?.scrollToBottom();
     },
     refit: () => {
-      syncFocusToServerRef.current?.(true);
+      forceFocusAssertRef.current?.();
       reconcilerRef.current?.request("refit");
       xtermRef.current?.scrollToBottom();
     },
@@ -391,6 +389,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       if (reconcilerRef.current === instance) {
         reconcilerRef.current = null;
         syncFocusToServerRef.current = null;
+        forceFocusAssertRef.current = null;
       }
     };
 
@@ -524,7 +523,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       const getDesiredFocus = () =>
         visibleRef.current &&
         !document.hidden &&
-        (windowFocusedRef.current || textareaFocusedRef.current);
+        (document.hasFocus() || textareaFocusedRef.current);
       const syncFocusToServer = (force = false) => {
         const socket = wsRef.current;
         const next = getDesiredFocus() ? "focus" : "blur";
@@ -542,6 +541,17 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
         }
       };
       syncFocusToServerRef.current = syncFocusToServer;
+      const forceFocusAssert = () => {
+        const socket = wsRef.current;
+        if (!socket || socket.readyState !== WebSocket.OPEN) return;
+        try {
+          socket.send(JSON.stringify({ type: "client_focus" }));
+          lastSentFocusStateRef.current = "focus";
+        } catch {
+          // A later derived-state trigger or socket-open flush retries focus.
+        }
+      };
+      forceFocusAssertRef.current = forceFocusAssert;
 
       // Load WebGL renderer for better performance (falls back to DOM renderer)
       try {
@@ -1128,13 +1138,11 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       };
 
       const handleWindowFocus = () => {
-        windowFocusedRef.current = true;
         syncFocusToServer();
         reconciler.request("window-focus");
       };
 
       const handleWindowBlur = () => {
-        windowFocusedRef.current = false;
         syncFocusToServer();
       };
 

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -165,6 +165,10 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
   const webglAddonRef = useRef<WebglAddonType | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const clientInstanceIdRef = useRef<string | null>(null);
+  const previousSessionIdentityRef = useRef<{
+    sessionId: string;
+    tmuxSessionName: string;
+  } | null>(null);
   const reconcilerRef = useRef<ResizeReconciler | null>(null);
   const visibleRef = useRef(visible);
   const isActiveRef = useRef(isActive);
@@ -383,12 +387,19 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
     let mounted = true;
     isUnmountingRef.current = false;
     intentionalExitRef.current = false;
-    const clientInstanceId = crypto.randomUUID();
-    clientInstanceIdRef.current = clientInstanceId;
-    // [remote-dev-d5ci] Fresh effect run == a new session/socket → the upcoming
-    // open is a FIRST connect, not a reconnect. (Stays true across reconnect
-    // attempts within this same effect run.)
-    hasConnectedBeforeRef.current = false;
+    if (clientInstanceIdRef.current === null) {
+      clientInstanceIdRef.current = crypto.randomUUID();
+    }
+    const clientInstanceId = clientInstanceIdRef.current;
+    const previousSessionIdentity = previousSessionIdentityRef.current;
+    const isDifferentSession =
+      !previousSessionIdentity ||
+      previousSessionIdentity.sessionId !== sessionId ||
+      previousSessionIdentity.tmuxSessionName !== tmuxSessionName;
+    previousSessionIdentityRef.current = { sessionId, tmuxSessionName };
+    // A same-session effect restart is another reopen of this mounted client,
+    // while a different session must begin with a genuine focus assertion.
+    if (isDifferentSession) hasConnectedBeforeRef.current = false;
     lastDesiredFocusStateRef.current = null;
     pendingGenuineFocusRef.current = false;
 
@@ -1282,9 +1293,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       searchAddonRef.current = null;
       webglAddonRef.current = null;
       wsRef.current = null;
-      if (clientInstanceIdRef.current === clientInstanceId) {
-        clientInstanceIdRef.current = null;
-      }
+      textareaFocusedRef.current = false;
     };
   }, [sessionId, tmuxSessionName, projectPath, wsUrl, updateStatus, terminalType, markIntentionalExit, focusIfPresented]);
 

--- a/src/components/terminal/TerminalWithKeyboard.tsx
+++ b/src/components/terminal/TerminalWithKeyboard.tsx
@@ -83,6 +83,7 @@ interface TerminalWithKeyboardProps {
   notificationsEnabled?: boolean;
   isRecording?: boolean;
   isActive?: boolean;
+  visible?: boolean;
   /** Environment variables to inject into new terminal sessions */
   environmentVars?: Record<string, string> | null;
   /**
@@ -134,6 +135,7 @@ export const TerminalWithKeyboard = forwardRef<TerminalWithKeyboardRef, Terminal
   notificationsEnabled,
   isRecording,
   isActive,
+  visible = true,
   environmentVars,
   mobileChrome = "builtin",
   onStatusChange,
@@ -267,6 +269,7 @@ export const TerminalWithKeyboard = forwardRef<TerminalWithKeyboardRef, Terminal
         notificationsEnabled={notificationsEnabled}
         isRecording={isRecording}
         isActive={isActive}
+        visible={visible}
         environmentVars={environmentVars}
         terminalType={session?.terminalType}
         mobileMode={isMobile}

--- a/src/components/terminal/resize-reconciler.test.ts
+++ b/src/components/terminal/resize-reconciler.test.ts
@@ -187,14 +187,23 @@ describe("ResizeReconciler", () => {
     });
   });
 
-  it("finding #6: stale socket identity — notifySocketOpen(oldWs) is a no-op", () => {
+  it("finding #6: stale socket identity — notifySocketOpen(oldWs) is a no-op", async () => {
+    host.ws.readyState = WebSocket.CONNECTING;
+    reconciler.request("active");
+    await host.pumpUntilIdle();
+    expect(reconciler.getDesiredDims()).toEqual({ cols: 100, rows: 30 });
+
     const oldWs = host.ws;
+    oldWs.readyState = WebSocket.OPEN;
     host.ws = new FakeWebSocket();
+    host.fitCalls = 0;
 
     reconciler.notifySocketOpen(oldWs as unknown as WebSocket);
+    await host.pumpUntilIdle();
 
     expect(host.ws.sent).toHaveLength(0);
     expect(oldWs.sent).toHaveLength(0);
+    expect(host.fitCalls).toBe(0);
   });
 
   it("finding #6: dispose cancels in-flight work; all methods no-op after", async () => {

--- a/src/components/terminal/resize-reconciler.test.ts
+++ b/src/components/terminal/resize-reconciler.test.ts
@@ -250,7 +250,7 @@ describe("ResizeReconciler", () => {
     expect(reconciler.getDesiredDims()).toBeNull();
   });
 
-  it("request while page hidden is deferred, not dropped", async () => {
+  it("request while page hidden is dropped by design; every reveal path re-requests", async () => {
     host.pageVisible = false;
     reconciler.request("window-resize");
     await host.pumpUntilIdle();

--- a/src/components/terminal/resize-reconciler.test.ts
+++ b/src/components/terminal/resize-reconciler.test.ts
@@ -21,6 +21,7 @@ class FakeHost implements ReconcilerHost {
   panelVisible = true;
   pageVisible = true;
   fitNoopMode = false;
+  fitResultOverride: { cols: number; rows: number } | null = null;
   grid = { cols: 80, rows: 24 };
   fitCalls = 0;
   ws = new FakeWebSocket();
@@ -36,6 +37,10 @@ class FakeHost implements ReconcilerHost {
   fitVerified() {
     this.fitCalls++;
     if (this.fitNoopMode) return null;
+    if (this.fitResultOverride) {
+      this.grid = { ...this.fitResultOverride };
+      return { ...this.grid };
+    }
 
     const proposal = {
       cols: Math.floor(this.rect.width / 8),
@@ -178,7 +183,8 @@ describe("ResizeReconciler", () => {
     expect(reconciler.getDesiredDims()).toBeNull();
 
     host.fitNoopMode = false;
-    reconciler.request("window-focus");
+    reconciler.observeRect(800, 480);
+    await vi.advanceTimersByTimeAsync(20);
     await host.pumpUntilIdle();
     expect(host.sentResizes.at(-1)).toEqual({
       type: "resize",
@@ -246,6 +252,15 @@ describe("ResizeReconciler", () => {
     reconciler.request("window-resize");
     await host.pumpUntilIdle();
 
+    expect(host.sentResizes).toHaveLength(0);
+    expect(reconciler.getDesiredDims()).toBeNull();
+
+    host.rect = { width: 800, height: 480 };
+    host.fitResultOverride = { cols: MIN_COLS - 1, rows: MIN_ROWS - 1 };
+    reconciler.request("window-resize");
+    await host.pumpUntilIdle();
+
+    expect(host.fitCalls).toBe(1);
     expect(host.sentResizes).toHaveLength(0);
     expect(reconciler.getDesiredDims()).toBeNull();
   });

--- a/src/components/terminal/resize-reconciler.test.ts
+++ b/src/components/terminal/resize-reconciler.test.ts
@@ -219,15 +219,14 @@ describe("ResizeReconciler", () => {
     expect(await result).toEqual({ cols: 100, rows: 30 });
   });
 
-  it("supersede: a newer request cancels an older in-flight generation", async () => {
-    const older = reconciler.reconcileOnce("window-resize");
+  it("reconcileOnce follows a superseding request to the latest verified dimensions", async () => {
+    const result = reconciler.reconcileOnce("post-init");
     await host.pump(1);
     host.rect = { width: 960, height: 640 };
-    const newer = reconciler.reconcileOnce("visual-viewport");
+    reconciler.request("resize-observer");
     await host.pumpUntilIdle();
 
-    expect(await older).toBeNull();
-    expect(await newer).toEqual({ cols: 120, rows: 40 });
+    expect(await result).toEqual({ cols: 120, rows: 40 });
     expect(host.sentResizes).toEqual([
       { type: "resize", cols: 120, rows: 40 },
     ]);

--- a/src/components/terminal/resize-reconciler.test.ts
+++ b/src/components/terminal/resize-reconciler.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  MIN_COLS,
+  MIN_ROWS,
+  ResizeReconciler,
+  type ReconcilerHost,
+} from "./resize-reconciler";
+
+class FakeWebSocket {
+  readyState: number = WebSocket.OPEN;
+  sent: string[] = [];
+
+  send(frame: string) {
+    this.sent.push(frame);
+  }
+}
+
+class FakeHost implements ReconcilerHost {
+  rect = { width: 800, height: 480 };
+  panelVisible = true;
+  pageVisible = true;
+  fitNoopMode = false;
+  grid = { cols: 80, rows: 24 };
+  fitCalls = 0;
+  ws = new FakeWebSocket();
+  private nextRafId = 1;
+  private rafQueue = new Map<number, () => void>();
+
+  getContainer() {
+    return {
+      getBoundingClientRect: () => ({ ...this.rect }),
+    } as HTMLElement;
+  }
+
+  fitVerified() {
+    this.fitCalls++;
+    if (this.fitNoopMode) return null;
+
+    const proposal = {
+      cols: Math.floor(this.rect.width / 8),
+      rows: Math.floor(this.rect.height / 16),
+    };
+    if (proposal.cols < MIN_COLS || proposal.rows < MIN_ROWS) return null;
+    this.grid = proposal;
+    return { ...this.grid };
+  }
+
+  isPageVisible() {
+    return this.pageVisible;
+  }
+
+  isPanelVisible() {
+    return this.panelVisible;
+  }
+
+  getWebSocket() {
+    return this.ws as unknown as WebSocket;
+  }
+
+  raf(cb: () => void) {
+    const id = this.nextRafId++;
+    this.rafQueue.set(id, cb);
+    return id;
+  }
+
+  caf(id: number) {
+    this.rafQueue.delete(id);
+  }
+
+  async pump(count = 1) {
+    for (let index = 0; index < count; index++) {
+      const next = this.rafQueue.entries().next().value as
+        | [number, () => void]
+        | undefined;
+      if (!next) {
+        await Promise.resolve();
+        continue;
+      }
+      this.rafQueue.delete(next[0]);
+      next[1]();
+      await Promise.resolve();
+    }
+  }
+
+  async pumpUntilIdle() {
+    let emptyPasses = 0;
+    for (let iteration = 0; iteration < 100; iteration++) {
+      if (this.rafQueue.size > 0) {
+        emptyPasses = 0;
+        await this.pump(1);
+      } else {
+        await Promise.resolve();
+        emptyPasses++;
+        if (emptyPasses >= 3 && this.rafQueue.size === 0) return;
+      }
+    }
+    throw new Error("rAF queue did not become idle");
+  }
+
+  get sentResizes() {
+    return this.ws.sent
+      .map((frame) => JSON.parse(frame) as { type: string; cols: number; rows: number })
+      .filter((frame) => frame.type === "resize");
+  }
+}
+
+describe("ResizeReconciler", () => {
+  let host: FakeHost;
+  let reconciler: ResizeReconciler;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    host = new FakeHost();
+    reconciler = new ResizeReconciler(host);
+  });
+
+  afterEach(() => {
+    reconciler.dispose();
+    vi.useRealTimers();
+  });
+
+  it("RC-A: rect observed then hidden before debounce — re-show at same size still fits", async () => {
+    host.rect = { width: 800, height: 480 };
+    reconciler.observeRect(800, 480);
+    host.panelVisible = false;
+    reconciler.notifyPanelVisibility(false);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(host.fitCalls).toBe(0);
+
+    host.panelVisible = true;
+    reconciler.notifyPanelVisibility(true);
+    await host.pumpUntilIdle();
+
+    expect(host.sentResizes.at(-1)).toEqual({
+      type: "resize",
+      cols: 100,
+      rows: 30,
+    });
+  });
+
+  it("RC-B: hide mid-settle aborts without fitting; reveal replays", async () => {
+    reconciler.request("window-resize");
+    await host.pump(1);
+    host.panelVisible = false;
+    reconciler.notifyPanelVisibility(false);
+    await host.pumpUntilIdle();
+    expect(host.fitCalls).toBe(0);
+
+    host.panelVisible = true;
+    reconciler.notifyPanelVisibility(true);
+    await host.pumpUntilIdle();
+    expect(host.fitCalls).toBeGreaterThan(0);
+  });
+
+  it("RC-I: socket closed at send time — dims queued and replayed on open", async () => {
+    host.ws.readyState = WebSocket.CONNECTING;
+    reconciler.request("active");
+    await host.pumpUntilIdle();
+    expect(host.sentResizes).toHaveLength(0);
+    expect(reconciler.getDesiredDims()).toEqual({ cols: 100, rows: 30 });
+
+    host.ws.readyState = WebSocket.OPEN;
+    reconciler.notifySocketOpen(host.ws as unknown as WebSocket);
+    expect(host.sentResizes.at(-1)).toEqual({
+      type: "resize",
+      cols: 100,
+      rows: 30,
+    });
+  });
+
+  it("finding #5: no-op fit commits nothing and sends nothing", async () => {
+    host.fitNoopMode = true;
+    reconciler.observeRect(800, 480);
+    await vi.advanceTimersByTimeAsync(20);
+    await host.pumpUntilIdle();
+    expect(host.sentResizes).toHaveLength(0);
+    expect(reconciler.getDesiredDims()).toBeNull();
+
+    host.fitNoopMode = false;
+    reconciler.request("window-focus");
+    await host.pumpUntilIdle();
+    expect(host.sentResizes.at(-1)).toEqual({
+      type: "resize",
+      cols: 100,
+      rows: 30,
+    });
+  });
+
+  it("finding #6: stale socket identity — notifySocketOpen(oldWs) is a no-op", () => {
+    const oldWs = host.ws;
+    host.ws = new FakeWebSocket();
+
+    reconciler.notifySocketOpen(oldWs as unknown as WebSocket);
+
+    expect(host.ws.sent).toHaveLength(0);
+    expect(oldWs.sent).toHaveLength(0);
+  });
+
+  it("finding #6: dispose cancels in-flight work; all methods no-op after", async () => {
+    reconciler.request("active");
+    await host.pump(1);
+    reconciler.dispose();
+    await host.pumpUntilIdle();
+    expect(host.fitCalls).toBe(0);
+
+    reconciler.request("active");
+    reconciler.notifyPanelVisibility(true);
+    reconciler.observeRect(900, 500);
+    reconciler.notifySocketOpen(host.ws as unknown as WebSocket);
+    await vi.advanceTimersByTimeAsync(20);
+    await host.pumpUntilIdle();
+    expect(host.fitCalls).toBe(0);
+  });
+
+  it("reconcileOnce resolves with verified dims (pre-connect path)", async () => {
+    const result = reconciler.reconcileOnce("post-init");
+    await host.pumpUntilIdle();
+    expect(await result).toEqual({ cols: 100, rows: 30 });
+  });
+
+  it("supersede: a newer request cancels an older in-flight generation", async () => {
+    const older = reconciler.reconcileOnce("window-resize");
+    await host.pump(1);
+    host.rect = { width: 960, height: 640 };
+    const newer = reconciler.reconcileOnce("visual-viewport");
+    await host.pumpUntilIdle();
+
+    expect(await older).toBeNull();
+    expect(await newer).toEqual({ cols: 120, rows: 40 });
+    expect(host.sentResizes).toEqual([
+      { type: "resize", cols: 120, rows: 40 },
+    ]);
+  });
+
+  it("never sends grids below 10×3 and does not commit them", async () => {
+    host.rect = { width: 72, height: 32 };
+    reconciler.request("window-resize");
+    await host.pumpUntilIdle();
+
+    expect(host.sentResizes).toHaveLength(0);
+    expect(reconciler.getDesiredDims()).toBeNull();
+  });
+
+  it("request while page hidden is deferred, not dropped", async () => {
+    host.pageVisible = false;
+    reconciler.request("window-resize");
+    await host.pumpUntilIdle();
+    expect(host.fitCalls).toBe(0);
+
+    host.pageVisible = true;
+    reconciler.request("page-visible");
+    await host.pumpUntilIdle();
+    expect(host.sentResizes.at(-1)).toEqual({
+      type: "resize",
+      cols: 100,
+      rows: 30,
+    });
+  });
+});

--- a/src/components/terminal/resize-reconciler.ts
+++ b/src/components/terminal/resize-reconciler.ts
@@ -1,10 +1,5 @@
-export const SETTLE_MIN_WIDTH = 100;
-export const SETTLE_MIN_HEIGHT = 80;
 export const MIN_COLS = 10;
 export const MIN_ROWS = 3;
-export const SETTLE_STABLE_FRAMES = 2;
-export const SETTLE_MAX_FRAMES = 10;
-export const OBSERVER_DEBOUNCE_MS = 16;
 
 export type ReconcileReason =
   | "panel-visible"
@@ -52,13 +47,13 @@ interface RectSize {
 }
 
 const DEFAULT_LIMITS: ReconcilerLimits = {
-  minWidth: SETTLE_MIN_WIDTH,
-  minHeight: SETTLE_MIN_HEIGHT,
+  minWidth: 100,
+  minHeight: 80,
   minCols: MIN_COLS,
   minRows: MIN_ROWS,
-  stableFrames: SETTLE_STABLE_FRAMES,
-  maxFrames: SETTLE_MAX_FRAMES,
-  observerDebounceMs: OBSERVER_DEBOUNCE_MS,
+  stableFrames: 2,
+  maxFrames: 10,
+  observerDebounceMs: 16,
 };
 
 export class ResizeReconciler {
@@ -66,11 +61,10 @@ export class ResizeReconciler {
   private disposed = false;
   private epoch = 0;
   private generation = 0;
-  private pendingWhileHidden = false;
   private committedRect: RectSize | null = null;
   private desiredDims: FitResult | null = null;
   private observerTimer: ReturnType<typeof setTimeout> | null = null;
-  private readonly pendingFrames = new Map<number, (current: boolean) => void>();
+  private readonly pendingFrames = new Map<number, () => void>();
 
   constructor(
     private readonly host: ReconcilerHost,
@@ -91,7 +85,8 @@ export class ResizeReconciler {
     if (this.disposed) return;
 
     if (!visible) {
-      this.pendingWhileHidden = true;
+      // Dropping the committed rect is what makes an identical-size reveal
+      // reconcile again instead of being deduped away (RC-A).
       this.committedRect = null;
       this.generation++;
       this.cancelPendingFrames();
@@ -102,7 +97,6 @@ export class ResizeReconciler {
       return;
     }
 
-    this.pendingWhileHidden = false;
     this.request("panel-visible");
   }
 
@@ -153,24 +147,15 @@ export class ResizeReconciler {
     const epoch = this.epoch;
     const generation = ++this.generation;
     this.cancelPendingFrames();
+    if (!this.isLive(epoch, generation)) return null;
 
-    if (!this.isVisible()) {
-      this.pendingWhileHidden = true;
-      return null;
-    }
-
-    this.pendingWhileHidden = false;
     let lastWidth = 0;
     let lastHeight = 0;
     let stableFrames = 0;
 
     for (let attempt = 0; attempt < this.limits.maxFrames; attempt++) {
-      if (!(await this.nextFrame(epoch, generation))) return null;
-      if (!this.isCurrent(epoch, generation)) return null;
-      if (!this.isVisible()) {
-        this.pendingWhileHidden = true;
-        return null;
-      }
+      await this.nextFrame();
+      if (!this.isLive(epoch, generation)) return null;
 
       const rect = this.getRect();
       if (!rect || !this.isMeasurable(rect)) continue;
@@ -185,11 +170,7 @@ export class ResizeReconciler {
       }
     }
 
-    if (!this.isCurrent(epoch, generation)) return null;
-    if (!this.isVisible()) {
-      this.pendingWhileHidden = true;
-      return null;
-    }
+    if (!this.isLive(epoch, generation)) return null;
 
     const rect = this.getRect();
     if (!rect || !this.isMeasurable(rect)) return null;
@@ -204,16 +185,15 @@ export class ResizeReconciler {
     this.desiredDims = { ...dims };
     const socket = this.host.getWebSocket();
     if (socket?.readyState === WebSocket.OPEN) this.sendResize(socket, dims);
-    if (!this.isCurrent(epoch, generation)) return null;
     this.host.onDimensions?.(dims.cols, dims.rows);
     return { ...dims };
   }
 
-  private nextFrame(epoch: number, generation: number): Promise<boolean> {
+  private nextFrame(): Promise<void> {
     return new Promise((resolve) => {
       const id = this.host.raf(() => {
         this.pendingFrames.delete(id);
-        resolve(this.isCurrent(epoch, generation));
+        resolve();
       });
       this.pendingFrames.set(id, resolve);
     });
@@ -222,7 +202,7 @@ export class ResizeReconciler {
   private cancelPendingFrames() {
     for (const [id, resolve] of this.pendingFrames) {
       this.host.caf(id);
-      resolve(false);
+      resolve();
     }
     this.pendingFrames.clear();
   }
@@ -233,6 +213,12 @@ export class ResizeReconciler {
       epoch === this.epoch &&
       generation === this.generation
     );
+  }
+
+  /** Re-checked after every async boundary: a superseded or hidden generation
+   *  must abort before it can measure or fit (RC-B). */
+  private isLive(epoch: number, generation: number) {
+    return this.isCurrent(epoch, generation) && this.isVisible();
   }
 
   private isVisible() {

--- a/src/components/terminal/resize-reconciler.ts
+++ b/src/components/terminal/resize-reconciler.ts
@@ -46,6 +46,18 @@ interface RectSize {
   height: number;
 }
 
+type ReconcileRunOutcome =
+  | { generation: number; status: "verified"; dims: FitResult }
+  | { generation: number; status: "hidden" | "invalid" | "disposed" }
+  | { generation: number; status: "superseded" };
+
+interface ReconcileRun {
+  generation: number;
+  outcome: Promise<ReconcileRunOutcome>;
+}
+
+const MAX_RECONCILE_ONCE_SUPERSESSIONS = 5;
+
 const DEFAULT_LIMITS: ReconcilerLimits = {
   minWidth: 100,
   minHeight: 80,
@@ -65,6 +77,7 @@ export class ResizeReconciler {
   private desiredDims: FitResult | null = null;
   private observerTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly pendingFrames = new Map<number, () => void>();
+  private latestRun: ReconcileRun | null = null;
 
   constructor(
     private readonly host: ReconcilerHost,
@@ -74,11 +87,24 @@ export class ResizeReconciler {
   }
 
   request(_reason: ReconcileReason): void {
-    void this.startReconcile();
+    void this.startReconcile().outcome;
   }
 
-  reconcileOnce(_reason: ReconcileReason): Promise<FitResult | null> {
-    return this.startReconcile();
+  async reconcileOnce(_reason: ReconcileReason): Promise<FitResult | null> {
+    let run = this.startReconcile();
+    let supersessions = 0;
+
+    while (true) {
+      const outcome = await run.outcome;
+      if (outcome.status === "verified") return { ...outcome.dims };
+      if (outcome.status !== "superseded") return null;
+      if (supersessions >= MAX_RECONCILE_ONCE_SUPERSESSIONS) return null;
+      supersessions++;
+
+      const latest = this.latestRun;
+      if (!latest || latest.generation <= outcome.generation) return null;
+      run = latest;
+    }
   }
 
   notifyPanelVisibility(visible: boolean): void {
@@ -97,6 +123,8 @@ export class ResizeReconciler {
       return;
     }
 
+    // Reveal replay: hidden requests are intentionally dropped because every
+    // panel reveal unconditionally starts a fresh reconciliation here.
     this.request("panel-visible");
   }
 
@@ -141,13 +169,33 @@ export class ResizeReconciler {
     this.cancelPendingFrames();
   }
 
-  private async startReconcile(): Promise<FitResult | null> {
-    if (this.disposed) return null;
-
+  private startReconcile(): ReconcileRun {
+    if (this.disposed) {
+      return {
+        generation: this.generation,
+        outcome: Promise.resolve({
+          generation: this.generation,
+          status: "disposed",
+        }),
+      };
+    }
     const epoch = this.epoch;
     const generation = ++this.generation;
     this.cancelPendingFrames();
-    if (!this.isLive(epoch, generation)) return null;
+    const run = {
+      generation,
+      outcome: this.runReconcile(epoch, generation),
+    };
+    this.latestRun = run;
+    return run;
+  }
+
+  private async runReconcile(
+    epoch: number,
+    generation: number,
+  ): Promise<ReconcileRunOutcome> {
+    const initialAbort = this.abortOutcome(epoch, generation);
+    if (initialAbort) return initialAbort;
 
     let lastWidth = 0;
     let lastHeight = 0;
@@ -155,7 +203,8 @@ export class ResizeReconciler {
 
     for (let attempt = 0; attempt < this.limits.maxFrames; attempt++) {
       await this.nextFrame();
-      if (!this.isLive(epoch, generation)) return null;
+      const frameAbort = this.abortOutcome(epoch, generation);
+      if (frameAbort) return frameAbort;
 
       const rect = this.getRect();
       if (!rect || !this.isMeasurable(rect)) continue;
@@ -170,15 +219,20 @@ export class ResizeReconciler {
       }
     }
 
-    if (!this.isLive(epoch, generation)) return null;
+    const settleAbort = this.abortOutcome(epoch, generation);
+    if (settleAbort) return settleAbort;
 
     const rect = this.getRect();
-    if (!rect || !this.isMeasurable(rect)) return null;
+    if (!rect || !this.isMeasurable(rect)) {
+      return { generation, status: "invalid" };
+    }
 
     const dims = this.host.fitVerified();
-    if (!this.isCurrent(epoch, generation) || !dims) return null;
+    const fitAbort = this.abortOutcome(epoch, generation);
+    if (fitAbort) return fitAbort;
+    if (!dims) return { generation, status: "invalid" };
     if (dims.cols < this.limits.minCols || dims.rows < this.limits.minRows) {
-      return null;
+      return { generation, status: "invalid" };
     }
 
     this.committedRect = rect;
@@ -186,7 +240,7 @@ export class ResizeReconciler {
     const socket = this.host.getWebSocket();
     if (socket?.readyState === WebSocket.OPEN) this.sendResize(socket, dims);
     this.host.onDimensions?.(dims.cols, dims.rows);
-    return { ...dims };
+    return { generation, status: "verified", dims: { ...dims } };
   }
 
   private nextFrame(): Promise<void> {
@@ -217,8 +271,18 @@ export class ResizeReconciler {
 
   /** Re-checked after every async boundary: a superseded or hidden generation
    *  must abort before it can measure or fit (RC-B). */
-  private isLive(epoch: number, generation: number) {
-    return this.isCurrent(epoch, generation) && this.isVisible();
+  private abortOutcome(
+    epoch: number,
+    generation: number,
+  ): ReconcileRunOutcome | null {
+    if (this.disposed || epoch !== this.epoch) {
+      return { generation, status: "disposed" };
+    }
+    if (!this.isVisible()) return { generation, status: "hidden" };
+    if (!this.isCurrent(epoch, generation)) {
+      return { generation, status: "superseded" };
+    }
+    return null;
   }
 
   private isVisible() {

--- a/src/components/terminal/resize-reconciler.ts
+++ b/src/components/terminal/resize-reconciler.ts
@@ -1,0 +1,265 @@
+export const SETTLE_MIN_WIDTH = 100;
+export const SETTLE_MIN_HEIGHT = 80;
+export const MIN_COLS = 10;
+export const MIN_ROWS = 3;
+export const SETTLE_STABLE_FRAMES = 2;
+export const SETTLE_MAX_FRAMES = 10;
+export const OBSERVER_DEBOUNCE_MS = 16;
+
+export type ReconcileReason =
+  | "panel-visible"
+  | "page-visible"
+  | "window-focus"
+  | "window-resize"
+  | "visual-viewport"
+  | "resize-observer"
+  | "font-change"
+  | "socket-open"
+  | "post-init"
+  | "active"
+  | "refit"
+  | "dpr-change";
+
+export interface FitResult {
+  cols: number;
+  rows: number;
+}
+
+export interface ReconcilerHost {
+  getContainer(): HTMLElement | null;
+  fitVerified(): FitResult | null;
+  isPageVisible(): boolean;
+  isPanelVisible(): boolean;
+  getWebSocket(): WebSocket | null;
+  onDimensions?(cols: number, rows: number): void;
+  raf(cb: () => void): number;
+  caf(id: number): void;
+}
+
+export interface ReconcilerLimits {
+  minWidth: number;
+  minHeight: number;
+  minCols: number;
+  minRows: number;
+  stableFrames: number;
+  maxFrames: number;
+  observerDebounceMs: number;
+}
+
+interface RectSize {
+  width: number;
+  height: number;
+}
+
+const DEFAULT_LIMITS: ReconcilerLimits = {
+  minWidth: SETTLE_MIN_WIDTH,
+  minHeight: SETTLE_MIN_HEIGHT,
+  minCols: MIN_COLS,
+  minRows: MIN_ROWS,
+  stableFrames: SETTLE_STABLE_FRAMES,
+  maxFrames: SETTLE_MAX_FRAMES,
+  observerDebounceMs: OBSERVER_DEBOUNCE_MS,
+};
+
+export class ResizeReconciler {
+  private readonly limits: ReconcilerLimits;
+  private disposed = false;
+  private epoch = 0;
+  private generation = 0;
+  private pendingWhileHidden = false;
+  private committedRect: RectSize | null = null;
+  private desiredDims: FitResult | null = null;
+  private observerTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly pendingFrames = new Map<number, (current: boolean) => void>();
+
+  constructor(
+    private readonly host: ReconcilerHost,
+    opts: Partial<ReconcilerLimits> = {},
+  ) {
+    this.limits = { ...DEFAULT_LIMITS, ...opts };
+  }
+
+  request(_reason: ReconcileReason): void {
+    void this.startReconcile();
+  }
+
+  reconcileOnce(_reason: ReconcileReason): Promise<FitResult | null> {
+    return this.startReconcile();
+  }
+
+  notifyPanelVisibility(visible: boolean): void {
+    if (this.disposed) return;
+
+    if (!visible) {
+      this.pendingWhileHidden = true;
+      this.committedRect = null;
+      this.generation++;
+      this.cancelPendingFrames();
+      if (this.observerTimer !== null) {
+        clearTimeout(this.observerTimer);
+        this.observerTimer = null;
+      }
+      return;
+    }
+
+    this.pendingWhileHidden = false;
+    this.request("panel-visible");
+  }
+
+  observeRect(width: number, height: number): void {
+    if (this.disposed) return;
+    if (
+      this.committedRect?.width === width &&
+      this.committedRect.height === height
+    ) {
+      return;
+    }
+
+    if (this.observerTimer !== null) clearTimeout(this.observerTimer);
+    const epoch = this.epoch;
+    this.observerTimer = setTimeout(() => {
+      this.observerTimer = null;
+      if (this.disposed || epoch !== this.epoch) return;
+      this.request("resize-observer");
+    }, this.limits.observerDebounceMs);
+  }
+
+  notifySocketOpen(socket: WebSocket): void {
+    if (this.disposed || socket !== this.host.getWebSocket()) return;
+
+    if (this.desiredDims) this.sendResize(socket, this.desiredDims);
+    this.request("socket-open");
+  }
+
+  getDesiredDims(): FitResult | null {
+    return this.desiredDims ? { ...this.desiredDims } : null;
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.epoch++;
+    this.generation++;
+    if (this.observerTimer !== null) {
+      clearTimeout(this.observerTimer);
+      this.observerTimer = null;
+    }
+    this.cancelPendingFrames();
+  }
+
+  private async startReconcile(): Promise<FitResult | null> {
+    if (this.disposed) return null;
+
+    const epoch = this.epoch;
+    const generation = ++this.generation;
+    this.cancelPendingFrames();
+
+    if (!this.isVisible()) {
+      this.pendingWhileHidden = true;
+      return null;
+    }
+
+    this.pendingWhileHidden = false;
+    let lastWidth = 0;
+    let lastHeight = 0;
+    let stableFrames = 0;
+
+    for (let attempt = 0; attempt < this.limits.maxFrames; attempt++) {
+      if (!(await this.nextFrame(epoch, generation))) return null;
+      if (!this.isCurrent(epoch, generation)) return null;
+      if (!this.isVisible()) {
+        this.pendingWhileHidden = true;
+        return null;
+      }
+
+      const rect = this.getRect();
+      if (!rect || !this.isMeasurable(rect)) continue;
+
+      if (rect.width === lastWidth && rect.height === lastHeight) {
+        stableFrames++;
+        if (stableFrames >= this.limits.stableFrames) break;
+      } else {
+        stableFrames = 0;
+        lastWidth = rect.width;
+        lastHeight = rect.height;
+      }
+    }
+
+    if (!this.isCurrent(epoch, generation)) return null;
+    if (!this.isVisible()) {
+      this.pendingWhileHidden = true;
+      return null;
+    }
+
+    const rect = this.getRect();
+    if (!rect || !this.isMeasurable(rect)) return null;
+
+    const dims = this.host.fitVerified();
+    if (!this.isCurrent(epoch, generation) || !dims) return null;
+    if (dims.cols < this.limits.minCols || dims.rows < this.limits.minRows) {
+      return null;
+    }
+
+    this.committedRect = rect;
+    this.desiredDims = { ...dims };
+    const socket = this.host.getWebSocket();
+    if (socket?.readyState === WebSocket.OPEN) this.sendResize(socket, dims);
+    if (!this.isCurrent(epoch, generation)) return null;
+    this.host.onDimensions?.(dims.cols, dims.rows);
+    return { ...dims };
+  }
+
+  private nextFrame(epoch: number, generation: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      const id = this.host.raf(() => {
+        this.pendingFrames.delete(id);
+        resolve(this.isCurrent(epoch, generation));
+      });
+      this.pendingFrames.set(id, resolve);
+    });
+  }
+
+  private cancelPendingFrames() {
+    for (const [id, resolve] of this.pendingFrames) {
+      this.host.caf(id);
+      resolve(false);
+    }
+    this.pendingFrames.clear();
+  }
+
+  private isCurrent(epoch: number, generation: number) {
+    return (
+      !this.disposed &&
+      epoch === this.epoch &&
+      generation === this.generation
+    );
+  }
+
+  private isVisible() {
+    return this.host.isPageVisible() && this.host.isPanelVisible();
+  }
+
+  private getRect(): RectSize | null {
+    const container = this.host.getContainer();
+    if (!container) return null;
+    const { width, height } = container.getBoundingClientRect();
+    return { width, height };
+  }
+
+  private isMeasurable(rect: RectSize) {
+    return (
+      rect.width >= this.limits.minWidth &&
+      rect.height >= this.limits.minHeight
+    );
+  }
+
+  private sendResize(socket: WebSocket, dims: FitResult) {
+    try {
+      socket.send(
+        JSON.stringify({ type: "resize", cols: dims.cols, rows: dims.rows }),
+      );
+    } catch {
+      // Desired dimensions stay queued for the next socket-open replay.
+    }
+  }
+}

--- a/src/components/terminal/resize-reconciler.ts
+++ b/src/components/terminal/resize-reconciler.ts
@@ -56,6 +56,8 @@ interface ReconcileRun {
   outcome: Promise<ReconcileRunOutcome>;
 }
 
+// The pre-connect await is accepted-reflow best-effort after five consecutive
+// supersessions; the socket-open reconciliation heals any remaining mismatch.
 const MAX_RECONCILE_ONCE_SUPERSESSIONS = 5;
 
 const DEFAULT_LIMITS: ReconcilerLimits = {

--- a/src/lib/terminal-plugins/plugins/agent-plugin-client.tsx
+++ b/src/lib/terminal-plugins/plugins/agent-plugin-client.tsx
@@ -44,6 +44,7 @@ function AgentSessionComponent(props: TerminalTypeClientComponentProps) {
     notificationsEnabled,
     isRecording,
     isActive,
+    visible,
     environmentVars,
     onOutput,
     onDimensionsChange,
@@ -80,6 +81,7 @@ function AgentSessionComponent(props: TerminalTypeClientComponentProps) {
       notificationsEnabled={notificationsEnabled}
       isRecording={isRecording}
       isActive={isActive}
+      visible={visible}
       environmentVars={environmentVars}
       onOutput={onOutput}
       onDimensionsChange={onDimensionsChange}

--- a/src/lib/terminal-plugins/plugins/loop-agent-plugin-client.tsx
+++ b/src/lib/terminal-plugins/plugins/loop-agent-plugin-client.tsx
@@ -25,6 +25,7 @@ function LoopAgentSessionComponent({
   scrollback,
   tmuxHistoryLimit,
   isActive,
+  visible,
   environmentVars,
   onAgentActivityStatus,
   onBeadsIssuesUpdated,
@@ -47,6 +48,7 @@ function LoopAgentSessionComponent({
       scrollback={scrollback}
       tmuxHistoryLimit={tmuxHistoryLimit}
       isActive={isActive}
+      parentVisible={visible}
       environmentVars={environmentVars}
       onAgentActivityStatus={onAgentActivityStatus}
       onBeadsIssuesUpdated={onBeadsIssuesUpdated}

--- a/src/lib/terminal-plugins/plugins/shell-plugin-client.tsx
+++ b/src/lib/terminal-plugins/plugins/shell-plugin-client.tsx
@@ -42,6 +42,7 @@ function ShellSessionComponent(props: TerminalTypeClientComponentProps) {
     notificationsEnabled,
     isRecording,
     isActive,
+    visible,
     environmentVars,
     onOutput,
     onDimensionsChange,
@@ -78,6 +79,7 @@ function ShellSessionComponent(props: TerminalTypeClientComponentProps) {
       notificationsEnabled={notificationsEnabled}
       isRecording={isRecording}
       isActive={isActive}
+      visible={visible}
       environmentVars={environmentVars}
       onOutput={onOutput}
       onDimensionsChange={onDimensionsChange}

--- a/src/lib/terminal-plugins/plugins/ssh-plugin-client.tsx
+++ b/src/lib/terminal-plugins/plugins/ssh-plugin-client.tsx
@@ -40,6 +40,7 @@ function SshSessionComponent(props: TerminalTypeClientComponentProps) {
     notificationsEnabled,
     isRecording,
     isActive,
+    visible,
     environmentVars,
     onOutput,
     onDimensionsChange,
@@ -76,6 +77,7 @@ function SshSessionComponent(props: TerminalTypeClientComponentProps) {
       notificationsEnabled={notificationsEnabled}
       isRecording={isRecording}
       isActive={isActive}
+      visible={visible}
       environmentVars={environmentVars}
       onOutput={onOutput}
       onDimensionsChange={onDimensionsChange}

--- a/src/lib/terminal-plugins/plugins/terminal-visible-propagation.test.tsx
+++ b/src/lib/terminal-plugins/plugins/terminal-visible-propagation.test.tsx
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentType, ReactNode } from "react";
+
+import type { TerminalSession } from "@/types/session";
+import type { TerminalTypeClientComponentProps } from "@/types/terminal-type-client";
+
+const capture = vi.hoisted(() => ({
+  adapterTerminalProps: [] as Array<Record<string, unknown>>,
+  loopTerminalProps: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("next/dynamic", () => ({
+  default: () => (props: Record<string, unknown>) => {
+    capture.adapterTerminalProps.push(props);
+    return null;
+  },
+}));
+
+vi.mock("@/components/terminal/Terminal", () => ({
+  Terminal: (props: Record<string, unknown>) => {
+    capture.loopTerminalProps.push(props);
+    return null;
+  },
+}));
+
+vi.mock("@/contexts/SessionContext", () => ({
+  useSessionContext: () => ({ getAgentActivityStatus: () => "idle" }),
+}));
+
+vi.mock("@/hooks/useLoopOutputParser", () => ({
+  useLoopOutputParser: () => ({ handleOutput: vi.fn(), reset: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useLoopScheduler", () => ({
+  useLoopScheduler: () => {},
+}));
+
+vi.mock("@/components/loop/LoopMessageBubble", () => ({
+  LoopMessageBubble: () => null,
+}));
+
+vi.mock("@/components/loop/LoopChatInput", () => ({
+  LoopChatInput: () => null,
+}));
+
+vi.mock("@/components/loop/LoopStatusBar", async () => {
+  const React = await import("react");
+  return {
+    LoopStatusBar: ({ onToggleTerminal }: { onToggleTerminal: () => void }) =>
+      React.createElement(
+        "button",
+        { type: "button", onClick: onToggleTerminal },
+        "toggle terminal",
+      ),
+  };
+});
+
+vi.mock("@/components/loop/TerminalDrawer", () => ({
+  TerminalDrawer: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { AgentClientPlugin } from "./agent-plugin-client";
+import { LoopAgentClientPlugin } from "./loop-agent-plugin-client";
+import { ShellClientPlugin } from "./shell-plugin-client";
+import { SshClientPlugin } from "./ssh-plugin-client";
+
+const session = {
+  id: "s1",
+  name: "Session",
+  tmuxSessionName: "rdv-s1",
+  terminalType: "shell",
+  projectPath: "/tmp/project",
+  projectId: "p1",
+  typeMetadata: null,
+  agentProvider: "claude",
+} as TerminalSession;
+
+const baseProps = {
+  session,
+  wsUrl: "ws://localhost:3001",
+  sessionToken: null,
+  cols: 80,
+  rows: 24,
+  fontSize: 14,
+  fontFamily: "monospace",
+  isActive: true,
+} satisfies TerminalTypeClientComponentProps;
+
+function renderPlugin(
+  component: ComponentType<TerminalTypeClientComponentProps>,
+  visible: boolean,
+) {
+  const Component = component;
+  render(
+    <Component
+      {...({ ...baseProps, visible } as TerminalTypeClientComponentProps)}
+    />,
+  );
+}
+
+describe("terminal plugin visible propagation", () => {
+  beforeEach(() => {
+    capture.adapterTerminalProps.length = 0;
+    capture.loopTerminalProps.length = 0;
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it.each([
+    ["shell", ShellClientPlugin.component],
+    ["agent", AgentClientPlugin.component],
+    ["ssh", SshClientPlugin.component],
+  ])("forwards visible=false through the %s adapter", (_name, component) => {
+    renderPlugin(component, false);
+
+    expect(capture.adapterTerminalProps.at(-1)?.visible).toBe(false);
+  });
+
+  it("combines loop parent visibility with the open terminal drawer", () => {
+    renderPlugin(LoopAgentClientPlugin.component, false);
+    fireEvent.click(screen.getByRole("button", { name: "toggle terminal" }));
+
+    expect(capture.loopTerminalProps.at(-1)?.visible).toBe(false);
+  });
+});

--- a/src/server/__tests__/promotion-defer.test.ts
+++ b/src/server/__tests__/promotion-defer.test.ts
@@ -2,7 +2,9 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  clearTerminatedSessionControllerState,
+  clearSessionControllerState,
+  handleClientFocus,
+  pickNextPrimaryConnection,
   PrimaryPromotionCoordinator,
   parseInitialTerminalDimensions,
   type PromotionConnectionState,
@@ -55,7 +57,7 @@ class FakePromotionHost implements PromotionCoordinatorHost {
 
 function visibleOpenConnection(
   connectionId: string,
-  lastFocusAt = Date.now(),
+  lastFocusAt = 0,
 ): FocusedPromotionConnectionState {
   return { connectionId, isVisible: true, isSocketOpen: true, lastFocusAt };
 }
@@ -80,6 +82,18 @@ describe("PrimaryPromotionCoordinator", () => {
     coordinator.dispose();
     vi.useRealTimers();
   });
+
+  const focus = (
+    connectionId: string,
+    message: { force?: boolean; reassert?: boolean } = {},
+  ) => {
+    handleClientFocus(
+      host.connections.get(connectionId)!,
+      message,
+      (force, reassert) =>
+        coordinator.requestPromotion("s1", connectionId, force, reassert),
+    );
+  };
 
   it("promotes the still-mapped open visible candidate when the cooldown expires", () => {
     coordinator.requestPromotion("s1", "B", false);
@@ -160,32 +174,48 @@ describe("PrimaryPromotionCoordinator", () => {
     expect(host.broadcasts).toHaveLength(0);
   });
 
-  it("keeps a newer deferred challenger when the primary flushes focus", () => {
-    const now = Date.now();
-    host.connections.get("A")!.lastFocusAt = now - 20;
-    host.connections.get("B")!.lastFocusAt = now - 10;
-    coordinator.requestPromotion("s1", "B", false);
-
-    coordinator.requestPromotion("s1", "A", false);
+  it("promotes a genuine challenger after the primary reconnect-flushes a reassert", () => {
+    focus("B");
+    vi.advanceTimersByTime(100);
+    focus("A", { reassert: true });
 
     expect(coordinator.getPendingCandidate("s1")).toBe("B");
-    vi.advanceTimersByTime(1000);
+    expect(host.connections.get("A")!.lastFocusAt).toBe(0);
+    vi.advanceTimersByTime(900);
     expect(host.primaries.get("s1")).toBe("B");
   });
 
   it("does not promote a deferred challenger after the primary genuinely refocuses", () => {
-    const now = Date.now();
-    host.connections.get("B")!.lastFocusAt = now - 10;
-    coordinator.requestPromotion("s1", "B", false);
-
-    host.connections.get("A")!.lastFocusAt = now;
-    coordinator.requestPromotion("s1", "A", false);
+    focus("B");
+    vi.advanceTimersByTime(100);
+    focus("A");
 
     expect(coordinator.getPendingCandidate("s1")).toBe("B");
-    vi.advanceTimersByTime(1000);
+    vi.advanceTimersByTime(900);
     expect(host.primaries.get("s1")).toBe("A");
     expect(coordinator.getPendingCandidate("s1")).toBeNull();
     expect(host.broadcasts).toHaveLength(0);
+  });
+
+  it("does not let a non-primary reassert replace or register a pending candidate", () => {
+    focus("B");
+    focus("C", { reassert: true });
+
+    expect(coordinator.getPendingCandidate("s1")).toBe("B");
+    expect(host.connections.get("C")!.lastFocusAt).toBe(0);
+  });
+
+  it("promotes the deferred challenger when the newer primary has blurred", () => {
+    focus("B");
+    vi.advanceTimersByTime(100);
+    focus("A");
+    host.connections.get("A")!.isVisible = false;
+    coordinator.notifyBlur("s1", "A");
+
+    vi.advanceTimersByTime(900);
+
+    expect(host.primaries.get("s1")).toBe("B");
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
   });
 
   it("clearSession removes a pending candidate and cancels its timer", () => {
@@ -219,12 +249,31 @@ describe("parseInitialTerminalDimensions", () => {
   });
 });
 
-describe("terminated session cleanup", () => {
-  it("clears both tmux sizing and deferred promotion state", () => {
+describe("replacement primary selection", () => {
+  it("prefers visible connections and keeps pool order for zero-timestamp ties", () => {
+    expect(
+      pickNextPrimaryConnection([
+        { connectionId: "A", isVisible: false, lastFocusAt: 0 },
+        { connectionId: "B", isVisible: true, lastFocusAt: 0 },
+        { connectionId: "C", isVisible: true, lastFocusAt: 0 },
+      ]),
+    ).toBe("B");
+
+    expect(
+      pickNextPrimaryConnection([
+        { connectionId: "A", isVisible: false, lastFocusAt: 0 },
+        { connectionId: "B", isVisible: false, lastFocusAt: 0 },
+      ]),
+    ).toBe("A");
+  });
+});
+
+describe("last-connection controller cleanup", () => {
+  it("clears both tmux sizing and deferred promotion state unconditionally", () => {
     const sizeController = { clearSession: vi.fn() };
     const promotionCoordinator = { clearSession: vi.fn() };
 
-    clearTerminatedSessionControllerState(
+    clearSessionControllerState(
       "s1",
       sizeController,
       promotionCoordinator,

--- a/src/server/__tests__/promotion-defer.test.ts
+++ b/src/server/__tests__/promotion-defer.test.ts
@@ -459,6 +459,21 @@ describe("PrimaryPromotionCoordinator", () => {
     expect(host.broadcasts).toHaveLength(0);
   });
 
+  it("ignores older-generation same-instance genuine focus against its newer primary", () => {
+    const candidate = host.connections.get("B")!;
+    candidate.clientInstanceId = "stable-instance";
+    candidate.connectionSeq = 10;
+    const primary = host.connections.get("C")!;
+    primary.clientInstanceId = "stable-instance";
+    primary.connectionSeq = 11;
+    host.primaries.set("s1", "C");
+    host.lastPromotionAt.set("s1", Date.now() - 1000);
+
+    expect(coordinator.requestPromotion("s1", "B", false)).toBe("ignored");
+    expect(host.primaries.get("s1")).toBe("C");
+    expect(host.broadcasts).toHaveLength(0);
+  });
+
   it("defers genuine focus from the primary's newer same-instance socket until cooldown expiry", () => {
     host.connections.get("A")!.clientInstanceId = "stable-instance";
     host.connections.get("B")!.clientInstanceId = "stable-instance";

--- a/src/server/__tests__/promotion-defer.test.ts
+++ b/src/server/__tests__/promotion-defer.test.ts
@@ -535,7 +535,7 @@ describe("PrimaryPromotionCoordinator", () => {
     expect(host.broadcasts).toHaveLength(0);
     vi.advanceTimersByTime(700);
 
-    expect(["B", "C", "D"]).toContain(host.primaries.get("s1"));
+    expect(host.primaries.get("s1")).toBe("D");
     expect(host.broadcasts).toEqual(["s1"]);
     expect(host.reassertions).toHaveLength(1);
   });
@@ -728,16 +728,16 @@ describe("replacement primary selection", () => {
   it("prefers visible connections and keeps pool order for zero-timestamp ties", () => {
     expect(
       pickNextPrimaryConnection([
-        { connectionId: "A", isVisible: false, lastFocusAt: 0, lastInputAt: 0 },
-        { connectionId: "B", isVisible: true, lastFocusAt: 0, lastInputAt: 0 },
-        { connectionId: "C", isVisible: true, lastFocusAt: 0, lastInputAt: 0 },
+        { connectionId: "A", connectionSeq: 1, clientInstanceId: null, isVisible: false, lastFocusAt: 0, lastInputAt: 0 },
+        { connectionId: "B", connectionSeq: 2, clientInstanceId: null, isVisible: true, lastFocusAt: 0, lastInputAt: 0 },
+        { connectionId: "C", connectionSeq: 3, clientInstanceId: null, isVisible: true, lastFocusAt: 0, lastInputAt: 0 },
       ]),
     ).toBe("B");
 
     expect(
       pickNextPrimaryConnection([
-        { connectionId: "A", isVisible: false, lastFocusAt: 0, lastInputAt: 0 },
-        { connectionId: "B", isVisible: false, lastFocusAt: 0, lastInputAt: 0 },
+        { connectionId: "A", connectionSeq: 1, clientInstanceId: null, isVisible: false, lastFocusAt: 0, lastInputAt: 0 },
+        { connectionId: "B", connectionSeq: 2, clientInstanceId: null, isVisible: false, lastFocusAt: 0, lastInputAt: 0 },
       ]),
     ).toBe("A");
   });
@@ -745,8 +745,8 @@ describe("replacement primary selection", () => {
   it("ranks visible handoff survivors by their latest focus or input engagement", () => {
     expect(
       pickNextPrimaryConnection([
-        { connectionId: "B", isVisible: true, lastFocusAt: 100, lastInputAt: 900 },
-        { connectionId: "C", isVisible: true, lastFocusAt: 500, lastInputAt: 0 },
+        { connectionId: "B", connectionSeq: 1, clientInstanceId: null, isVisible: true, lastFocusAt: 100, lastInputAt: 900 },
+        { connectionId: "C", connectionSeq: 2, clientInstanceId: null, isVisible: true, lastFocusAt: 500, lastInputAt: 0 },
       ]),
     ).toBe("B");
   });
@@ -754,10 +754,41 @@ describe("replacement primary selection", () => {
   it("falls back to focus recency when viewer-only engagement ties", () => {
     expect(
       pickNextPrimaryConnection([
-        { connectionId: "B", isVisible: false, lastFocusAt: 100, lastInputAt: 900 },
-        { connectionId: "C", isVisible: false, lastFocusAt: 900, lastInputAt: 0 },
+        { connectionId: "B", connectionSeq: 1, clientInstanceId: null, isVisible: false, lastFocusAt: 100, lastInputAt: 900 },
+        { connectionId: "C", connectionSeq: 2, clientInstanceId: null, isVisible: false, lastFocusAt: 900, lastInputAt: 0 },
       ]),
     ).toBe("C");
+  });
+
+  it("excludes a freshened older-generation zombie before ranking handoff engagement", () => {
+    expect(
+      pickNextPrimaryConnection([
+        {
+          connectionId: "phone-zombie",
+          connectionSeq: 10,
+          clientInstanceId: "phone-instance",
+          isVisible: true,
+          lastFocusAt: 1000,
+          lastInputAt: 0,
+        },
+        {
+          connectionId: "phone-live",
+          connectionSeq: 11,
+          clientInstanceId: "phone-instance",
+          isVisible: true,
+          lastFocusAt: 100,
+          lastInputAt: 0,
+        },
+        {
+          connectionId: "challenger",
+          connectionSeq: 12,
+          clientInstanceId: "challenger-instance",
+          isVisible: true,
+          lastFocusAt: 500,
+          lastInputAt: 0,
+        },
+      ]),
+    ).toBe("challenger");
   });
 });
 

--- a/src/server/__tests__/promotion-defer.test.ts
+++ b/src/server/__tests__/promotion-defer.test.ts
@@ -13,6 +13,7 @@ import {
   resolveClientInstanceId,
   sweepClientInstanceRecency,
   tmuxSessionConfirmedAbsent,
+  type PromotionRequestResult,
   type PromotionConnectionState,
   type PromotionCoordinatorHost,
 } from "@/server/terminal";
@@ -116,14 +117,22 @@ describe("PrimaryPromotionCoordinator", () => {
     now: () => number = Date.now,
     recency: ClientInstanceFocusRecency | undefined = undefined,
   ) => {
+    let result: PromotionRequestResult | undefined;
     handleClientFocus(
       host.connections.get(connectionId)!,
       message,
-      (force, reassert) =>
-        coordinator.requestPromotion("s1", connectionId, force, reassert),
+      (force, reassert) => {
+        result = coordinator.requestPromotion(
+          "s1",
+          connectionId,
+          force,
+          reassert,
+        );
+      },
       now,
       recency,
     );
+    return result;
   };
 
   const connectInstance = (
@@ -440,11 +449,35 @@ describe("PrimaryPromotionCoordinator", () => {
     expect(host.broadcasts).toHaveLength(0);
   });
 
-  it("does not give an older same-instance socket the request-time bypass", () => {
+  it("does not let an older same-instance genuine focus replace a pending challenger", () => {
+    const primary = host.connections.get("C")!;
+    primary.clientInstanceId = "stable-instance";
+    primary.connectionSeq = 11;
+    primary.lastFocusAt = Date.now();
+    host.primaries.set("s1", "C");
+
+    const challenger = visibleOpenConnection("D", Date.now() + 1);
+    challenger.clientInstanceId = "challenger-instance";
+    host.connections.set("D", challenger);
+    expect(coordinator.requestPromotion("s1", "D", false)).toBe("deferred");
+    expect(coordinator.getPendingCandidate("s1")).toBe("D");
+
+    const zombie = host.connections.get("B")!;
+    zombie.clientInstanceId = "stable-instance";
+    zombie.connectionSeq = 10;
+    expect(focus("B")).toBe("ignored");
+    expect(coordinator.getPendingCandidate("s1")).toBe("D");
+
+    vi.advanceTimersByTime(1000);
+
+    expect(host.primaries.get("s1")).toBe("D");
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+  });
+
+  it("ignores an older same-instance reassert even with fresher engagement", () => {
     const candidate = host.connections.get("B")!;
     candidate.clientInstanceId = "stable-instance";
     candidate.connectionSeq = 10;
-    candidate.lastFocusAt = 500;
     const primary = host.connections.get("C")!;
     primary.clientInstanceId = "stable-instance";
     primary.connectionSeq = 11;
@@ -452,9 +485,9 @@ describe("PrimaryPromotionCoordinator", () => {
     host.primaries.set("s1", "C");
     host.lastPromotionAt.set("s1", Date.now() - 1000);
 
-    expect(coordinator.requestPromotion("s1", "B", false, true)).toBe(
-      "ignored",
-    );
+    expect(focus("B", {}, () => 501)).toBe("ignored");
+    expect(candidate.lastFocusAt).toBe(501);
+    expect(focus("B", { reassert: true })).toBe("ignored");
     expect(host.primaries.get("s1")).toBe("C");
     expect(host.broadcasts).toHaveLength(0);
   });

--- a/src/server/__tests__/promotion-defer.test.ts
+++ b/src/server/__tests__/promotion-defer.test.ts
@@ -12,6 +12,7 @@ import {
   recordClientInput,
   resolveClientInstanceId,
   sweepClientInstanceRecency,
+  tmuxSessionConfirmedAbsent,
   type PromotionConnectionState,
   type PromotionCoordinatorHost,
 } from "@/server/terminal";
@@ -197,6 +198,31 @@ describe("PrimaryPromotionCoordinator", () => {
     expect(host.primaries.get("s1")).toBe("C");
   });
 
+  it("preserves a deferred challenger when disconnect handoff elects another connection", () => {
+    host.connections.get("A")!.lastFocusAt = 50;
+    host.connections.get("B")!.lastFocusAt = 200;
+    host.connections.get("C")!.lastFocusAt = 100;
+    host.connections.get("C")!.lastInputAt = 300;
+    coordinator.requestPromotion("s1", "B", false);
+
+    coordinator.notifyDisconnect("s1", "A");
+    host.connections.delete("A");
+    const nextPrimary = pickNextPrimaryConnection([
+      host.connections.get("B")!,
+      host.connections.get("C")!,
+    ]);
+    expect(nextPrimary).toBe("C");
+    coordinator.clearPendingPromotionIfCandidate("s1", nextPrimary!);
+    host.primaries.set("s1", nextPrimary!);
+    host.lastPromotionAt.set("s1", Date.now());
+
+    expect(coordinator.getPendingCandidate("s1")).toBe("B");
+    vi.advanceTimersByTime(1000);
+
+    expect(host.primaries.get("s1")).toBe("B");
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+  });
+
   it("a successful forced promotion cancels an existing deferred promotion", () => {
     coordinator.requestPromotion("s1", "B", false);
     coordinator.requestPromotion("s1", "B", true);
@@ -226,6 +252,18 @@ describe("PrimaryPromotionCoordinator", () => {
     expect(host.connections.get("A")!.lastFocusAt).toBe(0);
     vi.advanceTimersByTime(900);
     expect(host.primaries.get("s1")).toBe("B");
+  });
+
+  it("keeps a genuine pending reason when the same candidate later reasserts", () => {
+    host.connections.get("A")!.lastFocusAt = 100;
+    focus("B", {}, () => 200);
+    focus("B", { reassert: true });
+
+    host.connections.get("A")!.lastInputAt = 300;
+    vi.advanceTimersByTime(1000);
+
+    expect(host.primaries.get("s1")).toBe("B");
+    expect(host.broadcasts).toEqual(["s1"]);
   });
 
   it("does not promote a deferred challenger after the primary genuinely refocuses", () => {
@@ -666,6 +704,48 @@ describe("client instance engagement recency", () => {
     });
   });
 
+  it("refreshes an already-live same-instance replacement during disconnect flush", () => {
+    const recency = new ClientInstanceFocusRecency();
+    recency.recordInput("s1", "phone-instance", 1000);
+    const oldConnection = {
+      ...visibleOpenConnection("phone-old"),
+      lastInputAt: 1500,
+      sessionId: "s1",
+      clientInstanceId: "phone-instance",
+    };
+    const replacement = {
+      ...visibleOpenConnection("phone-new"),
+      lastInputAt: recency.getLastInputAt("s1", "phone-instance"),
+      sessionId: "s1",
+      clientInstanceId: "phone-instance",
+    };
+    flushClientInstanceRecency(
+      oldConnection,
+      recency,
+      [replacement],
+    );
+
+    expect(replacement.lastInputAt).toBe(1500);
+    const promotionHost = new FakePromotionHost();
+    promotionHost.connections.set("A", {
+      ...visibleOpenConnection("A"),
+      lastInputAt: 1200,
+    });
+    promotionHost.connections.set("phone-new", replacement);
+    promotionHost.primaries.set("s1", "A");
+    promotionHost.lastPromotionAt.set("s1", Date.now() - 1000);
+    const promotionCoordinator = new PrimaryPromotionCoordinator(
+      promotionHost,
+      1000,
+    );
+    try {
+      promotionCoordinator.requestPromotion("s1", "phone-new", false, true);
+      expect(promotionHost.primaries.get("s1")).toBe("phone-new");
+    } finally {
+      promotionCoordinator.dispose();
+    }
+  });
+
   it("caps each session at 16 instances and evicts the oldest engagement", () => {
     const recency = new ClientInstanceFocusRecency();
     recency.recordGenuineFocus("s1", "instance-0", 1);
@@ -699,10 +779,69 @@ describe("client instance recency orphan sweep", () => {
     sweepClientInstanceRecency(
       recency,
       () => 0,
-      (tmuxSessionName) => tmuxSessionName === `rdv-${liveSessionId}`,
+      (tmuxSessionName) => tmuxSessionName === `rdv-${deadSessionId}`,
     );
 
     expect(recency.getSessionIds()).toEqual([liveSessionId]);
     expect(recency.getLastInputAt(liveSessionId, "live-instance")).toBe(200);
+  });
+
+  it("preserves recency when the tmux absence probe throws transiently", () => {
+    const recency = new ClientInstanceFocusRecency();
+    const sessionId = "00000000-0000-4000-8000-000000000003";
+    recency.recordInput(sessionId, "stable-instance", 300);
+
+    sweepClientInstanceRecency(
+      recency,
+      () => 0,
+      (tmuxSessionName) =>
+        tmuxSessionConfirmedAbsent(tmuxSessionName, () => {
+          throw Object.assign(new Error("resource temporarily unavailable"), {
+            code: "EAGAIN",
+          });
+        }),
+    );
+
+    expect(recency.getSessionIds()).toEqual([sessionId]);
+  });
+
+  it("preserves recency when tmux reports a transient socket failure", () => {
+    const recency = new ClientInstanceFocusRecency();
+    const sessionId = "00000000-0000-4000-8000-000000000005";
+    recency.recordInput(sessionId, "stable-instance", 500);
+
+    sweepClientInstanceRecency(
+      recency,
+      () => 0,
+      (tmuxSessionName) =>
+        tmuxSessionConfirmedAbsent(tmuxSessionName, () => {
+          throw Object.assign(new Error("tmux socket unavailable"), {
+            status: 1,
+            stderr: Buffer.from("error connecting to tmux socket (EAGAIN)"),
+          });
+        }),
+    );
+
+    expect(recency.getSessionIds()).toEqual([sessionId]);
+  });
+
+  it("clears recency when tmux cleanly reports no such session", () => {
+    const recency = new ClientInstanceFocusRecency();
+    const sessionId = "00000000-0000-4000-8000-000000000004";
+    recency.recordInput(sessionId, "stable-instance", 400);
+
+    sweepClientInstanceRecency(
+      recency,
+      () => 0,
+      (tmuxSessionName) =>
+        tmuxSessionConfirmedAbsent(tmuxSessionName, () => {
+          throw Object.assign(new Error("tmux has-session exited 1"), {
+            status: 1,
+            stderr: Buffer.from("can't find session"),
+          });
+        }),
+    );
+
+    expect(recency.getSessionIds()).toEqual([]);
   });
 });

--- a/src/server/__tests__/promotion-defer.test.ts
+++ b/src/server/__tests__/promotion-defer.test.ts
@@ -2,14 +2,19 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  clearTerminatedSessionControllerState,
   PrimaryPromotionCoordinator,
   parseInitialTerminalDimensions,
   type PromotionConnectionState,
   type PromotionCoordinatorHost,
 } from "@/server/terminal";
 
+type FocusedPromotionConnectionState = PromotionConnectionState & {
+  lastFocusAt: number;
+};
+
 class FakePromotionHost implements PromotionCoordinatorHost {
-  readonly connections = new Map<string, PromotionConnectionState>();
+  readonly connections = new Map<string, FocusedPromotionConnectionState>();
   readonly primaries = new Map<string, string>();
   readonly lastPromotionAt = new Map<string, number>();
   readonly reassertions: Array<{ sessionId: string; connectionId: string }> = [];
@@ -48,8 +53,11 @@ class FakePromotionHost implements PromotionCoordinatorHost {
   }
 }
 
-function visibleOpenConnection(connectionId: string): PromotionConnectionState {
-  return { connectionId, isVisible: true, isSocketOpen: true };
+function visibleOpenConnection(
+  connectionId: string,
+  lastFocusAt = Date.now(),
+): FocusedPromotionConnectionState {
+  return { connectionId, isVisible: true, isSocketOpen: true, lastFocusAt };
 }
 
 describe("PrimaryPromotionCoordinator", () => {
@@ -151,6 +159,44 @@ describe("PrimaryPromotionCoordinator", () => {
     expect(host.reassertions).toEqual([{ sessionId: "s1", connectionId: "A" }]);
     expect(host.broadcasts).toHaveLength(0);
   });
+
+  it("keeps a newer deferred challenger when the primary flushes focus", () => {
+    const now = Date.now();
+    host.connections.get("A")!.lastFocusAt = now - 20;
+    host.connections.get("B")!.lastFocusAt = now - 10;
+    coordinator.requestPromotion("s1", "B", false);
+
+    coordinator.requestPromotion("s1", "A", false);
+
+    expect(coordinator.getPendingCandidate("s1")).toBe("B");
+    vi.advanceTimersByTime(1000);
+    expect(host.primaries.get("s1")).toBe("B");
+  });
+
+  it("does not promote a deferred challenger after the primary genuinely refocuses", () => {
+    const now = Date.now();
+    host.connections.get("B")!.lastFocusAt = now - 10;
+    coordinator.requestPromotion("s1", "B", false);
+
+    host.connections.get("A")!.lastFocusAt = now;
+    coordinator.requestPromotion("s1", "A", false);
+
+    expect(coordinator.getPendingCandidate("s1")).toBe("B");
+    vi.advanceTimersByTime(1000);
+    expect(host.primaries.get("s1")).toBe("A");
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+    expect(host.broadcasts).toHaveLength(0);
+  });
+
+  it("clearSession removes a pending candidate and cancels its timer", () => {
+    coordinator.requestPromotion("s1", "B", false);
+
+    coordinator.clearSession("s1");
+    vi.advanceTimersByTime(1000);
+
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+    expect(host.primaries.get("s1")).toBe("A");
+  });
 });
 
 describe("parseInitialTerminalDimensions", () => {
@@ -170,5 +216,21 @@ describe("parseInitialTerminalDimensions", () => {
     expect(parseInitialTerminalDimensions(undefined, undefined)).toEqual({ cols: 80, rows: 24 });
     expect(parseInitialTerminalDimensions("nope", "NaN")).toEqual({ cols: 80, rows: 24 });
     expect(parseInitialTerminalDimensions("0", "-1")).toEqual({ cols: 80, rows: 24 });
+  });
+});
+
+describe("terminated session cleanup", () => {
+  it("clears both tmux sizing and deferred promotion state", () => {
+    const sizeController = { clearSession: vi.fn() };
+    const promotionCoordinator = { clearSession: vi.fn() };
+
+    clearTerminatedSessionControllerState(
+      "s1",
+      sizeController,
+      promotionCoordinator,
+    );
+
+    expect(sizeController.clearSession).toHaveBeenCalledWith("s1");
+    expect(promotionCoordinator.clearSession).toHaveBeenCalledWith("s1");
   });
 });

--- a/src/server/__tests__/promotion-defer.test.ts
+++ b/src/server/__tests__/promotion-defer.test.ts
@@ -4,12 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ClientInstanceFocusRecency,
   clearSessionControllerState,
+  flushClientInstanceRecency,
   handleClientFocus,
   pickNextPrimaryConnection,
   PrimaryPromotionCoordinator,
   parseInitialTerminalDimensions,
   recordClientInput,
   resolveClientInstanceId,
+  sweepClientInstanceRecency,
   type PromotionConnectionState,
   type PromotionCoordinatorHost,
 } from "@/server/terminal";
@@ -292,6 +294,27 @@ describe("PrimaryPromotionCoordinator", () => {
     expect(host.primaries.get("s1")).toBe("phone-new");
   });
 
+  it("flushes exact connection-local recency on disconnect so reconnect engagement wins", () => {
+    const oldConnection = connectInstance("phone-old", "phone-instance");
+    oldConnection.lastFocusAt = 1100;
+
+    recordClientInput(oldConnection, () => 1000, instanceRecency);
+    recordClientInput(oldConnection, () => 1500, instanceRecency);
+    expect(instanceRecency.getLastInputAt("s1", "phone-instance")).toBe(1000);
+
+    flushClientInstanceRecency(oldConnection, instanceRecency);
+    host.connections.delete("phone-old");
+    const reconnect = connectInstance("phone-new", "phone-instance");
+    host.connections.get("A")!.lastInputAt = 1250;
+
+    focus("phone-new", { reassert: true });
+    vi.advanceTimersByTime(1000);
+
+    expect(reconnect.lastFocusAt).toBe(1100);
+    expect(reconnect.lastInputAt).toBe(1500);
+    expect(host.primaries.get("s1")).toBe("phone-new");
+  });
+
   it("does not let a focus-fresh unattended reconnect rob an actively typed primary", () => {
     const primary = host.connections.get("A")!;
     primary.lastFocusAt = 500;
@@ -305,7 +328,7 @@ describe("PrimaryPromotionCoordinator", () => {
     expect(coordinator.getPendingCandidate("s1")).toBeNull();
   });
 
-  it("promotes a reconnect over its half-open same-instance primary immediately", () => {
+  it("defers a reconnect over its half-open same-instance primary until cooldown expiry", () => {
     const zombie = host.connections.get("A")!;
     zombie.clientInstanceId = "stable-instance";
     zombie.lastFocusAt = 500;
@@ -317,18 +340,46 @@ describe("PrimaryPromotionCoordinator", () => {
 
     focus("B", { reassert: true });
 
+    expect(host.primaries.get("s1")).toBe("A");
+    expect(coordinator.getPendingCandidate("s1")).toBe("B");
+
+    vi.advanceTimersByTime(1000);
+
     expect(host.primaries.get("s1")).toBe("B");
     expect(coordinator.getPendingCandidate("s1")).toBeNull();
   });
 
-  it("promotes a genuine focus from the primary's newer same-instance socket immediately", () => {
+  it("defers genuine focus from the primary's newer same-instance socket until cooldown expiry", () => {
     host.connections.get("A")!.clientInstanceId = "stable-instance";
     host.connections.get("B")!.clientInstanceId = "stable-instance";
 
     focus("B");
 
+    expect(host.primaries.get("s1")).toBe("A");
+    expect(coordinator.getPendingCandidate("s1")).toBe("B");
+
+    vi.advanceTimersByTime(1000);
+
     expect(host.primaries.get("s1")).toBe("B");
     expect(coordinator.getPendingCandidate("s1")).toBeNull();
+  });
+
+  it("coalesces rapid same-instance flap promotions within one cooldown", () => {
+    host.connections.get("A")!.clientInstanceId = "stable-instance";
+    for (const connectionId of ["B", "C", "D"]) {
+      const connection = visibleOpenConnection(connectionId);
+      connection.clientInstanceId = "stable-instance";
+      host.connections.set(connectionId, connection);
+      focus(connectionId, { reassert: true });
+      vi.advanceTimersByTime(100);
+    }
+
+    expect(host.broadcasts).toHaveLength(0);
+    vi.advanceTimersByTime(700);
+
+    expect(["B", "C", "D"]).toContain(host.primaries.get("s1"));
+    expect(host.broadcasts).toEqual(["s1"]);
+    expect(host.reassertions).toHaveLength(1);
   });
 
   it("inherits genuine focus recency across two connections with the same clientInstanceId", () => {
@@ -424,6 +475,43 @@ describe("PrimaryPromotionCoordinator", () => {
     expect(host.primaries.get("s1")).toBe("B");
   });
 
+  it("lets deferred genuine focus beat a primary that keeps typing", () => {
+    const primary = host.connections.get("A")!;
+    primary.lastFocusAt = 100;
+    primary.lastInputAt = 700;
+    handleClientFocus(
+      host.connections.get("B")!,
+      {},
+      (force, reassert) =>
+        coordinator.requestPromotion("s1", "B", force, reassert),
+      () => 200,
+    );
+
+    primary.lastInputAt = 900;
+    vi.advanceTimersByTime(1000);
+
+    expect(host.primaries.get("s1")).toBe("B");
+    expect(host.broadcasts).toEqual(["s1"]);
+  });
+
+  it("drops a deferred reassert challenger when the primary types more recently", () => {
+    const primary = host.connections.get("A")!;
+    primary.lastFocusAt = 100;
+    primary.lastInputAt = 700;
+    const challenger = host.connections.get("B")!;
+    challenger.lastFocusAt = 200;
+    challenger.lastInputAt = 800;
+
+    focus("B", { reassert: true });
+    expect(coordinator.getPendingCandidate("s1")).toBe("B");
+
+    primary.lastInputAt = 900;
+    vi.advanceTimersByTime(1000);
+
+    expect(host.primaries.get("s1")).toBe("A");
+    expect(host.broadcasts).toHaveLength(0);
+  });
+
   it("retains the current primary when both deferred recency timestamps are zero", () => {
     coordinator.requestPromotion("s1", "B", false);
 
@@ -482,18 +570,36 @@ describe("replacement primary selection", () => {
   it("prefers visible connections and keeps pool order for zero-timestamp ties", () => {
     expect(
       pickNextPrimaryConnection([
-        { connectionId: "A", isVisible: false, lastFocusAt: 0 },
-        { connectionId: "B", isVisible: true, lastFocusAt: 0 },
-        { connectionId: "C", isVisible: true, lastFocusAt: 0 },
+        { connectionId: "A", isVisible: false, lastFocusAt: 0, lastInputAt: 0 },
+        { connectionId: "B", isVisible: true, lastFocusAt: 0, lastInputAt: 0 },
+        { connectionId: "C", isVisible: true, lastFocusAt: 0, lastInputAt: 0 },
       ]),
     ).toBe("B");
 
     expect(
       pickNextPrimaryConnection([
-        { connectionId: "A", isVisible: false, lastFocusAt: 0 },
-        { connectionId: "B", isVisible: false, lastFocusAt: 0 },
+        { connectionId: "A", isVisible: false, lastFocusAt: 0, lastInputAt: 0 },
+        { connectionId: "B", isVisible: false, lastFocusAt: 0, lastInputAt: 0 },
       ]),
     ).toBe("A");
+  });
+
+  it("ranks visible handoff survivors by their latest focus or input engagement", () => {
+    expect(
+      pickNextPrimaryConnection([
+        { connectionId: "B", isVisible: true, lastFocusAt: 100, lastInputAt: 900 },
+        { connectionId: "C", isVisible: true, lastFocusAt: 500, lastInputAt: 0 },
+      ]),
+    ).toBe("B");
+  });
+
+  it("falls back to focus recency when viewer-only engagement ties", () => {
+    expect(
+      pickNextPrimaryConnection([
+        { connectionId: "B", isVisible: false, lastFocusAt: 100, lastInputAt: 900 },
+        { connectionId: "C", isVisible: false, lastFocusAt: 900, lastInputAt: 0 },
+      ]),
+    ).toBe("C");
   });
 });
 
@@ -541,6 +647,25 @@ describe("client instance engagement recency", () => {
     expect(recency.getLastInputAt("s1", "stable-instance")).toBe(2000);
   });
 
+  it("does not let an older disconnect flush regress newer instance recency", () => {
+    const recency = new ClientInstanceFocusRecency();
+    recency.recordGenuineFocus("s1", "stable-instance", 500);
+    recency.recordInput("s1", "stable-instance", 900);
+
+    flushClientInstanceRecency({
+      lastFocusAt: 400,
+      lastInputAt: 800,
+      lastInputRecencyWriteAt: 0,
+      sessionId: "s1",
+      clientInstanceId: "stable-instance",
+    }, recency);
+
+    expect(recency.getRecency("s1", "stable-instance")).toEqual({
+      genuineFocusAt: 500,
+      inputAt: 900,
+    });
+  });
+
   it("caps each session at 16 instances and evicts the oldest engagement", () => {
     const recency = new ClientInstanceFocusRecency();
     recency.recordGenuineFocus("s1", "instance-0", 1);
@@ -560,5 +685,24 @@ describe("client instance engagement recency", () => {
       inputAt: 0,
     });
     expect(recency.getLastGenuineFocusAt("s1", "instance-16")).toBe(17);
+  });
+});
+
+describe("client instance recency orphan sweep", () => {
+  it("clears zero-connection dead-tmux entries and preserves live-tmux entries", () => {
+    const recency = new ClientInstanceFocusRecency();
+    const deadSessionId = "00000000-0000-4000-8000-000000000001";
+    const liveSessionId = "00000000-0000-4000-8000-000000000002";
+    recency.recordInput(deadSessionId, "dead-instance", 100);
+    recency.recordInput(liveSessionId, "live-instance", 200);
+
+    sweepClientInstanceRecency(
+      recency,
+      () => 0,
+      (tmuxSessionName) => tmuxSessionName === `rdv-${liveSessionId}`,
+    );
+
+    expect(recency.getSessionIds()).toEqual([liveSessionId]);
+    expect(recency.getLastInputAt(liveSessionId, "live-instance")).toBe(200);
   });
 });

--- a/src/server/__tests__/promotion-defer.test.ts
+++ b/src/server/__tests__/promotion-defer.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@/server/terminal";
 
 type FocusedPromotionConnectionState = PromotionConnectionState & {
+  connectionSeq: number;
   lastFocusAt: number;
   lastInputAt: number;
   lastInputRecencyWriteAt: number;
@@ -25,12 +26,15 @@ type FocusedPromotionConnectionState = PromotionConnectionState & {
   clientInstanceId: string | null;
 };
 
+let nextConnectionSeq = 0;
+
 class FakePromotionHost implements PromotionCoordinatorHost {
   readonly connections = new Map<string, FocusedPromotionConnectionState>();
   readonly primaries = new Map<string, string>();
   readonly lastPromotionAt = new Map<string, number>();
   readonly reassertions: Array<{ sessionId: string; connectionId: string }> = [];
   readonly broadcasts: string[] = [];
+  currentTime: number | null = null;
 
   getConnection(connectionId: string): PromotionConnectionState | undefined {
     return this.connections.get(connectionId);
@@ -61,16 +65,18 @@ class FakePromotionHost implements PromotionCoordinatorHost {
   }
 
   now(): number {
-    return Date.now();
+    return this.currentTime ?? Date.now();
   }
 }
 
 function visibleOpenConnection(
   connectionId: string,
   lastFocusAt = 0,
+  connectionSeq = ++nextConnectionSeq,
 ): FocusedPromotionConnectionState {
   return {
     connectionId,
+    connectionSeq,
     clientInstanceId: null,
     isVisible: true,
     isSocketOpen: true,
@@ -91,6 +97,7 @@ describe("PrimaryPromotionCoordinator", () => {
     host = new FakePromotionHost();
     coordinator = new PrimaryPromotionCoordinator(host, 1000);
     instanceRecency = new ClientInstanceFocusRecency();
+    nextConnectionSeq = 0;
     host.connections.set("A", visibleOpenConnection("A"));
     host.connections.set("B", visibleOpenConnection("B"));
     host.connections.set("C", visibleOpenConnection("C"));
@@ -219,6 +226,31 @@ describe("PrimaryPromotionCoordinator", () => {
     expect(coordinator.getPendingCandidate("s1")).toBe("B");
     vi.advanceTimersByTime(1000);
 
+    expect(host.primaries.get("s1")).toBe("B");
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+  });
+
+  it("re-defers after a handoff starts a fresh cooldown and eventually promotes", () => {
+    const startedAt = 10_000;
+    host.currentTime = startedAt;
+    host.lastPromotionAt.set("s1", startedAt);
+    host.connections.get("B")!.lastFocusAt = startedAt + 300;
+    host.connections.get("C")!.lastFocusAt = startedAt + 100;
+
+    coordinator.requestPromotion("s1", "B", false);
+    vi.advanceTimersByTime(200);
+    host.currentTime = startedAt + 200;
+
+    host.primaries.set("s1", "C");
+    host.lastPromotionAt.set("s1", host.now());
+
+    host.currentTime = startedAt + 1000;
+    vi.advanceTimersByTime(800);
+    expect(host.primaries.get("s1")).toBe("C");
+    expect(coordinator.getPendingCandidate("s1")).toBe("B");
+
+    host.currentTime = startedAt + 1200;
+    vi.advanceTimersByTime(200);
     expect(host.primaries.get("s1")).toBe("B");
     expect(coordinator.getPendingCandidate("s1")).toBeNull();
   });
@@ -385,6 +417,46 @@ describe("PrimaryPromotionCoordinator", () => {
 
     expect(host.primaries.get("s1")).toBe("B");
     expect(coordinator.getPendingCandidate("s1")).toBeNull();
+  });
+
+  it("drops an older pending socket instead of replacing its newer same-instance primary", () => {
+    const candidate = host.connections.get("B")!;
+    candidate.clientInstanceId = "stable-instance";
+    candidate.connectionSeq = 10;
+    candidate.lastFocusAt = 500;
+    coordinator.requestPromotion("s1", "B", false);
+
+    const replacement = host.connections.get("C")!;
+    replacement.clientInstanceId = "stable-instance";
+    replacement.connectionSeq = 11;
+    replacement.lastFocusAt = 500;
+    host.primaries.set("s1", "C");
+    host.lastPromotionAt.set("s1", Date.now());
+
+    vi.advanceTimersByTime(1000);
+
+    expect(host.primaries.get("s1")).toBe("C");
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+    expect(host.broadcasts).toHaveLength(0);
+  });
+
+  it("does not give an older same-instance socket the request-time bypass", () => {
+    const candidate = host.connections.get("B")!;
+    candidate.clientInstanceId = "stable-instance";
+    candidate.connectionSeq = 10;
+    candidate.lastFocusAt = 500;
+    const primary = host.connections.get("C")!;
+    primary.clientInstanceId = "stable-instance";
+    primary.connectionSeq = 11;
+    primary.lastFocusAt = 500;
+    host.primaries.set("s1", "C");
+    host.lastPromotionAt.set("s1", Date.now() - 1000);
+
+    expect(coordinator.requestPromotion("s1", "B", false, true)).toBe(
+      "ignored",
+    );
+    expect(host.primaries.get("s1")).toBe("C");
+    expect(host.broadcasts).toHaveLength(0);
   });
 
   it("defers genuine focus from the primary's newer same-instance socket until cooldown expiry", () => {
@@ -843,5 +915,49 @@ describe("client instance recency orphan sweep", () => {
     );
 
     expect(recency.getSessionIds()).toEqual([]);
+  });
+});
+
+describe("tmuxSessionConfirmedAbsent", () => {
+  const probeFailure = (stderr: string) => () => {
+    throw Object.assign(new Error("tmux has-session exited 1"), {
+      status: 1,
+      stderr: Buffer.from(stderr),
+    });
+  };
+
+  it("accepts the tmux 3.7b missing-server socket response", () => {
+    expect(
+      tmuxSessionConfirmedAbsent(
+        "rdv-s1",
+        probeFailure(
+          "error connecting to /private/tmp/tmux-501/default (No such file or directory)",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts an explicit missing-session response", () => {
+    expect(
+      tmuxSessionConfirmedAbsent(
+        "rdv-s1",
+        probeFailure("can't find session: rdv-s1"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not accept a silent nonzero exit as confirmed absence", () => {
+    expect(
+      tmuxSessionConfirmedAbsent("rdv-s1", probeFailure("")),
+    ).toBe(false);
+  });
+
+  it("does not accept unrelated nonzero stderr as confirmed absence", () => {
+    expect(
+      tmuxSessionConfirmedAbsent(
+        "rdv-s1",
+        probeFailure("open terminal failed: Operation not permitted (EPERM)"),
+      ),
+    ).toBe(false);
   });
 });

--- a/src/server/__tests__/promotion-defer.test.ts
+++ b/src/server/__tests__/promotion-defer.test.ts
@@ -2,17 +2,21 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ClientInstanceFocusRecency,
   clearSessionControllerState,
   handleClientFocus,
   pickNextPrimaryConnection,
   PrimaryPromotionCoordinator,
   parseInitialTerminalDimensions,
+  resolveClientInstanceId,
   type PromotionConnectionState,
   type PromotionCoordinatorHost,
 } from "@/server/terminal";
 
 type FocusedPromotionConnectionState = PromotionConnectionState & {
   lastFocusAt: number;
+  sessionId?: string;
+  clientInstanceId?: string;
 };
 
 class FakePromotionHost implements PromotionCoordinatorHost {
@@ -65,12 +69,14 @@ function visibleOpenConnection(
 describe("PrimaryPromotionCoordinator", () => {
   let host: FakePromotionHost;
   let coordinator: PrimaryPromotionCoordinator;
+  let instanceRecency: ClientInstanceFocusRecency;
 
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2030-01-01T00:00:00Z"));
     host = new FakePromotionHost();
     coordinator = new PrimaryPromotionCoordinator(host, 1000);
+    instanceRecency = new ClientInstanceFocusRecency();
     host.connections.set("A", visibleOpenConnection("A"));
     host.connections.set("B", visibleOpenConnection("B"));
     host.connections.set("C", visibleOpenConnection("C"));
@@ -86,13 +92,34 @@ describe("PrimaryPromotionCoordinator", () => {
   const focus = (
     connectionId: string,
     message: { force?: boolean; reassert?: boolean } = {},
+    now: () => number = Date.now,
+    recency: ClientInstanceFocusRecency | undefined = undefined,
   ) => {
     handleClientFocus(
       host.connections.get(connectionId)!,
       message,
       (force, reassert) =>
         coordinator.requestPromotion("s1", connectionId, force, reassert),
+      now,
+      recency,
     );
+  };
+
+  const connectInstance = (
+    connectionId: string,
+    clientInstanceId: string | undefined,
+  ): FocusedPromotionConnectionState => {
+    const resolvedInstanceId = resolveClientInstanceId(clientInstanceId, connectionId);
+    const connection = {
+      ...visibleOpenConnection(
+        connectionId,
+        instanceRecency.getLastGenuineFocusAt("s1", resolvedInstanceId),
+      ),
+      sessionId: "s1",
+      clientInstanceId: resolvedInstanceId,
+    };
+    host.connections.set(connectionId, connection);
+    return connection;
   };
 
   it("promotes the still-mapped open visible candidate when the cooldown expires", () => {
@@ -200,12 +227,68 @@ describe("PrimaryPromotionCoordinator", () => {
     expect(host.broadcasts).toHaveLength(0);
   });
 
-  it("does not let a non-primary reassert replace or register a pending candidate", () => {
+  it("does not let a recency-qualified reassert replace an existing pending candidate", () => {
     focus("B");
+    host.connections.get("C")!.lastFocusAt = Date.now() + 1;
     focus("C", { reassert: true });
 
     expect(coordinator.getPendingCandidate("s1")).toBe("B");
-    expect(host.connections.get("C")!.lastFocusAt).toBe(0);
+    expect(host.connections.get("C")!.lastFocusAt).toBe(Date.now() + 1);
+  });
+
+  it("lets a mobile-style reconnect with newer inherited recency contest and win after cooldown", () => {
+    host.connections.get("A")!.lastFocusAt = 100;
+    const firstPhone = connectInstance("phone-old", "phone-instance");
+    handleClientFocus(firstPhone, {}, vi.fn(), () => 200, instanceRecency);
+    host.connections.delete("phone-old");
+
+    connectInstance("phone-new", "phone-instance");
+    focus("phone-new", { reassert: true });
+
+    expect(coordinator.getPendingCandidate("s1")).toBe("phone-new");
+    expect(host.primaries.get("s1")).toBe("A");
+    vi.advanceTimersByTime(1000);
+    expect(host.primaries.get("s1")).toBe("phone-new");
+  });
+
+  it("ignores an unattended reconnect whose inherited recency is older than the active phone", () => {
+    host.connections.get("A")!.lastFocusAt = 300;
+    const firstDesktop = connectInstance("desktop-old", "desktop-instance");
+    handleClientFocus(firstDesktop, {}, vi.fn(), () => 100, instanceRecency);
+    host.connections.delete("desktop-old");
+
+    connectInstance("desktop-new", "desktop-instance");
+    focus("desktop-new", { reassert: true });
+
+    expect(host.primaries.get("s1")).toBe("A");
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+  });
+
+  it("inherits genuine focus recency across two connections with the same clientInstanceId", () => {
+    host.connections.get("A")!.lastFocusAt = 100;
+    host.lastPromotionAt.set("s1", Date.now() - 1000);
+    const first = connectInstance("first", "stable-instance");
+    handleClientFocus(first, {}, vi.fn(), () => 250, instanceRecency);
+    host.connections.delete("first");
+
+    const reconnect = connectInstance("second", "stable-instance");
+    expect(reconnect.lastFocusAt).toBe(250);
+    focus("second", { reassert: true }, () => 999, instanceRecency);
+
+    expect(reconnect.lastFocusAt).toBe(250);
+    expect(host.primaries.get("s1")).toBe("second");
+  });
+
+  it("does not inherit focus recency when clientInstanceId is absent", () => {
+    const first = connectInstance("legacy-first", undefined);
+    handleClientFocus(first, {}, vi.fn(), () => 250, instanceRecency);
+    host.connections.delete("legacy-first");
+
+    const reconnect = connectInstance("legacy-second", undefined);
+
+    expect(first.clientInstanceId).toBe("legacy-first");
+    expect(reconnect.clientInstanceId).toBe("legacy-second");
+    expect(reconnect.lastFocusAt).toBe(0);
   });
 
   it("treats genuine and reassert open flushes as distinct promotion intents", () => {
@@ -351,14 +434,17 @@ describe("last-connection controller cleanup", () => {
   it("clears both tmux sizing and deferred promotion state unconditionally", () => {
     const sizeController = { clearSession: vi.fn() };
     const promotionCoordinator = { clearSession: vi.fn() };
+    const focusRecency = { clearSession: vi.fn() };
 
     clearSessionControllerState(
       "s1",
       sizeController,
       promotionCoordinator,
+      focusRecency,
     );
 
     expect(sizeController.clearSession).toHaveBeenCalledWith("s1");
     expect(promotionCoordinator.clearSession).toHaveBeenCalledWith("s1");
+    expect(focusRecency.clearSession).toHaveBeenCalledWith("s1");
   });
 });

--- a/src/server/__tests__/promotion-defer.test.ts
+++ b/src/server/__tests__/promotion-defer.test.ts
@@ -96,6 +96,7 @@ describe("PrimaryPromotionCoordinator", () => {
   };
 
   it("promotes the still-mapped open visible candidate when the cooldown expires", () => {
+    host.connections.get("B")!.lastFocusAt = Date.now();
     coordinator.requestPromotion("s1", "B", false);
 
     expect(coordinator.getPendingCandidate("s1")).toBe("B");
@@ -144,6 +145,8 @@ describe("PrimaryPromotionCoordinator", () => {
   });
 
   it("a replaced candidate survives disconnect cleanup for the previous candidate", () => {
+    host.connections.get("B")!.lastFocusAt = Date.now();
+    host.connections.get("C")!.lastFocusAt = Date.now();
     coordinator.requestPromotion("s1", "B", false);
     coordinator.requestPromotion("s1", "C", false);
 
@@ -203,6 +206,82 @@ describe("PrimaryPromotionCoordinator", () => {
 
     expect(coordinator.getPendingCandidate("s1")).toBe("B");
     expect(host.connections.get("C")!.lastFocusAt).toBe(0);
+  });
+
+  it("treats genuine and reassert open flushes as distinct promotion intents", () => {
+    const now = Date.now();
+    host.lastPromotionAt.set("s1", now - 1000);
+    host.connections.get("B")!.isVisible = false;
+
+    focus("B");
+    expect(host.connections.get("B")!.isVisible).toBe(true);
+    expect(host.primaries.get("s1")).toBe("B");
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+
+    host.primaries.set("s1", "A");
+    host.lastPromotionAt.set("s1", now);
+    host.connections.get("B")!.isVisible = false;
+    focus("B");
+    expect(host.connections.get("B")!.isVisible).toBe(true);
+    expect(host.primaries.get("s1")).toBe("A");
+    expect(coordinator.getPendingCandidate("s1")).toBe("B");
+
+    host.connections.get("C")!.isVisible = false;
+    focus("C", { reassert: true });
+    expect(host.connections.get("C")!.isVisible).toBe(true);
+    expect(host.primaries.get("s1")).toBe("A");
+    expect(coordinator.getPendingCandidate("s1")).toBe("B");
+    expect(host.connections.get("C")!.lastFocusAt).toBe(0);
+  });
+
+  it("keeps the current primary when deferred focus recency timestamps tie", () => {
+    const timestamp = Date.now();
+    handleClientFocus(
+      host.connections.get("B")!,
+      {},
+      (force, reassert) =>
+        coordinator.requestPromotion("s1", "B", force, reassert),
+      () => timestamp,
+    );
+    handleClientFocus(
+      host.connections.get("A")!,
+      {},
+      (force, reassert) =>
+        coordinator.requestPromotion("s1", "A", force, reassert),
+      () => timestamp,
+    );
+
+    vi.advanceTimersByTime(1000);
+
+    expect(host.primaries.get("s1")).toBe("A");
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+    expect(host.broadcasts).toHaveLength(0);
+  });
+
+  it("promotes a genuinely newer deferred candidate over a zero-recency primary", () => {
+    handleClientFocus(
+      host.connections.get("B")!,
+      {},
+      (force, reassert) =>
+        coordinator.requestPromotion("s1", "B", force, reassert),
+      () => 1,
+    );
+
+    vi.advanceTimersByTime(1000);
+
+    expect(host.connections.get("A")!.lastFocusAt).toBe(0);
+    expect(host.connections.get("B")!.lastFocusAt).toBe(1);
+    expect(host.primaries.get("s1")).toBe("B");
+  });
+
+  it("retains the current primary when both deferred recency timestamps are zero", () => {
+    coordinator.requestPromotion("s1", "B", false);
+
+    vi.advanceTimersByTime(1000);
+
+    expect(host.connections.get("A")!.lastFocusAt).toBe(0);
+    expect(host.connections.get("B")!.lastFocusAt).toBe(0);
+    expect(host.primaries.get("s1")).toBe("A");
   });
 
   it("promotes the deferred challenger when the newer primary has blurred", () => {

--- a/src/server/__tests__/promotion-defer.test.ts
+++ b/src/server/__tests__/promotion-defer.test.ts
@@ -8,6 +8,7 @@ import {
   pickNextPrimaryConnection,
   PrimaryPromotionCoordinator,
   parseInitialTerminalDimensions,
+  recordClientInput,
   resolveClientInstanceId,
   type PromotionConnectionState,
   type PromotionCoordinatorHost,
@@ -15,8 +16,10 @@ import {
 
 type FocusedPromotionConnectionState = PromotionConnectionState & {
   lastFocusAt: number;
+  lastInputAt: number;
+  lastInputRecencyWriteAt: number;
   sessionId?: string;
-  clientInstanceId?: string;
+  clientInstanceId: string | null;
 };
 
 class FakePromotionHost implements PromotionCoordinatorHost {
@@ -63,7 +66,15 @@ function visibleOpenConnection(
   connectionId: string,
   lastFocusAt = 0,
 ): FocusedPromotionConnectionState {
-  return { connectionId, isVisible: true, isSocketOpen: true, lastFocusAt };
+  return {
+    connectionId,
+    clientInstanceId: null,
+    isVisible: true,
+    isSocketOpen: true,
+    lastFocusAt,
+    lastInputAt: 0,
+    lastInputRecencyWriteAt: 0,
+  };
 }
 
 describe("PrimaryPromotionCoordinator", () => {
@@ -110,11 +121,11 @@ describe("PrimaryPromotionCoordinator", () => {
     clientInstanceId: string | undefined,
   ): FocusedPromotionConnectionState => {
     const resolvedInstanceId = resolveClientInstanceId(clientInstanceId, connectionId);
+    const inherited = instanceRecency.getRecency("s1", resolvedInstanceId);
     const connection = {
-      ...visibleOpenConnection(
-        connectionId,
-        instanceRecency.getLastGenuineFocusAt("s1", resolvedInstanceId),
-      ),
+      ...visibleOpenConnection(connectionId, inherited.genuineFocusAt),
+      lastInputAt: inherited.inputAt,
+      lastInputRecencyWriteAt: 0,
       sessionId: "s1",
       clientInstanceId: resolvedInstanceId,
     };
@@ -261,6 +272,62 @@ describe("PrimaryPromotionCoordinator", () => {
     focus("desktop-new", { reassert: true });
 
     expect(host.primaries.get("s1")).toBe("A");
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+  });
+
+  it("uses inherited input engagement to let an actively typed client reclaim on reconnect", () => {
+    host.connections.get("A")!.lastFocusAt = 500;
+    const firstPhone = connectInstance("phone-old", "phone-instance");
+    handleClientFocus(firstPhone, {}, vi.fn(), () => 100, instanceRecency);
+    recordClientInput(firstPhone, () => 800, instanceRecency);
+    host.connections.delete("phone-old");
+
+    const reconnect = connectInstance("phone-new", "phone-instance");
+    focus("phone-new", { reassert: true });
+
+    expect(reconnect.lastFocusAt).toBe(100);
+    expect(reconnect.lastInputAt).toBe(800);
+    expect(coordinator.getPendingCandidate("s1")).toBe("phone-new");
+    vi.advanceTimersByTime(1000);
+    expect(host.primaries.get("s1")).toBe("phone-new");
+  });
+
+  it("does not let a focus-fresh unattended reconnect rob an actively typed primary", () => {
+    const primary = host.connections.get("A")!;
+    primary.lastFocusAt = 500;
+    primary.lastInputAt = 900;
+    const desktop = connectInstance("desktop", "desktop-instance");
+    desktop.lastFocusAt = 800;
+
+    focus("desktop", { reassert: true });
+
+    expect(host.primaries.get("s1")).toBe("A");
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+  });
+
+  it("promotes a reconnect over its half-open same-instance primary immediately", () => {
+    const zombie = host.connections.get("A")!;
+    zombie.clientInstanceId = "stable-instance";
+    zombie.lastFocusAt = 500;
+    zombie.lastInputAt = 900;
+    const reconnect = host.connections.get("B")!;
+    reconnect.clientInstanceId = "stable-instance";
+    reconnect.lastFocusAt = 500;
+    reconnect.lastInputAt = 900;
+
+    focus("B", { reassert: true });
+
+    expect(host.primaries.get("s1")).toBe("B");
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+  });
+
+  it("promotes a genuine focus from the primary's newer same-instance socket immediately", () => {
+    host.connections.get("A")!.clientInstanceId = "stable-instance";
+    host.connections.get("B")!.clientInstanceId = "stable-instance";
+
+    focus("B");
+
+    expect(host.primaries.get("s1")).toBe("B");
     expect(coordinator.getPendingCandidate("s1")).toBeNull();
   });
 
@@ -431,20 +498,67 @@ describe("replacement primary selection", () => {
 });
 
 describe("last-connection controller cleanup", () => {
-  it("clears both tmux sizing and deferred promotion state unconditionally", () => {
+  it("preserves engagement across a total disconnect so reconnect can inherit it", () => {
     const sizeController = { clearSession: vi.fn() };
     const promotionCoordinator = { clearSession: vi.fn() };
-    const focusRecency = { clearSession: vi.fn() };
+    const focusRecency = new ClientInstanceFocusRecency();
+    focusRecency.recordGenuineFocus("s1", "stable-instance", 123);
+    focusRecency.recordInput("s1", "stable-instance", 456);
 
     clearSessionControllerState(
       "s1",
       sizeController,
       promotionCoordinator,
-      focusRecency,
     );
 
     expect(sizeController.clearSession).toHaveBeenCalledWith("s1");
     expect(promotionCoordinator.clearSession).toHaveBeenCalledWith("s1");
-    expect(focusRecency.clearSession).toHaveBeenCalledWith("s1");
+    expect(focusRecency.getRecency("s1", "stable-instance")).toEqual({
+      genuineFocusAt: 123,
+      inputAt: 456,
+    });
+  });
+});
+
+describe("client instance engagement recency", () => {
+  it("keeps connection input exact while throttling inherited-map writes to once per second", () => {
+    const recency = new ClientInstanceFocusRecency();
+    recency.recordInput("s1", "stable-instance", 900);
+    const connection = {
+      lastInputAt: 900,
+      lastInputRecencyWriteAt: 0,
+      sessionId: "s1",
+      clientInstanceId: "stable-instance",
+    };
+
+    recordClientInput(connection, () => 1000, recency);
+    recordClientInput(connection, () => 1500, recency);
+
+    expect(connection.lastInputAt).toBe(1500);
+    expect(recency.getLastInputAt("s1", "stable-instance")).toBe(1000);
+
+    recordClientInput(connection, () => 2000, recency);
+    expect(recency.getLastInputAt("s1", "stable-instance")).toBe(2000);
+  });
+
+  it("caps each session at 16 instances and evicts the oldest engagement", () => {
+    const recency = new ClientInstanceFocusRecency();
+    recency.recordGenuineFocus("s1", "instance-0", 1);
+    recency.recordInput("s1", "instance-0", 100);
+    for (let index = 1; index < 16; index++) {
+      recency.recordGenuineFocus("s1", `instance-${index}`, index + 1);
+    }
+
+    recency.recordGenuineFocus("s1", "instance-16", 17);
+
+    expect(recency.getRecency("s1", "instance-0")).toEqual({
+      genuineFocusAt: 1,
+      inputAt: 100,
+    });
+    expect(recency.getRecency("s1", "instance-1")).toEqual({
+      genuineFocusAt: 0,
+      inputAt: 0,
+    });
+    expect(recency.getLastGenuineFocusAt("s1", "instance-16")).toBe(17);
   });
 });

--- a/src/server/__tests__/promotion-defer.test.ts
+++ b/src/server/__tests__/promotion-defer.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PrimaryPromotionCoordinator,
+  parseInitialTerminalDimensions,
+  type PromotionConnectionState,
+  type PromotionCoordinatorHost,
+} from "@/server/terminal";
+
+class FakePromotionHost implements PromotionCoordinatorHost {
+  readonly connections = new Map<string, PromotionConnectionState>();
+  readonly primaries = new Map<string, string>();
+  readonly lastPromotionAt = new Map<string, number>();
+  readonly reassertions: Array<{ sessionId: string; connectionId: string }> = [];
+  readonly broadcasts: string[] = [];
+
+  getConnection(connectionId: string): PromotionConnectionState | undefined {
+    return this.connections.get(connectionId);
+  }
+
+  getPrimary(sessionId: string): string | undefined {
+    return this.primaries.get(sessionId);
+  }
+
+  setPrimary(sessionId: string, connectionId: string): void {
+    this.primaries.set(sessionId, connectionId);
+  }
+
+  getLastPromotionAt(sessionId: string): number | undefined {
+    return this.lastPromotionAt.get(sessionId);
+  }
+
+  setLastPromotionAt(sessionId: string, timestamp: number): void {
+    this.lastPromotionAt.set(sessionId, timestamp);
+  }
+
+  reassertSize(sessionId: string, connectionId: string): void {
+    this.reassertions.push({ sessionId, connectionId });
+  }
+
+  broadcastPrimaryChanged(sessionId: string): void {
+    this.broadcasts.push(sessionId);
+  }
+
+  now(): number {
+    return Date.now();
+  }
+}
+
+function visibleOpenConnection(connectionId: string): PromotionConnectionState {
+  return { connectionId, isVisible: true, isSocketOpen: true };
+}
+
+describe("PrimaryPromotionCoordinator", () => {
+  let host: FakePromotionHost;
+  let coordinator: PrimaryPromotionCoordinator;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2030-01-01T00:00:00Z"));
+    host = new FakePromotionHost();
+    coordinator = new PrimaryPromotionCoordinator(host, 1000);
+    host.connections.set("A", visibleOpenConnection("A"));
+    host.connections.set("B", visibleOpenConnection("B"));
+    host.connections.set("C", visibleOpenConnection("C"));
+    host.primaries.set("s1", "A");
+    host.lastPromotionAt.set("s1", Date.now());
+  });
+
+  afterEach(() => {
+    coordinator.dispose();
+    vi.useRealTimers();
+  });
+
+  it("promotes the still-mapped open visible candidate when the cooldown expires", () => {
+    coordinator.requestPromotion("s1", "B", false);
+
+    expect(coordinator.getPendingCandidate("s1")).toBe("B");
+    expect(host.primaries.get("s1")).toBe("A");
+
+    vi.advanceTimersByTime(1000);
+
+    expect(host.primaries.get("s1")).toBe("B");
+    expect(host.reassertions).toEqual([{ sessionId: "s1", connectionId: "B" }]);
+    expect(host.broadcasts).toEqual(["s1"]);
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+  });
+
+  it("drops a deferred candidate that is no longer socket-open at timer fire", () => {
+    coordinator.requestPromotion("s1", "B", false);
+    host.connections.get("B")!.isSocketOpen = false;
+
+    vi.advanceTimersByTime(1000);
+
+    expect(host.primaries.get("s1")).toBe("A");
+    expect(host.reassertions).toHaveLength(0);
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+  });
+
+  it("drops a deferred candidate that is no longer visible at timer fire", () => {
+    coordinator.requestPromotion("s1", "B", false);
+    host.connections.get("B")!.isVisible = false;
+
+    vi.advanceTimersByTime(1000);
+
+    expect(host.primaries.get("s1")).toBe("A");
+    expect(host.reassertions).toHaveLength(0);
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+  });
+
+  it("client blur clears pending only when the blurring connection is the candidate", () => {
+    coordinator.requestPromotion("s1", "B", false);
+    coordinator.notifyBlur("s1", "A");
+    expect(coordinator.getPendingCandidate("s1")).toBe("B");
+
+    coordinator.notifyBlur("s1", "B");
+    vi.advanceTimersByTime(1000);
+
+    expect(host.primaries.get("s1")).toBe("A");
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+  });
+
+  it("a replaced candidate survives disconnect cleanup for the previous candidate", () => {
+    coordinator.requestPromotion("s1", "B", false);
+    coordinator.requestPromotion("s1", "C", false);
+
+    coordinator.notifyDisconnect("s1", "B");
+    expect(coordinator.getPendingCandidate("s1")).toBe("C");
+
+    vi.advanceTimersByTime(1000);
+    expect(host.primaries.get("s1")).toBe("C");
+  });
+
+  it("a successful forced promotion cancels an existing deferred promotion", () => {
+    coordinator.requestPromotion("s1", "B", false);
+    coordinator.requestPromotion("s1", "B", true);
+
+    expect(host.primaries.get("s1")).toBe("B");
+    expect(coordinator.getPendingCandidate("s1")).toBeNull();
+
+    vi.advanceTimersByTime(1000);
+    expect(host.broadcasts).toEqual(["s1"]);
+    expect(host.reassertions).toEqual([{ sessionId: "s1", connectionId: "B" }]);
+  });
+
+  it("an already-primary focus always forces a size reassertion", () => {
+    coordinator.requestPromotion("s1", "A", false);
+
+    expect(host.primaries.get("s1")).toBe("A");
+    expect(host.reassertions).toEqual([{ sessionId: "s1", connectionId: "A" }]);
+    expect(host.broadcasts).toHaveLength(0);
+  });
+});
+
+describe("parseInitialTerminalDimensions", () => {
+  it("clamps a 2x1 initial URL grid to 10x3", () => {
+    expect(parseInitialTerminalDimensions("2", "1")).toEqual({ cols: 10, rows: 3 });
+  });
+
+  it("clamps a 9x2 initial URL grid to 10x3", () => {
+    expect(parseInitialTerminalDimensions("9", "2")).toEqual({ cols: 10, rows: 3 });
+  });
+
+  it("preserves the minimum valid 10x3 initial URL grid", () => {
+    expect(parseInitialTerminalDimensions("10", "3")).toEqual({ cols: 10, rows: 3 });
+  });
+
+  it("uses 80x24 defaults for absent, nonnumeric, or nonpositive dimensions", () => {
+    expect(parseInitialTerminalDimensions(undefined, undefined)).toEqual({ cols: 80, rows: 24 });
+    expect(parseInitialTerminalDimensions("nope", "NaN")).toEqual({ cols: 80, rows: 24 });
+    expect(parseInitialTerminalDimensions("0", "-1")).toEqual({ cols: 80, rows: 24 });
+  });
+});

--- a/src/server/__tests__/promotion-defer.test.ts
+++ b/src/server/__tests__/promotion-defer.test.ts
@@ -760,6 +760,60 @@ describe("replacement primary selection", () => {
     ).toBe("C");
   });
 
+  it("elects a hidden live generation instead of its visible zombie sibling", () => {
+    expect(
+      pickNextPrimaryConnection([
+        {
+          connectionId: "phone-zombie",
+          connectionSeq: 10,
+          clientInstanceId: "phone-instance",
+          isVisible: true,
+          lastFocusAt: 1000,
+          lastInputAt: 0,
+        },
+        {
+          connectionId: "phone-live",
+          connectionSeq: 11,
+          clientInstanceId: "phone-instance",
+          isVisible: false,
+          lastFocusAt: 100,
+          lastInputAt: 0,
+        },
+      ]),
+    ).toBe("phone-live");
+  });
+
+  it("prefers another visible instance over a hidden live generation's visible zombie", () => {
+    expect(
+      pickNextPrimaryConnection([
+        {
+          connectionId: "phone-zombie",
+          connectionSeq: 10,
+          clientInstanceId: "phone-instance",
+          isVisible: true,
+          lastFocusAt: 1000,
+          lastInputAt: 0,
+        },
+        {
+          connectionId: "phone-live",
+          connectionSeq: 11,
+          clientInstanceId: "phone-instance",
+          isVisible: false,
+          lastFocusAt: 100,
+          lastInputAt: 0,
+        },
+        {
+          connectionId: "challenger",
+          connectionSeq: 12,
+          clientInstanceId: "challenger-instance",
+          isVisible: true,
+          lastFocusAt: 500,
+          lastInputAt: 0,
+        },
+      ]),
+    ).toBe("challenger");
+  });
+
   it("excludes a freshened older-generation zombie before ranking handoff engagement", () => {
     expect(
       pickNextPrimaryConnection([

--- a/src/server/__tests__/terminal-message-buffer.test.ts
+++ b/src/server/__tests__/terminal-message-buffer.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+import { bufferTerminalMessages } from "@/server/terminal";
+
+class FakeWebSocket extends EventEmitter {
+  emitMessage(type: string): void {
+    this.emit("message", Buffer.from(JSON.stringify({ type })));
+  }
+}
+
+describe("terminal connection setup message buffering", () => {
+  it("processes frames received during async setup in order before live frames", async () => {
+    const ws = new FakeWebSocket();
+    const bufferedMessages = bufferTerminalMessages(ws);
+    const processed: string[] = [];
+
+    ws.emitMessage("client_focus");
+    await Promise.resolve();
+    ws.emitMessage("resize");
+
+    bufferedMessages.activate((message) => {
+      processed.push(JSON.parse(message.toString()).type as string);
+    });
+    ws.emitMessage("input");
+
+    expect(processed).toEqual(["client_focus", "resize", "input"]);
+  });
+
+  it("drops buffered frames and removes the listener when setup fails", () => {
+    const ws = new FakeWebSocket();
+    const bufferedMessages = bufferTerminalMessages(ws);
+
+    ws.emitMessage("client_focus");
+    bufferedMessages.discard();
+
+    expect(ws.listenerCount("message")).toBe(0);
+  });
+});

--- a/src/server/__tests__/terminal-message-buffer.test.ts
+++ b/src/server/__tests__/terminal-message-buffer.test.ts
@@ -52,13 +52,20 @@ describe("terminal connection setup message buffering", () => {
     const bufferedMessages = bufferTerminalMessages(ws);
     const processed: string[] = [];
     const destroyPty = vi.fn();
+    const setupLog = { debug: vi.fn() };
     const pty = { id: "pty-1" };
     let registered = false;
 
     ws.emitMessage("client_focus");
     ws.emit("close", 1006, Buffer.from("setup closed"));
 
-    if (!abortTerminalSetupIfClosed(bufferedMessages, pty, destroyPty)) {
+    if (!abortTerminalSetupIfClosed(
+      bufferedMessages,
+      pty,
+      destroyPty,
+      "session-1",
+      setupLog,
+    )) {
       registered = true;
       bufferedMessages.activate({
         message(message) {
@@ -80,6 +87,10 @@ describe("terminal connection setup message buffering", () => {
     expect(ws.listenerCount("message")).toBe(0);
     expect(ws.listenerCount("close")).toBe(0);
     expect(ws.listenerCount("error")).toBe(0);
+    expect(setupLog.debug).toHaveBeenCalledWith(
+      "Terminal setup aborted after socket closed",
+      { sessionId: "session-1", closeCode: 1006 },
+    );
   });
 
   it("catches and logs an error emitted before activation", () => {

--- a/src/server/__tests__/terminal-message-buffer.test.ts
+++ b/src/server/__tests__/terminal-message-buffer.test.ts
@@ -8,8 +8,19 @@ import {
 } from "@/server/terminal";
 
 class FakeWebSocket extends EventEmitter {
+  readonly closeCalls: Array<{ code?: number; reason?: string }> = [];
+
   emitMessage(type: string): void {
     this.emit("message", Buffer.from(JSON.stringify({ type })));
+  }
+
+  emitRaw(message: Buffer): void {
+    this.emit("message", message);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason });
+    this.emit("close", code ?? 1000, Buffer.from(reason ?? ""));
   }
 }
 
@@ -95,7 +106,7 @@ describe("terminal connection setup message buffering", () => {
 
   it("catches and logs an error emitted before activation", () => {
     const ws = new FakeWebSocket();
-    const setupLog = { error: vi.fn() };
+    const setupLog = { error: vi.fn(), warn: vi.fn() };
     const bufferedMessages = bufferTerminalMessages(ws, setupLog);
     const error = new Error("socket failed during setup");
 
@@ -111,7 +122,7 @@ describe("terminal connection setup message buffering", () => {
 
   it("transfers close and error handling when activation succeeds", () => {
     const ws = new FakeWebSocket();
-    const setupLog = { error: vi.fn() };
+    const setupLog = { error: vi.fn(), warn: vi.fn() };
     const bufferedMessages = bufferTerminalMessages(ws, setupLog);
     const close = vi.fn();
     const error = vi.fn();
@@ -124,5 +135,53 @@ describe("terminal connection setup message buffering", () => {
     expect(close).toHaveBeenCalledWith(1000, Buffer.from("done"));
     expect(error).toHaveBeenCalledWith(liveError);
     expect(setupLog.error).not.toHaveBeenCalled();
+  });
+
+  it("closes with 1009 and aborts setup cleanly when the frame cap overflows", () => {
+    const ws = new FakeWebSocket();
+    const setupLog = { error: vi.fn(), warn: vi.fn() };
+    const bufferedMessages = bufferTerminalMessages(ws, setupLog);
+    const destroyPty = vi.fn();
+    const pty = { id: "pty-overflow" };
+
+    for (let index = 0; index <= 256; index++) {
+      ws.emitMessage("input");
+    }
+
+    expect(ws.closeCalls).toEqual([{
+      code: 1009,
+      reason: "Terminal setup message buffer overflow",
+    }]);
+    expect(bufferedMessages.wasClosed()).toBe(true);
+    expect(abortTerminalSetupIfClosed(
+      bufferedMessages,
+      pty,
+      destroyPty,
+      "session-overflow",
+    )).toBe(true);
+    expect(destroyPty).toHaveBeenCalledTimes(1);
+    expect(ws.listenerCount("message")).toBe(0);
+    expect(ws.listenerCount("close")).toBe(0);
+    expect(ws.listenerCount("error")).toBe(0);
+    expect(setupLog.warn).toHaveBeenCalledWith(
+      "Terminal setup message buffer overflow",
+      expect.objectContaining({ frameCount: 256 }),
+    );
+  });
+
+  it("closes with 1009 when buffered payload exceeds one MiB", () => {
+    const ws = new FakeWebSocket();
+    const setupLog = { error: vi.fn(), warn: vi.fn() };
+    const bufferedMessages = bufferTerminalMessages(ws, setupLog);
+
+    ws.emitRaw(Buffer.alloc(1024 * 1024));
+    ws.emitRaw(Buffer.from("x"));
+
+    expect(bufferedMessages.wasClosed()).toBe(true);
+    expect(ws.closeCalls.at(-1)?.code).toBe(1009);
+    expect(setupLog.warn).toHaveBeenCalledWith(
+      "Terminal setup message buffer overflow",
+      expect.objectContaining({ payloadBytes: 1024 * 1024 }),
+    );
   });
 });

--- a/src/server/__tests__/terminal-message-buffer.test.ts
+++ b/src/server/__tests__/terminal-message-buffer.test.ts
@@ -1,8 +1,11 @@
 // @vitest-environment node
 
 import { EventEmitter } from "node:events";
-import { describe, expect, it } from "vitest";
-import { bufferTerminalMessages } from "@/server/terminal";
+import { describe, expect, it, vi } from "vitest";
+import {
+  abortTerminalSetupIfClosed,
+  bufferTerminalMessages,
+} from "@/server/terminal";
 
 class FakeWebSocket extends EventEmitter {
   emitMessage(type: string): void {
@@ -20,8 +23,12 @@ describe("terminal connection setup message buffering", () => {
     await Promise.resolve();
     ws.emitMessage("resize");
 
-    bufferedMessages.activate((message) => {
-      processed.push(JSON.parse(message.toString()).type as string);
+    bufferedMessages.activate({
+      message(message) {
+        processed.push(JSON.parse(message.toString()).type as string);
+      },
+      close: vi.fn(),
+      error: vi.fn(),
     });
     ws.emitMessage("input");
 
@@ -36,5 +43,75 @@ describe("terminal connection setup message buffering", () => {
     bufferedMessages.discard();
 
     expect(ws.listenerCount("message")).toBe(0);
+    expect(ws.listenerCount("close")).toBe(0);
+    expect(ws.listenerCount("error")).toBe(0);
+  });
+
+  it("aborts a setup closed before activation, destroys its PTY, and drains no frames", () => {
+    const ws = new FakeWebSocket();
+    const bufferedMessages = bufferTerminalMessages(ws);
+    const processed: string[] = [];
+    const destroyPty = vi.fn();
+    const pty = { id: "pty-1" };
+    let registered = false;
+
+    ws.emitMessage("client_focus");
+    ws.emit("close", 1006, Buffer.from("setup closed"));
+
+    if (!abortTerminalSetupIfClosed(bufferedMessages, pty, destroyPty)) {
+      registered = true;
+      bufferedMessages.activate({
+        message(message) {
+          processed.push(JSON.parse(message.toString()).type as string);
+        },
+        close: vi.fn(),
+        error: vi.fn(),
+      });
+    }
+
+    expect(bufferedMessages.wasClosed()).toBe(true);
+    expect(bufferedMessages.getCloseInfo()).toEqual({
+      code: 1006,
+      reason: Buffer.from("setup closed"),
+    });
+    expect(registered).toBe(false);
+    expect(destroyPty).toHaveBeenCalledWith(pty);
+    expect(processed).toEqual([]);
+    expect(ws.listenerCount("message")).toBe(0);
+    expect(ws.listenerCount("close")).toBe(0);
+    expect(ws.listenerCount("error")).toBe(0);
+  });
+
+  it("catches and logs an error emitted before activation", () => {
+    const ws = new FakeWebSocket();
+    const setupLog = { error: vi.fn() };
+    const bufferedMessages = bufferTerminalMessages(ws, setupLog);
+    const error = new Error("socket failed during setup");
+
+    expect(() => ws.emit("error", error)).not.toThrow();
+
+    expect(bufferedMessages.wasClosed()).toBe(true);
+    expect(setupLog.error).toHaveBeenCalledWith(
+      "Terminal connection error during setup",
+      { error: String(error) },
+    );
+    bufferedMessages.discard();
+  });
+
+  it("transfers close and error handling when activation succeeds", () => {
+    const ws = new FakeWebSocket();
+    const setupLog = { error: vi.fn() };
+    const bufferedMessages = bufferTerminalMessages(ws, setupLog);
+    const close = vi.fn();
+    const error = vi.fn();
+
+    bufferedMessages.activate({ message: vi.fn(), close, error });
+    ws.emit("close", 1000, Buffer.from("done"));
+    const liveError = new Error("live socket error");
+    ws.emit("error", liveError);
+
+    expect(close).toHaveBeenCalledWith(1000, Buffer.from("done"));
+    expect(error).toHaveBeenCalledWith(liveError);
+    expect(setupLog.error).not.toHaveBeenCalled();
   });
 });

--- a/src/server/__tests__/tmux-size-controller.test.ts
+++ b/src/server/__tests__/tmux-size-controller.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Logger } from "@/lib/logger";
+import {
+  TmuxSizeController,
+  type TmuxExec,
+} from "@/server/tmux-size-controller";
+
+class FakeTmuxExec {
+  readonly calls: Array<{
+    args: string[];
+    callback: (err: Error | null) => void;
+  }> = [];
+
+  readonly exec: TmuxExec = (args, callback) => {
+    this.calls.push({ args, callback });
+  };
+
+  completeNext(error: Error | null = null): void {
+    const call = this.calls.find((candidate) => !this.completed.has(candidate));
+    if (!call) throw new Error("No pending tmux exec call");
+    this.completed.add(call);
+    call.callback(error);
+  }
+
+  private readonly completed = new Set<(typeof this.calls)[number]>();
+}
+
+function makeLogger(): Logger {
+  return {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+  };
+}
+
+describe("TmuxSizeController", () => {
+  let exec: FakeTmuxExec;
+  let controller: TmuxSizeController;
+
+  beforeEach(() => {
+    exec = new FakeTmuxExec();
+    controller = new TmuxSizeController(exec.exec, makeLogger());
+  });
+
+  it("RC-H: serializes resize-window calls and applies the latest requested size last", () => {
+    controller.requestResize("s1", "rdv-s1", 100, 30);
+    controller.requestResize("s1", "rdv-s1", 120, 40);
+
+    expect(exec.calls).toHaveLength(1);
+    exec.completeNext();
+
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls.at(-1)?.args).toEqual([
+      "resize-window",
+      "-t",
+      "rdv-s1",
+      "-x",
+      "120",
+      "-y",
+      "40",
+    ]);
+
+    exec.completeNext();
+    expect(controller.getAppliedSize("s1")).toEqual({ cols: 120, rows: 40 });
+  });
+
+  it("force bypasses the applied-size dedupe for focus reassertion", () => {
+    controller.requestResize("s1", "rdv-s1", 100, 30);
+    exec.completeNext();
+
+    controller.requestResize("s1", "rdv-s1", 100, 30);
+    expect(exec.calls).toHaveLength(1);
+
+    controller.requestResize("s1", "rdv-s1", 100, 30, { force: true });
+    expect(exec.calls).toHaveLength(2);
+  });
+
+  it("clearSession prevents an old in-flight callback from mutating a recreated session", () => {
+    controller.requestResize("s1", "rdv-s1", 100, 30);
+    controller.requestResize("s1", "rdv-s1", 110, 35);
+    controller.clearSession("s1");
+    controller.requestResize("s1", "rdv-s1", 120, 40);
+
+    expect(exec.calls).toHaveLength(1);
+    exec.completeNext();
+    expect(controller.getAppliedSize("s1")).not.toEqual({ cols: 100, rows: 30 });
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls.at(-1)?.args).toContain("120");
+
+    exec.completeNext();
+    expect(controller.getAppliedSize("s1")).toEqual({ cols: 120, rows: 40 });
+  });
+
+  it("does not mark a failed resize as applied and retries it on the next request", () => {
+    controller.requestResize("s1", "rdv-s1", 100, 30);
+    exec.completeNext(new Error("tmux unavailable"));
+
+    expect(controller.getAppliedSize("s1")).toBeNull();
+
+    controller.requestResize("s1", "rdv-s1", 100, 30);
+    expect(exec.calls).toHaveLength(2);
+    exec.completeNext();
+    expect(controller.getAppliedSize("s1")).toEqual({ cols: 100, rows: 30 });
+  });
+});

--- a/src/server/__tests__/tmux-size-controller.test.ts
+++ b/src/server/__tests__/tmux-size-controller.test.ts
@@ -79,13 +79,34 @@ describe("TmuxSizeController", () => {
     expect(exec.calls).toHaveLength(2);
   });
 
+  it("keeps a queued force sticky across a same-size non-forced overwrite", () => {
+    controller.requestResize("s1", "rdv-s1", 100, 30);
+    exec.completeNext();
+
+    controller.requestResize("s1", "rdv-s1", 120, 40);
+    controller.requestResize("s1", "rdv-s1", 100, 30, { force: true });
+    controller.requestResize("s1", "rdv-s1", 100, 30);
+    exec.completeNext(new Error("first resize failed"));
+
+    expect(exec.calls).toHaveLength(3);
+    expect(exec.calls.at(-1)?.args).toEqual([
+      "resize-window",
+      "-t",
+      "rdv-s1",
+      "-x",
+      "100",
+      "-y",
+      "30",
+    ]);
+  });
+
   it("clearSession prevents an old in-flight callback from mutating a recreated session", () => {
     controller.requestResize("s1", "rdv-s1", 100, 30);
     controller.requestResize("s1", "rdv-s1", 110, 35);
     controller.clearSession("s1");
     controller.requestResize("s1", "rdv-s1", 120, 40);
 
-    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls).toHaveLength(2);
     exec.completeNext();
     expect(controller.getAppliedSize("s1")).not.toEqual({ cols: 100, rows: 30 });
     expect(exec.calls).toHaveLength(2);
@@ -93,6 +114,21 @@ describe("TmuxSizeController", () => {
 
     exec.completeNext();
     expect(controller.getAppliedSize("s1")).toEqual({ cols: 120, rows: 40 });
+  });
+
+  it("clearSession deletes both maps and a callback finding no state is safe", () => {
+    controller.requestResize("s1", "rdv-s1", 100, 30);
+
+    controller.clearSession("s1");
+
+    const internals = controller as unknown as {
+      sessions: Map<string, unknown>;
+      sessionEpochs: Map<string, unknown>;
+    };
+    expect(internals.sessions.has("s1")).toBe(false);
+    expect(internals.sessionEpochs.has("s1")).toBe(false);
+    expect(() => exec.completeNext()).not.toThrow();
+    expect(controller.getAppliedSize("s1")).toBeNull();
   });
 
   it("does not mark a failed resize as applied and retries it on the next request", () => {

--- a/src/server/__tests__/tmux-size-controller.test.ts
+++ b/src/server/__tests__/tmux-size-controller.test.ts
@@ -142,14 +142,19 @@ describe("TmuxSizeController", () => {
     expect(controller.getAppliedSize("s1")).toBeNull();
   });
 
-  it("does not mark a failed resize as applied and retries it on the next request", () => {
+  it("clears a stale applied size after failed forced repair and retries an ordinary request", () => {
     controller.requestResize("s1", "rdv-s1", 100, 30);
+    exec.completeNext();
+
+    expect(controller.getAppliedSize("s1")).toEqual({ cols: 100, rows: 30 });
+
+    controller.requestResize("s1", "rdv-s1", 100, 30, { force: true });
     exec.completeNext(new Error("tmux unavailable"));
 
     expect(controller.getAppliedSize("s1")).toBeNull();
 
     controller.requestResize("s1", "rdv-s1", 100, 30);
-    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls).toHaveLength(3);
     exec.completeNext();
     expect(controller.getAppliedSize("s1")).toEqual({ cols: 100, rows: 30 });
   });

--- a/src/server/__tests__/tmux-size-controller.test.ts
+++ b/src/server/__tests__/tmux-size-controller.test.ts
@@ -6,6 +6,7 @@ import {
   TmuxSizeController,
   type TmuxExec,
 } from "@/server/tmux-size-controller";
+import { requestRestartPrimaryResize } from "@/server/terminal";
 
 class FakeTmuxExec {
   readonly calls: Array<{
@@ -113,6 +114,34 @@ describe("TmuxSizeController", () => {
 
     exec.completeNext();
     expect(controller.getAppliedSize("s1")).toEqual({ cols: 120, rows: 40 });
+  });
+
+  it("queues a forced current-primary size after recreation behind a stale in-flight exec", () => {
+    controller.requestResize("s1", "rdv-s1", 80, 24);
+    controller.clearSession("s1");
+
+    requestRestartPrimaryResize(
+      controller,
+      "s1",
+      "rdv-s1",
+      { lastCols: 132, lastRows: 43 },
+    );
+
+    expect(exec.calls).toHaveLength(1);
+    exec.completeNext();
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls.at(-1)?.args).toEqual([
+      "resize-window",
+      "-t",
+      "rdv-s1",
+      "-x",
+      "132",
+      "-y",
+      "43",
+    ]);
+
+    exec.completeNext();
+    expect(controller.getAppliedSize("s1")).toEqual({ cols: 132, rows: 43 });
   });
 
   it("a stale callback for an evicted state pumps the current live state", () => {

--- a/src/server/__tests__/tmux-size-controller.test.ts
+++ b/src/server/__tests__/tmux-size-controller.test.ts
@@ -100,15 +100,14 @@ describe("TmuxSizeController", () => {
     ]);
   });
 
-  it("clearSession prevents an old in-flight callback from mutating a recreated session", () => {
+  it("serializes the same tmux name across clearSession and recreation", () => {
     controller.requestResize("s1", "rdv-s1", 100, 30);
-    controller.requestResize("s1", "rdv-s1", 110, 35);
     controller.clearSession("s1");
     controller.requestResize("s1", "rdv-s1", 120, 40);
 
-    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls).toHaveLength(1);
     exec.completeNext();
-    expect(controller.getAppliedSize("s1")).not.toEqual({ cols: 100, rows: 30 });
+
     expect(exec.calls).toHaveLength(2);
     expect(exec.calls.at(-1)?.args).toContain("120");
 
@@ -116,18 +115,30 @@ describe("TmuxSizeController", () => {
     expect(controller.getAppliedSize("s1")).toEqual({ cols: 120, rows: 40 });
   });
 
-  it("clearSession deletes both maps and a callback finding no state is safe", () => {
+  it("a stale callback for an evicted state pumps the current live state", () => {
     controller.requestResize("s1", "rdv-s1", 100, 30);
+    controller.clearSession("s1");
+    controller.requestResize("s1", "rdv-s1", 120, 40);
+
+    exec.completeNext();
+
+    expect(controller.getAppliedSize("s1")).toBeNull();
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls.at(-1)?.args).toContain("120");
+  });
+
+  it("clearSession evicts state and its stale callback is an identity no-op", () => {
+    controller.requestResize("s1", "rdv-s1", 100, 30);
+    const staleState = (
+      controller as unknown as { sessions: Map<string, unknown> }
+    ).sessions.get("s1");
 
     controller.clearSession("s1");
 
-    const internals = controller as unknown as {
-      sessions: Map<string, unknown>;
-      sessionEpochs: Map<string, unknown>;
-    };
+    const internals = controller as unknown as { sessions: Map<string, unknown> };
     expect(internals.sessions.has("s1")).toBe(false);
-    expect(internals.sessionEpochs.has("s1")).toBe(false);
     expect(() => exec.completeNext()).not.toThrow();
+    expect(internals.sessions.get("s1")).not.toBe(staleState);
     expect(controller.getAppliedSize("s1")).toBeNull();
   });
 

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -688,6 +688,7 @@ export class PrimaryPromotionCoordinator {
       primary.clientInstanceId !== null &&
       primary.clientInstanceId === candidate.clientInstanceId &&
       candidate.connectionSeq < primary.connectionSeq;
+    if (olderSameClientInstance) return "ignored";
 
     if (reassert) {
       const pendingCandidate = this.pendingCandidates.get(sessionId)?.connectionId;
@@ -715,8 +716,6 @@ export class PrimaryPromotionCoordinator {
       );
       return "deferred";
     }
-
-    if (!reassert && olderSameClientInstance) return "ignored";
 
     return this.promote(sessionId, connectionId, now);
   }

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -1473,23 +1473,23 @@ export function pickNextPrimaryConnection(
   >,
 ): string | null {
   if (conns.length === 0) return null;
-  const visible = conns.filter((c) => c.isVisible);
-  const pool = visible.length > 0 ? visible : conns;
-  const newestConnectionByInstance = new Map<string, (typeof pool)[number]>();
-  for (const connection of pool) {
+  const newestConnectionByInstance = new Map<string, (typeof conns)[number]>();
+  for (const connection of conns) {
     if (connection.clientInstanceId === null) continue;
     const newest = newestConnectionByInstance.get(connection.clientInstanceId);
     if (!newest || connection.connectionSeq > newest.connectionSeq) {
       newestConnectionByInstance.set(connection.clientInstanceId, connection);
     }
   }
-  const eligible = pool.filter(
+  const eligible = conns.filter(
     (connection) =>
       connection.clientInstanceId === null ||
       newestConnectionByInstance.get(connection.clientInstanceId) === connection,
   );
-  let best = eligible[0];
-  for (const c of eligible) {
+  const visible = eligible.filter((connection) => connection.isVisible);
+  const pool = visible.length > 0 ? visible : eligible;
+  let best = pool[0];
+  for (const c of pool) {
     const engagement = connectionEngagement(c);
     const bestEngagement = connectionEngagement(best);
     if (

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -301,14 +301,10 @@ export class PrimaryPromotionCoordinator {
       if (this.pendingTimers.get(sessionId) !== timer) return;
       this.pendingTimers.delete(sessionId);
 
+      // Only the still-mapped candidate may promote; requestPromotion
+      // re-validates it and drops the pending entry when it no longer
+      // qualifies (closed socket, hidden panel).
       if (this.pendingCandidates.get(sessionId) !== connectionId) return;
-      const candidate = this.host.getConnection(connectionId);
-      if (!candidate?.isSocketOpen || !candidate.isVisible) {
-        this.pendingCandidates.delete(sessionId);
-        return;
-      }
-      if (this.pendingCandidates.get(sessionId) !== connectionId) return;
-
       this.requestPromotion(sessionId, connectionId, false);
     }, Math.max(0, delayMs));
     this.pendingTimers.set(sessionId, timer);
@@ -371,12 +367,8 @@ const primaryPromotions = new PrimaryPromotionCoordinator(
         { force: true },
       );
     },
-    broadcastPrimaryChanged(sessionId) {
-      broadcastPrimaryChanged(sessionId);
-    },
-    now() {
-      return Date.now();
-    },
+    broadcastPrimaryChanged,
+    now: () => Date.now(),
   },
   PROMOTION_COOLDOWN_MS,
 );
@@ -864,7 +856,8 @@ function broadcastPrimaryChanged(sessionId: string): void {
 
 /**
  * Promote `connectionId` to be the session's primary (tmux-resize controller).
- * Honors a per-session cooldown unless `force` is true.
+ * A request blocked by the per-session cooldown is deferred until the cooldown
+ * expires, not dropped, unless `force` is true.
  */
 function tryPromoteToPrimary(sessionId: string, connectionId: string, force: boolean): void {
   const result = primaryPromotions.requestPromotion(sessionId, connectionId, force);

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -19,6 +19,7 @@ import { getSchedulerHealth } from "./scheduler-health.js";
 import { validateWsToken, getAuthSecret, CONTROL_SESSION_SENTINEL } from "../lib/ws-token.js";
 import { createLogger } from "../lib/logger.js";
 import { WS_PATH_PREFIX } from "../lib/base-path.js";
+import { TmuxSizeController, type TmuxExec } from "./tmux-size-controller.js";
 import {
   PROXY_WS_PATH_PATTERN,
   handleProxyWsUpgrade,
@@ -37,6 +38,11 @@ const internalLog = createLogger("InternalAPI");
 const ptyLog = createLogger("PtyControl");
 const peerLog = createLogger("PeerAPI");
 const usageLog = createLogger("UsageLimit");
+
+const execTmux: TmuxExec = (args, callback) => {
+  execFile("tmux", args, { cwd: STABLE_SPAWN_CWD }, (error) => callback(error));
+};
+const tmuxSize = new TmuxSizeController(execTmux, log);
 
 /** Retry an async operation up to maxRetries times with exponential backoff (for SQLITE_BUSY) */
 async function retryOnBusy<T>(fn: () => Promise<T>, maxRetries = 2): Promise<T> {
@@ -84,6 +90,32 @@ function getCleanEnvironment(): Record<string, string> {
  */
 function validateSessionName(name: string): boolean {
   return /^rdv-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(name);
+}
+
+const DEFAULT_TERMINAL_COLS = 80;
+const DEFAULT_TERMINAL_ROWS = 24;
+const MIN_TERMINAL_COLS = 10;
+const MIN_TERMINAL_ROWS = 3;
+
+/**
+ * Parse and clamp the initial terminal dimensions carried in the WS URL.
+ * Positive legacy-client grids below 10x3 are intentionally clamped to the
+ * protocol's resize minima; absent, invalid, and nonpositive values keep the
+ * established 80x24 defaults.
+ */
+export function parseInitialTerminalDimensions(
+  colsParam: unknown,
+  rowsParam: unknown,
+): { cols: number; rows: number } {
+  const parsedCols = Number.parseInt(String(colsParam), 10);
+  const parsedRows = Number.parseInt(String(rowsParam), 10);
+  const cols = Number.isFinite(parsedCols) && parsedCols > 0
+    ? Math.max(MIN_TERMINAL_COLS, parsedCols)
+    : DEFAULT_TERMINAL_COLS;
+  const rows = Number.isFinite(parsedRows) && parsedRows > 0
+    ? Math.max(MIN_TERMINAL_ROWS, parsedRows)
+    : DEFAULT_TERMINAL_ROWS;
+  return { cols, rows };
 }
 
 /**
@@ -165,6 +197,129 @@ interface TerminalConnection {
   isControl?: boolean;
 }
 
+export interface PromotionConnectionState {
+  connectionId: string;
+  isVisible: boolean;
+  isSocketOpen: boolean;
+}
+
+export interface PromotionCoordinatorHost {
+  getConnection(connectionId: string): PromotionConnectionState | undefined;
+  getPrimary(sessionId: string): string | undefined;
+  setPrimary(sessionId: string, connectionId: string): void;
+  getLastPromotionAt(sessionId: string): number | undefined;
+  setLastPromotionAt(sessionId: string, timestamp: number): void;
+  reassertSize(sessionId: string, connectionId: string): void;
+  broadcastPrimaryChanged(sessionId: string): void;
+  now(): number;
+}
+
+export type PromotionRequestResult =
+  | "ignored"
+  | "already-primary"
+  | "deferred"
+  | "promoted";
+
+/**
+ * Coordinates focus-driven primary selection and cooldown deferral.
+ * Pending candidates are session-scoped and identity-conditional: blur or
+ * disconnect only cancels the same connection that is currently pending.
+ */
+export class PrimaryPromotionCoordinator {
+  private readonly pendingCandidates = new Map<string, string>();
+  private readonly pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  constructor(
+    private readonly host: PromotionCoordinatorHost,
+    private readonly cooldownMs: number,
+  ) {}
+
+  requestPromotion(
+    sessionId: string,
+    connectionId: string,
+    force: boolean,
+  ): PromotionRequestResult {
+    const candidate = this.host.getConnection(connectionId);
+    if (!candidate?.isSocketOpen || !candidate.isVisible) {
+      this.clearIfCandidate(sessionId, connectionId);
+      return "ignored";
+    }
+
+    if (this.host.getPrimary(sessionId) === connectionId) {
+      this.clearPendingPromotion(sessionId);
+      this.host.reassertSize(sessionId, connectionId);
+      return "already-primary";
+    }
+
+    const now = this.host.now();
+    const lastPromotionAt = this.host.getLastPromotionAt(sessionId) ?? 0;
+    const elapsed = now - lastPromotionAt;
+    if (!force && elapsed < this.cooldownMs) {
+      this.defer(sessionId, connectionId, this.cooldownMs - elapsed);
+      return "deferred";
+    }
+
+    this.clearPendingPromotion(sessionId);
+    this.host.setPrimary(sessionId, connectionId);
+    this.host.setLastPromotionAt(sessionId, now);
+    this.host.reassertSize(sessionId, connectionId);
+    this.host.broadcastPrimaryChanged(sessionId);
+    return "promoted";
+  }
+
+  notifyBlur(sessionId: string, connectionId: string): void {
+    this.clearIfCandidate(sessionId, connectionId);
+  }
+
+  notifyDisconnect(sessionId: string, connectionId: string): void {
+    this.clearIfCandidate(sessionId, connectionId);
+  }
+
+  getPendingCandidate(sessionId: string): string | null {
+    return this.pendingCandidates.get(sessionId) ?? null;
+  }
+
+  clearPendingPromotion(sessionId: string): void {
+    this.pendingCandidates.delete(sessionId);
+    const timer = this.pendingTimers.get(sessionId);
+    if (timer) clearTimeout(timer);
+    this.pendingTimers.delete(sessionId);
+  }
+
+  dispose(): void {
+    for (const timer of this.pendingTimers.values()) clearTimeout(timer);
+    this.pendingTimers.clear();
+    this.pendingCandidates.clear();
+  }
+
+  private defer(sessionId: string, connectionId: string, delayMs: number): void {
+    const existingTimer = this.pendingTimers.get(sessionId);
+    if (existingTimer) clearTimeout(existingTimer);
+
+    this.pendingCandidates.set(sessionId, connectionId);
+    const timer = setTimeout(() => {
+      if (this.pendingTimers.get(sessionId) !== timer) return;
+      this.pendingTimers.delete(sessionId);
+
+      if (this.pendingCandidates.get(sessionId) !== connectionId) return;
+      const candidate = this.host.getConnection(connectionId);
+      if (!candidate?.isSocketOpen || !candidate.isVisible) {
+        this.pendingCandidates.delete(sessionId);
+        return;
+      }
+      if (this.pendingCandidates.get(sessionId) !== connectionId) return;
+
+      this.requestPromotion(sessionId, connectionId, false);
+    }, Math.max(0, delayMs));
+    this.pendingTimers.set(sessionId, timer);
+  }
+
+  private clearIfCandidate(sessionId: string, connectionId: string): void {
+    if (this.pendingCandidates.get(sessionId) !== connectionId) return;
+    this.clearPendingPromotion(sessionId);
+  }
+}
+
 // CONTROL_SESSION_SENTINEL (the reserved control-mode sessionId) is imported
 // from ws-token so the token minter (API route) and this acceptor agree.
 
@@ -181,6 +336,50 @@ const sessionPrimaryConnection = new Map<string, string>();
 // ping-pong between two side-by-side windows.
 const sessionLastPromotionAt = new Map<string, number>();
 const PROMOTION_COOLDOWN_MS = 1000;
+
+const primaryPromotions = new PrimaryPromotionCoordinator(
+  {
+    getConnection(connectionId) {
+      const connection = connections.get(connectionId);
+      if (!connection) return undefined;
+      return {
+        connectionId,
+        isVisible: connection.isVisible,
+        isSocketOpen: connection.ws.readyState === WebSocket.OPEN,
+      };
+    },
+    getPrimary(sessionId) {
+      return sessionPrimaryConnection.get(sessionId);
+    },
+    setPrimary(sessionId, connectionId) {
+      sessionPrimaryConnection.set(sessionId, connectionId);
+    },
+    getLastPromotionAt(sessionId) {
+      return sessionLastPromotionAt.get(sessionId);
+    },
+    setLastPromotionAt(sessionId, timestamp) {
+      sessionLastPromotionAt.set(sessionId, timestamp);
+    },
+    reassertSize(sessionId, connectionId) {
+      const connection = connections.get(connectionId);
+      if (!connection?.lastCols || !connection.lastRows) return;
+      tmuxSize.requestResize(
+        sessionId,
+        connection.tmuxSessionName,
+        connection.lastCols,
+        connection.lastRows,
+        { force: true },
+      );
+    },
+    broadcastPrimaryChanged(sessionId) {
+      broadcastPrimaryChanged(sessionId);
+    },
+    now() {
+      return Date.now();
+    },
+  },
+  PROMOTION_COOLDOWN_MS,
+);
 
 /** Get all active connections for a session */
 function getConnectionsForSession(sessionId: string): TerminalConnection[] {
@@ -647,20 +846,6 @@ function broadcastToSession(sessionId: string, data: Record<string, unknown>): v
   }
 }
 
-/** Run `tmux resize-window` for the given session asynchronously. */
-function runTmuxResize(tmuxSessionName: string, cols: number, rows: number): void {
-  execFile(
-    "tmux",
-    ["resize-window", "-t", tmuxSessionName, "-x", String(cols), "-y", String(rows)],
-    { cwd: STABLE_SPAWN_CWD },
-    (err) => {
-      if (err) {
-        log.warn("tmux resize-window failed", { error: String(err), tmuxSessionName, cols, rows });
-      }
-    },
-  );
-}
-
 /** Notify each connection in the session whether it is the current primary. */
 function broadcastPrimaryChanged(sessionId: string): void {
   const primaryId = sessionPrimaryConnection.get(sessionId);
@@ -682,27 +867,12 @@ function broadcastPrimaryChanged(sessionId: string): void {
  * Honors a per-session cooldown unless `force` is true.
  */
 function tryPromoteToPrimary(sessionId: string, connectionId: string, force: boolean): void {
-  const currentPrimary = sessionPrimaryConnection.get(sessionId);
-  if (currentPrimary === connectionId) return;
-
-  const now = Date.now();
-  const lastPromo = sessionLastPromotionAt.get(sessionId) ?? 0;
-  const msSincePrev = now - lastPromo;
-  if (!force && msSincePrev < PROMOTION_COOLDOWN_MS) {
-    log.debug("promotion denied (cooldown)", { connectionId, sessionId, msSincePrev });
-    return;
+  const result = primaryPromotions.requestPromotion(sessionId, connectionId, force);
+  if (result === "deferred") {
+    log.debug("promotion deferred (cooldown)", { connectionId, sessionId });
+  } else if (result === "promoted") {
+    log.debug("promoted connection to primary", { connectionId, sessionId, force });
   }
-
-  sessionPrimaryConnection.set(sessionId, connectionId);
-  sessionLastPromotionAt.set(sessionId, now);
-
-  const conn = connections.get(connectionId);
-  if (conn?.lastCols && conn?.lastRows) {
-    runTmuxResize(conn.tmuxSessionName, conn.lastCols, conn.lastRows);
-  }
-
-  log.debug("promoted connection to primary", { connectionId, sessionId, force });
-  broadcastPrimaryChanged(sessionId);
 }
 
 /**
@@ -763,6 +933,8 @@ function cleanupConnection(connectionId: string): void {
     return;
   }
 
+  primaryPromotions.notifyDisconnect(conn.sessionId, connectionId);
+
   // Remove from session connections and update session-level state
   const connSet = sessionConnections.get(conn.sessionId);
   if (connSet) {
@@ -801,11 +973,18 @@ function cleanupConnection(connectionId: string): void {
     // remaining connection and apply its size to tmux.
     const nextPrimary = pickNextPrimary(conn.sessionId);
     if (nextPrimary) {
+      primaryPromotions.clearPendingPromotion(conn.sessionId);
       sessionPrimaryConnection.set(conn.sessionId, nextPrimary);
       sessionLastPromotionAt.set(conn.sessionId, Date.now());
       const nextConn = connections.get(nextPrimary);
       if (nextConn?.lastCols && nextConn?.lastRows) {
-        runTmuxResize(nextConn.tmuxSessionName, nextConn.lastCols, nextConn.lastRows);
+        tmuxSize.requestResize(
+          conn.sessionId,
+          nextConn.tmuxSessionName,
+          nextConn.lastCols,
+          nextConn.lastRows,
+          { force: true },
+        );
       }
       log.debug("primary handoff on disconnect", { from: connectionId, to: nextPrimary, sessionId: conn.sessionId });
       broadcastPrimaryChanged(conn.sessionId);
@@ -3041,8 +3220,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
     const sessionId = authResult.sessionId;
     const userId = authResult.userId;
     const tmuxSessionName = (query.tmuxSession as string) || `rdv-${sessionId}`;
-    const cols = parseInt(query.cols as string) || 80;
-    const rows = parseInt(query.rows as string) || 24;
+    const { cols, rows } = parseInitialTerminalDimensions(query.cols, query.rows);
     const rawCwd = query.cwd as string | undefined;
     // tmux history-limit (scrollback buffer) - default 50000 lines
     const tmuxHistoryLimit = parseInt(query.tmuxHistoryLimit as string) || 50000;
@@ -3325,14 +3503,12 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
           case "resize": {
             // Ignore resize events with invalid dimensions
             // This prevents tmux from shrinking when tabs are hidden
-            const MIN_COLS = 10;
-            const MIN_ROWS = 3;
             const nextCols = Number(msg.cols);
             const nextRows = Number(msg.rows);
             if (!Number.isFinite(nextCols) || !Number.isFinite(nextRows)) {
               break;
             }
-            if (nextCols < MIN_COLS || nextRows < MIN_ROWS) {
+            if (nextCols < MIN_TERMINAL_COLS || nextRows < MIN_TERMINAL_ROWS) {
               break;
             }
 
@@ -3347,23 +3523,24 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
               connection.resizeTimeout = null;
 
               if (!pending) return;
-              if (pending.cols === connection.lastCols && pending.rows === connection.lastRows) {
-                return;
+              const dimensionsChanged =
+                pending.cols !== connection.lastCols || pending.rows !== connection.lastRows;
+              if (dimensionsChanged) {
+                connection.lastCols = pending.cols;
+                connection.lastRows = pending.rows;
+
+                // Resize this connection's PTY only when its grid changed.
+                try {
+                  connection.pty?.resize(pending.cols, pending.rows);
+                } catch {
+                  // Ignore resize errors from pty
+                }
               }
 
-              connection.lastCols = pending.cols;
-              connection.lastRows = pending.rows;
-
-              // Always resize this connection's PTY
-              try {
-                connection.pty?.resize(pending.cols, pending.rows);
-              } catch {
-                // Ignore resize errors from pty
-              }
-
-              // Only resize the tmux window if this is the primary connection
+              // Always pass primary resize intent to the controller. Its
+              // applied-size cache makes already-converged requests free.
               if (sessionPrimaryConnection.get(sessionId) === connectionId) {
-                runTmuxResize(tmuxSessionName, pending.cols, pending.rows);
+                tmuxSize.requestResize(sessionId, tmuxSessionName, pending.cols, pending.rows);
               }
             }, 50);
             break;
@@ -3378,6 +3555,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
           }
           case "client_blur": {
             connection.isVisible = false;
+            primaryPromotions.notifyBlur(sessionId, connectionId);
             // Bookkeeping only — do not change primary on blur.
             break;
           }
@@ -3414,9 +3592,16 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
 
               // Use synchronous kill so the session is fully gone before we
               // recreate it — avoids a race between async kill and sync create.
+              let tmuxSessionConfirmedGone = false;
               try {
                 execFileSync("tmux", ["kill-session", "-t", tmuxSessionName], { stdio: "pipe", cwd: STABLE_SPAWN_CWD });
-              } catch { /* session may already be dead */ }
+                tmuxSessionConfirmedGone = true;
+              } catch {
+                // A failed kill is safe to treat as gone only when tmux confirms
+                // the session no longer exists (it may already have died).
+                tmuxSessionConfirmedGone = !tmuxSessionExists(tmuxSessionName);
+              }
+              if (tmuxSessionConfirmedGone) tmuxSize.clearSession(sessionId);
               // Re-validate the connect-time cwd — the directory may have been
               // deleted (e.g. a worktree removed) since this WS attached.
               createTmuxSession(
@@ -3608,6 +3793,7 @@ export function shutdownTerminalConnections(): void {
     conn.ws.close();
     log.debug("Closed PTY wrapper", { connectionId: id, sessionId: conn.sessionId });
   }
+  primaryPromotions.dispose();
   connections.clear();
   sessionConnections.clear();
   sessionPrimaryConnection.clear();

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -125,6 +125,7 @@ interface TerminalMessageSocket<TMessage> {
   off(event: "message", listener: (message: TMessage) => void): unknown;
   off(event: "close", listener: (code: number, reason: Buffer) => void): unknown;
   off(event: "error", listener: (error: Error) => void): unknown;
+  close(code?: number, reason?: string): unknown;
 }
 
 export interface TerminalSocketHandlers<TMessage> {
@@ -145,6 +146,24 @@ export interface BufferedTerminalMessages<TMessage> {
   getCloseInfo(): TerminalSetupCloseInfo | null;
 }
 
+const TERMINAL_SETUP_MAX_BUFFERED_FRAMES = 256;
+const TERMINAL_SETUP_MAX_BUFFERED_BYTES = 1024 * 1024;
+const TERMINAL_SETUP_OVERFLOW_REASON = "Terminal setup message buffer overflow";
+
+function terminalMessageByteLength(message: unknown): number {
+  if (typeof message === "string") return Buffer.byteLength(message);
+  if (Buffer.isBuffer(message)) return message.byteLength;
+  if (message instanceof ArrayBuffer) return message.byteLength;
+  if (ArrayBuffer.isView(message)) return message.byteLength;
+  if (Array.isArray(message)) {
+    return message.reduce(
+      (total, part) => total + terminalMessageByteLength(part),
+      0,
+    );
+  }
+  return Buffer.byteLength(String(message));
+}
+
 /**
  * Synchronously capture terminal frames while async connection setup runs.
  * Activation swaps in the production handler before replaying the captured
@@ -152,13 +171,44 @@ export interface BufferedTerminalMessages<TMessage> {
  */
 export function bufferTerminalMessages<TMessage>(
   ws: TerminalMessageSocket<TMessage>,
-  setupLog: Pick<typeof log, "error"> = log,
+  setupLog: Pick<typeof log, "error" | "warn"> = log,
 ): BufferedTerminalMessages<TMessage> {
   let pending: TMessage[] | null = [];
+  let pendingPayloadBytes = 0;
   let closed = false;
   let closeInfo: TerminalSetupCloseInfo | null = null;
   const buffer = (message: TMessage): void => {
-    pending?.push(message);
+    if (!pending) return;
+    const messageBytes = terminalMessageByteLength(message);
+    if (
+      pending.length >= TERMINAL_SETUP_MAX_BUFFERED_FRAMES ||
+      pendingPayloadBytes + messageBytes > TERMINAL_SETUP_MAX_BUFFERED_BYTES
+    ) {
+      const frameCount = pending.length;
+      const payloadBytes = pendingPayloadBytes;
+      closed = true;
+      closeInfo = {
+        code: 1009,
+        reason: Buffer.from(TERMINAL_SETUP_OVERFLOW_REASON),
+      };
+      pending = null;
+      removeSetupListeners();
+      setupLog.warn(TERMINAL_SETUP_OVERFLOW_REASON, {
+        frameCount,
+        payloadBytes,
+        rejectedMessageBytes: messageBytes,
+      });
+      try {
+        ws.close(1009, TERMINAL_SETUP_OVERFLOW_REASON);
+      } catch (error) {
+        setupLog.error("Failed to close overflowing terminal setup socket", {
+          error: String(error),
+        });
+      }
+      return;
+    }
+    pending.push(message);
+    pendingPayloadBytes += messageBytes;
   };
   const setupClose = (code: number, reason: Buffer): void => {
     closed = true;
@@ -353,6 +403,10 @@ export interface ClientInputConnectionState {
   clientInstanceId?: string | null;
 }
 
+export interface ClientRecencyConnectionState extends ClientInputConnectionState {
+  lastFocusAt: number;
+}
+
 export interface ClientInstanceRecency {
   genuineFocusAt: number;
   inputAt: number;
@@ -382,6 +436,10 @@ export class ClientInstanceFocusRecency {
 
   getLastInputAt(sessionId: string, clientInstanceId: string): number {
     return this.getRecency(sessionId, clientInstanceId).inputAt;
+  }
+
+  getSessionIds(): string[] {
+    return [...this.sessions.keys()];
   }
 
   recordGenuineFocus(
@@ -469,7 +527,52 @@ export function recordClientInput(
   connection.lastInputRecencyWriteAt = timestamp;
 }
 
-function connectionEngagement(connection: PromotionConnectionState): number {
+/** Persist exact socket-local timestamps before the socket is discarded. */
+export function flushClientInstanceRecency(
+  connection: ClientRecencyConnectionState,
+  instanceRecency: ClientInstanceFocusRecency,
+): void {
+  if (!connection.sessionId || !connection.clientInstanceId) return;
+  const current = instanceRecency.getRecency(
+    connection.sessionId,
+    connection.clientInstanceId,
+  );
+  instanceRecency.recordGenuineFocus(
+    connection.sessionId,
+    connection.clientInstanceId,
+    Math.max(current.genuineFocusAt, connection.lastFocusAt),
+  );
+  instanceRecency.recordInput(
+    connection.sessionId,
+    connection.clientInstanceId,
+    Math.max(current.inputAt, connection.lastInputAt),
+  );
+}
+
+function deriveTmuxSessionName(sessionId: string): string | null {
+  const tmuxSessionName = `rdv-${sessionId}`;
+  return validateSessionName(tmuxSessionName) ? tmuxSessionName : null;
+}
+
+/** Remove stable-instance history once both the sockets and tmux session are gone. */
+export function sweepClientInstanceRecency(
+  instanceRecency: ClientInstanceFocusRecency,
+  getLiveConnectionCount: (sessionId: string) => number,
+  sessionExists: (tmuxSessionName: string) => boolean,
+  sessionNameForId: (sessionId: string) => string | null = deriveTmuxSessionName,
+): void {
+  for (const sessionId of instanceRecency.getSessionIds()) {
+    if (getLiveConnectionCount(sessionId) > 0) continue;
+    const tmuxSessionName = sessionNameForId(sessionId);
+    if (!tmuxSessionName || !sessionExists(tmuxSessionName)) {
+      instanceRecency.clearSession(sessionId);
+    }
+  }
+}
+
+function connectionEngagement(
+  connection: Pick<PromotionConnectionState, "lastFocusAt" | "lastInputAt">,
+): number {
   return Math.max(connection.lastFocusAt, connection.lastInputAt);
 }
 
@@ -514,7 +617,10 @@ export function handleClientFocus(
  * disconnect only cancels the same connection that is currently pending.
  */
 export class PrimaryPromotionCoordinator {
-  private readonly pendingCandidates = new Map<string, string>();
+  private readonly pendingCandidates = new Map<
+    string,
+    { connectionId: string; reason: "genuine" | "reassert" }
+  >();
   private readonly pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   constructor(
@@ -543,18 +649,16 @@ export class PrimaryPromotionCoordinator {
     const primary = primaryId
       ? this.host.getConnection(primaryId)
       : undefined;
-    if (
+    const sameClientInstance =
       primary?.clientInstanceId !== null &&
-      primary?.clientInstanceId === candidate.clientInstanceId
-    ) {
-      return this.promote(sessionId, connectionId, this.host.now());
-    }
+      primary?.clientInstanceId === candidate.clientInstanceId;
 
     if (reassert) {
-      const pendingCandidate = this.pendingCandidates.get(sessionId);
+      const pendingCandidate = this.pendingCandidates.get(sessionId)?.connectionId;
       if (pendingCandidate && pendingCandidate !== connectionId) return "ignored";
 
       if (
+        !sameClientInstance &&
         primary?.isSocketOpen &&
         primary.isVisible &&
         connectionEngagement(primary) >= connectionEngagement(candidate)
@@ -567,7 +671,12 @@ export class PrimaryPromotionCoordinator {
     const lastPromotionAt = this.host.getLastPromotionAt(sessionId) ?? 0;
     const elapsed = now - lastPromotionAt;
     if (!force && elapsed < this.cooldownMs) {
-      this.defer(sessionId, connectionId, this.cooldownMs - elapsed);
+      this.defer(
+        sessionId,
+        connectionId,
+        this.cooldownMs - elapsed,
+        reassert ? "reassert" : "genuine",
+      );
       return "deferred";
     }
 
@@ -583,7 +692,7 @@ export class PrimaryPromotionCoordinator {
   }
 
   getPendingCandidate(sessionId: string): string | null {
-    return this.pendingCandidates.get(sessionId) ?? null;
+    return this.pendingCandidates.get(sessionId)?.connectionId ?? null;
   }
 
   clearPendingPromotion(sessionId: string): void {
@@ -603,11 +712,27 @@ export class PrimaryPromotionCoordinator {
     this.pendingCandidates.clear();
   }
 
-  private defer(sessionId: string, connectionId: string, delayMs: number): void {
+  private defer(
+    sessionId: string,
+    connectionId: string,
+    delayMs: number,
+    reason: "genuine" | "reassert",
+  ): void {
     const existingTimer = this.pendingTimers.get(sessionId);
     if (existingTimer) clearTimeout(existingTimer);
 
-    this.pendingCandidates.set(sessionId, connectionId);
+    const existingPending = this.pendingCandidates.get(sessionId);
+    const pendingReason =
+      reason === "genuine" ||
+      (existingPending?.connectionId === connectionId &&
+        existingPending.reason === "genuine")
+        ? "genuine"
+        : "reassert";
+    const pendingPromotion = {
+      connectionId,
+      reason: pendingReason,
+    } as const;
+    this.pendingCandidates.set(sessionId, pendingPromotion);
     const timer = setTimeout(() => {
       if (this.pendingTimers.get(sessionId) !== timer) return;
       this.pendingTimers.delete(sessionId);
@@ -615,7 +740,7 @@ export class PrimaryPromotionCoordinator {
       // Only the still-mapped candidate may promote; requestPromotion
       // re-validates it and drops the pending entry when it no longer
       // qualifies (closed socket, hidden panel).
-      if (this.pendingCandidates.get(sessionId) !== connectionId) return;
+      if (this.pendingCandidates.get(sessionId) !== pendingPromotion) return;
       const candidate = this.host.getConnection(connectionId);
       if (!candidate?.isSocketOpen || !candidate.isVisible) {
         this.clearIfCandidate(sessionId, connectionId);
@@ -636,20 +761,25 @@ export class PrimaryPromotionCoordinator {
         !sameClientInstance &&
         primary?.isSocketOpen &&
         primary.isVisible &&
-        // Date.now() can collapse challenger and primary engagement into one
-        // millisecond. Keep the current primary when engagement ties.
-        connectionEngagement(primary) >= connectionEngagement(candidate)
+        (pendingReason === "genuine"
+          ? primary.lastFocusAt >= candidate.lastFocusAt
+          : connectionEngagement(primary) >= connectionEngagement(candidate))
       ) {
         this.clearIfCandidate(sessionId, connectionId);
         return;
       }
-      this.requestPromotion(sessionId, connectionId, false);
+      this.requestPromotion(
+        sessionId,
+        connectionId,
+        false,
+        pendingReason === "reassert",
+      );
     }, Math.max(0, delayMs));
     this.pendingTimers.set(sessionId, timer);
   }
 
   private clearIfCandidate(sessionId: string, connectionId: string): void {
-    if (this.pendingCandidates.get(sessionId) !== connectionId) return;
+    if (this.pendingCandidates.get(sessionId)?.connectionId !== connectionId) return;
     this.clearPendingPromotion(sessionId);
   }
 
@@ -674,6 +804,25 @@ export function clearSessionControllerState(
 ): void {
   sizeController.clearSession(sessionId);
   promotionCoordinator.clearSession(sessionId);
+}
+
+/** Reconcile a recreated same-name tmux session to the current primary size. */
+export function requestRestartPrimaryResize(
+  sizeController: Pick<TmuxSizeController, "requestResize">,
+  sessionId: string,
+  tmuxSessionName: string,
+  primaryConnection:
+    | Pick<TerminalConnection, "lastCols" | "lastRows">
+    | undefined,
+): void {
+  if (!primaryConnection?.lastCols || !primaryConnection.lastRows) return;
+  sizeController.requestResize(
+    sessionId,
+    tmuxSessionName,
+    primaryConnection.lastCols,
+    primaryConnection.lastRows,
+    { force: true },
+  );
 }
 
 // CONTROL_SESSION_SENTINEL (the reserved control-mode sessionId) is imported
@@ -1244,11 +1393,14 @@ function tryPromoteToPrimary(
 
 /**
  * Select the best replacement primary from a session's remaining connections:
- * prefer visible connections, break ties by most recent `lastFocusAt`.
+ * prefer visible connections, then rank by latest focus or input engagement.
  */
 export function pickNextPrimaryConnection(
   conns: ReadonlyArray<
-    Pick<PromotionConnectionState, "connectionId" | "isVisible" | "lastFocusAt">
+    Pick<
+      PromotionConnectionState,
+      "connectionId" | "isVisible" | "lastFocusAt" | "lastInputAt"
+    >
   >,
 ): string | null {
   if (conns.length === 0) return null;
@@ -1256,7 +1408,14 @@ export function pickNextPrimaryConnection(
   const pool = visible.length > 0 ? visible : conns;
   let best = pool[0];
   for (const c of pool) {
-    if (c.lastFocusAt > best.lastFocusAt) best = c;
+    const engagement = connectionEngagement(c);
+    const bestEngagement = connectionEngagement(best);
+    if (
+      engagement > bestEngagement ||
+      (engagement === bestEngagement && c.lastFocusAt > best.lastFocusAt)
+    ) {
+      best = c;
+    }
   }
   return best.connectionId;
 }
@@ -1307,6 +1466,7 @@ function cleanupConnection(connectionId: string): void {
     return;
   }
 
+  flushClientInstanceRecency(conn, clientInstanceFocusRecency);
   primaryPromotions.notifyDisconnect(conn.sessionId, connectionId);
 
   // Remove from session connections and update session-level state
@@ -3531,6 +3691,17 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       .catch((err) => log.error("Liveness sweep failed", { error: String(err) }));
   }, 30_000);
 
+  // Stable client engagement outlives transient socket gaps, but must not
+  // retain an unbounded set of sessions after tmux is killed out-of-band.
+  const clientRecencySweepTimer = setInterval(() => {
+    sweepClientInstanceRecency(
+      clientInstanceFocusRecency,
+      (sessionId) => sessionConnections.get(sessionId)?.size ?? 0,
+      tmuxSessionExists,
+    );
+  }, 10 * 60 * 1000);
+  clientRecencySweepTimer.unref();
+
   wss.on("connection", async (ws, req) => {
     // The browser flushes focus and resize intent from its onopen callback.
     // Capture those frames before any awaited ownership/DB/setup work so a
@@ -3669,6 +3840,16 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
             columns: { id: true, userId: true, projectPath: true },
           })) ?? null;
       } catch (error) {
+        if (
+          abortTerminalSetupIfClosed(
+            bufferedMessages,
+            null,
+            () => {},
+            sessionId,
+          )
+        ) {
+          return;
+        }
         // Fail CLOSED: if we cannot verify ownership, do not attach.
         bufferedMessages.discard();
         log.error("tmuxSession ownership lookup failed", {
@@ -3678,6 +3859,17 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
         });
         ws.send(JSON.stringify({ type: "error", message: "Authorization check failed" }));
         ws.close(4002, "Authorization check failed");
+        return;
+      }
+
+      if (
+        abortTerminalSetupIfClosed(
+          bufferedMessages,
+          null,
+          () => {},
+          sessionId,
+        )
+      ) {
         return;
       }
 
@@ -4048,6 +4240,9 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
             const otherConns = getConnectionsForSession(sessionId).filter(
               (c) => c.connectionId !== connectionId
             );
+            const restartPrimaryConnection = connections.get(
+              sessionPrimaryConnection.get(sessionId) ?? "",
+            );
             try {
               // Destroy PTYs for ALL connections to this session before
               // killing the tmux session, so their onExit handlers see the
@@ -4125,6 +4320,13 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
                   }
                 }
               }
+
+              requestRestartPrimaryResize(
+                tmuxSize,
+                sessionId,
+                tmuxSessionName,
+                restartPrimaryConnection,
+              );
 
               newPty.onData((data) => {
                 if (ws.readyState === WebSocket.OPEN) {

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -221,6 +221,31 @@ export type PromotionRequestResult =
   | "deferred"
   | "promoted";
 
+export interface ClientFocusMessage {
+  force?: boolean;
+  reassert?: boolean;
+}
+
+export interface ClientFocusConnectionState {
+  isVisible: boolean;
+  lastFocusAt: number;
+}
+
+/** Apply client_focus bookkeeping before invoking promotion, matching the
+ * production WebSocket ordering. Reconnect flushes are visibility/size
+ * reassertions only and therefore do not alter focus recency. */
+export function handleClientFocus(
+  connection: ClientFocusConnectionState,
+  message: ClientFocusMessage,
+  promote: (force: boolean, reassert: boolean) => void,
+  now: () => number = Date.now,
+): void {
+  const reassert = message.reassert === true;
+  connection.isVisible = true;
+  if (!reassert) connection.lastFocusAt = now();
+  promote(message.force === true, reassert);
+}
+
 /**
  * Coordinates focus-driven primary selection and cooldown deferral.
  * Pending candidates are session-scoped and identity-conditional: blur or
@@ -239,8 +264,21 @@ export class PrimaryPromotionCoordinator {
     sessionId: string,
     connectionId: string,
     force: boolean,
+    reassert = false,
   ): PromotionRequestResult {
     const candidate = this.host.getConnection(connectionId);
+    if (reassert) {
+      if (
+        candidate?.isSocketOpen &&
+        candidate.isVisible &&
+        this.host.getPrimary(sessionId) === connectionId
+      ) {
+        this.host.reassertSize(sessionId, connectionId);
+        return "already-primary";
+      }
+      return "ignored";
+    }
+
     if (!candidate?.isSocketOpen || !candidate.isVisible) {
       this.clearIfCandidate(sessionId, connectionId);
       return "ignored";
@@ -322,7 +360,11 @@ export class PrimaryPromotionCoordinator {
       const primary = primaryId
         ? this.host.getConnection(primaryId)
         : undefined;
-      if (primary && primary.lastFocusAt > candidate.lastFocusAt) {
+      if (
+        primary?.isSocketOpen &&
+        primary.isVisible &&
+        primary.lastFocusAt > candidate.lastFocusAt
+      ) {
         this.clearIfCandidate(sessionId, connectionId);
         return;
       }
@@ -337,7 +379,7 @@ export class PrimaryPromotionCoordinator {
   }
 }
 
-export function clearTerminatedSessionControllerState(
+export function clearSessionControllerState(
   sessionId: string,
   sizeController: Pick<TmuxSizeController, "clearSession">,
   promotionCoordinator: Pick<PrimaryPromotionCoordinator, "clearSession">,
@@ -890,8 +932,18 @@ function broadcastPrimaryChanged(sessionId: string): void {
  * A request blocked by the per-session cooldown is deferred until the cooldown
  * expires, not dropped, unless `force` is true.
  */
-function tryPromoteToPrimary(sessionId: string, connectionId: string, force: boolean): void {
-  const result = primaryPromotions.requestPromotion(sessionId, connectionId, force);
+function tryPromoteToPrimary(
+  sessionId: string,
+  connectionId: string,
+  force: boolean,
+  reassert = false,
+): void {
+  const result = primaryPromotions.requestPromotion(
+    sessionId,
+    connectionId,
+    force,
+    reassert,
+  );
   if (result === "deferred") {
     log.debug("promotion deferred (cooldown)", { connectionId, sessionId });
   } else if (result === "promoted") {
@@ -903,8 +955,11 @@ function tryPromoteToPrimary(sessionId: string, connectionId: string, force: boo
  * Select the best replacement primary from a session's remaining connections:
  * prefer visible connections, break ties by most recent `lastFocusAt`.
  */
-function pickNextPrimary(sessionId: string): string | null {
-  const conns = getConnectionsForSession(sessionId);
+export function pickNextPrimaryConnection(
+  conns: ReadonlyArray<
+    Pick<PromotionConnectionState, "connectionId" | "isVisible" | "lastFocusAt">
+  >,
+): string | null {
   if (conns.length === 0) return null;
   const visible = conns.filter((c) => c.isVisible);
   const pool = visible.length > 0 ? visible : conns;
@@ -913,6 +968,10 @@ function pickNextPrimary(sessionId: string): string | null {
     if (c.lastFocusAt > best.lastFocusAt) best = c;
   }
   return best.connectionId;
+}
+
+function pickNextPrimary(sessionId: string): string | null {
+  return pickNextPrimaryConnection(getConnectionsForSession(sessionId));
 }
 
 /**
@@ -971,16 +1030,16 @@ function cleanupConnection(connectionId: string): void {
     sessionConnections.delete(conn.sessionId);
     sessionPrimaryConnection.delete(conn.sessionId);
     sessionLastPromotionAt.delete(conn.sessionId);
+    clearSessionControllerState(
+      conn.sessionId,
+      tmuxSize,
+      primaryPromotions,
+    );
     // [remote-dev-f9y9] Keep status indicators + progress in memory across a
     // transient WS disconnect (tmux/agent still alive) so a reconnecting client
     // recovers them via the attach-time replay below — they have no DB fallback.
     // Only drop them when the session itself has ended (tmux gone).
     if (!tmuxSessionExists(conn.tmuxSessionName)) {
-      clearTerminatedSessionControllerState(
-        conn.sessionId,
-        tmuxSize,
-        primaryPromotions,
-      );
       sessionStatusIndicators.delete(conn.sessionId);
       sessionProgressBars.delete(conn.sessionId);
     }
@@ -3224,7 +3283,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
         resizeTimeout: null,
         terminalType: "control",
         userId: authResult.userId,
-        lastFocusAt: Date.now(),
+        lastFocusAt: 0,
         isVisible: false,
         isControl: true,
       };
@@ -3466,7 +3525,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       resizeTimeout: null,
       terminalType,
       userId,
-      lastFocusAt: Date.now(),
+      lastFocusAt: 0,
       isVisible: true,
     };
 
@@ -3575,11 +3634,20 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
             break;
           }
           case "client_focus": {
-            connection.lastFocusAt = Date.now();
-            connection.isVisible = true;
-            const force = msg.force === true;
-            log.debug("client_focus received", { connectionId, sessionId, force });
-            tryPromoteToPrimary(sessionId, connectionId, force);
+            handleClientFocus(connection, msg, (force, reassert) => {
+              log.debug("client_focus received", {
+                connectionId,
+                sessionId,
+                force,
+                reassert,
+              });
+              tryPromoteToPrimary(
+                sessionId,
+                connectionId,
+                force,
+                reassert,
+              );
+            });
             break;
           }
           case "client_blur": {

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -1,4 +1,4 @@
-import { WebSocketServer, WebSocket } from "ws";
+import { WebSocketServer, WebSocket, type RawData } from "ws";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import * as pty from "node-pty";
 import type { IPty } from "node-pty";
@@ -116,6 +116,47 @@ export function parseInitialTerminalDimensions(
     ? Math.max(MIN_TERMINAL_ROWS, parsedRows)
     : DEFAULT_TERMINAL_ROWS;
   return { cols, rows };
+}
+
+interface TerminalMessageSocket<TMessage> {
+  on(event: "message", listener: (message: TMessage) => void): unknown;
+  off(event: "message", listener: (message: TMessage) => void): unknown;
+}
+
+export interface BufferedTerminalMessages<TMessage> {
+  activate(handler: (message: TMessage) => void): void;
+  discard(): void;
+}
+
+/**
+ * Synchronously capture terminal frames while async connection setup runs.
+ * Activation swaps in the production handler before replaying the captured
+ * frames in arrival order; discard releases setup-failure buffers.
+ */
+export function bufferTerminalMessages<TMessage>(
+  ws: TerminalMessageSocket<TMessage>,
+): BufferedTerminalMessages<TMessage> {
+  let pending: TMessage[] | null = [];
+  const buffer = (message: TMessage): void => {
+    pending?.push(message);
+  };
+  ws.on("message", buffer);
+
+  return {
+    activate(handler) {
+      if (!pending) return;
+      const buffered = pending;
+      pending = null;
+      ws.off("message", buffer);
+      ws.on("message", handler);
+      for (const message of buffered) handler(message);
+    },
+    discard() {
+      if (!pending) return;
+      pending = null;
+      ws.off("message", buffer);
+    },
+  };
 }
 
 /**
@@ -363,7 +404,9 @@ export class PrimaryPromotionCoordinator {
       if (
         primary?.isSocketOpen &&
         primary.isVisible &&
-        primary.lastFocusAt > candidate.lastFocusAt
+        // Date.now() can collapse a challenger focus and primary refocus into
+        // one millisecond. Keep the current primary when recency ties.
+        primary.lastFocusAt >= candidate.lastFocusAt
       ) {
         this.clearIfCandidate(sessionId, connectionId);
         return;
@@ -3239,11 +3282,16 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
   }, 30_000);
 
   wss.on("connection", async (ws, req) => {
+    // The browser flushes focus and resize intent from its onopen callback.
+    // Capture those frames before any awaited ownership/DB/setup work so a
+    // slow connection setup cannot silently lose them.
+    const bufferedMessages = bufferTerminalMessages<RawData>(ws);
     const query = Object.fromEntries(new URL(req.url || "", "http://localhost").searchParams);
 
     // SECURITY: Validate authentication token
     const token = query.token as string | undefined;
     if (!token) {
+      bufferedMessages.discard();
       ws.send(JSON.stringify({ type: "error", message: "Authentication required" }));
       ws.close(4001, "Authentication required");
       return;
@@ -3251,6 +3299,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
 
     const authResult = validateWsToken(token);
     if (!authResult) {
+      bufferedMessages.discard();
       ws.send(JSON.stringify({ type: "error", message: "Invalid or expired token" }));
       ws.close(4002, "Invalid or expired token");
       return;
@@ -3265,6 +3314,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
     // early-return). Reuses the exact same HMAC token auth as terminal sockets.
     if (query.control === "1") {
       if (authResult.sessionId !== CONTROL_SESSION_SENTINEL) {
+        bufferedMessages.discard();
         ws.send(JSON.stringify({ type: "error", message: "Invalid control token" }));
         ws.close(4002, "Invalid control token");
         return;
@@ -3301,6 +3351,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       });
 
       ws.send(JSON.stringify({ type: "control_ready" }));
+      bufferedMessages.discard();
       return;
     }
 
@@ -3317,6 +3368,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
 
     // SECURITY: Validate tmux session name to prevent command injection
     if (!validateSessionName(tmuxSessionName)) {
+      bufferedMessages.discard();
       ws.send(JSON.stringify({ type: "error", message: "Invalid session name" }));
       ws.close(4003, "Invalid session name");
       return;
@@ -3353,6 +3405,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
           })) ?? null;
       } catch (error) {
         // Fail CLOSED: if we cannot verify ownership, do not attach.
+        bufferedMessages.discard();
         log.error("tmuxSession ownership lookup failed", {
           tmuxSessionName,
           sessionId,
@@ -3367,6 +3420,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
         // Reachable only when a row EXISTS and belongs to a DIFFERENT user
         // (the remote-dev-yk42 cross-user attach); creation (null) + same-user
         // attach are authorized above.
+        bufferedMessages.discard();
         log.warn("Rejected WS connect: tmuxSession owned by a different user", {
           tmuxSessionName,
           tokenSessionId: sessionId,
@@ -3503,6 +3557,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
         }
       }
     } catch (error) {
+      bufferedMessages.discard();
       log.error("Failed to create/attach tmux session", { connectionId, sessionId, error: String(error) });
       ws.send(JSON.stringify({
         type: "error",
@@ -3580,7 +3635,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       cleanupConnection(connectionId);
     });
 
-    ws.on("message", (message) => {
+    const handleMessage = (message: RawData): void => {
       try {
         const msg = JSON.parse(message.toString());
 
@@ -3825,7 +3880,8 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
           connection.pty?.write(message.toString());
         }
       }
-    });
+    };
+    bufferedMessages.activate(handleMessage);
 
     ws.on("close", () => {
       log.debug("WebSocket closed", { connectionId, sessionId });

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -329,6 +329,7 @@ export function isTmuxSessionAuthorized(
 
 interface TerminalConnection {
   connectionId: string;
+  connectionSeq: number;
   clientInstanceId: string;
   // [remote-dev-d5ci] null for control-mode connections (no PTY/tmux attach).
   pty: IPty | null;
@@ -360,6 +361,7 @@ interface TerminalConnection {
 
 export interface PromotionConnectionState {
   connectionId: string;
+  connectionSeq: number;
   clientInstanceId: string | null;
   isVisible: boolean;
   isSocketOpen: boolean;
@@ -676,16 +678,18 @@ export class PrimaryPromotionCoordinator {
     const primary = primaryId
       ? this.host.getConnection(primaryId)
       : undefined;
-    const sameClientInstance =
-      primary?.clientInstanceId !== null &&
-      primary?.clientInstanceId === candidate.clientInstanceId;
+    const newerSameClientInstance =
+      primary !== undefined &&
+      primary.clientInstanceId !== null &&
+      primary.clientInstanceId === candidate.clientInstanceId &&
+      candidate.connectionSeq > primary.connectionSeq;
 
     if (reassert) {
       const pendingCandidate = this.pendingCandidates.get(sessionId)?.connectionId;
       if (pendingCandidate && pendingCandidate !== connectionId) return "ignored";
 
       if (
-        !sameClientInstance &&
+        !newerSameClientInstance &&
         primary?.isSocketOpen &&
         primary.isVisible &&
         connectionEngagement(primary) >= connectionEngagement(candidate)
@@ -790,10 +794,20 @@ export class PrimaryPromotionCoordinator {
         ? this.host.getConnection(primaryId)
         : undefined;
       const sameClientInstance =
-        primary?.clientInstanceId !== null &&
-        primary?.clientInstanceId === candidate.clientInstanceId;
+        primary !== undefined &&
+        primary.clientInstanceId !== null &&
+        primary.clientInstanceId === candidate.clientInstanceId;
       if (
-        !sameClientInstance &&
+        sameClientInstance &&
+        candidate.connectionSeq < primary.connectionSeq
+      ) {
+        this.clearIfCandidate(sessionId, connectionId);
+        return;
+      }
+      const newerSameClientInstance =
+        sameClientInstance && candidate.connectionSeq > primary.connectionSeq;
+      if (
+        !newerSameClientInstance &&
         primary?.isSocketOpen &&
         primary.isVisible &&
         (pendingReason === "genuine"
@@ -864,6 +878,7 @@ export function requestRestartPrimaryResize(
 
 // All active connections, keyed by connectionId (UUID)
 const connections = new Map<string, TerminalConnection>();
+let nextConnectionSeq = 0;
 
 // Session -> connection IDs for multi-client support
 const sessionConnections = new Map<string, Set<string>>();
@@ -884,6 +899,7 @@ const primaryPromotions = new PrimaryPromotionCoordinator(
       if (!connection) return undefined;
       return {
         connectionId,
+        connectionSeq: connection.connectionSeq,
         isVisible: connection.isVisible,
         isSocketOpen: connection.ws.readyState === WebSocket.OPEN,
         lastFocusAt: connection.lastFocusAt,
@@ -1617,8 +1633,7 @@ export function tmuxSessionConfirmedAbsent(
     return false;
   } catch (error) {
     if (!error || typeof error !== "object") return false;
-    const { status, stderr } = error as {
-      status?: unknown;
+    const { stderr } = error as {
       stderr?: unknown;
     };
     const stderrText = Buffer.isBuffer(stderr)
@@ -1626,11 +1641,8 @@ export function tmuxSessionConfirmedAbsent(
       : typeof stderr === "string"
         ? stderr
         : "";
-    if (/can't find session|no server running/i.test(stderrText)) return true;
-    return (
-      typeof status === "number" &&
-      status !== 0 &&
-      stderrText.trim().length === 0
+    return /can't find session|no server running|error connecting to .*(No such file or directory|Connection refused)/i.test(
+      stderrText,
     );
   }
 }
@@ -3827,6 +3839,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       }
       const controlConnection: TerminalConnection = {
         connectionId: controlConnectionId,
+        connectionSeq: ++nextConnectionSeq,
         clientInstanceId: controlConnectionId,
         pty: null,
         ws,
@@ -4135,6 +4148,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
     );
     const connection: TerminalConnection = {
       connectionId,
+      connectionSeq: ++nextConnectionSeq,
       clientInstanceId,
       pty: ptyProcess,
       ws,

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -211,10 +211,16 @@ export function abortTerminalSetupIfClosed<TMessage, TPty>(
   bufferedMessages: BufferedTerminalMessages<TMessage>,
   ptyProcess: TPty | null,
   destroyPty: (ptyProcess: TPty) => void,
+  sessionId: string,
+  setupLog: Pick<typeof log, "debug"> = log,
 ): boolean {
   if (!bufferedMessages.wasClosed()) return false;
   bufferedMessages.discard();
   if (ptyProcess !== null) destroyPty(ptyProcess);
+  setupLog.debug("Terminal setup aborted after socket closed", {
+    sessionId,
+    closeCode: bufferedMessages.getCloseInfo()?.code ?? null,
+  });
   return true;
 }
 
@@ -288,8 +294,12 @@ interface TerminalConnection {
   terminalType: "shell" | "agent" | "file" | string;
   // User ID for session service calls
   userId: string;
-  // Last-focus bookkeeping for primary-connection election (focus-based promotion).
+  // Focus half of engagement bookkeeping for primary-connection election.
   lastFocusAt: number;
+  // Server-observed terminal input is the second half of engagement recency.
+  lastInputAt: number;
+  // Last input timestamp copied to the stable-instance map (writes are throttled).
+  lastInputRecencyWriteAt: number;
   isVisible: boolean;
   // [remote-dev-d5ci] Lightweight control connection: registered in the
   // `connections` map only so broadcasts reach it (sidebar live updates without
@@ -300,9 +310,11 @@ interface TerminalConnection {
 
 export interface PromotionConnectionState {
   connectionId: string;
+  clientInstanceId: string | null;
   isVisible: boolean;
   isSocketOpen: boolean;
   lastFocusAt: number;
+  lastInputAt: number;
 }
 
 export interface PromotionCoordinatorHost {
@@ -331,16 +343,45 @@ export interface ClientFocusConnectionState {
   isVisible: boolean;
   lastFocusAt: number;
   sessionId?: string;
-  clientInstanceId?: string;
+  clientInstanceId?: string | null;
 }
 
-/** Server-owned genuine-focus timestamps keyed by stable mounted client
+export interface ClientInputConnectionState {
+  lastInputAt: number;
+  lastInputRecencyWriteAt: number;
+  sessionId?: string;
+  clientInstanceId?: string | null;
+}
+
+export interface ClientInstanceRecency {
+  genuineFocusAt: number;
+  inputAt: number;
+}
+
+const CLIENT_INSTANCE_RECENCY_CAP = 16;
+const INPUT_RECENCY_WRITE_INTERVAL_MS = 1000;
+
+/** Server-owned focus and input recency keyed by stable mounted client
  * identity. A missing URL identity resolves to the one-off connection id. */
 export class ClientInstanceFocusRecency {
-  private readonly sessions = new Map<string, Map<string, number>>();
+  private readonly sessions = new Map<
+    string,
+    Map<string, ClientInstanceRecency>
+  >();
+
+  getRecency(sessionId: string, clientInstanceId: string): ClientInstanceRecency {
+    const recency = this.sessions.get(sessionId)?.get(clientInstanceId);
+    return recency
+      ? { ...recency }
+      : { genuineFocusAt: 0, inputAt: 0 };
+  }
 
   getLastGenuineFocusAt(sessionId: string, clientInstanceId: string): number {
-    return this.sessions.get(sessionId)?.get(clientInstanceId) ?? 0;
+    return this.getRecency(sessionId, clientInstanceId).genuineFocusAt;
+  }
+
+  getLastInputAt(sessionId: string, clientInstanceId: string): number {
+    return this.getRecency(sessionId, clientInstanceId).inputAt;
   }
 
   recordGenuineFocus(
@@ -348,12 +389,23 @@ export class ClientInstanceFocusRecency {
     clientInstanceId: string,
     timestamp: number,
   ): void {
-    let instances = this.sessions.get(sessionId);
-    if (!instances) {
-      instances = new Map();
-      this.sessions.set(sessionId, instances);
-    }
-    instances.set(clientInstanceId, timestamp);
+    const current = this.getRecency(sessionId, clientInstanceId);
+    this.setRecency(sessionId, clientInstanceId, {
+      ...current,
+      genuineFocusAt: timestamp,
+    });
+  }
+
+  recordInput(
+    sessionId: string,
+    clientInstanceId: string,
+    timestamp: number,
+  ): void {
+    const current = this.getRecency(sessionId, clientInstanceId);
+    this.setRecency(sessionId, clientInstanceId, {
+      ...current,
+      inputAt: timestamp,
+    });
   }
 
   clearSession(sessionId: string): void {
@@ -363,6 +415,62 @@ export class ClientInstanceFocusRecency {
   clear(): void {
     this.sessions.clear();
   }
+
+  private setRecency(
+    sessionId: string,
+    clientInstanceId: string,
+    recency: ClientInstanceRecency,
+  ): void {
+    let instances = this.sessions.get(sessionId);
+    if (!instances) {
+      instances = new Map();
+      this.sessions.set(sessionId, instances);
+    }
+    instances.set(clientInstanceId, recency);
+    if (instances.size <= CLIENT_INSTANCE_RECENCY_CAP) return;
+
+    let stalestInstanceId: string | null = null;
+    let stalestEngagement = Number.POSITIVE_INFINITY;
+    for (const [instanceId, instanceRecency] of instances) {
+      const engagement = Math.max(
+        instanceRecency.genuineFocusAt,
+        instanceRecency.inputAt,
+      );
+      if (engagement < stalestEngagement) {
+        stalestEngagement = engagement;
+        stalestInstanceId = instanceId;
+      }
+    }
+    if (stalestInstanceId) instances.delete(stalestInstanceId);
+  }
+}
+
+/** Record exact per-socket input engagement while limiting stable-map churn. */
+export function recordClientInput(
+  connection: ClientInputConnectionState,
+  now: () => number = Date.now,
+  instanceRecency?: ClientInstanceFocusRecency,
+): void {
+  const timestamp = now();
+  connection.lastInputAt = timestamp;
+  if (!connection.sessionId || !connection.clientInstanceId) return;
+  if (
+    connection.lastInputRecencyWriteAt !== 0 &&
+    timestamp - connection.lastInputRecencyWriteAt <
+      INPUT_RECENCY_WRITE_INTERVAL_MS
+  ) {
+    return;
+  }
+  instanceRecency?.recordInput(
+    connection.sessionId,
+    connection.clientInstanceId,
+    timestamp,
+  );
+  connection.lastInputRecencyWriteAt = timestamp;
+}
+
+function connectionEngagement(connection: PromotionConnectionState): number {
+  return Math.max(connection.lastFocusAt, connection.lastInputAt);
 }
 
 export function resolveClientInstanceId(
@@ -432,17 +540,24 @@ export class PrimaryPromotionCoordinator {
       return "already-primary";
     }
 
+    const primary = primaryId
+      ? this.host.getConnection(primaryId)
+      : undefined;
+    if (
+      primary?.clientInstanceId !== null &&
+      primary?.clientInstanceId === candidate.clientInstanceId
+    ) {
+      return this.promote(sessionId, connectionId, this.host.now());
+    }
+
     if (reassert) {
       const pendingCandidate = this.pendingCandidates.get(sessionId);
       if (pendingCandidate && pendingCandidate !== connectionId) return "ignored";
 
-      const primary = primaryId
-        ? this.host.getConnection(primaryId)
-        : undefined;
       if (
         primary?.isSocketOpen &&
         primary.isVisible &&
-        primary.lastFocusAt >= candidate.lastFocusAt
+        connectionEngagement(primary) >= connectionEngagement(candidate)
       ) {
         return "ignored";
       }
@@ -456,12 +571,7 @@ export class PrimaryPromotionCoordinator {
       return "deferred";
     }
 
-    this.clearPendingPromotion(sessionId);
-    this.host.setPrimary(sessionId, connectionId);
-    this.host.setLastPromotionAt(sessionId, now);
-    this.host.reassertSize(sessionId, connectionId);
-    this.host.broadcastPrimaryChanged(sessionId);
-    return "promoted";
+    return this.promote(sessionId, connectionId, now);
   }
 
   notifyBlur(sessionId: string, connectionId: string): void {
@@ -519,12 +629,16 @@ export class PrimaryPromotionCoordinator {
       const primary = primaryId
         ? this.host.getConnection(primaryId)
         : undefined;
+      const sameClientInstance =
+        primary?.clientInstanceId !== null &&
+        primary?.clientInstanceId === candidate.clientInstanceId;
       if (
+        !sameClientInstance &&
         primary?.isSocketOpen &&
         primary.isVisible &&
-        // Date.now() can collapse a challenger focus and primary refocus into
-        // one millisecond. Keep the current primary when recency ties.
-        primary.lastFocusAt >= candidate.lastFocusAt
+        // Date.now() can collapse challenger and primary engagement into one
+        // millisecond. Keep the current primary when engagement ties.
+        connectionEngagement(primary) >= connectionEngagement(candidate)
       ) {
         this.clearIfCandidate(sessionId, connectionId);
         return;
@@ -538,17 +652,28 @@ export class PrimaryPromotionCoordinator {
     if (this.pendingCandidates.get(sessionId) !== connectionId) return;
     this.clearPendingPromotion(sessionId);
   }
+
+  private promote(
+    sessionId: string,
+    connectionId: string,
+    timestamp: number,
+  ): PromotionRequestResult {
+    this.clearPendingPromotion(sessionId);
+    this.host.setPrimary(sessionId, connectionId);
+    this.host.setLastPromotionAt(sessionId, timestamp);
+    this.host.reassertSize(sessionId, connectionId);
+    this.host.broadcastPrimaryChanged(sessionId);
+    return "promoted";
+  }
 }
 
 export function clearSessionControllerState(
   sessionId: string,
   sizeController: Pick<TmuxSizeController, "clearSession">,
   promotionCoordinator: Pick<PrimaryPromotionCoordinator, "clearSession">,
-  focusRecency: Pick<ClientInstanceFocusRecency, "clearSession">,
 ): void {
   sizeController.clearSession(sessionId);
   promotionCoordinator.clearSession(sessionId);
-  focusRecency.clearSession(sessionId);
 }
 
 // CONTROL_SESSION_SENTINEL (the reserved control-mode sessionId) is imported
@@ -579,6 +704,8 @@ const primaryPromotions = new PrimaryPromotionCoordinator(
         isVisible: connection.isVisible,
         isSocketOpen: connection.ws.readyState === WebSocket.OPEN,
         lastFocusAt: connection.lastFocusAt,
+        lastInputAt: connection.lastInputAt,
+        clientInstanceId: connection.clientInstanceId,
       };
     },
     getPrimary(sessionId) {
@@ -1190,7 +1317,8 @@ function cleanupConnection(connectionId: string): void {
 
   const isLastConnection = !connSet || connSet.size === 0;
   if (isLastConnection) {
-    // Last connection closed — clean up all session-level state
+    // Last connection closed — clear ephemeral controller state. Stable client
+    // engagement remains until tmux itself is confirmed gone.
     sessionConnections.delete(conn.sessionId);
     sessionPrimaryConnection.delete(conn.sessionId);
     sessionLastPromotionAt.delete(conn.sessionId);
@@ -1198,13 +1326,13 @@ function cleanupConnection(connectionId: string): void {
       conn.sessionId,
       tmuxSize,
       primaryPromotions,
-      clientInstanceFocusRecency,
     );
     // [remote-dev-f9y9] Keep status indicators + progress in memory across a
     // transient WS disconnect (tmux/agent still alive) so a reconnecting client
     // recovers them via the attach-time replay below — they have no DB fallback.
     // Only drop them when the session itself has ended (tmux gone).
     if (!tmuxSessionExists(conn.tmuxSessionName)) {
+      clientInstanceFocusRecency.clearSession(conn.sessionId);
       sessionStatusIndicators.delete(conn.sessionId);
       sessionProgressBars.delete(conn.sessionId);
     }
@@ -3447,6 +3575,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
           bufferedMessages,
           null,
           () => {},
+          authResult.sessionId,
         )
       ) {
         return;
@@ -3466,6 +3595,8 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
         terminalType: "control",
         userId: authResult.userId,
         lastFocusAt: 0,
+        lastInputAt: 0,
+        lastInputRecencyWriteAt: 0,
         isVisible: false,
         isControl: true,
       };
@@ -3589,6 +3720,11 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
 
     // Check if tmux session exists (for attach vs create decision)
     const tmuxExists = tmuxSessionExists(tmuxSessionName);
+    if (!tmuxExists) {
+      // The tmux lifecycle, not a transient socket gap, owns stable-instance
+      // engagement history. A confirmed-missing session starts fresh.
+      clientInstanceFocusRecency.clearSession(sessionId);
+    }
 
     if (resolved.tier !== "query") {
       // Warn on BOTH branches: on CREATE the fallback decides where the new
@@ -3616,6 +3752,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
         bufferedMessages,
         null,
         () => {},
+        sessionId,
       )
     ) {
       return;
@@ -3720,11 +3857,16 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
         bufferedMessages,
         ptyProcess,
         safeDestroyPty,
+        sessionId,
       )
     ) {
       return;
     }
 
+    const inheritedRecency = clientInstanceFocusRecency.getRecency(
+      sessionId,
+      clientInstanceId,
+    );
     const connection: TerminalConnection = {
       connectionId,
       clientInstanceId,
@@ -3739,10 +3881,11 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       resizeTimeout: null,
       terminalType,
       userId,
-      lastFocusAt: clientInstanceFocusRecency.getLastGenuineFocusAt(
-        sessionId,
-        clientInstanceId,
-      ),
+      lastFocusAt: inheritedRecency.genuineFocusAt,
+      lastInputAt: inheritedRecency.inputAt,
+      // Throttling is connection-local: the first keystroke on a replacement
+      // socket refreshes stable inheritance immediately.
+      lastInputRecencyWriteAt: 0,
       isVisible: true,
     };
 
@@ -3803,6 +3946,11 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
 
         switch (msg.type) {
           case "input":
+            recordClientInput(
+              connection,
+              Date.now,
+              clientInstanceFocusRecency,
+            );
             connection.pty?.write(msg.data);
             break;
           case "resize": {
@@ -3926,8 +4074,8 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
                   sessionId,
                   tmuxSize,
                   primaryPromotions,
-                  clientInstanceFocusRecency,
                 );
+                clientInstanceFocusRecency.clearSession(sessionId);
               }
               // Re-validate the connect-time cwd — the directory may have been
               // deleted (e.g. a worktree removed) since this WS attached.

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -531,22 +531,41 @@ export function recordClientInput(
 export function flushClientInstanceRecency(
   connection: ClientRecencyConnectionState,
   instanceRecency: ClientInstanceFocusRecency,
+  liveConnections: Iterable<ClientRecencyConnectionState> = [],
 ): void {
   if (!connection.sessionId || !connection.clientInstanceId) return;
   const current = instanceRecency.getRecency(
     connection.sessionId,
     connection.clientInstanceId,
   );
+  const genuineFocusAt = Math.max(
+    current.genuineFocusAt,
+    connection.lastFocusAt,
+  );
+  const inputAt = Math.max(current.inputAt, connection.lastInputAt);
   instanceRecency.recordGenuineFocus(
     connection.sessionId,
     connection.clientInstanceId,
-    Math.max(current.genuineFocusAt, connection.lastFocusAt),
+    genuineFocusAt,
   );
   instanceRecency.recordInput(
     connection.sessionId,
     connection.clientInstanceId,
-    Math.max(current.inputAt, connection.lastInputAt),
+    inputAt,
   );
+  for (const liveConnection of liveConnections) {
+    if (
+      liveConnection.sessionId !== connection.sessionId ||
+      liveConnection.clientInstanceId !== connection.clientInstanceId
+    ) {
+      continue;
+    }
+    liveConnection.lastFocusAt = Math.max(
+      liveConnection.lastFocusAt,
+      genuineFocusAt,
+    );
+    liveConnection.lastInputAt = Math.max(liveConnection.lastInputAt, inputAt);
+  }
 }
 
 function deriveTmuxSessionName(sessionId: string): string | null {
@@ -558,13 +577,21 @@ function deriveTmuxSessionName(sessionId: string): string | null {
 export function sweepClientInstanceRecency(
   instanceRecency: ClientInstanceFocusRecency,
   getLiveConnectionCount: (sessionId: string) => number,
-  sessionExists: (tmuxSessionName: string) => boolean,
+  sessionConfirmedAbsent: (tmuxSessionName: string) => boolean,
   sessionNameForId: (sessionId: string) => string | null = deriveTmuxSessionName,
 ): void {
   for (const sessionId of instanceRecency.getSessionIds()) {
     if (getLiveConnectionCount(sessionId) > 0) continue;
     const tmuxSessionName = sessionNameForId(sessionId);
-    if (!tmuxSessionName || !sessionExists(tmuxSessionName)) {
+    let confirmedAbsent = !tmuxSessionName;
+    if (tmuxSessionName) {
+      try {
+        confirmedAbsent = sessionConfirmedAbsent(tmuxSessionName);
+      } catch {
+        confirmedAbsent = false;
+      }
+    }
+    if (confirmedAbsent) {
       instanceRecency.clearSession(sessionId);
     }
   }
@@ -702,6 +729,14 @@ export class PrimaryPromotionCoordinator {
     this.pendingTimers.delete(sessionId);
   }
 
+  clearPendingPromotionIfCandidate(
+    sessionId: string,
+    connectionId: string,
+  ): void {
+    if (this.pendingCandidates.get(sessionId)?.connectionId !== connectionId) return;
+    this.clearPendingPromotion(sessionId);
+  }
+
   clearSession(sessionId: string): void {
     this.clearPendingPromotion(sessionId);
   }
@@ -779,8 +814,7 @@ export class PrimaryPromotionCoordinator {
   }
 
   private clearIfCandidate(sessionId: string, connectionId: string): void {
-    if (this.pendingCandidates.get(sessionId)?.connectionId !== connectionId) return;
-    this.clearPendingPromotion(sessionId);
+    this.clearPendingPromotionIfCandidate(sessionId, connectionId);
   }
 
   private promote(
@@ -1466,7 +1500,11 @@ function cleanupConnection(connectionId: string): void {
     return;
   }
 
-  flushClientInstanceRecency(conn, clientInstanceFocusRecency);
+  flushClientInstanceRecency(
+    conn,
+    clientInstanceFocusRecency,
+    connections.values(),
+  );
   primaryPromotions.notifyDisconnect(conn.sessionId, connectionId);
 
   // Remove from session connections and update session-level state
@@ -1491,7 +1529,7 @@ function cleanupConnection(connectionId: string): void {
     // transient WS disconnect (tmux/agent still alive) so a reconnecting client
     // recovers them via the attach-time replay below — they have no DB fallback.
     // Only drop them when the session itself has ended (tmux gone).
-    if (!tmuxSessionExists(conn.tmuxSessionName)) {
+    if (tmuxSessionConfirmedAbsent(conn.tmuxSessionName)) {
       clientInstanceFocusRecency.clearSession(conn.sessionId);
       sessionStatusIndicators.delete(conn.sessionId);
       sessionProgressBars.delete(conn.sessionId);
@@ -1514,7 +1552,10 @@ function cleanupConnection(connectionId: string): void {
     // remaining connection and apply its size to tmux.
     const nextPrimary = pickNextPrimary(conn.sessionId);
     if (nextPrimary) {
-      primaryPromotions.clearPendingPromotion(conn.sessionId);
+      primaryPromotions.clearPendingPromotionIfCandidate(
+        conn.sessionId,
+        nextPrimary,
+      );
       sessionPrimaryConnection.set(conn.sessionId, nextPrimary);
       sessionLastPromotionAt.set(conn.sessionId, Date.now());
       const nextConn = connections.get(nextPrimary);
@@ -1558,6 +1599,39 @@ function tmuxSessionExists(sessionName: string): boolean {
     return true;
   } catch {
     return false;
+  }
+}
+
+/** Return true only when tmux cleanly confirms that a session is absent. */
+export function tmuxSessionConfirmedAbsent(
+  sessionName: string,
+  probe: (sessionName: string) => void = (name) => {
+    execFileSync("tmux", ["has-session", "-t", name], {
+      stdio: "pipe",
+      cwd: STABLE_SPAWN_CWD,
+    });
+  },
+): boolean {
+  try {
+    probe(sessionName);
+    return false;
+  } catch (error) {
+    if (!error || typeof error !== "object") return false;
+    const { status, stderr } = error as {
+      status?: unknown;
+      stderr?: unknown;
+    };
+    const stderrText = Buffer.isBuffer(stderr)
+      ? stderr.toString("utf8")
+      : typeof stderr === "string"
+        ? stderr
+        : "";
+    if (/can't find session|no server running/i.test(stderrText)) return true;
+    return (
+      typeof status === "number" &&
+      status !== 0 &&
+      stderrText.trim().length === 0
+    );
   }
 }
 
@@ -3697,7 +3771,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
     sweepClientInstanceRecency(
       clientInstanceFocusRecency,
       (sessionId) => sessionConnections.get(sessionId)?.size ?? 0,
-      tmuxSessionExists,
+      tmuxSessionConfirmedAbsent,
     );
   }, 10 * 60 * 1000);
   clientRecencySweepTimer.unref();
@@ -3912,7 +3986,7 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
 
     // Check if tmux session exists (for attach vs create decision)
     const tmuxExists = tmuxSessionExists(tmuxSessionName);
-    if (!tmuxExists) {
+    if (!tmuxExists && tmuxSessionConfirmedAbsent(tmuxSessionName)) {
       // The tmux lifecycle, not a transient socket gap, owns stable-instance
       // engagement history. A confirmed-missing session starts fresh.
       clientInstanceFocusRecency.clearSession(sessionId);
@@ -4262,7 +4336,9 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
               } catch {
                 // A failed kill is safe to treat as gone only when tmux confirms
                 // the session no longer exists (it may already have died).
-                tmuxSessionConfirmedGone = !tmuxSessionExists(tmuxSessionName);
+                tmuxSessionConfirmedGone = tmuxSessionConfirmedAbsent(
+                  tmuxSessionName,
+                );
               }
               if (tmuxSessionConfirmedGone) {
                 clearSessionControllerState(

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -201,6 +201,7 @@ export interface PromotionConnectionState {
   connectionId: string;
   isVisible: boolean;
   isSocketOpen: boolean;
+  lastFocusAt: number;
 }
 
 export interface PromotionCoordinatorHost {
@@ -246,7 +247,6 @@ export class PrimaryPromotionCoordinator {
     }
 
     if (this.host.getPrimary(sessionId) === connectionId) {
-      this.clearPendingPromotion(sessionId);
       this.host.reassertSize(sessionId, connectionId);
       return "already-primary";
     }
@@ -286,6 +286,10 @@ export class PrimaryPromotionCoordinator {
     this.pendingTimers.delete(sessionId);
   }
 
+  clearSession(sessionId: string): void {
+    this.clearPendingPromotion(sessionId);
+  }
+
   dispose(): void {
     for (const timer of this.pendingTimers.values()) clearTimeout(timer);
     this.pendingTimers.clear();
@@ -305,6 +309,23 @@ export class PrimaryPromotionCoordinator {
       // re-validates it and drops the pending entry when it no longer
       // qualifies (closed socket, hidden panel).
       if (this.pendingCandidates.get(sessionId) !== connectionId) return;
+      const candidate = this.host.getConnection(connectionId);
+      if (!candidate?.isSocketOpen || !candidate.isVisible) {
+        this.clearIfCandidate(sessionId, connectionId);
+        return;
+      }
+      const primaryId = this.host.getPrimary(sessionId);
+      if (primaryId === connectionId) {
+        this.clearIfCandidate(sessionId, connectionId);
+        return;
+      }
+      const primary = primaryId
+        ? this.host.getConnection(primaryId)
+        : undefined;
+      if (primary && primary.lastFocusAt > candidate.lastFocusAt) {
+        this.clearIfCandidate(sessionId, connectionId);
+        return;
+      }
       this.requestPromotion(sessionId, connectionId, false);
     }, Math.max(0, delayMs));
     this.pendingTimers.set(sessionId, timer);
@@ -314,6 +335,15 @@ export class PrimaryPromotionCoordinator {
     if (this.pendingCandidates.get(sessionId) !== connectionId) return;
     this.clearPendingPromotion(sessionId);
   }
+}
+
+export function clearTerminatedSessionControllerState(
+  sessionId: string,
+  sizeController: Pick<TmuxSizeController, "clearSession">,
+  promotionCoordinator: Pick<PrimaryPromotionCoordinator, "clearSession">,
+): void {
+  sizeController.clearSession(sessionId);
+  promotionCoordinator.clearSession(sessionId);
 }
 
 // CONTROL_SESSION_SENTINEL (the reserved control-mode sessionId) is imported
@@ -342,6 +372,7 @@ const primaryPromotions = new PrimaryPromotionCoordinator(
         connectionId,
         isVisible: connection.isVisible,
         isSocketOpen: connection.ws.readyState === WebSocket.OPEN,
+        lastFocusAt: connection.lastFocusAt,
       };
     },
     getPrimary(sessionId) {
@@ -945,6 +976,11 @@ function cleanupConnection(connectionId: string): void {
     // recovers them via the attach-time replay below — they have no DB fallback.
     // Only drop them when the session itself has ended (tmux gone).
     if (!tmuxSessionExists(conn.tmuxSessionName)) {
+      clearTerminatedSessionControllerState(
+        conn.sessionId,
+        tmuxSize,
+        primaryPromotions,
+      );
       sessionStatusIndicators.delete(conn.sessionId);
       sessionProgressBars.delete(conn.sessionId);
     }

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -683,6 +683,11 @@ export class PrimaryPromotionCoordinator {
       primary.clientInstanceId !== null &&
       primary.clientInstanceId === candidate.clientInstanceId &&
       candidate.connectionSeq > primary.connectionSeq;
+    const olderSameClientInstance =
+      primary !== undefined &&
+      primary.clientInstanceId !== null &&
+      primary.clientInstanceId === candidate.clientInstanceId &&
+      candidate.connectionSeq < primary.connectionSeq;
 
     if (reassert) {
       const pendingCandidate = this.pendingCandidates.get(sessionId)?.connectionId;
@@ -710,6 +715,8 @@ export class PrimaryPromotionCoordinator {
       );
       return "deferred";
     }
+
+    if (!reassert && olderSameClientInstance) return "ignored";
 
     return this.promote(sessionId, connectionId, now);
   }

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -120,12 +120,29 @@ export function parseInitialTerminalDimensions(
 
 interface TerminalMessageSocket<TMessage> {
   on(event: "message", listener: (message: TMessage) => void): unknown;
+  on(event: "close", listener: (code: number, reason: Buffer) => void): unknown;
+  on(event: "error", listener: (error: Error) => void): unknown;
   off(event: "message", listener: (message: TMessage) => void): unknown;
+  off(event: "close", listener: (code: number, reason: Buffer) => void): unknown;
+  off(event: "error", listener: (error: Error) => void): unknown;
+}
+
+export interface TerminalSocketHandlers<TMessage> {
+  message(message: TMessage): void;
+  close(code: number, reason: Buffer): void;
+  error(error: Error): void;
+}
+
+export interface TerminalSetupCloseInfo {
+  code: number;
+  reason: Buffer;
 }
 
 export interface BufferedTerminalMessages<TMessage> {
-  activate(handler: (message: TMessage) => void): void;
+  activate(handlers: TerminalSocketHandlers<TMessage>): void;
   discard(): void;
+  wasClosed(): boolean;
+  getCloseInfo(): TerminalSetupCloseInfo | null;
 }
 
 /**
@@ -135,28 +152,70 @@ export interface BufferedTerminalMessages<TMessage> {
  */
 export function bufferTerminalMessages<TMessage>(
   ws: TerminalMessageSocket<TMessage>,
+  setupLog: Pick<typeof log, "error"> = log,
 ): BufferedTerminalMessages<TMessage> {
   let pending: TMessage[] | null = [];
+  let closed = false;
+  let closeInfo: TerminalSetupCloseInfo | null = null;
   const buffer = (message: TMessage): void => {
     pending?.push(message);
   };
+  const setupClose = (code: number, reason: Buffer): void => {
+    closed = true;
+    closeInfo = { code, reason };
+  };
+  const setupError = (error: Error): void => {
+    closed = true;
+    setupLog.error("Terminal connection error during setup", {
+      error: String(error),
+    });
+  };
+  const removeSetupListeners = (): void => {
+    ws.off("message", buffer);
+    ws.off("close", setupClose);
+    ws.off("error", setupError);
+  };
   ws.on("message", buffer);
+  ws.on("close", setupClose);
+  ws.on("error", setupError);
 
   return {
-    activate(handler) {
+    activate(handlers) {
       if (!pending) return;
+      if (closed) {
+        pending = null;
+        removeSetupListeners();
+        return;
+      }
       const buffered = pending;
       pending = null;
-      ws.off("message", buffer);
-      ws.on("message", handler);
-      for (const message of buffered) handler(message);
+      removeSetupListeners();
+      ws.on("message", handlers.message);
+      ws.on("close", handlers.close);
+      ws.on("error", handlers.error);
+      for (const message of buffered) handlers.message(message);
     },
     discard() {
       if (!pending) return;
       pending = null;
-      ws.off("message", buffer);
+      removeSetupListeners();
     },
+    wasClosed: () => closed,
+    getCloseInfo: () => closeInfo,
   };
+}
+
+/** Release a PTY created by an async setup that lost its socket before the
+ * connection could be registered. Returns true when the caller must abort. */
+export function abortTerminalSetupIfClosed<TMessage, TPty>(
+  bufferedMessages: BufferedTerminalMessages<TMessage>,
+  ptyProcess: TPty | null,
+  destroyPty: (ptyProcess: TPty) => void,
+): boolean {
+  if (!bufferedMessages.wasClosed()) return false;
+  bufferedMessages.discard();
+  if (ptyProcess !== null) destroyPty(ptyProcess);
+  return true;
 }
 
 /**
@@ -214,6 +273,7 @@ export function isTmuxSessionAuthorized(
 
 interface TerminalConnection {
   connectionId: string;
+  clientInstanceId: string;
   // [remote-dev-d5ci] null for control-mode connections (no PTY/tmux attach).
   pty: IPty | null;
   ws: WebSocket;
@@ -270,6 +330,48 @@ export interface ClientFocusMessage {
 export interface ClientFocusConnectionState {
   isVisible: boolean;
   lastFocusAt: number;
+  sessionId?: string;
+  clientInstanceId?: string;
+}
+
+/** Server-owned genuine-focus timestamps keyed by stable mounted client
+ * identity. A missing URL identity resolves to the one-off connection id. */
+export class ClientInstanceFocusRecency {
+  private readonly sessions = new Map<string, Map<string, number>>();
+
+  getLastGenuineFocusAt(sessionId: string, clientInstanceId: string): number {
+    return this.sessions.get(sessionId)?.get(clientInstanceId) ?? 0;
+  }
+
+  recordGenuineFocus(
+    sessionId: string,
+    clientInstanceId: string,
+    timestamp: number,
+  ): void {
+    let instances = this.sessions.get(sessionId);
+    if (!instances) {
+      instances = new Map();
+      this.sessions.set(sessionId, instances);
+    }
+    instances.set(clientInstanceId, timestamp);
+  }
+
+  clearSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
+  }
+
+  clear(): void {
+    this.sessions.clear();
+  }
+}
+
+export function resolveClientInstanceId(
+  clientInstanceId: unknown,
+  connectionId: string,
+): string {
+  return typeof clientInstanceId === "string" && clientInstanceId.length > 0
+    ? clientInstanceId
+    : connectionId;
 }
 
 /** Apply client_focus bookkeeping before invoking promotion, matching the
@@ -280,10 +382,21 @@ export function handleClientFocus(
   message: ClientFocusMessage,
   promote: (force: boolean, reassert: boolean) => void,
   now: () => number = Date.now,
+  instanceRecency?: ClientInstanceFocusRecency,
 ): void {
   const reassert = message.reassert === true;
   connection.isVisible = true;
-  if (!reassert) connection.lastFocusAt = now();
+  if (!reassert) {
+    const timestamp = now();
+    connection.lastFocusAt = timestamp;
+    if (connection.sessionId && connection.clientInstanceId) {
+      instanceRecency?.recordGenuineFocus(
+        connection.sessionId,
+        connection.clientInstanceId,
+        timestamp,
+      );
+    }
+  }
   promote(message.force === true, reassert);
 }
 
@@ -308,26 +421,31 @@ export class PrimaryPromotionCoordinator {
     reassert = false,
   ): PromotionRequestResult {
     const candidate = this.host.getConnection(connectionId);
-    if (reassert) {
-      if (
-        candidate?.isSocketOpen &&
-        candidate.isVisible &&
-        this.host.getPrimary(sessionId) === connectionId
-      ) {
-        this.host.reassertSize(sessionId, connectionId);
-        return "already-primary";
-      }
-      return "ignored";
-    }
-
     if (!candidate?.isSocketOpen || !candidate.isVisible) {
       this.clearIfCandidate(sessionId, connectionId);
       return "ignored";
     }
 
-    if (this.host.getPrimary(sessionId) === connectionId) {
+    const primaryId = this.host.getPrimary(sessionId);
+    if (primaryId === connectionId) {
       this.host.reassertSize(sessionId, connectionId);
       return "already-primary";
+    }
+
+    if (reassert) {
+      const pendingCandidate = this.pendingCandidates.get(sessionId);
+      if (pendingCandidate && pendingCandidate !== connectionId) return "ignored";
+
+      const primary = primaryId
+        ? this.host.getConnection(primaryId)
+        : undefined;
+      if (
+        primary?.isSocketOpen &&
+        primary.isVisible &&
+        primary.lastFocusAt >= candidate.lastFocusAt
+      ) {
+        return "ignored";
+      }
     }
 
     const now = this.host.now();
@@ -426,9 +544,11 @@ export function clearSessionControllerState(
   sessionId: string,
   sizeController: Pick<TmuxSizeController, "clearSession">,
   promotionCoordinator: Pick<PrimaryPromotionCoordinator, "clearSession">,
+  focusRecency: Pick<ClientInstanceFocusRecency, "clearSession">,
 ): void {
   sizeController.clearSession(sessionId);
   promotionCoordinator.clearSession(sessionId);
+  focusRecency.clearSession(sessionId);
 }
 
 // CONTROL_SESSION_SENTINEL (the reserved control-mode sessionId) is imported
@@ -447,6 +567,7 @@ const sessionPrimaryConnection = new Map<string, string>();
 // ping-pong between two side-by-side windows.
 const sessionLastPromotionAt = new Map<string, number>();
 const PROMOTION_COOLDOWN_MS = 1000;
+const clientInstanceFocusRecency = new ClientInstanceFocusRecency();
 
 const primaryPromotions = new PrimaryPromotionCoordinator(
   {
@@ -1077,6 +1198,7 @@ function cleanupConnection(connectionId: string): void {
       conn.sessionId,
       tmuxSize,
       primaryPromotions,
+      clientInstanceFocusRecency,
     );
     // [remote-dev-f9y9] Keep status indicators + progress in memory across a
     // transient WS disconnect (tmux/agent still alive) so a reconnecting client
@@ -3320,8 +3442,18 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
         return;
       }
       const controlConnectionId = randomUUID();
+      if (
+        abortTerminalSetupIfClosed(
+          bufferedMessages,
+          null,
+          () => {},
+        )
+      ) {
+        return;
+      }
       const controlConnection: TerminalConnection = {
         connectionId: controlConnectionId,
+        clientInstanceId: controlConnectionId,
         pty: null,
         ws,
         sessionId: `${CONTROL_SESSION_SENTINEL}-${controlConnectionId}`,
@@ -3340,18 +3472,20 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       connections.set(controlConnectionId, controlConnection);
       log.debug("Control connection started", { connectionId: controlConnectionId, userId: authResult.userId });
 
-      ws.on("close", () => {
-        if (!connections.has(controlConnectionId)) return;
-        cleanupConnection(controlConnectionId);
-      });
-      ws.on("error", (error) => {
-        log.warn("Control connection error", { connectionId: controlConnectionId, error: String(error) });
-        if (!connections.has(controlConnectionId)) return;
-        cleanupConnection(controlConnectionId);
+      bufferedMessages.activate({
+        message: () => {},
+        close: () => {
+          if (!connections.has(controlConnectionId)) return;
+          cleanupConnection(controlConnectionId);
+        },
+        error: (error) => {
+          log.warn("Control connection error", { connectionId: controlConnectionId, error: String(error) });
+          if (!connections.has(controlConnectionId)) return;
+          cleanupConnection(controlConnectionId);
+        },
       });
 
       ws.send(JSON.stringify({ type: "control_ready" }));
-      bufferedMessages.discard();
       return;
     }
 
@@ -3448,6 +3582,10 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
 
     // Generate a unique connection ID for multi-client support
     const connectionId = randomUUID();
+    const clientInstanceId = resolveClientInstanceId(
+      query.clientInstanceId,
+      connectionId,
+    );
 
     // Check if tmux session exists (for attach vs create decision)
     const tmuxExists = tmuxSessionExists(tmuxSessionName);
@@ -3472,6 +3610,16 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
     log.debug("Connection request", { connectionId, sessionId, tmuxSessionName, tmuxExists });
 
     let ptyProcess: IPty;
+
+    if (
+      abortTerminalSetupIfClosed(
+        bufferedMessages,
+        null,
+        () => {},
+      )
+    ) {
+      return;
+    }
 
     try {
       if (tmuxExists) {
@@ -3567,8 +3715,19 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       return;
     }
 
+    if (
+      abortTerminalSetupIfClosed(
+        bufferedMessages,
+        ptyProcess,
+        safeDestroyPty,
+      )
+    ) {
+      return;
+    }
+
     const connection: TerminalConnection = {
       connectionId,
+      clientInstanceId,
       pty: ptyProcess,
       ws,
       sessionId,
@@ -3580,7 +3739,10 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
       resizeTimeout: null,
       terminalType,
       userId,
-      lastFocusAt: 0,
+      lastFocusAt: clientInstanceFocusRecency.getLastGenuineFocusAt(
+        sessionId,
+        clientInstanceId,
+      ),
       isVisible: true,
     };
 
@@ -3689,20 +3851,26 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
             break;
           }
           case "client_focus": {
-            handleClientFocus(connection, msg, (force, reassert) => {
-              log.debug("client_focus received", {
-                connectionId,
-                sessionId,
-                force,
-                reassert,
-              });
-              tryPromoteToPrimary(
-                sessionId,
-                connectionId,
-                force,
-                reassert,
-              );
-            });
+            handleClientFocus(
+              connection,
+              msg,
+              (force, reassert) => {
+                log.debug("client_focus received", {
+                  connectionId,
+                  sessionId,
+                  force,
+                  reassert,
+                });
+                tryPromoteToPrimary(
+                  sessionId,
+                  connectionId,
+                  force,
+                  reassert,
+                );
+              },
+              Date.now,
+              clientInstanceFocusRecency,
+            );
             break;
           }
           case "client_blur": {
@@ -3753,7 +3921,14 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
                 // the session no longer exists (it may already have died).
                 tmuxSessionConfirmedGone = !tmuxSessionExists(tmuxSessionName);
               }
-              if (tmuxSessionConfirmedGone) tmuxSize.clearSession(sessionId);
+              if (tmuxSessionConfirmedGone) {
+                clearSessionControllerState(
+                  sessionId,
+                  tmuxSize,
+                  primaryPromotions,
+                  clientInstanceFocusRecency,
+                );
+              }
               // Re-validate the connect-time cwd — the directory may have been
               // deleted (e.g. a worktree removed) since this WS attached.
               createTmuxSession(
@@ -3881,18 +4056,18 @@ export function createTerminalServer(options: ServerOptions = { port: 6002 }) {
         }
       }
     };
-    bufferedMessages.activate(handleMessage);
-
-    ws.on("close", () => {
-      log.debug("WebSocket closed", { connectionId, sessionId });
-      if (!connections.has(connectionId)) return;
-      cleanupConnection(connectionId);
-    });
-
-    ws.on("error", (error) => {
-      log.error("Terminal connection error", { connectionId, sessionId, error: String(error) });
-      if (!connections.has(connectionId)) return;
-      cleanupConnection(connectionId);
+    bufferedMessages.activate({
+      message: handleMessage,
+      close: () => {
+        log.debug("WebSocket closed", { connectionId, sessionId });
+        if (!connections.has(connectionId)) return;
+        cleanupConnection(connectionId);
+      },
+      error: (error) => {
+        log.error("Terminal connection error", { connectionId, sessionId, error: String(error) });
+        if (!connections.has(connectionId)) return;
+        cleanupConnection(connectionId);
+      },
     });
 
     // Send ready signal
@@ -3951,6 +4126,7 @@ export function shutdownTerminalConnections(): void {
   sessionConnections.clear();
   sessionPrimaryConnection.clear();
   sessionLastPromotionAt.clear();
+  clientInstanceFocusRecency.clear();
   // [remote-dev-f9y9] cleanupConnection now only drops these when tmux is gone
   // (so they survive a transient WS disconnect for the attach-time replay), so
   // full teardown must clear them explicitly.

--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -692,7 +692,15 @@ export class PrimaryPromotionCoordinator {
 
     if (reassert) {
       const pendingCandidate = this.pendingCandidates.get(sessionId)?.connectionId;
-      if (pendingCandidate && pendingCandidate !== connectionId) return "ignored";
+      if (pendingCandidate && pendingCandidate !== connectionId) {
+        const pendingConnection = this.host.getConnection(pendingCandidate);
+        const supersedesPendingSibling =
+          candidate.clientInstanceId !== null &&
+          pendingConnection?.clientInstanceId === candidate.clientInstanceId &&
+          candidate.connectionSeq > pendingConnection.connectionSeq;
+        if (!supersedesPendingSibling) return "ignored";
+        this.clearPendingPromotion(sessionId);
+      }
 
       if (
         !newerSameClientInstance &&
@@ -1455,15 +1463,33 @@ export function pickNextPrimaryConnection(
   conns: ReadonlyArray<
     Pick<
       PromotionConnectionState,
-      "connectionId" | "isVisible" | "lastFocusAt" | "lastInputAt"
+      | "connectionId"
+      | "connectionSeq"
+      | "clientInstanceId"
+      | "isVisible"
+      | "lastFocusAt"
+      | "lastInputAt"
     >
   >,
 ): string | null {
   if (conns.length === 0) return null;
   const visible = conns.filter((c) => c.isVisible);
   const pool = visible.length > 0 ? visible : conns;
-  let best = pool[0];
-  for (const c of pool) {
+  const newestConnectionByInstance = new Map<string, (typeof pool)[number]>();
+  for (const connection of pool) {
+    if (connection.clientInstanceId === null) continue;
+    const newest = newestConnectionByInstance.get(connection.clientInstanceId);
+    if (!newest || connection.connectionSeq > newest.connectionSeq) {
+      newestConnectionByInstance.set(connection.clientInstanceId, connection);
+    }
+  }
+  const eligible = pool.filter(
+    (connection) =>
+      connection.clientInstanceId === null ||
+      newestConnectionByInstance.get(connection.clientInstanceId) === connection,
+  );
+  let best = eligible[0];
+  for (const c of eligible) {
     const engagement = connectionEngagement(c);
     const bestEngagement = connectionEngagement(best);
     if (

--- a/src/server/tmux-size-controller.ts
+++ b/src/server/tmux-size-controller.ts
@@ -109,6 +109,11 @@ export class TmuxSizeController {
       const current = this.sessions.get(sessionId);
       if (current === state) {
         if (error) {
+          // A failed command means tmux's actual size is unknown. In
+          // particular, a forced repair may have followed an external tmux
+          // resize, so retaining the old cache would suppress the next
+          // ordinary same-size request forever.
+          state.applied = null;
           this.log.warn("tmux resize-window failed", {
             error: String(error),
             sessionId,

--- a/src/server/tmux-size-controller.ts
+++ b/src/server/tmux-size-controller.ts
@@ -15,10 +15,8 @@ interface ResizeRequest extends TmuxSize {
 }
 
 interface SessionSizeState {
-  epoch: number;
   applied: TmuxSize | null;
   desired: ResizeRequest | null;
-  busy: boolean;
 }
 
 function sizesEqual(left: TmuxSize | null, right: TmuxSize): boolean {
@@ -34,7 +32,7 @@ function sizesEqual(left: TmuxSize | null, right: TmuxSize): boolean {
  */
 export class TmuxSizeController {
   private readonly sessions = new Map<string, SessionSizeState>();
-  private readonly sessionEpochs = new Map<string, number>();
+  private readonly inFlightNames = new Map<string, object>();
 
   constructor(
     private readonly exec: TmuxExec,
@@ -60,20 +58,13 @@ export class TmuxSizeController {
   }
 
   /**
-   * Forget all sizing state for a tmux session that has been destroyed.
-   * Stale callbacks retain the old state identity and safely no-op after the
-   * maps are deleted, while a recreated session can start work immediately.
+   * Forget sizing state for a disconnected or destroyed session. An in-flight
+   * name lock deliberately survives eviction so a recreated state cannot run a
+   * concurrent command against the same tmux session. Its callback releases
+   * the lock, ignores the evicted state by object identity, and pumps live work.
    */
   clearSession(sessionId: string): void {
-    const state = this.sessions.get(sessionId);
-    if (state) {
-      state.epoch++;
-      state.applied = null;
-      state.desired = null;
-      state.busy = false;
-    }
     this.sessions.delete(sessionId);
-    this.sessionEpochs.delete(sessionId);
   }
 
   getAppliedSize(sessionId: string): TmuxSize | null {
@@ -86,36 +77,37 @@ export class TmuxSizeController {
     if (existing) return existing;
 
     const state: SessionSizeState = {
-      epoch: this.sessionEpochs.get(sessionId) ?? 0,
       applied: null,
       desired: null,
-      busy: false,
     };
     this.sessions.set(sessionId, state);
     return state;
   }
 
   private pump(sessionId: string, state: SessionSizeState): void {
-    if (state.busy) return;
-
     const request = state.desired;
     if (!request) return;
 
-    state.desired = null;
-    if (!request.force && sizesEqual(state.applied, request)) return;
+    if (!request.force && sizesEqual(state.applied, request)) {
+      state.desired = null;
+      return;
+    }
+    if (this.inFlightNames.has(request.tmuxSessionName)) return;
 
-    state.busy = true;
-    const requestEpoch = state.epoch;
+    state.desired = null;
+    const lock = {};
+    this.inFlightNames.set(request.tmuxSessionName, lock);
     let completed = false;
     const complete = (error: Error | null): void => {
       if (completed) return;
       completed = true;
 
-      const current = this.sessions.get(sessionId);
-      if (current !== state) return;
+      if (this.inFlightNames.get(request.tmuxSessionName) === lock) {
+        this.inFlightNames.delete(request.tmuxSessionName);
+      }
 
-      state.busy = false;
-      if (current.epoch === requestEpoch) {
+      const current = this.sessions.get(sessionId);
+      if (current === state) {
         if (error) {
           this.log.warn("tmux resize-window failed", {
             error: String(error),
@@ -129,7 +121,7 @@ export class TmuxSizeController {
         }
       }
 
-      this.pump(sessionId, state);
+      this.pumpCurrentStateForName(request.tmuxSessionName);
     };
 
     try {
@@ -147,6 +139,14 @@ export class TmuxSizeController {
       );
     } catch (error) {
       complete(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  private pumpCurrentStateForName(tmuxSessionName: string): void {
+    for (const [sessionId, state] of this.sessions) {
+      if (state.desired?.tmuxSessionName !== tmuxSessionName) continue;
+      this.pump(sessionId, state);
+      return;
     }
   }
 }

--- a/src/server/tmux-size-controller.ts
+++ b/src/server/tmux-size-controller.ts
@@ -1,0 +1,151 @@
+import type { Logger } from "@/lib/logger";
+
+export interface TmuxExec {
+  (args: string[], callback: (err: Error | null) => void): void;
+}
+
+interface TmuxSize {
+  cols: number;
+  rows: number;
+}
+
+interface ResizeRequest extends TmuxSize {
+  tmuxSessionName: string;
+  force: boolean;
+}
+
+interface SessionSizeState {
+  epoch: number;
+  applied: TmuxSize | null;
+  desired: ResizeRequest | null;
+  busy: boolean;
+}
+
+function sizesEqual(left: TmuxSize | null, right: TmuxSize): boolean {
+  return left?.cols === right.cols && left.rows === right.rows;
+}
+
+/**
+ * Serializes tmux window resizing per remote-dev session.
+ *
+ * Requests are latest-wins while an exec is in flight. The applied-size cache
+ * is only updated after a successful callback, and forced requests bypass that
+ * cache because tmux may have been resized by an external client.
+ */
+export class TmuxSizeController {
+  private readonly sessions = new Map<string, SessionSizeState>();
+  private readonly sessionEpochs = new Map<string, number>();
+
+  constructor(
+    private readonly exec: TmuxExec,
+    private readonly log: Logger,
+  ) {}
+
+  requestResize(
+    sessionId: string,
+    tmuxSessionName: string,
+    cols: number,
+    rows: number,
+    opts: { force?: boolean } = {},
+  ): void {
+    const state = this.getOrCreateState(sessionId);
+    state.desired = {
+      tmuxSessionName,
+      cols,
+      rows,
+      force: opts.force === true,
+    };
+    this.pump(sessionId, state);
+  }
+
+  /**
+   * Forget all sizing state for a tmux session that has been destroyed.
+   * The epoch remains incremented so callbacks from the destroyed session can
+   * never mutate a replacement session with the same remote-dev identity.
+   */
+  clearSession(sessionId: string): void {
+    const currentEpoch = this.sessionEpochs.get(sessionId) ?? 0;
+    const nextEpoch = currentEpoch + 1;
+    this.sessionEpochs.set(sessionId, nextEpoch);
+
+    const state = this.sessions.get(sessionId);
+    if (!state) return;
+    state.epoch = nextEpoch;
+    state.applied = null;
+    state.desired = null;
+  }
+
+  getAppliedSize(sessionId: string): TmuxSize | null {
+    const applied = this.sessions.get(sessionId)?.applied;
+    return applied ? { ...applied } : null;
+  }
+
+  private getOrCreateState(sessionId: string): SessionSizeState {
+    const existing = this.sessions.get(sessionId);
+    if (existing) return existing;
+
+    const state: SessionSizeState = {
+      epoch: this.sessionEpochs.get(sessionId) ?? 0,
+      applied: null,
+      desired: null,
+      busy: false,
+    };
+    this.sessions.set(sessionId, state);
+    return state;
+  }
+
+  private pump(sessionId: string, state: SessionSizeState): void {
+    if (state.busy) return;
+
+    const request = state.desired;
+    if (!request) return;
+
+    state.desired = null;
+    if (!request.force && sizesEqual(state.applied, request)) return;
+
+    state.busy = true;
+    const requestEpoch = state.epoch;
+    let completed = false;
+    const complete = (error: Error | null): void => {
+      if (completed) return;
+      completed = true;
+
+      const current = this.sessions.get(sessionId);
+      if (current !== state) return;
+
+      state.busy = false;
+      if (current.epoch === requestEpoch) {
+        if (error) {
+          this.log.warn("tmux resize-window failed", {
+            error: String(error),
+            sessionId,
+            tmuxSessionName: request.tmuxSessionName,
+            cols: request.cols,
+            rows: request.rows,
+          });
+        } else {
+          state.applied = { cols: request.cols, rows: request.rows };
+        }
+      }
+
+      this.pump(sessionId, state);
+    };
+
+    try {
+      this.exec(
+        [
+          "resize-window",
+          "-t",
+          request.tmuxSessionName,
+          "-x",
+          String(request.cols),
+          "-y",
+          String(request.rows),
+        ],
+        complete,
+      );
+    } catch (error) {
+      complete(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+}

--- a/src/server/tmux-size-controller.ts
+++ b/src/server/tmux-size-controller.ts
@@ -49,30 +49,31 @@ export class TmuxSizeController {
     opts: { force?: boolean } = {},
   ): void {
     const state = this.getOrCreateState(sessionId);
+    const force = state.desired?.force === true || opts.force === true;
     state.desired = {
       tmuxSessionName,
       cols,
       rows,
-      force: opts.force === true,
+      force,
     };
     this.pump(sessionId, state);
   }
 
   /**
    * Forget all sizing state for a tmux session that has been destroyed.
-   * The epoch remains incremented so callbacks from the destroyed session can
-   * never mutate a replacement session with the same remote-dev identity.
+   * Stale callbacks retain the old state identity and safely no-op after the
+   * maps are deleted, while a recreated session can start work immediately.
    */
   clearSession(sessionId: string): void {
-    const currentEpoch = this.sessionEpochs.get(sessionId) ?? 0;
-    const nextEpoch = currentEpoch + 1;
-    this.sessionEpochs.set(sessionId, nextEpoch);
-
     const state = this.sessions.get(sessionId);
-    if (!state) return;
-    state.epoch = nextEpoch;
-    state.applied = null;
-    state.desired = null;
+    if (state) {
+      state.epoch++;
+      state.applied = null;
+      state.desired = null;
+      state.busy = false;
+    }
+    this.sessions.delete(sessionId);
+    this.sessionEpochs.delete(sessionId);
   }
 
   getAppliedSize(sessionId: string): TmuxSize | null {

--- a/src/types/terminal-type.ts
+++ b/src/types/terminal-type.ts
@@ -332,6 +332,8 @@ export interface TerminalRenderProps {
   fontFamily: string;
   /** Whether session is active (vs suspended) */
   isActive: boolean;
+  /** Whether the containing panel is currently visible */
+  visible?: boolean;
   /** Callback when terminal resizes */
   onResize?: (cols: number, rows: number) => void;
   /** Callback when terminal data received */
@@ -504,4 +506,3 @@ export interface SessionProgress {
   label?: string;
   updatedAt: string;
 }
-


### PR DESCRIPTION
## Summary

Fixes the long-standing race where the web terminal does not resize on focus. Root-caused to nine interacting defects (RC-A…RC-I) across the client fit pipeline, panel visibility, server resize dedupe, and multi-client primary promotion — spec at `docs/claude/plans/2026-08-02-terminal-resize-reconciliation.md`.

**Client**: all fit paths replaced by a React-free per-terminal `ResizeReconciler` (generation/epoch cancellation, never-fit-while-hidden re-checked per rAF, rect cache committed only after a verified fit, desired-dims replay on socket open with socket identity). A `visible` prop is threaded from SessionManager through every terminal plugin adapter so hidden panels never fit and never send `client_focus`; visibility refs are commit-synchronous (`useLayoutEffect`).

**Server**: `TmuxSizeController` serializes `tmux resize-window` latest-wins with sticky force and failure-clearing; primary promotion is arbitrated by an engagement signal (`max(genuine focus, server-observed input)`) inherited per `(session, clientInstanceId)` across reconnects, with generation-aware (`connectionSeq`) same-instance reclaim, reason-tracked deferrals (genuine focus is never vetoed by typing), instance-deduped disconnect handoff, tri-state tmux confirmed-absence gating recency lifecycle, and a capped pre-setup message buffer.

## Key decisions

- **Focus-wins**: a deliberate device switch (genuine focus edge) always beats input engagement; engagement arbitrates only reconnect reasserts.
- **Within one client instance, only the newest socket generation is live** — older generations can never claim or hold primary regardless of stale visibility/engagement flags.
- Accepted trade-offs (documented in the epic): bounded reconcileOnce supersession, redundant resize-window per reattach, StrictMode dev-only genuine first flush, viewer-only ties fall back to focus recency, server-observed input only (no new protocol messages).

## Review

Four-model adversarial gauntlet (Antigravity/Gemini, Cursor Agent, Codex gpt-5.6-sol xhigh, Claude Fable) over 9 rounds with 8 fix batches; **unanimous CLEAN attestation on the final SHA**. DRY/simplification pass included.

## Test plan

- 3205 tests green (baseline ~3096; +~110 new: reconciler invariants RC-A…RC-I, promotion/defer/handoff interleavings, tmux size controller, message buffer, visible-prop propagation, refit/focus flush semantics)
- `bun run lint`, `bun run typecheck`, `bun run build` all clean on HEAD
- Empirical verification of tmux 3.7b stderr shapes for confirmed-absence matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)