### PR TITLE
feat: preserve OSC 8 links through tmux clients

### DIFF
--- a/src/server/terminal.ts
+++ b/src/server/terminal.ts
@@ -20,6 +20,7 @@ import { validateWsToken, getAuthSecret, CONTROL_SESSION_SENTINEL } from "../lib
 import { createLogger } from "../lib/logger.js";
 import { WS_PATH_PREFIX } from "../lib/base-path.js";
 import { TmuxSizeController, type TmuxExec } from "./tmux-size-controller.js";
+import { TmuxAttachArgumentResolver } from "./tmux-hyperlinks.js";
 import {
   PROXY_WS_PATH_PATTERN,
   handleProxyWsUpgrade,
@@ -43,6 +44,10 @@ const execTmux: TmuxExec = (args, callback) => {
   execFile("tmux", args, { cwd: STABLE_SPAWN_CWD }, (error) => callback(error));
 };
 const tmuxSize = new TmuxSizeController(execTmux, log);
+const tmuxAttachArguments = new TmuxAttachArgumentResolver(
+  () => execFileSync("tmux", ["-V"], { cwd: STABLE_SPAWN_CWD }).toString(),
+  log,
+);
 
 /** Retry an async operation up to maxRetries times with exponential backoff (for SQLITE_BUSY) */
 async function retryOnBusy<T>(fn: () => Promise<T>, maxRetries = 2): Promise<T> {
@@ -1740,7 +1745,7 @@ function attachToTmuxSession(
 
   // SECURITY: Spawn tmux directly with array arguments - no shell interpolation
   // Use clean environment to prevent framework internal vars from leaking
-  const ptyProcess = pty.spawn("tmux", ["attach-session", "-t", sessionName], {
+  const ptyProcess = pty.spawn("tmux", tmuxAttachArguments.forSession(sessionName), {
     name: "xterm-256color",
     cols,
     rows,

--- a/src/server/tmux-hyperlinks.test.ts
+++ b/src/server/tmux-hyperlinks.test.ts
@@ -89,4 +89,22 @@ describe("tmux hyperlink client capability", () => {
       expect(warn).toHaveBeenCalledTimes(1);
     },
   );
+
+  it("falls back and warns once when reading the version throws", () => {
+    const readVersion = vi.fn((): string | null => {
+      throw new Error("spawn tmux ENOENT");
+    });
+    const warn = vi.fn();
+    const resolver = new TmuxAttachArgumentResolver(readVersion, { warn });
+
+    expect(resolver.forSession("rdv-probe-error")).toEqual([
+      "attach-session",
+      "-t",
+      "rdv-probe-error",
+    ]);
+    expect(resolver.forSession("rdv-again")).toEqual(["attach-session", "-t", "rdv-again"]);
+
+    expect(readVersion).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/server/tmux-hyperlinks.test.ts
+++ b/src/server/tmux-hyperlinks.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildTmuxAttachArgs,
+  parseTmuxVersion,
+  tmuxSupportsHyperlinks,
+  TmuxAttachArgumentResolver,
+} from "./tmux-hyperlinks";
+
+describe("parseTmuxVersion", () => {
+  it.each([
+    ["tmux 3.3", { major: 3, minor: 3 }],
+    ["tmux 3.4", { major: 3, minor: 4 }],
+    ["tmux 3.7b", { major: 3, minor: 7 }],
+  ])("parses %s", (output, expected) => {
+    expect(parseTmuxVersion(output)).toEqual(expected);
+  });
+
+  it.each([undefined, null, "", "tmux", "tmux version 3.7", "tmux 3.x", "3.7b"])(
+    "rejects missing or malformed version output %#",
+    (output) => {
+      expect(parseTmuxVersion(output)).toBeNull();
+    },
+  );
+});
+
+describe("tmux hyperlink client capability", () => {
+  it("requires tmux 3.4 or newer", () => {
+    expect(tmuxSupportsHyperlinks(parseTmuxVersion("tmux 3.3"))).toBe(false);
+    expect(tmuxSupportsHyperlinks(parseTmuxVersion("tmux 3.4"))).toBe(true);
+    expect(tmuxSupportsHyperlinks(parseTmuxVersion("tmux 3.7b"))).toBe(true);
+  });
+
+  it("places the client feature before attach-session only when supported", () => {
+    expect(buildTmuxAttachArgs("rdv-supported", true)).toEqual([
+      "-T",
+      "hyperlinks",
+      "attach-session",
+      "-t",
+      "rdv-supported",
+    ]);
+    expect(buildTmuxAttachArgs("rdv-fallback", false)).toEqual([
+      "attach-session",
+      "-t",
+      "rdv-fallback",
+    ]);
+  });
+
+  it("uses the top-level client feature for tmux 3.4 without a compatibility warning", () => {
+    const readVersion = vi.fn(() => "tmux 3.4");
+    const warn = vi.fn();
+    const resolver = new TmuxAttachArgumentResolver(readVersion, { warn });
+
+    expect(resolver.forSession("rdv-supported")).toEqual([
+      "-T",
+      "hyperlinks",
+      "attach-session",
+      "-t",
+      "rdv-supported",
+    ]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("caches an unsupported version and warns once while retaining fallback args", () => {
+    const readVersion = vi.fn(() => "tmux 3.3");
+    const warn = vi.fn();
+    const resolver = new TmuxAttachArgumentResolver(readVersion, { warn });
+
+    expect(resolver.forSession("rdv-first")).toEqual(["attach-session", "-t", "rdv-first"]);
+    expect(resolver.forSession("rdv-second")).toEqual(["attach-session", "-t", "rdv-second"]);
+
+    expect(readVersion).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("tmux 3.4+");
+  });
+
+  it.each([null, "tmux 3.x"])(
+    "falls back and warns once when the version is missing or malformed: %#",
+    (output) => {
+      const readVersion = vi.fn(() => output);
+      const warn = vi.fn();
+      const resolver = new TmuxAttachArgumentResolver(readVersion, { warn });
+
+      expect(resolver.forSession("rdv-missing")).toEqual(["attach-session", "-t", "rdv-missing"]);
+      expect(resolver.forSession("rdv-again")).toEqual(["attach-session", "-t", "rdv-again"]);
+
+      expect(readVersion).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledTimes(1);
+    },
+  );
+});

--- a/src/server/tmux-hyperlinks.ts
+++ b/src/server/tmux-hyperlinks.ts
@@ -1,0 +1,72 @@
+export interface TmuxVersion {
+  major: number;
+  minor: number;
+}
+
+interface TmuxWarningLogger {
+  warn(message: string, context: Record<string, unknown>): void;
+}
+
+/** Parse the stable `tmux -V` output, including release suffixes such as 3.7b. */
+export function parseTmuxVersion(output: unknown): TmuxVersion | null {
+  if (typeof output !== "string") return null;
+  const match = /^tmux\s+(\d+)\.(\d+)(?:[a-zA-Z][a-zA-Z0-9._-]*)?\s*$/.exec(output);
+  if (!match) return null;
+
+  return {
+    major: Number.parseInt(match[1]!, 10),
+    minor: Number.parseInt(match[2]!, 10),
+  };
+}
+
+/** `-T hyperlinks` was added to tmux clients in 3.4. */
+export function tmuxSupportsHyperlinks(version: TmuxVersion | null): boolean {
+  return version !== null && (version.major > 3 || (version.major === 3 && version.minor >= 4));
+}
+
+/** Build top-level tmux argv so client features precede the attach command. */
+export function buildTmuxAttachArgs(sessionName: string, supportsHyperlinks: boolean): string[] {
+  const attachArgs = ["attach-session", "-t", sessionName];
+  return supportsHyperlinks ? ["-T", "hyperlinks", ...attachArgs] : attachArgs;
+}
+
+/**
+ * Resolves tmux's local feature support once for this terminal-server process.
+ * A failed, malformed, or old version check must never prevent an attach.
+ */
+export class TmuxAttachArgumentResolver {
+  private supportsHyperlinks: boolean | null = null;
+  private resolved = false;
+
+  constructor(
+    private readonly readVersion: () => string | null,
+    private readonly log: TmuxWarningLogger,
+  ) {}
+
+  forSession(sessionName: string): string[] {
+    if (!this.resolved) this.resolveCapability();
+    return buildTmuxAttachArgs(sessionName, this.supportsHyperlinks === true);
+  }
+
+  private resolveCapability(): void {
+    this.resolved = true;
+    let output: string | null = null;
+    try {
+      output = this.readVersion();
+    } catch {
+      // An unavailable tmux binary uses the same non-blocking fallback.
+    }
+
+    const version = parseTmuxVersion(output);
+    this.supportsHyperlinks = tmuxSupportsHyperlinks(version);
+    if (!this.supportsHyperlinks) {
+      this.log.warn(
+        "tmux 3.4+ is required to preserve OSC 8 hyperlinks; attaching without -T hyperlinks",
+        {
+          tmuxVersion: output?.trim() || null,
+          requiredTmuxVersion: "3.4",
+        },
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the tmux leg of remote-dev-psic by advertising tmux client feature `hyperlinks` on project-controlled attach clients. This keeps exact OSC 8 link targets available to xterm.js without changing tmux server or user configuration.

## Root cause and compatibility

The terminal server previously started clients with `tmux attach-session -t SESSION`; those clients did not advertise hyperlink support, so tmux could not preserve OSC 8 targets through the attachment.

A cached local version check now selects client-scoped `tmux -T hyperlinks attach-session -t SESSION` only for tmux 3.4+. Old, missing, malformed, or unreadable versions retain the existing attach argv and emit one actionable process-lifetime warning. `xterm-256color`, `default-terminal`, global/user config, and `allow-passthrough` are unchanged.

## Tests

- Unit coverage for 3.3, 3.4, 3.7b, malformed/missing versions, exact argv order, fallback behavior, capability caching, and once-only warnings.
- `bun run test:run src/server` (188 tests), `bun run typecheck`, targeted ESLint, and `bun run terminal:build` pass.
- Isolated `tmux -L` smoke accepted `-T hyperlinks` and cleaned its unique socket.

Refs remote-dev-psic and remote-dev-psic.2.