### PR TITLE
Fix multi-row links in cursor-positioned TUIs

### DIFF
--- a/src/components/terminal/Terminal.fontRace.test.tsx
+++ b/src/components/terminal/Terminal.fontRace.test.tsx
@@ -24,6 +24,8 @@ import { useState, useEffect } from "react";
 const xtermInstances: Array<{
   options: { fontSize: number; fontFamily: string; [k: string]: unknown };
 }> = [];
+const linkRegistrationOrder: string[] = [];
+const webLinkHandlers: Array<(event: MouseEvent, uri: string) => void> = [];
 
 vi.mock("@xterm/xterm", () => {
   class FakeTerminal {
@@ -48,7 +50,13 @@ vi.mock("@xterm/xterm", () => {
       this.textarea = document.createElement("textarea");
       xtermInstances.push(this);
     }
-    loadAddon() {}
+    loadAddon(addon: { activate?: (terminal: FakeTerminal) => void }) {
+      addon.activate?.(this);
+    }
+    registerLinkProvider() {
+      linkRegistrationOrder.push("custom-provider");
+      return { dispose: () => {} };
+    }
     open() {}
     onData() {
       return { dispose: () => {} };
@@ -79,7 +87,12 @@ vi.mock("@xterm/addon-fit", () => ({
 
 vi.mock("@xterm/addon-web-links", () => ({
   WebLinksAddon: class {
-    activate() {}
+    constructor(private handler: (event: MouseEvent, uri: string) => void) {
+      webLinkHandlers.push(handler);
+    }
+    activate() {
+      linkRegistrationOrder.push("web-links-addon");
+    }
     dispose() {}
   },
 }));
@@ -202,6 +215,8 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.fetch = originalFetch;
   xtermInstances.length = 0;
+  linkRegistrationOrder.length = 0;
+  webLinkHandlers.length = 0;
   cleanup();
 });
 
@@ -232,6 +247,7 @@ let TerminalUnderTest: (props: { fontSize: number }) => React.ReactElement;
 
 describe("Terminal fontSize race (remote-dev-3gtr)", () => {
   it("applies latest fontSize even when prefs resolve during async init", async () => {
+    const openWindow = vi.spyOn(window, "open").mockReturnValue({} as Window);
     const Terminal = await getTerminal();
 
     function TerminalWrapper({ fontSize }: { fontSize: number }) {
@@ -280,5 +296,36 @@ describe("Terminal fontSize race (remote-dev-3gtr)", () => {
     });
 
     expect(xterm.options.fontSize).toBe(20);
+
+    expect(linkRegistrationOrder).toEqual([
+      "custom-provider",
+      "web-links-addon",
+    ]);
+
+    const osc8Handler = xterm.options.linkHandler as {
+      allowNonHttpProtocols: boolean;
+      activate(event: MouseEvent, text: string): void;
+    };
+    const event = new MouseEvent("click");
+    osc8Handler.activate(event, "javascript:alert(1)");
+    webLinkHandlers[0]!(event, "file:///tmp/unsafe");
+    expect(openWindow).not.toHaveBeenCalled();
+
+    osc8Handler.activate(event, "https://osc.test/path");
+    webLinkHandlers[0]!(event, "http://web.test/path");
+    expect(osc8Handler.allowNonHttpProtocols).toBe(false);
+    expect(openWindow).toHaveBeenNthCalledWith(
+      1,
+      "https://osc.test/path",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(openWindow).toHaveBeenNthCalledWith(
+      2,
+      "http://web.test/path",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    openWindow.mockRestore();
   });
 });

--- a/src/components/terminal/Terminal.fontRace.test.tsx
+++ b/src/components/terminal/Terminal.fontRace.test.tsx
@@ -26,6 +26,14 @@ const xtermInstances: Array<{
 }> = [];
 const linkRegistrationOrder: string[] = [];
 const webLinkHandlers: Array<(event: MouseEvent, uri: string) => void> = [];
+const webLinkOptions: Array<{
+  hover?(event: MouseEvent, text: string, range: {
+    start: { x: number; y: number };
+    end: { x: number; y: number };
+  }): void;
+  leave?(event: MouseEvent, text: string): void;
+}> = [];
+const WEB_LINK_TARGET = "http://web.test/path";
 
 vi.mock("@xterm/xterm", () => {
   class FakeTerminal {
@@ -38,7 +46,25 @@ vi.mock("@xterm/xterm", () => {
     rows = 24;
     textarea: HTMLTextAreaElement;
     buffer = {
-      active: { type: "normal" as const, viewportY: 0, baseY: 0 },
+      active: {
+        type: "normal" as const,
+        viewportY: 0,
+        baseY: 0,
+        length: 1,
+        getLine(index: number) {
+          if (index !== 0) return undefined;
+          return {
+            isWrapped: false,
+            length: 80,
+            getCell(column: number) {
+              return {
+                getChars: () => WEB_LINK_TARGET[column] ?? "",
+                getWidth: () => 1,
+              };
+            },
+          };
+        },
+      },
       onBufferChange: () => ({ dispose: () => {} }),
     };
     constructor(options: Record<string, unknown>) {
@@ -87,8 +113,12 @@ vi.mock("@xterm/addon-fit", () => ({
 
 vi.mock("@xterm/addon-web-links", () => ({
   WebLinksAddon: class {
-    constructor(private handler: (event: MouseEvent, uri: string) => void) {
+    constructor(
+      private handler: (event: MouseEvent, uri: string) => void,
+      options: (typeof webLinkOptions)[number],
+    ) {
       webLinkHandlers.push(handler);
+      webLinkOptions.push(options);
     }
     activate() {
       linkRegistrationOrder.push("web-links-addon");
@@ -217,6 +247,7 @@ afterEach(() => {
   xtermInstances.length = 0;
   linkRegistrationOrder.length = 0;
   webLinkHandlers.length = 0;
+  webLinkOptions.length = 0;
   cleanup();
 });
 
@@ -312,8 +343,16 @@ describe("Terminal fontSize race (remote-dev-3gtr)", () => {
     expect(openWindow).not.toHaveBeenCalled();
 
     osc8Handler.activate(event, "https://osc.test/path");
-    webLinkHandlers[0]!(event, "http://web.test/path");
+    webLinkHandlers[0]!(event, WEB_LINK_TARGET);
     expect(osc8Handler.allowNonHttpProtocols).toBe(false);
+    expect(openWindow).toHaveBeenCalledTimes(1);
+
+    const webRange = {
+      start: { x: 1, y: 1 },
+      end: { x: WEB_LINK_TARGET.length, y: 1 },
+    };
+    webLinkOptions[0]!.hover!(event, WEB_LINK_TARGET, webRange);
+    webLinkHandlers[0]!(event, WEB_LINK_TARGET);
     expect(openWindow).toHaveBeenNthCalledWith(
       1,
       "https://osc.test/path",
@@ -322,10 +361,14 @@ describe("Terminal fontSize race (remote-dev-3gtr)", () => {
     );
     expect(openWindow).toHaveBeenNthCalledWith(
       2,
-      "http://web.test/path",
+      WEB_LINK_TARGET,
       "_blank",
       "noopener,noreferrer",
     );
+
+    webLinkOptions[0]!.leave!(event, WEB_LINK_TARGET);
+    webLinkHandlers[0]!(event, WEB_LINK_TARGET);
+    expect(openWindow).toHaveBeenCalledTimes(2);
     openWindow.mockRestore();
   });
 });

--- a/src/components/terminal/Terminal.refit.test.tsx
+++ b/src/components/terminal/Terminal.refit.test.tsx
@@ -164,6 +164,9 @@ vi.mock("@xterm/xterm", () => {
     loadAddon(addon: { activate?: (terminal: FakeTerminal) => void }) {
       addon.activate?.(this);
     }
+    registerLinkProvider() {
+      return { dispose: () => {} };
+    }
     open() {}
     onData() {
       return { dispose: () => {} };

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -16,7 +16,7 @@ import { createTouchScrollHandlers } from "./touch-scroll";
 import { createTouchInteractions, createTouchModeRef } from "./useTouchInteractions";
 import {
   createHttpLinkOpener,
-  createTerminalLinkProvider,
+  createTerminalLinkController,
 } from "./terminal-links";
 import {
   MIN_COLS,
@@ -506,9 +506,26 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       });
 
       fitAddon = new FitAddon();
-      const webLinksAddon = new WebLinksAddon((_event, uri) => {
-        openTerminalHttpLink(uri);
+      const terminalLinks = createTerminalLinkController(terminal, {
+        open: openTerminalHttpLink,
       });
+      const webLinksAddon = new WebLinksAddon(
+        (_event, uri) => {
+          terminalLinks.activateWebLink(uri);
+        },
+        {
+          // WebLinksAddon passes its ILink's actual 1-based inclusive buffer
+          // range here, despite the public option type being named
+          // IViewportRange. The controller deliberately consumes those same
+          // buffer coordinates when it rechecks the current rows.
+          hover: (_event, text, range) => {
+            terminalLinks.hoverWebLink(text, range);
+          },
+          leave: (_event, text) => {
+            terminalLinks.leaveWebLink(text);
+          },
+        },
+      );
       const imageAddon = new ImageAddon();
       const searchAddon = new SearchAddon();
 
@@ -517,9 +534,7 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
       // from later providers. Register before WebLinksAddon so its truncated
       // first-row match cannot win over a reconstructed multi-row candidate.
       terminalDisposablesRef.current.push(
-        terminal.registerLinkProvider(
-          createTerminalLinkProvider(terminal, { open: openTerminalHttpLink }),
-        ),
+        terminal.registerLinkProvider(terminalLinks.linkProvider),
       );
       terminal.loadAddon(webLinksAddon);
       terminal.loadAddon(imageAddon);

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -15,6 +15,10 @@ import { AuthErrorOverlay } from "./AuthErrorOverlay";
 import { createTouchScrollHandlers } from "./touch-scroll";
 import { createTouchInteractions, createTouchModeRef } from "./useTouchInteractions";
 import {
+  createHttpLinkOpener,
+  createTerminalLinkProvider,
+} from "./terminal-links";
+import {
   MIN_COLS,
   MIN_ROWS,
   ResizeReconciler,
@@ -473,6 +477,10 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
         brightWhite: theme.brightWhite,
       };
 
+      // OSC 8, inferred TUI links, and WebLinksAddon all cross the same
+      // HTTP(S)-only opener boundary.
+      const openTerminalHttpLink = createHttpLinkOpener();
+
       terminal = new XTerm({
         cursorBlink: true,
         cursorStyle: theme.cursorStyle,
@@ -489,14 +497,30 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(function Terminal
         macOptionClickForcesSelection: true,
         // Right-click selects word under cursor (macOS-style behavior)
         rightClickSelectsWord: true,
+        linkHandler: {
+          allowNonHttpProtocols: false,
+          activate: (_event, text) => {
+            openTerminalHttpLink(text);
+          },
+        },
       });
 
       fitAddon = new FitAddon();
-      const webLinksAddon = new WebLinksAddon();
+      const webLinksAddon = new WebLinksAddon((_event, uri) => {
+        openTerminalHttpLink(uri);
+      });
       const imageAddon = new ImageAddon();
       const searchAddon = new SearchAddon();
 
       terminal.loadAddon(fitAddon);
+      // xterm gives earlier providers priority and removes overlapping ranges
+      // from later providers. Register before WebLinksAddon so its truncated
+      // first-row match cannot win over a reconstructed multi-row candidate.
+      terminalDisposablesRef.current.push(
+        terminal.registerLinkProvider(
+          createTerminalLinkProvider(terminal, { open: openTerminalHttpLink }),
+        ),
+      );
       terminal.loadAddon(webLinksAddon);
       terminal.loadAddon(imageAddon);
       terminal.loadAddon(searchAddon);

--- a/src/components/terminal/terminal-links.realXterm.test.ts
+++ b/src/components/terminal/terminal-links.realXterm.test.ts
@@ -164,6 +164,68 @@ describe("terminal links against real xterm.js", () => {
     expect(core.linkifier?.currentLink?.link.range).toEqual(custom.range);
   });
 
+  it("uses a non-navigating custom guard when the structural scan is clipped", async () => {
+    const { term, parent, screen, core } = openRealTerminal();
+    disposals.push(() => {
+      term.dispose();
+      parent.remove();
+    });
+
+    const target = "https://example.test/a-long-continuation";
+    const first = target.slice(0, COLS);
+    const second = target.slice(COLS);
+    await write(term, `${first}\x1b[2;1H${second}`);
+    expect(term.buffer.active.getLine(1)?.isWrapped).toBe(false);
+
+    const confirm = vi.fn(() => true);
+    const customOpen = vi.fn(() => true);
+    const stockOpen = vi.fn();
+    term.registerLinkProvider(
+      createTerminalLinkProvider(term, {
+        cellBudget: COLS,
+        confirm,
+        open: customOpen,
+      }),
+    );
+    term.loadAddon(new WebLinksAddon((_event, text) => stockOpen(text)));
+
+    const providers = core._linkProviderService.linkProviders;
+    const guard = provide(providers[1], 1)[0];
+    const stock = provide(providers[2], 1)[0];
+    expect(guard).toMatchObject({
+      text: first,
+      decorations: { pointerCursor: false, underline: false },
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: COLS, y: 1 },
+      },
+    });
+    expect(stock.text).toBe(first);
+
+    screen.dispatchEvent(
+      new MouseEvent("mousemove", {
+        bubbles: true,
+        clientX: CELL_WIDTH / 2,
+        clientY: CELL_HEIGHT / 2,
+      }),
+    );
+    expect(core.linkifier?.currentLink?.link).toMatchObject({
+      text: guard.text,
+      range: guard.range,
+    });
+
+    screen.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        clientX: CELL_WIDTH / 2,
+        clientY: CELL_HEIGHT / 2,
+      }),
+    );
+    expect(confirm).not.toHaveBeenCalled();
+    expect(customOpen).not.toHaveBeenCalled();
+    expect(stockOpen).not.toHaveBeenCalled();
+  });
+
   it("keeps OSC 8 first priority while filtering unsafe protocols", async () => {
     const openWindow = vi.fn(() => ({}) as Window);
     const safeOpen = createHttpLinkOpener(openWindow);

--- a/src/components/terminal/terminal-links.realXterm.test.ts
+++ b/src/components/terminal/terminal-links.realXterm.test.ts
@@ -215,8 +215,17 @@ describe("terminal links against real xterm.js", () => {
     });
 
     screen.dispatchEvent(
-      new MouseEvent("click", {
+      new MouseEvent("mousedown", {
         bubbles: true,
+        button: 0,
+        clientX: CELL_WIDTH / 2,
+        clientY: CELL_HEIGHT / 2,
+      }),
+    );
+    screen.dispatchEvent(
+      new MouseEvent("mouseup", {
+        bubbles: true,
+        button: 0,
         clientX: CELL_WIDTH / 2,
         clientY: CELL_HEIGHT / 2,
       }),

--- a/src/components/terminal/terminal-links.realXterm.test.ts
+++ b/src/components/terminal/terminal-links.realXterm.test.ts
@@ -57,12 +57,14 @@ function provide(provider: ILinkProvider, row: number): ILink[] {
 }
 
 function openRealTerminal(options: ConstructorParameters<typeof Terminal>[0] = {}) {
+  const cols = options.cols ?? COLS;
+  const rows = options.rows ?? ROWS;
   const parent = document.createElement("div");
   document.body.appendChild(parent);
   const term = new Terminal({
     allowProposedApi: true,
-    cols: COLS,
-    rows: ROWS,
+    cols,
+    rows,
     ...options,
   });
   term.open(parent);
@@ -73,10 +75,10 @@ function openRealTerminal(options: ConstructorParameters<typeof Terminal>[0] = {
     value: () => ({
       left: 0,
       top: 0,
-      right: COLS * CELL_WIDTH,
-      bottom: ROWS * CELL_HEIGHT,
-      width: COLS * CELL_WIDTH,
-      height: ROWS * CELL_HEIGHT,
+      right: cols * CELL_WIDTH,
+      bottom: rows * CELL_HEIGHT,
+      width: cols * CELL_WIDTH,
+      height: rows * CELL_HEIGHT,
       x: 0,
       y: 0,
       toJSON: () => "",
@@ -96,17 +98,40 @@ function openRealTerminal(options: ConstructorParameters<typeof Terminal>[0] = {
       get: (): RenderDimensions => ({
         css: {
           cell: { width: CELL_WIDTH, height: CELL_HEIGHT },
-          canvas: { width: COLS * CELL_WIDTH, height: ROWS * CELL_HEIGHT },
+          canvas: { width: cols * CELL_WIDTH, height: rows * CELL_HEIGHT },
         },
         device: {
           cell: { width: CELL_WIDTH, height: CELL_HEIGHT },
-          canvas: { width: COLS * CELL_WIDTH, height: ROWS * CELL_HEIGHT },
+          canvas: { width: cols * CELL_WIDTH, height: rows * CELL_HEIGHT },
         },
       }),
     });
   }
 
   return { term, parent, screen, core };
+}
+
+function movePointer(screen: HTMLElement, oneBasedColumn: number): void {
+  screen.dispatchEvent(
+    new MouseEvent("mousemove", {
+      bubbles: true,
+      clientX: (oneBasedColumn - 0.5) * CELL_WIDTH,
+      clientY: CELL_HEIGHT / 2,
+    }),
+  );
+}
+
+function clickPointer(screen: HTMLElement, oneBasedColumn: number): void {
+  for (const type of ["mousedown", "mouseup"]) {
+    screen.dispatchEvent(
+      new MouseEvent(type, {
+        bubbles: true,
+        button: 0,
+        clientX: (oneBasedColumn - 0.5) * CELL_WIDTH,
+        clientY: CELL_HEIGHT / 2,
+      }),
+    );
+  }
 }
 
 const disposals: Array<() => void> = [];
@@ -231,6 +256,124 @@ describe("terminal links against real xterm.js", () => {
       }),
     );
     expect(confirm).not.toHaveBeenCalled();
+    expect(customOpen).not.toHaveBeenCalled();
+    expect(stockOpen).not.toHaveBeenCalled();
+  });
+
+  it("guards WebLinksAddon's valid prefix when a clipped raw token is parser-invalid", async () => {
+    const text = "https://example.test[ rest";
+    const { term, parent, screen, core } = openRealTerminal({
+      cols: text.length,
+    });
+    disposals.push(() => {
+      term.dispose();
+      parent.remove();
+    });
+    await write(term, text);
+
+    const customOpen = vi.fn(() => true);
+    const stockOpen = vi.fn();
+    term.registerLinkProvider(
+      createTerminalLinkProvider(term, {
+        cellBudget: 21,
+        confirm: () => true,
+        open: customOpen,
+      }),
+    );
+    term.loadAddon(new WebLinksAddon((_event, target) => stockOpen(target)));
+
+    const providers = core._linkProviderService.linkProviders;
+    const custom = provide(providers[1], 1);
+    const stock = provide(providers[2], 1)[0];
+    expect(custom).toHaveLength(1);
+    expect(custom[0]).toMatchObject({
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: text.length, y: 1 },
+      },
+      decorations: { pointerCursor: false, underline: false },
+    });
+    expect(stock).toMatchObject({
+      text: "https://example.test",
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: 20, y: 1 },
+      },
+    });
+
+    movePointer(screen, 5);
+    expect(core.linkifier?.currentLink?.link).toMatchObject({
+      range: custom[0].range,
+      decorations: { pointerCursor: false, underline: false },
+    });
+    clickPointer(screen, 5);
+    expect(customOpen).not.toHaveBeenCalled();
+    expect(stockOpen).not.toHaveBeenCalled();
+  });
+
+  it("keeps clipped wide-cell guards disjoint so a later stock URL stays inert", async () => {
+    const prefix = "https://wide.test/";
+    const hidden = "https://hidden.test";
+    const cols = prefix.length + 2 + 1 + hidden.length;
+    const hiddenStart = prefix.length + 2 + 2;
+    const { term, parent, screen, core } = openRealTerminal({ cols });
+    disposals.push(() => {
+      term.dispose();
+      parent.remove();
+    });
+    await write(term, `${prefix}中 ${hidden}`);
+    expect(term.buffer.active.getLine(0)?.getCell(prefix.length)?.getWidth()).toBe(
+      2,
+    );
+    expect(
+      term.buffer.active.getLine(0)?.getCell(prefix.length + 1)?.getWidth(),
+    ).toBe(0);
+
+    const customOpen = vi.fn(() => true);
+    const stockOpen = vi.fn();
+    term.registerLinkProvider(
+      createTerminalLinkProvider(term, {
+        cellBudget: prefix.length + 1,
+        confirm: () => true,
+        open: customOpen,
+      }),
+    );
+    term.loadAddon(new WebLinksAddon((_event, target) => stockOpen(target)));
+
+    const providers = core._linkProviderService.linkProviders;
+    const custom = provide(providers[1], 1);
+    const hiddenStockLink = provide(providers[2], 1).find(
+      (link) => link.text === hidden,
+    );
+    expect(hiddenStockLink).toBeDefined();
+    for (let x = 1; x <= cols; x++) {
+      expect(
+        custom.filter(
+          (link) => link.range.start.x <= x && link.range.end.x >= x,
+        ),
+        `custom guard ownership at column ${x}`,
+      ).toHaveLength(1);
+    }
+
+    movePointer(screen, 5);
+    expect(core.linkifier?.currentLink?.link.decorations).toMatchObject({
+      pointerCursor: false,
+      underline: false,
+    });
+    clickPointer(screen, 5);
+
+    movePointer(screen, hiddenStart + 3);
+    expect(core.linkifier?.currentLink?.link).toMatchObject({
+      decorations: { pointerCursor: false, underline: false },
+    });
+    expect(core.linkifier?.currentLink?.link.range.start.x).toBeLessThanOrEqual(
+      hiddenStart,
+    );
+    expect(core.linkifier?.currentLink?.link.range.end.x).toBeGreaterThanOrEqual(
+      hiddenStart + hidden.length - 1,
+    );
+    clickPointer(screen, hiddenStart + 3);
+
     expect(customOpen).not.toHaveBeenCalled();
     expect(stockOpen).not.toHaveBeenCalled();
   });

--- a/src/components/terminal/terminal-links.realXterm.test.ts
+++ b/src/components/terminal/terminal-links.realXterm.test.ts
@@ -311,6 +311,63 @@ describe("terminal links against real xterm.js", () => {
     expect(stockOpen).not.toHaveBeenCalled();
   });
 
+  it("normalizes nested clipped guards before WebLinksAddon overlap pruning", async () => {
+    const inspected = "https://example.test[!https://nested.test";
+    const text = `${inspected} rest`;
+    const { term, parent, screen, core } = openRealTerminal({
+      cols: text.length,
+    });
+    disposals.push(() => {
+      term.dispose();
+      parent.remove();
+    });
+    await write(term, text);
+
+    const customOpen = vi.fn(() => true);
+    const stockOpen = vi.fn();
+    term.registerLinkProvider(
+      createTerminalLinkProvider(term, {
+        cellBudget: inspected.length,
+        confirm: () => true,
+        open: customOpen,
+      }),
+    );
+    term.loadAddon(new WebLinksAddon((_event, target) => stockOpen(target)));
+
+    const providers = core._linkProviderService.linkProviders;
+    const custom = provide(providers[1], 1);
+    const stock = provide(providers[2], 1);
+    expect(custom).toHaveLength(1);
+    expect(custom[0]).toMatchObject({
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: text.length, y: 1 },
+      },
+      decorations: { pointerCursor: false, underline: false },
+    });
+    expect(stock.map((link) => link.text)).toEqual([
+      "https://example.test",
+      "https://nested.test",
+    ]);
+
+    movePointer(screen, 5);
+    expect(core.linkifier?.currentLink?.link).toMatchObject({
+      range: custom[0].range,
+      decorations: { pointerCursor: false, underline: false },
+    });
+    clickPointer(screen, 5);
+
+    movePointer(screen, 27);
+    expect(core.linkifier?.currentLink?.link).toMatchObject({
+      range: custom[0].range,
+      decorations: { pointerCursor: false, underline: false },
+    });
+    clickPointer(screen, 27);
+
+    expect(customOpen).not.toHaveBeenCalled();
+    expect(stockOpen).not.toHaveBeenCalled();
+  });
+
   it("keeps clipped wide-cell guards disjoint so a later stock URL stays inert", async () => {
     const prefix = "https://wide.test/";
     const hidden = "https://hidden.test";

--- a/src/components/terminal/terminal-links.realXterm.test.ts
+++ b/src/components/terminal/terminal-links.realXterm.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Integration coverage against the installed xterm 6 implementation.
+ *
+ * This intentionally reaches into xterm's private provider registry and
+ * render dimensions. The public API can register providers but cannot inspect
+ * precedence or the active hover link, while happy-dom has no real layout.
+ * Keeping the coupling here gives us direct evidence that the real Linkifier
+ * selects the custom row-local segment ahead of WebLinksAddon's overlapping
+ * first-row fragment.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Terminal, type ILink, type ILinkProvider } from "@xterm/xterm";
+import { WebLinksAddon } from "@xterm/addon-web-links";
+
+import {
+  createHttpLinkOpener,
+  createTerminalLinkProvider,
+} from "./terminal-links";
+
+const COLS = 24;
+const ROWS = 6;
+const CELL_WIDTH = 8;
+const CELL_HEIGHT = 16;
+
+interface RenderDimensions {
+  css: {
+    cell: { width: number; height: number };
+    canvas: { width: number; height: number };
+  };
+  device: {
+    cell: { width: number; height: number };
+    canvas: { width: number; height: number };
+  };
+}
+
+interface RealXtermCore {
+  _linkProviderService: { linkProviders: ILinkProvider[] };
+  _charSizeService?: { width: number; height: number };
+  _renderService?: { dimensions?: RenderDimensions };
+  linkifier?: { currentLink?: { link: ILink } };
+}
+
+interface RealXtermInternals {
+  _core: RealXtermCore;
+}
+
+function write(term: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => term.write(data, resolve));
+}
+
+function provide(provider: ILinkProvider, row: number): ILink[] {
+  let result: ILink[] | undefined;
+  provider.provideLinks(row, (links) => {
+    result = links;
+  });
+  return result ?? [];
+}
+
+function openRealTerminal(options: ConstructorParameters<typeof Terminal>[0] = {}) {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  const term = new Terminal({
+    allowProposedApi: true,
+    cols: COLS,
+    rows: ROWS,
+    ...options,
+  });
+  term.open(parent);
+
+  const screen = term.element!.querySelector(".xterm-screen") as HTMLElement;
+  Object.defineProperty(screen, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({
+      left: 0,
+      top: 0,
+      right: COLS * CELL_WIDTH,
+      bottom: ROWS * CELL_HEIGHT,
+      width: COLS * CELL_WIDTH,
+      height: ROWS * CELL_HEIGHT,
+      x: 0,
+      y: 0,
+      toJSON: () => "",
+    }),
+  });
+  screen.style.paddingLeft = "0px";
+  screen.style.paddingTop = "0px";
+
+  const core = (term as unknown as RealXtermInternals)._core;
+  if (core._charSizeService) {
+    core._charSizeService.width = CELL_WIDTH;
+    core._charSizeService.height = CELL_HEIGHT;
+  }
+  if (core._renderService) {
+    Object.defineProperty(core._renderService, "dimensions", {
+      configurable: true,
+      get: (): RenderDimensions => ({
+        css: {
+          cell: { width: CELL_WIDTH, height: CELL_HEIGHT },
+          canvas: { width: COLS * CELL_WIDTH, height: ROWS * CELL_HEIGHT },
+        },
+        device: {
+          cell: { width: CELL_WIDTH, height: CELL_HEIGHT },
+          canvas: { width: COLS * CELL_WIDTH, height: ROWS * CELL_HEIGHT },
+        },
+      }),
+    });
+  }
+
+  return { term, parent, screen, core };
+}
+
+const disposals: Array<() => void> = [];
+
+afterEach(() => {
+  while (disposals.length > 0) disposals.pop()?.();
+  document.body.innerHTML = "";
+});
+
+describe("terminal links against real xterm.js", () => {
+  it("gives the custom row-local segment precedence over WebLinksAddon's fragment", async () => {
+    const { term, parent, screen, core } = openRealTerminal();
+    disposals.push(() => {
+      term.dispose();
+      parent.remove();
+    });
+
+    const target = "https://example.test/a-long-continuation";
+    const first = target.slice(0, COLS);
+    const second = target.slice(COLS);
+    await write(term, `${first}\x1b[2;1H${second}`);
+    expect(term.buffer.active.getLine(1)?.isWrapped).toBe(false);
+
+    term.registerLinkProvider(
+      createTerminalLinkProvider(term, {
+        confirm: () => true,
+        open: () => true,
+      }),
+    );
+    term.loadAddon(new WebLinksAddon(() => {}));
+
+    const providers = core._linkProviderService.linkProviders;
+    expect(providers).toHaveLength(3);
+    const custom = provide(providers[1], 1)[0];
+    const stock = provide(providers[2], 1)[0];
+    expect(custom).toMatchObject({
+      text: target,
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: COLS, y: 1 },
+      },
+    });
+    expect(stock.text).toBe(first);
+    expect(stock.range.start).toEqual(custom.range.start);
+    expect(stock.range.end.y).toBeGreaterThanOrEqual(custom.range.end.y);
+
+    screen.dispatchEvent(
+      new MouseEvent("mousemove", {
+        bubbles: true,
+        clientX: CELL_WIDTH / 2,
+        clientY: CELL_HEIGHT / 2,
+      }),
+    );
+    expect(core.linkifier?.currentLink?.link.text).toBe(target);
+    expect(core.linkifier?.currentLink?.link.range).toEqual(custom.range);
+  });
+
+  it("keeps OSC 8 first priority while filtering unsafe protocols", async () => {
+    const openWindow = vi.fn(() => ({}) as Window);
+    const safeOpen = createHttpLinkOpener(openWindow);
+    const { term, parent, core } = openRealTerminal({
+      linkHandler: {
+        allowNonHttpProtocols: false,
+        activate: (_event, text) => {
+          safeOpen(text);
+        },
+      },
+    });
+    disposals.push(() => {
+      term.dispose();
+      parent.remove();
+    });
+
+    const unsafe = "javascript:alert(1)";
+    const safe = "https://osc.test/path";
+    await write(
+      term,
+      `\x1b]8;;${unsafe}\x1b\\unsafe\x1b]8;;\x1b\\` +
+        `\x1b[2;1H\x1b]8;;${safe}\x1b\\safe\x1b]8;;\x1b\\`,
+    );
+
+    const oscProvider = core._linkProviderService.linkProviders[0];
+    expect(provide(oscProvider, 1)).toEqual([]);
+    const safeLink = provide(oscProvider, 2)[0];
+    expect(safeLink.text).toBe(safe);
+    safeLink.activate(new MouseEvent("click"), safeLink.text);
+    expect(openWindow).toHaveBeenCalledWith(
+      safe,
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+});

--- a/src/components/terminal/terminal-links.realXterm.test.ts
+++ b/src/components/terminal/terminal-links.realXterm.test.ts
@@ -14,6 +14,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 
 import {
   createHttpLinkOpener,
+  createTerminalLinkController,
   createTerminalLinkProvider,
 } from "./terminal-links";
 
@@ -324,27 +325,46 @@ describe("terminal links against real xterm.js", () => {
     await write(term, text);
 
     const customOpen = vi.fn(() => true);
-    const stockOpen = vi.fn();
+    const controller = createTerminalLinkController(term, {
+      cellBudget: text.length,
+      codeUnitBudget: inspected.length,
+      confirm: () => true,
+      open: customOpen,
+    });
+    const webActivate = vi.fn((target: string) =>
+      controller.activateWebLink(target),
+    );
     term.registerLinkProvider(
-      createTerminalLinkProvider(term, {
-        cellBudget: inspected.length,
-        confirm: () => true,
-        open: customOpen,
+      controller.linkProvider,
+    );
+    term.loadAddon(
+      new WebLinksAddon((_event, target) => webActivate(target), {
+        hover: (_event, target, range) =>
+          controller.hoverWebLink(target, range),
+        leave: (_event, target) => controller.leaveWebLink(target),
       }),
     );
-    term.loadAddon(new WebLinksAddon((_event, target) => stockOpen(target)));
 
     const providers = core._linkProviderService.linkProviders;
     const custom = provide(providers[1], 1);
     const stock = provide(providers[2], 1);
-    expect(custom).toHaveLength(1);
-    expect(custom[0]).toMatchObject({
-      range: {
+    expect(custom).toHaveLength(2);
+    expect(custom.map((link) => link.range)).toEqual([
+      {
         start: { x: 1, y: 1 },
+        end: { x: 22, y: 1 },
+      },
+      {
+        start: { x: 23, y: 1 },
         end: { x: text.length, y: 1 },
       },
-      decorations: { pointerCursor: false, underline: false },
-    });
+    ]);
+    for (const link of custom) {
+      expect(link.decorations).toMatchObject({
+        pointerCursor: false,
+        underline: false,
+      });
+    }
     expect(stock.map((link) => link.text)).toEqual([
       "https://example.test",
       "https://nested.test",
@@ -359,13 +379,175 @@ describe("terminal links against real xterm.js", () => {
 
     movePointer(screen, 27);
     expect(core.linkifier?.currentLink?.link).toMatchObject({
-      range: custom[0].range,
+      range: custom[1].range,
       decorations: { pointerCursor: false, underline: false },
     });
     clickPointer(screen, 27);
 
+    expect(webActivate).not.toHaveBeenCalled();
     expect(customOpen).not.toHaveBeenCalled();
-    expect(stockOpen).not.toHaveBeenCalled();
+  });
+
+  it("does not let a one-cell OSC 8 link expose a cached nested WebLinks fallback", async () => {
+    const inspected = "https://example.test[!https://nested.test";
+    const text = `${inspected} rest`;
+    const oscTarget = "https://osc.test/one";
+    const oscOpen = vi.fn();
+    const { term, parent, screen, core } = openRealTerminal({
+      cols: text.length,
+      linkHandler: {
+        allowNonHttpProtocols: false,
+        activate: (_event, target) => oscOpen(target),
+      },
+    });
+    disposals.push(() => {
+      term.dispose();
+      parent.remove();
+    });
+    await write(
+      term,
+      `\x1b]8;;${oscTarget}\x1b\\${text[0]}\x1b]8;;\x1b\\${text.slice(1)}`,
+    );
+
+    const customOpen = vi.fn(() => true);
+    const controller = createTerminalLinkController(term, {
+      cellBudget: text.length,
+      codeUnitBudget: inspected.length,
+      confirm: () => true,
+      open: customOpen,
+    });
+    const webActivate = vi.fn((target: string) =>
+      controller.activateWebLink(target),
+    );
+    term.registerLinkProvider(
+      controller.linkProvider,
+    );
+    term.loadAddon(
+      new WebLinksAddon((_event, target) => webActivate(target), {
+        hover: (_event, target, range) =>
+          controller.hoverWebLink(target, range),
+        leave: (_event, target) => controller.leaveWebLink(target),
+      }),
+    );
+
+    const providers = core._linkProviderService.linkProviders;
+    expect(provide(providers[0], 1)[0]).toMatchObject({
+      text: oscTarget,
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: 1, y: 1 },
+      },
+    });
+    expect(provide(providers[1], 1).map((link) => link.range)).toEqual([
+      {
+        start: { x: 1, y: 1 },
+        end: { x: 22, y: 1 },
+      },
+      {
+        start: { x: 23, y: 1 },
+        end: { x: text.length, y: 1 },
+      },
+    ]);
+
+    movePointer(screen, 1);
+    expect(core.linkifier?.currentLink?.link.text).toBe(oscTarget);
+    clickPointer(screen, 1);
+    expect(oscOpen).toHaveBeenCalledWith(oscTarget);
+
+    movePointer(screen, 27);
+    expect(core.linkifier?.currentLink?.link).toMatchObject({
+      range: {
+        start: { x: 23, y: 1 },
+        end: { x: text.length, y: 1 },
+      },
+      decorations: { pointerCursor: false, underline: false },
+    });
+    clickPointer(screen, 27);
+
+    expect(webActivate).not.toHaveBeenCalled();
+    expect(customOpen).not.toHaveBeenCalled();
+  });
+
+  it("does not let an OSC 8 guard-gap cell expose a disjoint stock prefix", async () => {
+    const inspected = "https://example.test[!https://nested.test";
+    const text = `${inspected} rest`;
+    const oscTarget = "https://osc.test/gap";
+    const oscOpen = vi.fn();
+    const { term, parent, screen, core } = openRealTerminal({
+      cols: text.length,
+      linkHandler: {
+        allowNonHttpProtocols: false,
+        activate: (_event, target) => oscOpen(target),
+      },
+    });
+    disposals.push(() => {
+      term.dispose();
+      parent.remove();
+    });
+    const gapIndex = 20;
+    await write(
+      term,
+      `${text.slice(0, gapIndex)}\x1b]8;;${oscTarget}\x1b\\${text[gapIndex]}\x1b]8;;\x1b\\${text.slice(gapIndex + 1)}`,
+    );
+
+    const customOpen = vi.fn(() => true);
+    const controller = createTerminalLinkController(term, {
+      cellBudget: text.length,
+      codeUnitBudget: inspected.length,
+      confirm: () => true,
+      open: customOpen,
+    });
+    const webActivate = vi.fn((target: string) =>
+      controller.activateWebLink(target),
+    );
+    term.registerLinkProvider(controller.linkProvider);
+    term.loadAddon(
+      new WebLinksAddon((_event, target) => webActivate(target), {
+        hover: (_event, target, range) =>
+          controller.hoverWebLink(target, range),
+        leave: (_event, target) => controller.leaveWebLink(target),
+      }),
+    );
+
+    const providers = core._linkProviderService.linkProviders;
+    expect(provide(providers[0], 1)[0]).toMatchObject({
+      text: oscTarget,
+      range: {
+        start: { x: gapIndex + 1, y: 1 },
+        end: { x: gapIndex + 1, y: 1 },
+      },
+    });
+    const outerStock = provide(providers[2], 1)[0];
+    expect(outerStock.range).toEqual({
+      start: { x: 1, y: 1 },
+      end: { x: 20, y: 1 },
+    });
+
+    movePointer(screen, gapIndex + 1);
+    expect(core.linkifier?.currentLink?.link.text).toBe(oscTarget);
+    clickPointer(screen, gapIndex + 1);
+    expect(oscOpen).toHaveBeenCalledWith(oscTarget);
+
+    movePointer(screen, 27);
+    expect(core.linkifier?.currentLink?.link).toMatchObject({
+      range: {
+        start: { x: 23, y: 1 },
+        end: { x: text.length, y: 1 },
+      },
+      decorations: { pointerCursor: false, underline: false },
+    });
+    clickPointer(screen, 27);
+
+    expect(webActivate).not.toHaveBeenCalled();
+
+    // Even if xterm changes its cross-provider pruning and lets this disjoint
+    // WebLinks candidate survive, its public callbacks still pass through the
+    // fresh-buffer controller and cannot bypass the current custom guard.
+    const hoverEvent = new MouseEvent("mousemove");
+    outerStock.hover?.(hoverEvent, outerStock.text);
+    outerStock.activate(new MouseEvent("mouseup"), outerStock.text);
+    expect(webActivate).toHaveBeenCalledWith("https://example.test");
+    expect(customOpen).not.toHaveBeenCalled();
   });
 
   it("keeps clipped wide-cell guards disjoint so a later stock URL stays inert", async () => {

--- a/src/components/terminal/terminal-links.test.ts
+++ b/src/components/terminal/terminal-links.test.ts
@@ -39,32 +39,40 @@ function rowsForUrl(
 }
 
 function terminalBuffer(rows: TerminalLinkRowSnapshot[]) {
-  return {
+  let activeRows = rows;
+  const terminal = {
     cols: rows[0]?.cells.length ?? 0,
     buffer: {
-      active: {
-        get length() {
-          return rows.length;
-        },
-        getLine(index: number) {
-          const source = rows[index];
-          if (!source) return undefined;
-          return {
-            isWrapped: source.isWrapped,
-            length: source.cells.length,
-            getCell(column: number) {
-              const cell = source.cells[column];
-              if (!cell) return undefined;
-              return {
-                getChars: () => cell.chars,
-                getWidth: () => cell.width,
-              };
-            },
-          };
-        },
+      get active() {
+        return {
+          get length() {
+            return activeRows.length;
+          },
+          getLine(index: number) {
+            const source = activeRows[index];
+            if (!source) return undefined;
+            return {
+              isWrapped: source.isWrapped,
+              length: source.cells.length,
+              getCell(column: number) {
+                const cell = source.cells[column];
+                if (!cell) return undefined;
+                return {
+                  getChars: () => cell.chars,
+                  getWidth: () => cell.width,
+                };
+              },
+            };
+          },
+        };
       },
     },
+    setActiveRows(nextRows: TerminalLinkRowSnapshot[]) {
+      activeRows = nextRows;
+      terminal.cols = nextRows[0]?.cells.length ?? terminal.cols;
+    },
   };
+  return terminal;
 }
 
 function provide(provider: ILinkProvider, oneBasedRow: number): ILink[] {
@@ -105,6 +113,42 @@ describe("terminal link security", () => {
 });
 
 describe("terminal link reconstruction", () => {
+  it.each([
+    ["https://example.test/pathlong", "continuation"],
+    ["https://example.test/?token=abc", "def"],
+  ])(
+    "never exposes a direct truncated fragment at an ambiguous alphanumeric hard boundary",
+    (prefix, continuation) => {
+      const cols = Math.max(prefix.length, continuation.length);
+      const rows = [row(0, prefix, cols), row(1, continuation, cols)];
+      const target = `${prefix}${continuation}`;
+      const confirm = vi.fn(() => true);
+      const open = vi.fn(() => true);
+      const provider = createTerminalLinkProvider(terminalBuffer(rows), {
+        confirm,
+        open,
+      });
+
+      for (const requestedRow of [1, 2]) {
+        const link = provide(provider, requestedRow)[0];
+        expect(link).toMatchObject({
+          text: target,
+          range: {
+            start: { y: requestedRow },
+            end: { y: requestedRow },
+          },
+        });
+        link.activate(new MouseEvent("click"), link.text);
+      }
+
+      expect(confirm).toHaveBeenCalledTimes(2);
+      expect(confirm).toHaveBeenNthCalledWith(1, target);
+      expect(confirm).toHaveBeenNthCalledWith(2, target);
+      expect(open).toHaveBeenNthCalledWith(1, target);
+      expect(open).toHaveBeenNthCalledWith(2, target);
+    },
+  );
+
   it("reconstructs a plain URL across hard terminal edges from either row", () => {
     const url = "https://example.test/a-long/path?value=one";
     const rows = rowsForUrl(url, 21);
@@ -114,9 +158,16 @@ describe("terminal link reconstruction", () => {
 
     expect(firstRowLinks).toHaveLength(1);
     expect(firstRowLinks[0]).toMatchObject({ text: url, requiresConfirmation: true });
-    expect(secondRowLinks).toEqual(firstRowLinks);
+    expect(secondRowLinks[0]).toMatchObject({
+      text: url,
+      requiresConfirmation: true,
+    });
     expect(firstRowLinks[0].range).toEqual({
       start: { x: 1, y: 1 },
+      end: { x: 21, y: 1 },
+    });
+    expect(secondRowLinks[0].range).toEqual({
+      start: { x: 1, y: 2 },
       end: { x: 21, y: 2 },
     });
   });
@@ -130,7 +181,7 @@ describe("terminal link reconstruction", () => {
         text: url,
         requiresConfirmation: false,
         range: {
-          start: { x: 1, y: 1 },
+          start: { x: 1, y: 2 },
           end: { x: 12, y: 2 },
         },
       },
@@ -150,7 +201,7 @@ describe("terminal link reconstruction", () => {
         text: url,
         requiresConfirmation: true,
         range: {
-          start: { x: 3, y: 1 },
+          start: { x: 3, y: 2 },
           end: { x: 14, y: 2 },
         },
       },
@@ -171,6 +222,51 @@ describe("terminal link reconstruction", () => {
     expect(links[0]).toMatchObject({ text: url, requiresConfirmation: true });
     expect(links[0].range).toEqual({
       start: { x: 3, y: 1 },
+      end: { x: 24, y: 1 },
+    });
+  });
+
+  it("returns only the visible URL cells as the hit range on each indented row", () => {
+    const url = "https://example.test/indented/path";
+    const cols = 24;
+    const contentCols = cols - 2;
+    const rows = rowsForUrl(url, contentCols).map((item) =>
+      row(item.index, `  ${item.cells.map((cell) => cell.chars).join("")}`, cols),
+    );
+    const provider = createTerminalLinkProvider(terminalBuffer(rows), {
+      confirm: () => true,
+      open: () => true,
+    });
+
+    expect(provide(provider, 1)[0].range).toEqual({
+      start: { x: 3, y: 1 },
+      end: { x: 24, y: 1 },
+    });
+    expect(provide(provider, 2)[0].range).toEqual({
+      start: { x: 3, y: 2 },
+      end: { x: 14, y: 2 },
+    });
+  });
+
+  it("excludes bordered panel gutters from every row-local hit range", () => {
+    const url = "https://example.test/panel/a-long-path";
+    const cols = 26;
+    const contentCols = cols - 4;
+    const rows = rowsForUrl(url, contentCols).map((item) => {
+      const content = item.cells.map((cell) => cell.chars || " ").join("");
+      return row(item.index, `│ ${content} │`, cols);
+    });
+    const provider = createTerminalLinkProvider(terminalBuffer(rows), {
+      confirm: () => true,
+      open: () => true,
+    });
+
+    expect(provide(provider, 1)[0].range).toEqual({
+      start: { x: 3, y: 1 },
+      end: { x: 24, y: 1 },
+    });
+    expect(provide(provider, 2)[0].range).toEqual({
+      start: { x: 3, y: 2 },
       end: { x: 18, y: 2 },
     });
   });
@@ -191,27 +287,99 @@ describe("terminal link reconstruction", () => {
         text: url,
         requiresConfirmation: true,
         range: {
-          start: { x: 6, y: 1 },
+          start: { x: 6, y: 2 },
           end: { x: 21, y: 2 },
         },
       },
     ]);
   });
 
-  it("does not append an unrelated next-row word to a complete last-cell URL", () => {
+  it("does not expose a complete last-cell URL as direct when the next row is ambiguous", () => {
     const url = "https://example.test/a";
     const cols = url.length;
     const rows = [row(0, url, cols), row(1, "unrelated status", cols)];
+    const inferred = `${url}unrelated`;
 
     expect(computeTerminalLinks(rows, 0)).toEqual([
       {
-        text: url,
-        requiresConfirmation: false,
+        text: inferred,
+        requiresConfirmation: true,
         range: {
           start: { x: 1, y: 1 },
           end: { x: cols, y: 1 },
         },
       },
+    ]);
+    expect(computeTerminalLinks(rows, 1)).toEqual([
+      {
+        text: inferred,
+        requiresConfirmation: true,
+        range: {
+          start: { x: 1, y: 2 },
+          end: { x: "unrelated".length, y: 2 },
+        },
+      },
+    ]);
+  });
+
+  it("treats a fresh HTTP scheme on the next row as a separate URL", () => {
+    const first = "https://first.test/path";
+    const second = "https://second.test/other";
+    const cols = Math.max(first.length, second.length);
+    const rows = [row(0, first.padEnd(cols, "x"), cols), row(1, second, cols)];
+    const firstTarget = first.padEnd(cols, "x");
+
+    expect(computeTerminalLinks(rows, 0).map((link) => link.text)).toEqual([
+      firstTarget,
+    ]);
+    expect(computeTerminalLinks(rows, 1).map((link) => link.text)).toEqual([
+      second,
+    ]);
+  });
+
+  it.each([
+    "- item",
+    "* item",
+    "# prompt",
+    "• bullet",
+    "◦ bullet",
+    "‣ bullet",
+  ])("does not cross into a leading prompt or bullet row: %s", (nextText) => {
+    const first = "https://example.test/path";
+    const cols = first.length;
+    const rows = [row(0, first, cols), row(1, nextText, cols)];
+
+    expect(computeTerminalLinks(rows, 0).map((link) => link.text)).toEqual([
+      first,
+    ]);
+    expect(computeTerminalLinks(rows, 1)).toEqual([]);
+  });
+
+  it("does not cross a blank hard row", () => {
+    const first = "https://example.test/path";
+    const cols = first.length;
+    const rows = [row(0, first, cols), row(1, "", cols)];
+
+    expect(computeTerminalLinks(rows, 0).map((link) => link.text)).toEqual([
+      first,
+    ]);
+    expect(computeTerminalLinks(rows, 1)).toEqual([]);
+  });
+
+  it("requires the complete labeled gutter exterior to remain stable", () => {
+    const trusted = "https://trusted.test";
+    const evil = `@evil.test/${"x".repeat(trusted.length - "@evil.test/".length)}`;
+    const makeLabeledRow = (index: number, label: string, content: string) => {
+      const text = `${label} │ ${content} │ ${label}`;
+      return row(index, text, text.length);
+    };
+    const rows = [
+      makeLabeledRow(0, "A", trusted),
+      makeLabeledRow(1, "B", evil),
+    ];
+
+    expect(computeTerminalLinks(rows, 0).map((link) => link.text)).toEqual([
+      trusted,
     ]);
     expect(computeTerminalLinks(rows, 1)).toEqual([]);
   });
@@ -226,6 +394,34 @@ describe("terminal link reconstruction", () => {
       "https://example.test/a",
       "https://second.test/b",
     ]);
+  });
+
+  it("supports IPv6, credentials, ports, escapes, query/hash, and balanced parentheses", () => {
+    const targets = [
+      "https://[::1]",
+      "https://[::1]:8443/path",
+      "https://user:pass@example.test:8443/a%20b?q=x%2Fy#frag",
+      "https://example.test/wiki/Foo_(bar)",
+    ];
+    const text = `${targets[0]} ${targets[1]}, ${targets[2]} ${targets[3]}.`;
+
+    expect(
+      computeTerminalLinks([row(0, text, text.length + 4)], 0).map(
+        (link) => link.text,
+      ),
+    ).toEqual(targets);
+  });
+
+  it("trims unmatched sentence delimiters but keeps balanced URL delimiters", () => {
+    const balanced = "https://example.test/wiki/Foo_(bar)";
+    const ipv6 = "https://[::1]";
+    const text = `${balanced}). ${ipv6}].`;
+
+    expect(
+      computeTerminalLinks([row(0, text, text.length + 2)], 0).map(
+        (link) => link.text,
+      ),
+    ).toEqual([balanced, ipv6]);
   });
 
   it("maps wide and combining cells back to xterm ranges", () => {
@@ -249,7 +445,7 @@ describe("terminal link reconstruction", () => {
         text: "https://example.test/cafe\u0301nd",
         requiresConfirmation: false,
         range: {
-          start: { x: 4, y: 1 },
+          start: { x: 1, y: 2 },
           end: { x: 3, y: 2 },
         },
       },
@@ -281,7 +477,7 @@ describe("terminal link reconstruction", () => {
         text: "https://example.test/caf中x",
         requiresConfirmation: false,
         range: {
-          start: { x: 1, y: 1 },
+          start: { x: 1, y: 2 },
           end: { x: 3, y: 2 },
         },
       },
@@ -306,6 +502,43 @@ describe("terminal link reconstruction", () => {
 });
 
 describe("terminal link provider", () => {
+  it("expands structurally beyond seventeen rows when the complete target is under budget", () => {
+    const cols = 12;
+    const url = `https://example.test/${"a".repeat(240)}`;
+    const rows = rowsForUrl(url, cols);
+    expect(rows.length).toBeGreaterThan(17);
+    const provider = createTerminalLinkProvider(terminalBuffer(rows), {
+      confirm: () => true,
+      open: () => true,
+    });
+
+    for (const rowIndex of [0, Math.floor(rows.length / 2), rows.length - 1]) {
+      const link = provide(provider, rowIndex + 1)[0];
+      expect(link).toMatchObject({
+        text: url,
+        range: {
+          start: { y: rowIndex + 1 },
+          end: { y: rowIndex + 1 },
+        },
+      });
+    }
+  });
+
+  it("returns no navigable fragment when a structural group exceeds the cell budget", () => {
+    const cols = 12;
+    const url = `https://example.test/${"a".repeat(240)}`;
+    const rows = rowsForUrl(url, cols);
+    const provider = createTerminalLinkProvider(terminalBuffer(rows), {
+      cellBudget: cols * 6,
+      confirm: () => true,
+      open: () => true,
+    });
+
+    for (const rowIndex of [0, Math.floor(rows.length / 2), rows.length - 1]) {
+      expect(provide(provider, rowIndex + 1)).toEqual([]);
+    }
+  });
+
   it("owns the complete hard-row range and confirms its full target synchronously", () => {
     const url = "https://example.test/a-long/path?value=one";
     const terminal = terminalBuffer(rowsForUrl(url, 21));
@@ -316,7 +549,13 @@ describe("terminal link provider", () => {
     const firstRowLink = provide(provider, 1)[0];
     const secondRowLink = provide(provider, 2)[0];
     expect(firstRowLink.text).toBe(url);
-    expect(secondRowLink).toMatchObject({ text: url, range: firstRowLink.range });
+    expect(secondRowLink).toMatchObject({
+      text: url,
+      range: {
+        start: { y: 2 },
+        end: { y: 2 },
+      },
+    });
 
     firstRowLink.activate(new MouseEvent("click"), firstRowLink.text);
     expect(confirm).toHaveBeenCalledWith(url);
@@ -360,8 +599,44 @@ describe("terminal link provider", () => {
       text: secondUrl,
       range: {
         start: { x: 1, y: 1 },
-        end: { x: 14, y: 2 },
+        end: { x: 24, y: 1 },
       },
     });
+  });
+
+  it("does not activate a cached link after the same cells are repainted", () => {
+    const cols = 18;
+    const oldUrl = "https://old.test/a-long/path";
+    const rows = rowsForUrl(oldUrl, cols);
+    const terminal = terminalBuffer(rows);
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(terminal, { confirm, open });
+    const cachedLink = provide(provider, 1)[0];
+
+    rows.splice(
+      0,
+      rows.length,
+      ...rowsForUrl("https://new.test/a-long/path", cols),
+    );
+    cachedLink.activate(new MouseEvent("click"), cachedLink.text);
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("does not activate a cached normal-buffer link after switching buffers", () => {
+    const oldUrl = "https://normal.test/path";
+    const terminal = terminalBuffer([row(0, oldUrl, 32)]);
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(terminal, { confirm, open });
+    const cachedLink = provide(provider, 1)[0];
+
+    terminal.setActiveRows([row(0, "alternate screen", 32)]);
+    cachedLink.activate(new MouseEvent("click"), cachedLink.text);
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
   });
 });

--- a/src/components/terminal/terminal-links.test.ts
+++ b/src/components/terminal/terminal-links.test.ts
@@ -868,6 +868,84 @@ describe("terminal link provider", () => {
     expect(open).not.toHaveBeenCalled();
   });
 
+  it("bounds invalid nested-scheme work and fails closed", () => {
+    const cols = 200;
+    const rowCount = 82;
+    const repeatedInvalidScheme = "https://[";
+    const text = repeatedInvalidScheme
+      .repeat(Math.ceil((cols * rowCount) / repeatedInvalidScheme.length))
+      .slice(0, cols * rowCount);
+    const rows = rowsForUrl(text, cols, (index) => index > 0);
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const controller = terminalLinkController(terminalBuffer(rows), {
+      confirm,
+      open,
+    });
+    const NativeURL = globalThis.URL;
+    const nativeSlice = String.prototype.slice;
+    let parseAttempts = 0;
+    let slicedCodeUnits = 0;
+    const CountingURL = new Proxy(NativeURL, {
+      construct(target, argumentsList) {
+        parseAttempts++;
+        return Reflect.construct(target, argumentsList, target);
+      },
+    });
+    const slice = vi
+      .spyOn(String.prototype, "slice")
+      .mockImplementation(function (this: string, start, end) {
+        const result = nativeSlice.call(this, start, end);
+        slicedCodeUnits += result.length;
+        return result;
+      });
+    vi.stubGlobal("URL", CountingURL);
+
+    let links: ILink[];
+    const started = performance.now();
+    try {
+      links = provide(controller.linkProvider, 41);
+    } finally {
+      slice.mockRestore();
+      vi.stubGlobal("URL", NativeURL);
+    }
+    const elapsed = performance.now() - started;
+
+    // Candidate suffixes also drive trimming and range remapping, so bounding
+    // both parser attempts and copied suffix units catches the quadratic path
+    // without making correctness depend on host timing.
+    expect(parseAttempts).toBeLessThanOrEqual(32);
+    expect(slicedCodeUnits).toBeLessThanOrEqual(text.length * 64);
+    expect(elapsed).toBeLessThan(1_000);
+
+    expect(links.length).toBeGreaterThan(0);
+    for (const link of links) {
+      expect(link.decorations).toMatchObject({
+        pointerCursor: false,
+        underline: false,
+      });
+      link.activate(new MouseEvent("click"), link.text);
+    }
+    for (let x = 1; x <= cols; x++) {
+      expect(
+        links.filter(
+          (link) => link.range.start.x <= x && link.range.end.x >= x,
+        ),
+        `inert ownership at column ${x}`,
+      ).toHaveLength(1);
+    }
+
+    const requestedText = text.slice(40 * cols, 41 * cols);
+    const schemeStart = requestedText.indexOf("https://");
+    controller.hoverWebLink("https://", {
+      start: { x: schemeStart + 1, y: 41 },
+      end: { x: schemeStart + "https://".length, y: 41 },
+    });
+    expect(controller.activateWebLink("https://")).toBe(false);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
   it("expands structurally beyond seventeen rows when the complete target is under budget", () => {
     const cols = 12;
     const url = `https://example.test/${"a".repeat(240)}`;

--- a/src/components/terminal/terminal-links.test.ts
+++ b/src/components/terminal/terminal-links.test.ts
@@ -337,10 +337,51 @@ describe("terminal link reconstruction", () => {
     ]);
   });
 
+  it.each(["?next=", "?source=terminal&url="])(
+    "keeps a fresh scheme as a query value after %s",
+    (query) => {
+      const first = `https://redirect.test/${query}`;
+      const second = "https://dest.test/path";
+      const target = `${first}${second}`;
+      const cols = first.length;
+      const confirm = vi.fn(() => true);
+      const open = vi.fn(() => true);
+      const provider = createTerminalLinkProvider(
+        terminalBuffer([row(0, first, cols), row(1, second, cols)]),
+        { confirm, open },
+      );
+
+      for (const requestedRow of [1, 2]) {
+        const link = provide(provider, requestedRow)[0];
+        expect(link).toMatchObject({
+          text: target,
+          range: {
+            start: { y: requestedRow },
+            end: { y: requestedRow },
+          },
+        });
+        link.activate(new MouseEvent("click"), link.text);
+      }
+      expect(confirm).toHaveBeenCalledTimes(2);
+      expect(confirm).toHaveBeenNthCalledWith(1, target);
+      expect(confirm).toHaveBeenNthCalledWith(2, target);
+      expect(open).toHaveBeenNthCalledWith(1, target);
+      expect(open).toHaveBeenNthCalledWith(2, target);
+    },
+  );
+
   it.each([
     "- item",
     "* item",
     "# prompt",
+    "$ prompt",
+    "% prompt",
+    "+ item",
+    "1. item",
+    "2) item",
+    "a. item",
+    "B) item",
+    "user@host:~$ command",
     "• bullet",
     "◦ bullet",
     "‣ bullet",
@@ -396,6 +437,25 @@ describe("terminal link reconstruction", () => {
     ]);
   });
 
+  it.each([
+    "https://example.test/download;",
+    "https://example.test/?q=ready!",
+    "https://example.test/#frag?",
+  ])("preserves URL-valid final punctuation during activation: %s", (target) => {
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer([row(0, target, target.length + 4)]),
+      { confirm, open },
+    );
+
+    const link = provide(provider, 1)[0];
+    expect(link.text).toBe(target);
+    link.activate(new MouseEvent("click"), link.text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledWith(target);
+  });
+
   it("supports IPv6, credentials, ports, escapes, query/hash, and balanced parentheses", () => {
     const targets = [
       "https://[::1]",
@@ -422,6 +482,24 @@ describe("terminal link reconstruction", () => {
         (link) => link.text,
       ),
     ).toEqual([balanced, ipv6]);
+  });
+
+  it("trims a large unmatched delimiter suffix in a bounded number of passes", () => {
+    const target = "https://example.test/path";
+    const text = `${target}${")".repeat(1_024)}`;
+    const source = row(0, text, text.length);
+    const slice = vi.spyOn(String.prototype, "slice");
+
+    try {
+      expect(computeTerminalLinks([source], 0).map((link) => link.text)).toEqual([
+        target,
+      ]);
+      // Counting full-string slice passes demonstrates bounded trimming without
+      // relying on a machine-dependent wall-clock threshold.
+      expect(slice.mock.calls.length).toBeLessThan(16);
+    } finally {
+      slice.mockRestore();
+    }
   });
 
   it("maps wide and combining cells back to xterm ranges", () => {
@@ -524,19 +602,166 @@ describe("terminal link provider", () => {
     }
   });
 
-  it("returns no navigable fragment when a structural group exceeds the cell budget", () => {
+  it("guards a clipped local fragment instead of exposing it to lower providers", () => {
     const cols = 12;
     const url = `https://example.test/${"a".repeat(240)}`;
     const rows = rowsForUrl(url, cols);
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
     const provider = createTerminalLinkProvider(terminalBuffer(rows), {
       cellBudget: cols * 6,
-      confirm: () => true,
-      open: () => true,
+      confirm,
+      open,
     });
 
-    for (const rowIndex of [0, Math.floor(rows.length / 2), rows.length - 1]) {
-      expect(provide(provider, rowIndex + 1)).toEqual([]);
-    }
+    const guard = provide(provider, 1)[0];
+    expect(guard).toMatchObject({
+      text: url.slice(0, cols),
+      decorations: { pointerCursor: false, underline: false },
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: cols, y: 1 },
+      },
+    });
+    guard.activate(new MouseEvent("click"), guard.text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+
+    expect(provide(provider, Math.floor(rows.length / 2) + 1)).toEqual([]);
+    expect(provide(provider, rows.length)).toEqual([]);
+  });
+
+  it("guards a budget edge immediately before an early-wrapped wide glyph", () => {
+    const prefix = "https://example.test/caf";
+    const cols = prefix.length + 1;
+    const firstCells = [
+      ...cellsFromText(prefix, prefix.length),
+      { chars: "", width: 1 },
+    ];
+    const secondCells: TerminalLinkCellSnapshot[] = [
+      { chars: "中", width: 2 },
+      { chars: "", width: 0 },
+      ...cellsFromText("", cols - 2),
+    ];
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer([
+        { index: 0, isWrapped: false, cells: firstCells },
+        { index: 1, isWrapped: true, cells: secondCells },
+      ]),
+      { cellBudget: cols, confirm, open },
+    );
+
+    const guard = provide(provider, 1)[0];
+    expect(guard).toMatchObject({
+      text: prefix,
+      decorations: { pointerCursor: false, underline: false },
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: prefix.length, y: 1 },
+      },
+    });
+    guard.activate(new MouseEvent("click"), guard.text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("keeps an unrelated ordinary exact link navigable and unguarded", () => {
+    const target = "https://ordinary.test/path";
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer([row(0, target, 40)]),
+      { cellBudget: 40, confirm, open },
+    );
+
+    const link = provide(provider, 1)[0];
+    expect(link.text).toBe(target);
+    expect(link.decorations).toBeUndefined();
+    link.activate(new MouseEvent("click"), link.text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledWith(target);
+  });
+
+  it("does not guard an exact link unrelated to a clipped row edge", () => {
+    const target = "https://ordinary.test/x";
+    const cols = target.length + 12;
+    const first = `${target} ${"a".repeat(cols - target.length - 1)}`;
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer([
+        row(0, first, cols),
+        row(1, "possible continuation", cols),
+      ]),
+      { cellBudget: cols, confirm, open },
+    );
+
+    const link = provide(provider, 1)[0];
+    expect(link.text).toBe(target);
+    expect(link.decorations).toBeUndefined();
+    link.activate(new MouseEvent("click"), link.text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledWith(target);
+  });
+
+  it("guards a fresh-scheme row when its possible query context is clipped", () => {
+    const first = "https://redirect.test/?next=";
+    const second = "https://dest.test/path";
+    const cols = first.length;
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer([row(0, first, cols), row(1, second, cols)]),
+      { cellBudget: cols, confirm, open },
+    );
+
+    const guard = provide(provider, 2)[0];
+    expect(guard).toMatchObject({
+      text: second,
+      decorations: { pointerCursor: false, underline: false },
+      range: {
+        start: { x: 1, y: 2 },
+        end: { x: second.length, y: 2 },
+      },
+    });
+    guard.activate(new MouseEvent("click"), guard.text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("guards a row whose combined-cell content exceeds the code-unit budget", () => {
+    const target = "https://example.test/path";
+    const cells: TerminalLinkCellSnapshot[] = [
+      ...cellsFromText(target, target.length),
+      { chars: `x${"\u0301".repeat(256)}`, width: 1 },
+    ];
+    const cols = cells.length;
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer([{ index: 0, isWrapped: false, cells }]),
+      {
+        cellBudget: cols,
+        codeUnitBudget: target.length + 8,
+        confirm,
+        open,
+      },
+    );
+
+    const guard = provide(provider, 1)[0];
+    expect(guard).toMatchObject({
+      text: target,
+      decorations: { pointerCursor: false, underline: false },
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: cols, y: 1 },
+      },
+    });
+    guard.activate(new MouseEvent("click"), guard.text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
   });
 
   it("owns the complete hard-row range and confirms its full target synchronously", () => {

--- a/src/components/terminal/terminal-links.test.ts
+++ b/src/components/terminal/terminal-links.test.ts
@@ -663,6 +663,26 @@ describe("terminal link reconstruction", () => {
 });
 
 describe("WebLinks activation arbitration", () => {
+  it("rejects a stock URL prefix before a structurally rejected hard row", () => {
+    const prefix = "https://origin.test/prefix/";
+    const cols = prefix.length;
+    const source = terminalBuffer([
+      row(0, prefix, cols),
+      row(1, "https://dest.test/tail", cols),
+    ]);
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const controller = terminalLinkController(source, { confirm, open });
+    controller.hoverWebLink(prefix, {
+      start: { x: 1, y: 1 },
+      end: { x: cols, y: 1 },
+    });
+
+    expect(controller.activateWebLink(prefix)).toBe(false);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
   it("opens an ordinary exact current link only while its hover range matches", () => {
     const target = "https://ordinary.test/path";
     const source = terminalBuffer([row(0, target, target.length + 4)]);
@@ -783,6 +803,71 @@ describe("WebLinks activation arbitration", () => {
 });
 
 describe("terminal link provider", () => {
+  it.each([
+    {
+      boundary: "a fresh-scheme row",
+      rows: [
+        row(0, "https://origin.test/prefix/", 27),
+        row(1, "https://dest.test/tail", 27),
+      ],
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: 27, y: 1 },
+      },
+    },
+    {
+      boundary: "a changed labeled gutter",
+      rows: [
+        row(0, "A │ https://origin.test/prefix/ │ A", 35),
+        row(1, "B │ https://dest.test/tail/more │ B", 35),
+      ],
+      range: {
+        start: { x: 5, y: 1 },
+        end: { x: 31, y: 1 },
+      },
+    },
+  ])(
+    "guards an edge-ending URL prefix before $boundary",
+    ({ rows, range }) => {
+      const prefix = "https://origin.test/prefix/";
+      const confirm = vi.fn(() => true);
+      const open = vi.fn(() => true);
+      const provider = createTerminalLinkProvider(terminalBuffer(rows), {
+        confirm,
+        open,
+      });
+
+      const link = provide(provider, 1)[0];
+      expect(link).toMatchObject({ text: prefix, range });
+      link.activate(new MouseEvent("click"), link.text);
+
+      expect(confirm).not.toHaveBeenCalled();
+      expect(open).not.toHaveBeenCalled();
+      expect(link.decorations).toMatchObject({
+        pointerCursor: false,
+        underline: false,
+      });
+    },
+  );
+
+  it("revalidates a cached edge link when a fresh-scheme hard row appears", () => {
+    const prefix = "https://origin.test/prefix/";
+    const cols = prefix.length;
+    const rows = [row(0, prefix, cols)];
+    const terminal = terminalBuffer(rows);
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(terminal, { confirm, open });
+    const cachedLink = provide(provider, 1)[0];
+    expect(cachedLink.decorations).toBeUndefined();
+
+    rows.push(row(1, "https://dest.test/tail", cols));
+    cachedLink.activate(new MouseEvent("click"), cachedLink.text);
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
   it("expands structurally beyond seventeen rows when the complete target is under budget", () => {
     const cols = 12;
     const url = `https://example.test/${"a".repeat(240)}`;

--- a/src/components/terminal/terminal-links.test.ts
+++ b/src/components/terminal/terminal-links.test.ts
@@ -407,6 +407,28 @@ describe("terminal link reconstruction", () => {
     expect(open).toHaveBeenNthCalledWith(3, target);
   });
 
+  it("does not treat an ampersand in a URL path as nested-URL query state", () => {
+    const parts = [
+      "https://redirect.test/path",
+      "padding=123456789012&next=",
+      "https://dest.test/path",
+    ];
+    const cols = parts[0].length;
+    expect(parts[1]).toHaveLength(cols);
+    const outerPath = `${parts[0]}${parts[1]}`;
+    const rows = parts.map((part, index) => row(index, part, cols));
+
+    expect(computeTerminalLinks(rows, 0).map((link) => link.text)).toEqual([
+      outerPath,
+    ]);
+    expect(computeTerminalLinks(rows, 1).map((link) => link.text)).toEqual([
+      outerPath,
+    ]);
+    expect(computeTerminalLinks(rows, 2).map((link) => link.text)).toEqual([
+      parts[2],
+    ]);
+  });
+
   it.each([
     "- item",
     "* item",
@@ -941,6 +963,71 @@ describe("terminal link provider", () => {
       decorations: { pointerCursor: false, underline: false },
     });
     guard.activate(new MouseEvent("click"), guard.text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("guards a stock-valid URL prefix when the clipped raw token is not parseable", () => {
+    const text = "https://example.test[ rest";
+    const cols = text.length;
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer([row(0, text, cols)]),
+      { cellBudget: 21, confirm, open },
+    );
+
+    const links = provide(provider, 1);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({
+      text: "https://example.test[",
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: cols, y: 1 },
+      },
+      decorations: { pointerCursor: false, underline: false },
+    });
+
+    links[0].activate(new MouseEvent("click"), links[0].text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("returns non-overlapping guards when a cell budget ends after a width-2 lead", () => {
+    const prefix = "https://wide.test/";
+    const hidden = "https://hidden.test";
+    const cells: TerminalLinkCellSnapshot[] = [
+      ...cellsFromText(prefix, prefix.length),
+      { chars: "中", width: 2 },
+      { chars: "", width: 0 },
+      { chars: " ", width: 1 },
+      ...cellsFromText(hidden, hidden.length),
+    ];
+    const cols = cells.length;
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer([{ index: 0, isWrapped: false, cells }]),
+      { cellBudget: prefix.length + 1, confirm, open },
+    );
+
+    const guards = provide(provider, 1);
+    expect(guards.length).toBeGreaterThan(0);
+    for (let x = 1; x <= cols; x++) {
+      expect(
+        guards.filter(
+          (guard) => guard.range.start.x <= x && guard.range.end.x >= x,
+        ),
+        `custom guard ownership at column ${x}`,
+      ).toHaveLength(1);
+    }
+    for (const guard of guards) {
+      expect(guard.decorations).toMatchObject({
+        pointerCursor: false,
+        underline: false,
+      });
+      guard.activate(new MouseEvent("click"), guard.text);
+    }
     expect(confirm).not.toHaveBeenCalled();
     expect(open).not.toHaveBeenCalled();
   });

--- a/src/components/terminal/terminal-links.test.ts
+++ b/src/components/terminal/terminal-links.test.ts
@@ -946,6 +946,64 @@ describe("terminal link provider", () => {
     expect(open).not.toHaveBeenCalled();
   });
 
+  it("bounds growing hard-row assignment context and fails closed", () => {
+    const rowText = "https://[?next=";
+    const cols = rowText.length;
+    const rowCount = 1_000;
+    const inputCodeUnits = cols * rowCount;
+    const rows = Array.from({ length: rowCount }, (_, index) =>
+      row(index, rowText, cols),
+    );
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const controller = terminalLinkController(terminalBuffer(rows), {
+      confirm,
+      open,
+    });
+    const nativeLastIndexOf = String.prototype.lastIndexOf;
+    let scannedCodeUnits = 0;
+    const lastIndexOf = vi
+      .spyOn(String.prototype, "lastIndexOf")
+      .mockImplementation(function (this: string, searchString, position) {
+        if (
+          searchString === "?" ||
+          searchString === "&" ||
+          searchString === "#"
+        ) {
+          scannedCodeUnits += this.length;
+        }
+        return nativeLastIndexOf.call(this, searchString, position);
+      });
+
+    let reconstructedWork: number;
+    let providerWork: number;
+    let links: ILink[];
+    try {
+      expect(computeTerminalLinks(rows, 499)).toEqual([]);
+      reconstructedWork = scannedCodeUnits;
+      scannedCodeUnits = 0;
+      links = provide(controller.linkProvider, 500);
+      providerWork = scannedCodeUnits;
+    } finally {
+      lastIndexOf.mockRestore();
+    }
+
+    const maxLinearWork = inputCodeUnits * 32;
+    expect(reconstructedWork).toBeLessThanOrEqual(maxLinearWork);
+    expect(providerWork).toBeLessThanOrEqual(maxLinearWork);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({
+      range: {
+        start: { x: 1, y: 500 },
+        end: { x: cols, y: 500 },
+      },
+      decorations: { pointerCursor: false, underline: false },
+    });
+    links[0].activate(new MouseEvent("click"), links[0].text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
   it("expands structurally beyond seventeen rows when the complete target is under budget", () => {
     const cols = 12;
     const url = `https://example.test/${"a".repeat(240)}`;

--- a/src/components/terminal/terminal-links.test.ts
+++ b/src/components/terminal/terminal-links.test.ts
@@ -212,6 +212,57 @@ describe("terminal link reconstruction", () => {
     ]);
   });
 
+  it("bounds confirmation-boundary lookup across many soft-wrapped links", () => {
+    const nativeSome = Array.prototype.some;
+    let boundaryVisits = 0;
+    const some = vi
+      .spyOn(Array.prototype, "some")
+      .mockImplementation(function (this: unknown[], predicate, thisArg) {
+        const first = this[0] as
+          | { index?: unknown; kind?: unknown }
+          | undefined;
+        if (
+          typeof first?.index === "number" &&
+          (first.kind === "soft" || first.kind === "hard")
+        ) {
+          // Every boundary in this fixture is soft, so `some` visits the whole
+          // array. Counting its length avoids a machine-dependent timing test.
+          boundaryVisits += this.length;
+        }
+        return Reflect.apply(nativeSome, this, [predicate, thisArg]);
+      });
+    const scaling: Array<{ rowCount: number; visits: number }> = [];
+
+    try {
+      for (const rowCount of [250, 500, 1_000, 2_000]) {
+        const rowText = "https://a.co x";
+        const cols = rowText.length;
+        const rows = Array.from({ length: rowCount }, (_, index) =>
+          row(index, rowText, cols, index > 0),
+        );
+        boundaryVisits = 0;
+
+        expect(computeTerminalLinks(rows, rowCount - 1)).toEqual([
+          {
+            text: "https://a.co",
+            requiresConfirmation: false,
+            range: {
+              start: { x: 1, y: rowCount },
+              end: { x: 12, y: rowCount },
+            },
+          },
+        ]);
+        scaling.push({ rowCount, visits: boundaryVisits });
+      }
+    } finally {
+      some.mockRestore();
+    }
+
+    for (const { rowCount, visits } of scaling) {
+      expect(visits, `${rowCount} soft rows`).toBeLessThanOrEqual(rowCount * 2);
+    }
+  });
+
   it("follows matching indentation on cursor-positioned rows", () => {
     const url = "https://example.test/indented/path";
     const cols = 24;

--- a/src/components/terminal/terminal-links.test.ts
+++ b/src/components/terminal/terminal-links.test.ts
@@ -370,6 +370,43 @@ describe("terminal link reconstruction", () => {
     },
   );
 
+  it("carries a nested URL assignment across three hard rows", () => {
+    const parts = [
+      "https://redirect.test/a?",
+      "padding=1234567890&next=",
+      "https://dest.test/path",
+    ];
+    const cols = parts[0].length;
+    expect(parts[1]).toHaveLength(cols);
+    const target = parts.join("");
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer(parts.map((part, index) => row(index, part, cols))),
+      { confirm, open },
+    );
+
+    for (const requestedRow of [1, 2, 3]) {
+      const link = provide(provider, requestedRow)[0];
+      expect(link).toMatchObject({
+        text: target,
+        range: {
+          start: { y: requestedRow },
+          end: { y: requestedRow },
+        },
+      });
+      link.activate(new MouseEvent("click"), link.text);
+    }
+    expect(confirm).toHaveBeenCalledTimes(3);
+    expect(confirm).toHaveBeenNthCalledWith(1, target);
+    expect(confirm).toHaveBeenNthCalledWith(2, target);
+    expect(confirm).toHaveBeenNthCalledWith(3, target);
+    expect(open).toHaveBeenCalledTimes(3);
+    expect(open).toHaveBeenNthCalledWith(1, target);
+    expect(open).toHaveBeenNthCalledWith(2, target);
+    expect(open).toHaveBeenNthCalledWith(3, target);
+  });
+
   it.each([
     "- item",
     "* item",
@@ -382,6 +419,10 @@ describe("terminal link reconstruction", () => {
     "a. item",
     "B) item",
     "user@host:~$ command",
+    "PS C:\\> command",
+    "[root@host ~]# command",
+    "(venv) user@host:~$ command",
+    "(.venv) $ command",
     "• bullet",
     "◦ bullet",
     "‣ bullet",
@@ -731,6 +772,34 @@ describe("terminal link provider", () => {
     expect(open).not.toHaveBeenCalled();
   });
 
+  it("guards a nested scheme when the outer lexical context is clipped", () => {
+    const parts = [
+      "https://redirect.test/a?",
+      "padding=1234567890&next=",
+      "https://dest.test/path",
+    ];
+    const cols = parts[0].length;
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer(parts.map((part, index) => row(index, part, cols))),
+      { cellBudget: cols * 2, confirm, open },
+    );
+
+    const guard = provide(provider, 3)[0];
+    expect(guard).toMatchObject({
+      text: parts[2],
+      decorations: { pointerCursor: false, underline: false },
+      range: {
+        start: { x: 1, y: 3 },
+        end: { x: parts[2].length, y: 3 },
+      },
+    });
+    guard.activate(new MouseEvent("click"), guard.text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
   it("guards a row whose combined-cell content exceeds the code-unit budget", () => {
     const target = "https://example.test/path";
     const cells: TerminalLinkCellSnapshot[] = [
@@ -758,6 +827,118 @@ describe("terminal link provider", () => {
         start: { x: 1, y: 1 },
         end: { x: cols, y: 1 },
       },
+    });
+    guard.activate(new MouseEvent("click"), guard.text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("keeps a resolved exact link before a code-unit-clipped span navigable", () => {
+    const target = "https://safe.test/path";
+    const unresolved = [
+      { chars: `x${"\u0301".repeat(256)}`, width: 1 },
+      ...cellsFromText("https://hidden.test", 19),
+    ];
+    const cells: TerminalLinkCellSnapshot[] = [
+      ...cellsFromText(target, target.length),
+      { chars: " ", width: 1 },
+      ...unresolved,
+    ];
+    const cols = cells.length;
+    const firstUnresolvedX = target.length + 2;
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer([{ index: 0, isWrapped: false, cells }]),
+      {
+        cellBudget: cols,
+        codeUnitBudget: target.length + 1,
+        confirm,
+        open,
+      },
+    );
+
+    const links = provide(provider, 1);
+    const exact = links.find((link) => !link.decorations);
+    const guard = links.find((link) => link.decorations?.underline === false);
+    expect(exact).toMatchObject({
+      text: target,
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: target.length, y: 1 },
+      },
+    });
+    expect(guard).toMatchObject({
+      range: {
+        start: { x: firstUnresolvedX, y: 1 },
+        end: { x: cols, y: 1 },
+      },
+      decorations: { pointerCursor: false, underline: false },
+    });
+
+    exact!.activate(new MouseEvent("click"), exact!.text);
+    guard!.activate(new MouseEvent("click"), guard!.text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith(target);
+  });
+
+  it("keeps a resolved exact link before a cell-budget-clipped span navigable", () => {
+    const target = "https://safe.test/path";
+    const cols = target.length + 24;
+    const inspectedText = `${target} `;
+    const firstUnresolvedX = inspectedText.length + 1;
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer([
+        row(0, `${inspectedText}https://hidden.test`, cols),
+      ]),
+      {
+        cellBudget: inspectedText.length,
+        confirm,
+        open,
+      },
+    );
+
+    const links = provide(provider, 1);
+    const exact = links.find((link) => !link.decorations);
+    const guard = links.find((link) => link.decorations?.underline === false);
+    expect(exact?.text).toBe(target);
+    expect(guard).toMatchObject({
+      range: {
+        start: { x: firstUnresolvedX, y: 1 },
+        end: { x: cols, y: 1 },
+      },
+      decorations: { pointerCursor: false, underline: false },
+    });
+
+    exact!.activate(new MouseEvent("click"), exact!.text);
+    guard!.activate(new MouseEvent("click"), guard!.text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith(target);
+  });
+
+  it("guards a raw token that only moves off the clipped edge after trimming", () => {
+    const first = "https://example.";
+    const second = "com/path";
+    const cols = first.length;
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer([row(0, first, cols), row(1, second, cols)]),
+      { cellBudget: cols, confirm, open },
+    );
+
+    const guard = provide(provider, 1)[0];
+    expect(guard).toMatchObject({
+      text: "https://example",
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: cols, y: 1 },
+      },
+      decorations: { pointerCursor: false, underline: false },
     });
     guard.activate(new MouseEvent("click"), guard.text);
     expect(confirm).not.toHaveBeenCalled();
@@ -859,6 +1040,33 @@ describe("terminal link provider", () => {
     const cachedLink = provide(provider, 1)[0];
 
     terminal.setActiveRows([row(0, "alternate screen", 32)]);
+    cachedLink.activate(new MouseEvent("click"), cachedLink.text);
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("does not activate a cached exact link after it becomes a guard", () => {
+    const target = "https://cached.test/path";
+    const cols = target.length;
+    const rows = [row(0, target, cols)];
+    const terminal = terminalBuffer(rows);
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(terminal, {
+      cellBudget: cols,
+      confirm,
+      open,
+    });
+    const cachedLink = provide(provider, 1)[0];
+    expect(cachedLink.decorations).toBeUndefined();
+
+    rows.push(row(1, "possible continuation", cols));
+    expect(provide(provider, 1)[0]).toMatchObject({
+      text: target,
+      range: cachedLink.range,
+      decorations: { pointerCursor: false, underline: false },
+    });
     cachedLink.activate(new MouseEvent("click"), cachedLink.text);
 
     expect(confirm).not.toHaveBeenCalled();

--- a/src/components/terminal/terminal-links.test.ts
+++ b/src/components/terminal/terminal-links.test.ts
@@ -1,0 +1,367 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  computeTerminalLinks,
+  createHttpLinkOpener,
+  createTerminalLinkProvider,
+  parseHttpUrl,
+  type TerminalLinkCellSnapshot,
+  type TerminalLinkRowSnapshot,
+} from "./terminal-links";
+import type { ILink, ILinkProvider } from "@xterm/xterm";
+
+function cellsFromText(text: string, cols: number): TerminalLinkCellSnapshot[] {
+  const cells = Array.from(text, (chars) => ({ chars, width: 1 }));
+  while (cells.length < cols) cells.push({ chars: "", width: 1 });
+  return cells.slice(0, cols);
+}
+
+function row(
+  index: number,
+  text: string,
+  cols: number,
+  isWrapped = false,
+): TerminalLinkRowSnapshot {
+  return { index, isWrapped, cells: cellsFromText(text, cols) };
+}
+
+function rowsForUrl(
+  url: string,
+  cols: number,
+  isWrapped: (index: number) => boolean = () => false,
+): TerminalLinkRowSnapshot[] {
+  const result: TerminalLinkRowSnapshot[] = [];
+  for (let offset = 0; offset < url.length; offset += cols) {
+    const index = result.length;
+    result.push(row(index, url.slice(offset, offset + cols), cols, isWrapped(index)));
+  }
+  return result;
+}
+
+function terminalBuffer(rows: TerminalLinkRowSnapshot[]) {
+  return {
+    cols: rows[0]?.cells.length ?? 0,
+    buffer: {
+      active: {
+        get length() {
+          return rows.length;
+        },
+        getLine(index: number) {
+          const source = rows[index];
+          if (!source) return undefined;
+          return {
+            isWrapped: source.isWrapped,
+            length: source.cells.length,
+            getCell(column: number) {
+              const cell = source.cells[column];
+              if (!cell) return undefined;
+              return {
+                getChars: () => cell.chars,
+                getWidth: () => cell.width,
+              };
+            },
+          };
+        },
+      },
+    },
+  };
+}
+
+function provide(provider: ILinkProvider, oneBasedRow: number): ILink[] {
+  let result: ILink[] | undefined;
+  provider.provideLinks(oneBasedRow, (links) => {
+    result = links;
+  });
+  return result ?? [];
+}
+
+describe("terminal link security", () => {
+  it("accepts only absolute HTTP and HTTPS URLs", () => {
+    expect(parseHttpUrl("https://example.com/a?q=1")?.href).toBe(
+      "https://example.com/a?q=1",
+    );
+    expect(parseHttpUrl("HTTP://EXAMPLE.COM/path")?.protocol).toBe("http:");
+
+    expect(parseHttpUrl("javascript:alert(1)")).toBeNull();
+    expect(parseHttpUrl("file:///etc/passwd")).toBeNull();
+    expect(parseHttpUrl("//example.com/path")).toBeNull();
+    expect(parseHttpUrl("not a URL")).toBeNull();
+  });
+
+  it("opens parsed links in an isolated new browsing context", () => {
+    const openWindow = vi.fn(() => ({}) as Window);
+    const open = createHttpLinkOpener(openWindow);
+
+    expect(open("https://example.com/a b")).toBe(true);
+    expect(openWindow).toHaveBeenCalledWith(
+      "https://example.com/a%20b",
+      "_blank",
+      "noopener,noreferrer",
+    );
+
+    expect(open("data:text/html,bad")).toBe(false);
+    expect(openWindow).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("terminal link reconstruction", () => {
+  it("reconstructs a plain URL across hard terminal edges from either row", () => {
+    const url = "https://example.test/a-long/path?value=one";
+    const rows = rowsForUrl(url, 21);
+
+    const firstRowLinks = computeTerminalLinks(rows, 0);
+    const secondRowLinks = computeTerminalLinks(rows, 1);
+
+    expect(firstRowLinks).toHaveLength(1);
+    expect(firstRowLinks[0]).toMatchObject({ text: url, requiresConfirmation: true });
+    expect(secondRowLinks).toEqual(firstRowLinks);
+    expect(firstRowLinks[0].range).toEqual({
+      start: { x: 1, y: 1 },
+      end: { x: 21, y: 2 },
+    });
+  });
+
+  it("treats genuine xterm soft wraps as exact links that may open directly", () => {
+    const url = "https://example.test/a-long/path";
+    const rows = rowsForUrl(url, 20, (index) => index > 0);
+
+    expect(computeTerminalLinks(rows, 1)).toEqual([
+      {
+        text: url,
+        requiresConfirmation: false,
+        range: {
+          start: { x: 1, y: 1 },
+          end: { x: 12, y: 2 },
+        },
+      },
+    ]);
+  });
+
+  it("follows matching indentation on cursor-positioned rows", () => {
+    const url = "https://example.test/indented/path";
+    const cols = 24;
+    const contentCols = cols - 2;
+    const rows = rowsForUrl(url, contentCols).map((item) =>
+      row(item.index, `  ${item.cells.map((cell) => cell.chars).join("")}`, cols),
+    );
+
+    expect(computeTerminalLinks(rows, 1)).toEqual([
+      {
+        text: url,
+        requiresConfirmation: true,
+        range: {
+          start: { x: 3, y: 1 },
+          end: { x: 14, y: 2 },
+        },
+      },
+    ]);
+  });
+
+  it("uses stable bordered panel gutters as effective content edges", () => {
+    const url = "https://example.test/panel/a-long-path";
+    const cols = 26;
+    const contentCols = cols - 4;
+    const rows = rowsForUrl(url, contentCols).map((item) => {
+      const content = item.cells.map((cell) => cell.chars || " ").join("");
+      return row(item.index, `│ ${content} │`, cols);
+    });
+
+    const links = computeTerminalLinks(rows, 0);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({ text: url, requiresConfirmation: true });
+    expect(links[0].range).toEqual({
+      start: { x: 3, y: 1 },
+      end: { x: 18, y: 2 },
+    });
+  });
+
+  it("skips stable labeled gutters repeated outside panel delimiters", () => {
+    const url = "https://example.test/panel/a-long-path";
+    const prefix = "12 │ ";
+    const suffix = " │ 12";
+    const contentCols = 22;
+    const cols = prefix.length + contentCols + suffix.length;
+    const rows = rowsForUrl(url, contentCols).map((item) => {
+      const content = item.cells.map((cell) => cell.chars || " ").join("");
+      return row(item.index, `${prefix}${content}${suffix}`, cols);
+    });
+
+    expect(computeTerminalLinks(rows, 1)).toEqual([
+      {
+        text: url,
+        requiresConfirmation: true,
+        range: {
+          start: { x: 6, y: 1 },
+          end: { x: 21, y: 2 },
+        },
+      },
+    ]);
+  });
+
+  it("does not append an unrelated next-row word to a complete last-cell URL", () => {
+    const url = "https://example.test/a";
+    const cols = url.length;
+    const rows = [row(0, url, cols), row(1, "unrelated status", cols)];
+
+    expect(computeTerminalLinks(rows, 0)).toEqual([
+      {
+        text: url,
+        requiresConfirmation: false,
+        range: {
+          start: { x: 1, y: 1 },
+          end: { x: cols, y: 1 },
+        },
+      },
+    ]);
+    expect(computeTerminalLinks(rows, 1)).toEqual([]);
+  });
+
+  it("stops at spaces and trims sentence punctuation", () => {
+    const cols = 60;
+    const rows = [
+      row(0, "See https://example.test/a). Then https://second.test/b,", cols),
+    ];
+
+    expect(computeTerminalLinks(rows, 0).map((link) => link.text)).toEqual([
+      "https://example.test/a",
+      "https://second.test/b",
+    ]);
+  });
+
+  it("maps wide and combining cells back to xterm ranges", () => {
+    const cells: TerminalLinkCellSnapshot[] = [
+      { chars: "中", width: 2 },
+      { chars: "", width: 0 },
+      { chars: " ", width: 1 },
+      ...cellsFromText("https://example.test/caf", 24),
+    ];
+    const first = { index: 0, isWrapped: false, cells };
+    const secondCells = [
+      { chars: "e\u0301", width: 1 },
+      { chars: "n", width: 1 },
+      { chars: "d", width: 1 },
+      ...cellsFromText("", cells.length - 3),
+    ];
+    const second = { index: 1, isWrapped: true, cells: secondCells };
+
+    expect(computeTerminalLinks([first, second], 1)).toEqual([
+      {
+        text: "https://example.test/cafe\u0301nd",
+        requiresConfirmation: false,
+        range: {
+          start: { x: 4, y: 1 },
+          end: { x: 3, y: 2 },
+        },
+      },
+    ]);
+  });
+
+  it("skips xterm's phantom last cell before an early-wrapped wide glyph", () => {
+    const firstCells = [
+      ...cellsFromText("https://example.test/caf", 24),
+      { chars: "", width: 1 },
+    ];
+    const secondCells: TerminalLinkCellSnapshot[] = [
+      { chars: "中", width: 2 },
+      { chars: "", width: 0 },
+      { chars: "x", width: 1 },
+      ...cellsFromText("", 22),
+    ];
+
+    expect(
+      computeTerminalLinks(
+        [
+          { index: 0, isWrapped: false, cells: firstCells },
+          { index: 1, isWrapped: true, cells: secondCells },
+        ],
+        1,
+      ),
+    ).toEqual([
+      {
+        text: "https://example.test/caf中x",
+        requiresConfirmation: false,
+        range: {
+          start: { x: 1, y: 1 },
+          end: { x: 3, y: 2 },
+        },
+      },
+    ]);
+  });
+
+  it("returns multiple HTTP links and ignores unsafe protocols", () => {
+    const cols = 90;
+    const rows = [
+      row(
+        0,
+        "javascript:alert(1) https://one.test/a file:///tmp/x http://two.test/b",
+        cols,
+      ),
+    ];
+
+    expect(computeTerminalLinks(rows, 0).map((link) => link.text)).toEqual([
+      "https://one.test/a",
+      "http://two.test/b",
+    ]);
+  });
+});
+
+describe("terminal link provider", () => {
+  it("owns the complete hard-row range and confirms its full target synchronously", () => {
+    const url = "https://example.test/a-long/path?value=one";
+    const terminal = terminalBuffer(rowsForUrl(url, 21));
+    const confirm = vi.fn(() => false);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(terminal, { confirm, open });
+
+    const firstRowLink = provide(provider, 1)[0];
+    const secondRowLink = provide(provider, 2)[0];
+    expect(firstRowLink.text).toBe(url);
+    expect(secondRowLink).toMatchObject({ text: url, range: firstRowLink.range });
+
+    firstRowLink.activate(new MouseEvent("click"), firstRowLink.text);
+    expect(confirm).toHaveBeenCalledWith(url);
+    expect(open).not.toHaveBeenCalled();
+
+    confirm.mockReturnValue(true);
+    secondRowLink.activate(new MouseEvent("click"), secondRowLink.text);
+    expect(open).toHaveBeenCalledWith(url);
+  });
+
+  it("opens natural soft wraps directly without confirmation", () => {
+    const url = "https://example.test/a-long/path";
+    const terminal = terminalBuffer(rowsForUrl(url, 20, (index) => index > 0));
+    const confirm = vi.fn(() => false);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(terminal, { confirm, open });
+
+    const link = provide(provider, 2)[0];
+    link.activate(new MouseEvent("click"), link.text);
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledWith(url);
+  });
+
+  it("recomputes from current cells and dimensions after repaint and resize", () => {
+    const firstUrl = "https://first.test/a-long/path";
+    const secondUrl = "https://second.test/a-much-longer/path";
+    const rows = rowsForUrl(firstUrl, 18);
+    const terminal = terminalBuffer(rows);
+    const provider = createTerminalLinkProvider(terminal, {
+      confirm: () => true,
+      open: () => true,
+    });
+
+    expect(provide(provider, 1)[0].text).toBe(firstUrl);
+
+    rows.splice(0, rows.length, ...rowsForUrl(secondUrl, 24));
+    terminal.cols = 24;
+
+    expect(provide(provider, 1)[0]).toMatchObject({
+      text: secondUrl,
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: 14, y: 2 },
+      },
+    });
+  });
+});

--- a/src/components/terminal/terminal-links.test.ts
+++ b/src/components/terminal/terminal-links.test.ts
@@ -337,7 +337,7 @@ describe("terminal link reconstruction", () => {
     ]);
   });
 
-  it.each(["?next=", "?source=terminal&url="])(
+  it.each(["?next=", "?source=terminal&url=", "#next="])(
     "keeps a fresh scheme as a query value after %s",
     (query) => {
       const first = `https://redirect.test/${query}`;
@@ -991,6 +991,84 @@ describe("terminal link provider", () => {
     links[0].activate(new MouseEvent("click"), links[0].text);
     expect(confirm).not.toHaveBeenCalled();
     expect(open).not.toHaveBeenCalled();
+  });
+
+  it("unions nested and outer clipped guards before xterm can prune the outer range", () => {
+    const inspected = "https://example.test[!https://nested.test";
+    const text = `${inspected} rest`;
+    const cols = text.length;
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer([row(0, text, cols)]),
+      { cellBudget: inspected.length, confirm, open },
+    );
+
+    const links = provide(provider, 1);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({
+      text: inspected,
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: cols, y: 1 },
+      },
+      decorations: { pointerCursor: false, underline: false },
+    });
+    for (let x = 1; x <= cols; x++) {
+      expect(
+        links.filter(
+          (link) => link.range.start.x <= x && link.range.end.x >= x,
+        ),
+        `normalized custom ownership at column ${x}`,
+      ).toHaveLength(1);
+    }
+
+    links[0].activate(new MouseEvent("click"), links[0].text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("preserves a disjoint exact link before normalized clipped guards", () => {
+    const safe = "https://safe.test/path";
+    const inspected = "https://example.test[!https://nested.test";
+    const text = `${safe} ${inspected} rest`;
+    const cols = text.length;
+    const guardStart = safe.length + 2;
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const provider = createTerminalLinkProvider(
+      terminalBuffer([row(0, text, cols)]),
+      {
+        cellBudget: safe.length + 1 + inspected.length,
+        confirm,
+        open,
+      },
+    );
+
+    const links = provide(provider, 1);
+    expect(links).toHaveLength(2);
+    const exact = links.find((link) => !link.decorations);
+    const guard = links.find((link) => link.decorations?.underline === false);
+    expect(exact).toMatchObject({
+      text: safe,
+      range: {
+        start: { x: 1, y: 1 },
+        end: { x: safe.length, y: 1 },
+      },
+    });
+    expect(guard).toMatchObject({
+      range: {
+        start: { x: guardStart, y: 1 },
+        end: { x: cols, y: 1 },
+      },
+      decorations: { pointerCursor: false, underline: false },
+    });
+
+    exact!.activate(new MouseEvent("click"), exact!.text);
+    guard!.activate(new MouseEvent("click"), guard!.text);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith(safe);
   });
 
   it("returns non-overlapping guards when a cell budget ends after a width-2 lead", () => {

--- a/src/components/terminal/terminal-links.test.ts
+++ b/src/components/terminal/terminal-links.test.ts
@@ -39,7 +39,10 @@ function rowsForUrl(
   return result;
 }
 
-function terminalBuffer(rows: TerminalLinkRowSnapshot[]) {
+function terminalBuffer(
+  rows: TerminalLinkRowSnapshot[],
+  onCellRead: () => void = () => {},
+) {
   let activeRows = rows;
   const terminal = {
     cols: rows[0]?.cells.length ?? 0,
@@ -56,6 +59,7 @@ function terminalBuffer(rows: TerminalLinkRowSnapshot[]) {
               isWrapped: source.isWrapped,
               length: source.cells.length,
               getCell(column: number) {
+                onCellRead();
                 const cell = source.cells[column];
                 if (!cell) return undefined;
                 return {
@@ -663,6 +667,56 @@ describe("terminal link reconstruction", () => {
 });
 
 describe("WebLinks activation arbitration", () => {
+  it("bounds total work across a multi-row WebLinks activation", () => {
+    const cols = 20;
+    const invalidPrefixes = "https://[x".repeat(40);
+    const target = `https://valid.test/${"a".repeat(4_000)}`;
+    const token = `${invalidPrefixes}${target}`;
+    expect(invalidPrefixes).toHaveLength(400);
+    expect(target).toHaveLength(4_019);
+    expect(token).toHaveLength(4_419);
+
+    let cellReads = 0;
+    const source = terminalBuffer(
+      rowsForUrl(token, cols, (index) => index > 0),
+      () => cellReads++,
+    );
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const controller = terminalLinkController(source, { confirm, open });
+    controller.hoverWebLink(target, {
+      start: { x: 1, y: 21 },
+      end: { x: 19, y: 221 },
+    });
+
+    const NativeURL = globalThis.URL;
+    let parseAttempts = 0;
+    const CountingURL = new Proxy(NativeURL, {
+      construct(targetConstructor, argumentsList) {
+        parseAttempts++;
+        return Reflect.construct(
+          targetConstructor,
+          argumentsList,
+          targetConstructor,
+        );
+      },
+    });
+    vi.stubGlobal("URL", CountingURL);
+    let activated: boolean;
+    try {
+      activated = controller.activateWebLink(target);
+    } finally {
+      vi.stubGlobal("URL", NativeURL);
+    }
+
+    expect.soft(parseAttempts).toBeLessThanOrEqual(64);
+    expect.soft(cellReads).toBeLessThanOrEqual(16_384);
+    expect.soft(activated).toBe(true);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith(target);
+  });
+
   it("rejects a stock URL prefix before a structurally rejected hard row", () => {
     const prefix = "https://origin.test/prefix/";
     const cols = prefix.length;

--- a/src/components/terminal/terminal-links.test.ts
+++ b/src/components/terminal/terminal-links.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-
 import {
   computeTerminalLinks,
+  createTerminalLinkController,
   createHttpLinkOpener,
   createTerminalLinkProvider,
   parseHttpUrl,
   type TerminalLinkCellSnapshot,
+  type TerminalLinkCandidate,
   type TerminalLinkRowSnapshot,
 } from "./terminal-links";
 import type { ILink, ILinkProvider } from "@xterm/xterm";
@@ -73,6 +74,25 @@ function terminalBuffer(rows: TerminalLinkRowSnapshot[]) {
     },
   };
   return terminal;
+}
+
+interface TestTerminalLinkController {
+  readonly linkProvider: ILinkProvider;
+  hoverWebLink(text: string, range: TerminalLinkCandidate["range"]): void;
+  leaveWebLink(text: string): void;
+  activateWebLink(text: string): boolean;
+}
+
+function terminalLinkController(
+  source: ReturnType<typeof terminalBuffer>,
+  options: {
+    confirm?: (target: string) => boolean;
+    open?: (target: string) => unknown;
+    cellBudget?: number;
+    codeUnitBudget?: number;
+  } = {},
+): TestTerminalLinkController {
+  return createTerminalLinkController(source, options);
 }
 
 function provide(provider: ILinkProvider, oneBasedRow: number): ILink[] {
@@ -642,6 +662,126 @@ describe("terminal link reconstruction", () => {
   });
 });
 
+describe("WebLinks activation arbitration", () => {
+  it("opens an ordinary exact current link only while its hover range matches", () => {
+    const target = "https://ordinary.test/path";
+    const source = terminalBuffer([row(0, target, target.length + 4)]);
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const controller = terminalLinkController(source, { confirm, open });
+    const range = {
+      start: { x: 1, y: 1 },
+      end: { x: target.length, y: 1 },
+    };
+
+    expect(controller.activateWebLink(target)).toBe(false);
+    controller.hoverWebLink(target, range);
+    expect(controller.activateWebLink(target)).toBe(true);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledWith(target);
+
+    controller.leaveWebLink(target);
+    expect(controller.activateWebLink(target)).toBe(false);
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects both stock prefixes inside a fresh clipped guard component", () => {
+    const inspected = "https://example.test[!https://nested.test";
+    const text = `${inspected} rest`;
+    const source = terminalBuffer([row(0, text, text.length)]);
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const controller = terminalLinkController(source, {
+      cellBudget: text.length,
+      codeUnitBudget: inspected.length,
+      confirm,
+      open,
+    });
+
+    const outer = "https://example.test";
+    controller.hoverWebLink(outer, {
+      start: { x: 1, y: 1 },
+      end: { x: outer.length, y: 1 },
+    });
+    expect(controller.activateWebLink(outer)).toBe(false);
+
+    const nested = "https://nested.test";
+    controller.hoverWebLink(nested, {
+      start: { x: 23, y: 1 },
+      end: { x: 41, y: 1 },
+    });
+    expect(controller.activateWebLink(nested)).toBe(false);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("confirms and opens only the complete inferred hard-row target", () => {
+    const target = "https://example.test/a-long/path?value=one";
+    const cols = 21;
+    const source = terminalBuffer(rowsForUrl(target, cols));
+    const confirm = vi.fn(() => false);
+    const open = vi.fn(() => true);
+    const controller = terminalLinkController(source, { confirm, open });
+    const stockText = target.slice(0, cols);
+    controller.hoverWebLink(stockText, {
+      start: { x: 1, y: 1 },
+      end: { x: cols, y: 1 },
+    });
+
+    expect(controller.activateWebLink(stockText)).toBe(false);
+    expect(confirm).toHaveBeenCalledWith(target);
+    expect(open).not.toHaveBeenCalled();
+
+    confirm.mockReturnValue(true);
+    expect(controller.activateWebLink(stockText)).toBe(true);
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith(target);
+    expect(open).not.toHaveBeenCalledWith(stockText);
+  });
+
+  it("rechecks every row intersected by a multi-row hover range", () => {
+    const target = "https://example.test/a-long/path";
+    const cols = 20;
+    const rows = rowsForUrl(target, cols);
+    const source = terminalBuffer(rows);
+    const confirm = vi.fn(() => true);
+    const open = vi.fn(() => true);
+    const controller = terminalLinkController(source, { confirm, open });
+    const stockText = target.slice(0, cols);
+    controller.hoverWebLink(stockText, {
+      start: { x: 1, y: 1 },
+      end: { x: target.length - cols, y: 2 },
+    });
+
+    expect(controller.activateWebLink(stockText)).toBe(true);
+    expect(confirm).toHaveBeenCalledWith(target);
+    expect(open).toHaveBeenCalledWith(target);
+
+    source.setActiveRows([
+      rows[0],
+      row(1, "repainted second row", cols),
+    ]);
+    expect(controller.activateWebLink(stockText)).toBe(false);
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when the hovered exact range is repainted before activation", () => {
+    const target = "https://stale.test/path";
+    const rows = [row(0, target, target.length + 4)];
+    const source = terminalBuffer(rows);
+    const open = vi.fn(() => true);
+    const controller = terminalLinkController(source, { open });
+    controller.hoverWebLink(target, {
+      start: { x: 1, y: 1 },
+      end: { x: target.length, y: 1 },
+    });
+
+    rows.splice(0, 1, row(0, "repainted terminal output", target.length + 4));
+    expect(controller.activateWebLink(target)).toBe(false);
+    expect(open).not.toHaveBeenCalled();
+  });
+});
+
 describe("terminal link provider", () => {
   it("expands structurally beyond seventeen rows when the complete target is under budget", () => {
     const cols = 12;
@@ -1005,15 +1145,23 @@ describe("terminal link provider", () => {
     );
 
     const links = provide(provider, 1);
-    expect(links).toHaveLength(1);
-    expect(links[0]).toMatchObject({
-      text: inspected,
-      range: {
+    expect(links).toHaveLength(2);
+    expect(links.map((link) => link.range)).toEqual([
+      {
         start: { x: 1, y: 1 },
+        end: { x: 22, y: 1 },
+      },
+      {
+        start: { x: 23, y: 1 },
         end: { x: cols, y: 1 },
       },
-      decorations: { pointerCursor: false, underline: false },
-    });
+    ]);
+    for (const link of links) {
+      expect(link).toMatchObject({
+        text: inspected,
+        decorations: { pointerCursor: false, underline: false },
+      });
+    }
     for (let x = 1; x <= cols; x++) {
       expect(
         links.filter(
@@ -1023,7 +1171,9 @@ describe("terminal link provider", () => {
       ).toHaveLength(1);
     }
 
-    links[0].activate(new MouseEvent("click"), links[0].text);
+    for (const link of links) {
+      link.activate(new MouseEvent("click"), link.text);
+    }
     expect(confirm).not.toHaveBeenCalled();
     expect(open).not.toHaveBeenCalled();
   });
@@ -1046,9 +1196,11 @@ describe("terminal link provider", () => {
     );
 
     const links = provide(provider, 1);
-    expect(links).toHaveLength(2);
+    expect(links).toHaveLength(3);
     const exact = links.find((link) => !link.decorations);
-    const guard = links.find((link) => link.decorations?.underline === false);
+    const guards = links.filter(
+      (link) => link.decorations?.underline === false,
+    );
     expect(exact).toMatchObject({
       text: safe,
       range: {
@@ -1056,16 +1208,27 @@ describe("terminal link provider", () => {
         end: { x: safe.length, y: 1 },
       },
     });
-    expect(guard).toMatchObject({
-      range: {
+    expect(guards.map((guard) => guard.range)).toEqual([
+      {
         start: { x: guardStart, y: 1 },
+        end: { x: guardStart + 21, y: 1 },
+      },
+      {
+        start: { x: guardStart + 22, y: 1 },
         end: { x: cols, y: 1 },
       },
-      decorations: { pointerCursor: false, underline: false },
-    });
+    ]);
+    for (const guard of guards) {
+      expect(guard.decorations).toMatchObject({
+        pointerCursor: false,
+        underline: false,
+      });
+    }
 
     exact!.activate(new MouseEvent("click"), exact!.text);
-    guard!.activate(new MouseEvent("click"), guard!.text);
+    for (const guard of guards) {
+      guard.activate(new MouseEvent("click"), guard.text);
+    }
     expect(confirm).not.toHaveBeenCalled();
     expect(open).toHaveBeenCalledTimes(1);
     expect(open).toHaveBeenCalledWith(safe);

--- a/src/components/terminal/terminal-links.ts
+++ b/src/components/terminal/terminal-links.ts
@@ -81,11 +81,16 @@ interface FullTerminalLinkCandidate {
   requiresConfirmation: boolean;
 }
 
+interface ProviderTerminalLinkCandidate extends TerminalLinkCandidate {
+  readonly guard: boolean;
+}
+
 const BORDER_CHARS = new Set(["│", "┃", "║", "|"]);
 const URL_START = /https?:\/\//gi;
 const URL_STOP = /[\s"'{}|\\^<>`]/u;
-const SENTENCE_PUNCTUATION = new Set([".", ",", "!", "?", ";", ":"]);
-const HARD_CONTINUATION_START = /^(?:https?:\/\/|[-*#]\s|[•◦‣⁃∙·▪▫●○◆◇▶▸])/iu;
+const TRAILING_SENTENCE_PUNCTUATION = new Set([".", ","]);
+const FRESH_HTTP_SCHEME = /^https?:\/\//iu;
+const HARD_BOUNDARY_START = /^(?:[-*#$%+>]\s|(?:\d+|[a-z])[.)]\s|[\w.-]+@[\w.-]+:\S*[$#%]\s|[•◦‣⁃∙·▪▫●○◆◇▶▸])/iu;
 
 function isBlankCell(cell: TerminalLinkCellSnapshot | undefined): boolean {
   return !cell || cell.width === 0 || cell.chars === "" || /^\s+$/u.test(cell.chars);
@@ -214,6 +219,19 @@ function matchingHardLayout(
   );
 }
 
+function expectsUrlValue(text: string): boolean {
+  const schemeIndex = text.search(/https?:\/\//iu);
+  if (schemeIndex < 0 || !text.endsWith("=")) return false;
+  const token = text.slice(schemeIndex);
+  const delimiterIndex = Math.max(
+    token.lastIndexOf("?"),
+    token.lastIndexOf("&"),
+    token.lastIndexOf("#"),
+  );
+  const key = token.slice(delimiterIndex + 1, -1);
+  return delimiterIndex >= 0 && key.length > 0 && !key.includes("=");
+}
+
 function connectionBetween(
   previous: TerminalLinkRowSnapshot,
   next: TerminalLinkRowSnapshot,
@@ -240,10 +258,13 @@ function connectionBetween(
   if (!matchingHardLayout(previousBounds, nextBounds)) return null;
   if (lastContentEnd(previous, previousBounds.end) !== previousBounds.end) return null;
   if (firstContentColumn(next, nextBounds.start) !== nextBounds.start) return null;
+  const nextText = cellsText(next, nextBounds.start, nextBounds.end);
+  if (HARD_BOUNDARY_START.test(nextText)) {
+    return null;
+  }
   if (
-    HARD_CONTINUATION_START.test(
-      cellsText(next, nextBounds.start, nextBounds.end),
-    )
+    FRESH_HTTP_SCHEME.test(nextText) &&
+    !expectsUrlValue(cellsText(previous, previousBounds.start, previousBounds.end))
   ) {
     return null;
   }
@@ -310,27 +331,47 @@ function assembleGroups(rows: readonly TerminalLinkRowSnapshot[]): AssembledGrou
 }
 
 function trimUrlToken(token: string): string {
-  let end = token.length;
-  let changed = true;
-  while (changed && end > 0) {
-    changed = false;
-    while (end > 0 && SENTENCE_PUNCTUATION.has(token[end - 1])) {
-      end--;
-      changed = true;
+  const closingBalance: Record<string, number> = {
+    ")": 0,
+    "]": 0,
+    "}": 0,
+  };
+  for (let index = 0; index < token.length; index++) {
+    switch (token[index]) {
+      case "(":
+        closingBalance[")"]++;
+        break;
+      case ")":
+        closingBalance[")"]--;
+        break;
+      case "[":
+        closingBalance["]"]++;
+        break;
+      case "]":
+        closingBalance["]"]--;
+        break;
+      case "{":
+        closingBalance["}"]++;
+        break;
+      case "}":
+        closingBalance["}"]--;
+        break;
     }
+  }
 
+  let end = token.length;
+  while (end > 0) {
     const last = token[end - 1];
-    const pairs: Record<string, string> = { ")": "(", "]": "[", "}": "{" };
-    const open = pairs[last];
-    if (open) {
-      const value = token.slice(0, end);
-      const opens = Array.from(value).filter((char) => char === open).length;
-      const closes = Array.from(value).filter((char) => char === last).length;
-      if (closes > opens) {
-        end--;
-        changed = true;
-      }
+    if (TRAILING_SENTENCE_PUNCTUATION.has(last)) {
+      end--;
+      continue;
     }
+    if (closingBalance[last] < 0) {
+      closingBalance[last]++;
+      end--;
+      continue;
+    }
+    break;
   }
   return token.slice(0, end);
 }
@@ -395,6 +436,31 @@ function linksInGroup(group: AssembledGroup): FullTerminalLinkCandidate[] {
   return result;
 }
 
+interface RequestedLinkSegment {
+  link: FullTerminalLinkCandidate;
+  range: TerminalLinkCandidate["range"];
+}
+
+function requestedLinkSegments(
+  rows: readonly TerminalLinkRowSnapshot[],
+  requestedRow: number,
+): RequestedLinkSegment[] {
+  const seen = new Set<string>();
+  return assembleGroups(rows)
+    .flatMap(linksInGroup)
+    .flatMap((link) =>
+      link.segments
+        .filter((range) => range.start.y === requestedRow + 1)
+        .map((range) => ({ link, range })),
+    )
+    .filter(({ link, range }) => {
+      const key = `${range.start.x}:${range.start.y}-${range.end.x}:${range.end.y}:${link.text}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
 /**
  * Compute terminal links from fresh buffer-like rows. The requested row is an
  * absolute zero-based buffer index; only links intersecting it are returned.
@@ -403,24 +469,11 @@ export function computeTerminalLinks(
   rows: readonly TerminalLinkRowSnapshot[],
   requestedRow: number,
 ): TerminalLinkCandidate[] {
-  const seen = new Set<string>();
-  return assembleGroups(rows)
-    .flatMap(linksInGroup)
-    .flatMap((link) =>
-      link.segments
-        .filter((range) => range.start.y === requestedRow + 1)
-        .map((range) => ({
-          text: link.text,
-          range,
-          requiresConfirmation: link.requiresConfirmation,
-        })),
-    )
-    .filter((link) => {
-      const key = `${link.range.start.x}:${link.range.start.y}-${link.range.end.x}:${link.range.end.y}:${link.text}`;
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    });
+  return requestedLinkSegments(rows, requestedRow).map(({ link, range }) => ({
+    text: link.text,
+    range,
+    requiresConfirmation: link.requiresConfirmation,
+  }));
 }
 
 interface TerminalLinkBufferCell {
@@ -453,9 +506,12 @@ export interface TerminalLinkProviderOptions {
   readonly open?: (target: string) => unknown;
   /** Maximum number of terminal cells inspected for one provider request. */
   readonly cellBudget?: number;
+  /** Maximum UTF-16 code units assembled for one provider request. */
+  readonly codeUnitBudget?: number;
 }
 
 const DEFAULT_LINK_SCAN_CELL_BUDGET = 16_384;
+const DEFAULT_LINK_SCAN_CODE_UNIT_BUDGET = 32_768;
 
 function defaultHardLinkConfirmation(target: string): boolean {
   return window.confirm(
@@ -463,27 +519,55 @@ function defaultHardLinkConfirmation(target: string): boolean {
   );
 }
 
+interface BufferRowSnapshot {
+  row: TerminalLinkRowSnapshot;
+  inspectedCodeUnits: number;
+  clipped: boolean;
+}
+
 function snapshotBufferRow(
   buffer: TerminalLinkBuffer,
   cols: number,
   index: number,
-): TerminalLinkRowSnapshot | null {
+  codeUnitBudget: number,
+): BufferRowSnapshot | null {
   const line = buffer.getLine(index);
   if (!line) return null;
   const cells: TerminalLinkCellSnapshot[] = [];
+  let inspectedCodeUnits = 0;
+  let clipped = false;
   for (let column = 0; column < cols; column++) {
+    if (clipped) {
+      cells.push({ chars: "", width: 1 });
+      continue;
+    }
     const cell = column < line.length ? line.getCell(column) : undefined;
+    const chars = cell?.getChars() ?? "";
+    const width = cell?.getWidth() ?? 1;
+    const codeUnits = width === 0 ? 0 : Math.max(1, chars.length);
+    if (inspectedCodeUnits + codeUnits > codeUnitBudget) {
+      clipped = true;
+      cells.push({ chars: "", width });
+      continue;
+    }
+    inspectedCodeUnits += codeUnits;
     cells.push({
-      chars: cell?.getChars() ?? "",
-      width: cell?.getWidth() ?? 1,
+      chars,
+      width,
     });
   }
-  return { index, isWrapped: line.isWrapped, cells };
+  return {
+    row: { index, isWrapped: line.isWrapped, cells },
+    inspectedCodeUnits,
+    clipped,
+  };
 }
 
 interface StructuralSnapshot {
   rows: TerminalLinkRowSnapshot[];
-  clipped: boolean;
+  clippedBefore: boolean;
+  clippedAfter: boolean;
+  guardWholeRequestedRow: boolean;
 }
 
 function couldContinueBefore(row: TerminalLinkRowSnapshot): boolean {
@@ -491,14 +575,20 @@ function couldContinueBefore(row: TerminalLinkRowSnapshot): boolean {
   if (row.isWrapped) return true;
   const bounds = contentBounds(row);
   if (firstContentColumn(row, bounds.start) !== bounds.start) return false;
-  return !HARD_CONTINUATION_START.test(
-    cellsText(row, bounds.start, bounds.end),
-  );
+  const text = cellsText(row, bounds.start, bounds.end);
+  // A fresh scheme is usually a boundary, but it can also be the value of a
+  // query parameter on the uninspected previous row. Resolve that context or
+  // conservatively guard it instead of exposing the nested URL as exact.
+  return !HARD_BOUNDARY_START.test(text);
 }
 
 function couldContinueAfter(row: TerminalLinkRowSnapshot): boolean {
   const bounds = contentBounds(row);
-  return lastContentEnd(row, bounds.end) === bounds.end;
+  const contentEnd = lastContentEnd(row, bounds.end);
+  return (
+    contentEnd === bounds.end ||
+    (contentEnd === bounds.end - 1 && isBlankCell(row.cells[bounds.end - 1]))
+  );
 }
 
 /**
@@ -512,30 +602,60 @@ function collectStructuralSnapshot(
   source: TerminalLinkSource,
   requestedRow: number,
   cellBudget: number,
+  codeUnitBudget: number,
 ): StructuralSnapshot {
   const buffer = source.buffer.active;
   const cols = source.cols;
   if (
     requestedRow < 0 ||
     requestedRow >= buffer.length ||
-    cols <= 0 ||
-    cellBudget < cols
+    cols <= 0
   ) {
-    return { rows: [], clipped: false };
+    return {
+      rows: [],
+      clippedBefore: false,
+      clippedAfter: false,
+      guardWholeRequestedRow: false,
+    };
+  }
+  if (cellBudget < cols) {
+    return {
+      rows: [],
+      clippedBefore: true,
+      clippedAfter: true,
+      guardWholeRequestedRow: true,
+    };
   }
 
-  const initial = snapshotBufferRow(buffer, cols, requestedRow);
-  if (!initial) return { rows: [], clipped: false };
+  const initial = snapshotBufferRow(buffer, cols, requestedRow, codeUnitBudget);
+  if (!initial) {
+    return {
+      rows: [],
+      clippedBefore: false,
+      clippedAfter: false,
+      guardWholeRequestedRow: false,
+    };
+  }
+  if (initial.clipped) {
+    return {
+      rows: [initial.row],
+      clippedBefore: true,
+      clippedAfter: true,
+      guardWholeRequestedRow: true,
+    };
+  }
 
   const rows = new Map<number, TerminalLinkRowSnapshot>([
-    [requestedRow, initial],
+    [requestedRow, initial.row],
   ]);
   let inspectedCells = cols;
+  let inspectedCodeUnits = initial.inspectedCodeUnits;
   let top = requestedRow;
   let bottom = requestedRow;
   let topOpen = top > 0;
   let bottomOpen = bottom < buffer.length - 1;
-  let clipped = false;
+  let clippedBefore = false;
+  let clippedAfter = false;
   let expandTopNext = true;
 
   while (topOpen || bottomOpen) {
@@ -549,14 +669,36 @@ function collectStructuralSnapshot(
       const couldContinue = expandTop
         ? couldContinueBefore(edge)
         : couldContinueAfter(edge);
-      if (couldContinue) clipped = true;
+      if (couldContinue) {
+        if (expandTop) clippedBefore = true;
+        else clippedAfter = true;
+      }
       if (expandTop) topOpen = false;
       else bottomOpen = false;
       continue;
     }
 
-    const adjacent = snapshotBufferRow(buffer, cols, adjacentIndex);
+    const adjacentSnapshot = snapshotBufferRow(
+      buffer,
+      cols,
+      adjacentIndex,
+      codeUnitBudget - inspectedCodeUnits,
+    );
     inspectedCells += cols;
+    inspectedCodeUnits += adjacentSnapshot?.inspectedCodeUnits ?? 0;
+    if (adjacentSnapshot?.clipped) {
+      const couldContinue = expandTop
+        ? couldContinueBefore(edge)
+        : couldContinueAfter(edge);
+      if (couldContinue) {
+        if (expandTop) clippedBefore = true;
+        else clippedAfter = true;
+      }
+      if (expandTop) topOpen = false;
+      else bottomOpen = false;
+      continue;
+    }
+    const adjacent = adjacentSnapshot?.row;
     const connection = adjacent
       ? expandTop
         ? connectionBetween(adjacent, edge)
@@ -580,18 +722,98 @@ function collectStructuralSnapshot(
 
   return {
     rows: [...rows.values()].sort((a, b) => a.index - b.index),
-    clipped,
+    clippedBefore,
+    clippedAfter,
+    guardWholeRequestedRow: false,
   };
+}
+
+function linkTouchesClippedEdge(
+  link: FullTerminalLinkCandidate,
+  snapshot: StructuralSnapshot,
+): boolean {
+  const top = snapshot.rows[0];
+  const bottom = snapshot.rows[snapshot.rows.length - 1];
+  if (snapshot.clippedBefore && top) {
+    const bounds = contentBounds(top);
+    const contentStart = firstContentColumn(top, bounds.start) + 1;
+    if (
+      link.segments.some(
+        (range) => range.start.y === top.index + 1 && range.start.x === contentStart,
+      )
+    ) {
+      return true;
+    }
+  }
+  if (snapshot.clippedAfter && bottom) {
+    const bounds = contentBounds(bottom);
+    const contentEnd = lastContentEnd(bottom, bounds.end);
+    if (
+      link.segments.some(
+        (range) => range.end.y === bottom.index + 1 && range.end.x === contentEnd,
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function computeCurrentTerminalLinks(
   source: TerminalLinkSource,
   requestedRow: number,
   cellBudget: number,
-): TerminalLinkCandidate[] {
-  const snapshot = collectStructuralSnapshot(source, requestedRow, cellBudget);
-  if (snapshot.clipped) return [];
-  return computeTerminalLinks(snapshot.rows, requestedRow);
+  codeUnitBudget: number,
+): ProviderTerminalLinkCandidate[] {
+  const snapshot = collectStructuralSnapshot(
+    source,
+    requestedRow,
+    cellBudget,
+    codeUnitBudget,
+  );
+  if (
+    snapshot.guardWholeRequestedRow ||
+    snapshot.clippedBefore ||
+    snapshot.clippedAfter
+  ) {
+    const requested = snapshot.rows.find((row) => row.index === requestedRow);
+    const localCandidates = requested
+      ? computeTerminalLinks([requested], requestedRow)
+      : [];
+    if (snapshot.guardWholeRequestedRow) {
+      return [
+        {
+          text: localCandidates[0]?.text ?? "",
+          range: {
+            start: { x: 1, y: requestedRow + 1 },
+            end: { x: source.cols, y: requestedRow + 1 },
+          },
+          requiresConfirmation: false,
+          guard: true,
+        },
+      ];
+    }
+    return requestedLinkSegments(snapshot.rows, requestedRow).map(
+      ({ link, range }) => {
+        const guard = linkTouchesClippedEdge(link, snapshot);
+        const localText = localCandidates.find(
+          (candidate) =>
+            candidate.range.start.x === range.start.x &&
+            candidate.range.end.x === range.end.x,
+        )?.text;
+        return {
+          text: guard ? (localText ?? link.text) : link.text,
+          range,
+          requiresConfirmation: link.requiresConfirmation,
+          guard,
+        };
+      },
+    );
+  }
+  return computeTerminalLinks(snapshot.rows, requestedRow).map((candidate) => ({
+    ...candidate,
+    guard: false,
+  }));
 }
 
 function linkIdentity(link: TerminalLinkCandidate): string {
@@ -615,10 +837,15 @@ export function createTerminalLinkProvider(
 ): ILinkProvider {
   const confirm = options.confirm ?? defaultHardLinkConfirmation;
   const open = options.open ?? createHttpLinkOpener();
-  const cellBudget = Math.max(
-    1,
-    options.cellBudget ?? DEFAULT_LINK_SCAN_CELL_BUDGET,
-  );
+  const requestedCellBudget = options.cellBudget ?? DEFAULT_LINK_SCAN_CELL_BUDGET;
+  const cellBudget = Number.isFinite(requestedCellBudget)
+    ? Math.max(1, Math.floor(requestedCellBudget))
+    : DEFAULT_LINK_SCAN_CELL_BUDGET;
+  const requestedCodeUnitBudget =
+    options.codeUnitBudget ?? DEFAULT_LINK_SCAN_CODE_UNIT_BUDGET;
+  const codeUnitBudget = Number.isFinite(requestedCodeUnitBudget)
+    ? Math.max(1, Math.floor(requestedCodeUnitBudget))
+    : DEFAULT_LINK_SCAN_CODE_UNIT_BUDGET;
 
   return {
     provideLinks(bufferLineNumber, callback) {
@@ -627,8 +854,17 @@ export function createTerminalLinkProvider(
         source,
         requestedRow,
         cellBudget,
+        codeUnitBudget,
       );
       const links = candidates.map((candidate) => {
+        if (candidate.guard) {
+          return {
+            text: candidate.text,
+            range: candidate.range,
+            decorations: { pointerCursor: false, underline: false },
+            activate: () => {},
+          };
+        }
         const identity = linkIdentity(candidate);
         return {
           text: candidate.text,
@@ -638,6 +874,7 @@ export function createTerminalLinkProvider(
               source,
               requestedRow,
               cellBudget,
+              codeUnitBudget,
             ).find((link) => linkIdentity(link) === identity);
             if (!current) return;
             if (current.requiresConfirmation && !confirm(current.text)) return;

--- a/src/components/terminal/terminal-links.ts
+++ b/src/components/terminal/terminal-links.ts
@@ -1296,12 +1296,18 @@ function exhaustedLinkScanGuard(
   );
 }
 
-function computeCurrentTerminalLinks(
+interface CurrentTerminalLinkAnalysis {
+  snapshot: StructuralSnapshot;
+  work: TerminalLinkScanWork;
+  analysis: TerminalLinkAnalysis;
+}
+
+function analyzeCurrentTerminalLinks(
   source: TerminalLinkSource,
   requestedRow: number,
   cellBudget: number,
   codeUnitBudget: number,
-): ProviderTerminalLinkCandidate[] {
+): CurrentTerminalLinkAnalysis {
   const work = linkScanWork(codeUnitBudget);
   const snapshot = collectStructuralSnapshot(
     source,
@@ -1311,9 +1317,22 @@ function computeCurrentTerminalLinks(
     work,
   );
   if (work.exhausted) {
-    return exhaustedLinkScanGuard(source, requestedRow);
+    return {
+      snapshot,
+      work,
+      analysis: { links: [], lexical: [], exhausted: true },
+    };
   }
   const analysis = analyzeTerminalLinks(snapshot.rows, work);
+  return { snapshot, work, analysis };
+}
+
+function currentTerminalLinksForRow(
+  source: TerminalLinkSource,
+  requestedRow: number,
+  current: CurrentTerminalLinkAnalysis,
+): ProviderTerminalLinkCandidate[] {
+  const { snapshot, work, analysis } = current;
   if (analysis.exhausted) {
     return exhaustedLinkScanGuard(source, requestedRow);
   }
@@ -1422,6 +1441,24 @@ function computeCurrentTerminalLinks(
     ),
     requestedRow,
     source.cols,
+  );
+}
+
+function computeCurrentTerminalLinks(
+  source: TerminalLinkSource,
+  requestedRow: number,
+  cellBudget: number,
+  codeUnitBudget: number,
+): ProviderTerminalLinkCandidate[] {
+  return currentTerminalLinksForRow(
+    source,
+    requestedRow,
+    analyzeCurrentTerminalLinks(
+      source,
+      requestedRow,
+      cellBudget,
+      codeUnitBudget,
+    ),
   );
 }
 
@@ -1560,17 +1597,22 @@ function resolveHoveredWebLink(
   }
   const rowCount = end.y - start.y + 1;
   if (rowCount * cols > cellBudget) return null;
+  const currentAnalysis = analyzeCurrentTerminalLinks(
+    source,
+    start.y - 1,
+    cellBudget,
+    codeUnitBudget,
+  );
 
   let resolved: ProviderTerminalLinkCandidate | null = null;
   for (let oneBasedRow = start.y; oneBasedRow <= end.y; oneBasedRow++) {
     const rowStart = oneBasedRow === start.y ? start.x : 1;
     const rowEnd = oneBasedRow === end.y ? end.x : cols;
     if (rowStart > rowEnd) return null;
-    const intersecting = computeCurrentTerminalLinks(
+    const intersecting = currentTerminalLinksForRow(
       source,
       oneBasedRow - 1,
-      cellBudget,
-      codeUnitBudget,
+      currentAnalysis,
     ).filter((candidate) =>
       rangesIntersect(
         candidate.range.start.x,

--- a/src/components/terminal/terminal-links.ts
+++ b/src/components/terminal/terminal-links.ts
@@ -78,6 +78,8 @@ interface AssembledGroup {
 interface FullTerminalLinkCandidate {
   text: string;
   segments: TerminalLinkCandidate["range"][];
+  rawSegments: TerminalLinkCandidate["range"][];
+  rawTermination: "separator" | "group-end";
   requiresConfirmation: boolean;
 }
 
@@ -90,7 +92,12 @@ const URL_START = /https?:\/\//gi;
 const URL_STOP = /[\s"'{}|\\^<>`]/u;
 const TRAILING_SENTENCE_PUNCTUATION = new Set([".", ","]);
 const FRESH_HTTP_SCHEME = /^https?:\/\//iu;
-const HARD_BOUNDARY_START = /^(?:[-*#$%+>]\s|(?:\d+|[a-z])[.)]\s|[\w.-]+@[\w.-]+:\S*[$#%]\s|[•◦‣⁃∙·▪▫●○◆◇▶▸])/iu;
+const HARD_BOUNDARY_STARTS = [
+  /^(?:[-*#$%+>]\s|(?:\d+|[a-z])[.)]\s|[\w.-]+@[\w.-]+:\S*[$#%]\s|[•◦‣⁃∙·▪▫●○◆◇▶▸])/iu,
+  /^PS [a-z]:\\[^>\r\n]*>\s/iu,
+  /^\[[\w.-]+@[\w.-]+(?:\s+[^\]\r\n]+)?\][#$%]\s/iu,
+  /^\([.\w-]+\)\s+(?:(?:[\w.-]+@[\w.-]+:\S*)?[$#%])\s/iu,
+];
 
 function isBlankCell(cell: TerminalLinkCellSnapshot | undefined): boolean {
   return !cell || cell.width === 0 || cell.chars === "" || /^\s+$/u.test(cell.chars);
@@ -219,10 +226,18 @@ function matchingHardLayout(
   );
 }
 
-function expectsUrlValue(text: string): boolean {
+function isHardBoundaryStart(text: string): boolean {
+  return HARD_BOUNDARY_STARTS.some((pattern) => pattern.test(text));
+}
+
+function hasUrlValueAssignmentSuffix(
+  text: string,
+  requireScheme: boolean,
+): boolean {
+  if (!text.endsWith("=")) return false;
   const schemeIndex = text.search(/https?:\/\//iu);
-  if (schemeIndex < 0 || !text.endsWith("=")) return false;
-  const token = text.slice(schemeIndex);
+  if (requireScheme && schemeIndex < 0) return false;
+  const token = schemeIndex >= 0 ? text.slice(schemeIndex) : text;
   const delimiterIndex = Math.max(
     token.lastIndexOf("?"),
     token.lastIndexOf("&"),
@@ -232,9 +247,15 @@ function expectsUrlValue(text: string): boolean {
   return delimiterIndex >= 0 && key.length > 0 && !key.includes("=");
 }
 
+function expectsUrlValue(text: string): boolean {
+  return hasUrlValueAssignmentSuffix(text, true);
+}
+
 function connectionBetween(
   previous: TerminalLinkRowSnapshot,
   next: TerminalLinkRowSnapshot,
+  previousContext?: string,
+  allowPartialUrlContext = false,
 ): RowConnection | null {
   if (next.index !== previous.index + 1) return null;
 
@@ -259,12 +280,22 @@ function connectionBetween(
   if (lastContentEnd(previous, previousBounds.end) !== previousBounds.end) return null;
   if (firstContentColumn(next, nextBounds.start) !== nextBounds.start) return null;
   const nextText = cellsText(next, nextBounds.start, nextBounds.end);
-  if (HARD_BOUNDARY_START.test(nextText)) {
+  if (isHardBoundaryStart(nextText)) {
     return null;
   }
   if (
     FRESH_HTTP_SCHEME.test(nextText) &&
-    !expectsUrlValue(cellsText(previous, previousBounds.start, previousBounds.end))
+    !expectsUrlValue(
+      previousContext ??
+        cellsText(previous, previousBounds.start, previousBounds.end),
+    ) &&
+    !(
+      allowPartialUrlContext &&
+      hasUrlValueAssignmentSuffix(
+        cellsText(previous, previousBounds.start, previousBounds.end),
+        false,
+      )
+    )
   ) {
     return null;
   }
@@ -296,12 +327,32 @@ function appendRowCells(
   }
 }
 
+function connectionsForRows(
+  rows: readonly TerminalLinkRowSnapshot[],
+): Array<RowConnection | null> {
+  const connections: Array<RowConnection | null> = [];
+  let context = "";
+  for (let index = 0; index < rows.length - 1; index++) {
+    const previous = rows[index];
+    const bounds = contentBounds(previous);
+    const incoming = connections[index - 1];
+    if (!incoming) context = "";
+    context += cellsText(
+      previous,
+      incoming?.nextStart ?? bounds.start,
+      bounds.end,
+    );
+    connections.push(
+      connectionBetween(previous, rows[index + 1], context),
+    );
+  }
+  return connections;
+}
+
 function assembleGroups(rows: readonly TerminalLinkRowSnapshot[]): AssembledGroup[] {
   if (rows.length === 0) return [];
   const sortedRows = [...rows].sort((a, b) => a.index - b.index);
-  const connections = sortedRows.slice(0, -1).map((row, index) =>
-    connectionBetween(row, sortedRows[index + 1]),
-  );
+  const connections = connectionsForRows(sortedRows);
   const groups: AssembledGroup[] = [];
 
   let rowIndex = 0;
@@ -413,19 +464,24 @@ function linksInGroup(group: AssembledGroup): FullTerminalLinkCandidate[] {
   let startMatch: RegExpExecArray | null;
   while ((startMatch = URL_START.exec(group.text))) {
     const start = startMatch.index;
-    let end = URL_START.lastIndex;
-    while (end < group.text.length && !URL_STOP.test(group.text[end])) end++;
+    let rawEnd = URL_START.lastIndex;
+    while (rawEnd < group.text.length && !URL_STOP.test(group.text[rawEnd])) {
+      rawEnd++;
+    }
 
-    const rawText = group.text.slice(start, end);
+    const rawText = group.text.slice(start, rawEnd);
     const text = trimUrlToken(rawText);
-    end -= rawText.length - text.length;
+    const end = rawEnd - (rawText.length - text.length);
     if (!text || !parseHttpUrl(text)) continue;
 
     const segments = segmentsForMapping(group.mapping, start, end);
-    if (segments.length === 0) continue;
+    const rawSegments = segmentsForMapping(group.mapping, start, rawEnd);
+    if (segments.length === 0 || rawSegments.length === 0) continue;
     result.push({
       text,
       segments,
+      rawSegments,
+      rawTermination: rawEnd === group.text.length ? "group-end" : "separator",
       requiresConfirmation: group.boundaries.some(
         (boundary) =>
           boundary.kind === "hard" && boundary.index > start && boundary.index < end,
@@ -521,7 +577,9 @@ function defaultHardLinkConfirmation(target: string): boolean {
 
 interface BufferRowSnapshot {
   row: TerminalLinkRowSnapshot;
+  inspectedCells: number;
   inspectedCodeUnits: number;
+  resolvedEndColumn: number;
   clipped: boolean;
 }
 
@@ -529,26 +587,23 @@ function snapshotBufferRow(
   buffer: TerminalLinkBuffer,
   cols: number,
   index: number,
+  cellBudget: number,
   codeUnitBudget: number,
 ): BufferRowSnapshot | null {
   const line = buffer.getLine(index);
   if (!line) return null;
   const cells: TerminalLinkCellSnapshot[] = [];
+  let inspectedCells = 0;
   let inspectedCodeUnits = 0;
-  let clipped = false;
   for (let column = 0; column < cols; column++) {
-    if (clipped) {
-      cells.push({ chars: "", width: 1 });
-      continue;
-    }
+    if (inspectedCells >= cellBudget) break;
     const cell = column < line.length ? line.getCell(column) : undefined;
+    inspectedCells++;
     const chars = cell?.getChars() ?? "";
     const width = cell?.getWidth() ?? 1;
     const codeUnits = width === 0 ? 0 : Math.max(1, chars.length);
     if (inspectedCodeUnits + codeUnits > codeUnitBudget) {
-      clipped = true;
-      cells.push({ chars: "", width });
-      continue;
+      break;
     }
     inspectedCodeUnits += codeUnits;
     cells.push({
@@ -558,8 +613,10 @@ function snapshotBufferRow(
   }
   return {
     row: { index, isWrapped: line.isWrapped, cells },
+    inspectedCells,
     inspectedCodeUnits,
-    clipped,
+    resolvedEndColumn: cells.length,
+    clipped: cells.length < cols,
   };
 }
 
@@ -567,7 +624,7 @@ interface StructuralSnapshot {
   rows: TerminalLinkRowSnapshot[];
   clippedBefore: boolean;
   clippedAfter: boolean;
-  guardWholeRequestedRow: boolean;
+  requestedResolvedEnd: number | null;
 }
 
 function couldContinueBefore(row: TerminalLinkRowSnapshot): boolean {
@@ -579,7 +636,7 @@ function couldContinueBefore(row: TerminalLinkRowSnapshot): boolean {
   // A fresh scheme is usually a boundary, but it can also be the value of a
   // query parameter on the uninspected previous row. Resolve that context or
   // conservatively guard it instead of exposing the nested URL as exact.
-  return !HARD_BOUNDARY_START.test(text);
+  return !isHardBoundaryStart(text);
 }
 
 function couldContinueAfter(row: TerminalLinkRowSnapshot): boolean {
@@ -615,40 +672,39 @@ function collectStructuralSnapshot(
       rows: [],
       clippedBefore: false,
       clippedAfter: false,
-      guardWholeRequestedRow: false,
-    };
-  }
-  if (cellBudget < cols) {
-    return {
-      rows: [],
-      clippedBefore: true,
-      clippedAfter: true,
-      guardWholeRequestedRow: true,
+      requestedResolvedEnd: null,
     };
   }
 
-  const initial = snapshotBufferRow(buffer, cols, requestedRow, codeUnitBudget);
+  const initial = snapshotBufferRow(
+    buffer,
+    cols,
+    requestedRow,
+    cellBudget,
+    codeUnitBudget,
+  );
   if (!initial) {
     return {
       rows: [],
       clippedBefore: false,
       clippedAfter: false,
-      guardWholeRequestedRow: false,
+      requestedResolvedEnd: null,
     };
   }
   if (initial.clipped) {
     return {
       rows: [initial.row],
-      clippedBefore: true,
+      clippedBefore:
+        requestedRow > 0 && couldContinueBefore(initial.row),
       clippedAfter: true,
-      guardWholeRequestedRow: true,
+      requestedResolvedEnd: initial.resolvedEndColumn,
     };
   }
 
   const rows = new Map<number, TerminalLinkRowSnapshot>([
     [requestedRow, initial.row],
   ]);
-  let inspectedCells = cols;
+  let inspectedCells = initial.inspectedCells;
   let inspectedCodeUnits = initial.inspectedCodeUnits;
   let top = requestedRow;
   let bottom = requestedRow;
@@ -657,6 +713,12 @@ function collectStructuralSnapshot(
   let clippedBefore = false;
   let clippedAfter = false;
   let expandTopNext = true;
+  const initialBounds = contentBounds(initial.row);
+  let connectionContext = cellsText(
+    initial.row,
+    initialBounds.start,
+    initialBounds.end,
+  );
 
   while (topOpen || bottomOpen) {
     const expandTop = topOpen && (!bottomOpen || expandTopNext);
@@ -682,9 +744,10 @@ function collectStructuralSnapshot(
       buffer,
       cols,
       adjacentIndex,
+      cols,
       codeUnitBudget - inspectedCodeUnits,
     );
-    inspectedCells += cols;
+    inspectedCells += adjacentSnapshot?.inspectedCells ?? 0;
     inspectedCodeUnits += adjacentSnapshot?.inspectedCodeUnits ?? 0;
     if (adjacentSnapshot?.clipped) {
       const couldContinue = expandTop
@@ -701,8 +764,8 @@ function collectStructuralSnapshot(
     const adjacent = adjacentSnapshot?.row;
     const connection = adjacent
       ? expandTop
-        ? connectionBetween(adjacent, edge)
-        : connectionBetween(edge, adjacent)
+        ? connectionBetween(adjacent, edge, undefined, true)
+        : connectionBetween(edge, adjacent, connectionContext)
       : null;
     if (!adjacent || !connection) {
       if (expandTop) topOpen = false;
@@ -712,9 +775,22 @@ function collectStructuralSnapshot(
 
     rows.set(adjacentIndex, adjacent);
     if (expandTop) {
+      const adjacentBounds = contentBounds(adjacent);
+      connectionContext =
+        cellsText(
+          adjacent,
+          adjacentBounds.start,
+          connection.previousEnd,
+        ) + connectionContext;
       top = adjacentIndex;
       topOpen = top > 0;
     } else {
+      const adjacentBounds = contentBounds(adjacent);
+      connectionContext += cellsText(
+        adjacent,
+        connection.nextStart,
+        adjacentBounds.end,
+      );
       bottom = adjacentIndex;
       bottomOpen = bottom < buffer.length - 1;
     }
@@ -724,7 +800,7 @@ function collectStructuralSnapshot(
     rows: [...rows.values()].sort((a, b) => a.index - b.index),
     clippedBefore,
     clippedAfter,
-    guardWholeRequestedRow: false,
+    requestedResolvedEnd: null,
   };
 }
 
@@ -734,22 +810,42 @@ function linkTouchesClippedEdge(
 ): boolean {
   const top = snapshot.rows[0];
   const bottom = snapshot.rows[snapshot.rows.length - 1];
-  if (snapshot.clippedBefore && top) {
-    const bounds = contentBounds(top);
-    const contentStart = firstContentColumn(top, bounds.start) + 1;
-    if (
-      link.segments.some(
-        (range) => range.start.y === top.index + 1 && range.start.x === contentStart,
-      )
-    ) {
-      return true;
+  if (snapshot.clippedBefore && top && link.rawSegments[0]) {
+    const firstRange = link.rawSegments[0];
+    const startRowPosition = snapshot.rows.findIndex(
+      (row) => row.index + 1 === firstRange.start.y,
+    );
+    const startRow = snapshot.rows[startRowPosition];
+    if (startRow) {
+      const bounds = contentBounds(startRow);
+      const startsAtContentEdge =
+        firstRange.start.x === firstContentColumn(startRow, bounds.start) + 1;
+      if (startsAtContentEdge && startRow.index === top.index) return true;
+
+      const previous = snapshot.rows[startRowPosition - 1];
+      if (startsAtContentEdge && previous) {
+        const previousBounds = contentBounds(previous);
+        if (
+          hasUrlValueAssignmentSuffix(
+            cellsText(previous, previousBounds.start, previousBounds.end),
+            false,
+          )
+        ) {
+          return true;
+        }
+      }
     }
   }
   if (snapshot.clippedAfter && bottom) {
     const bounds = contentBounds(bottom);
     const contentEnd = lastContentEnd(bottom, bounds.end);
+    const possibleEarlyWideWrap =
+      snapshot.requestedResolvedEnd === null &&
+      contentEnd === bounds.end - 1 &&
+      isBlankCell(bottom.cells[bounds.end - 1]);
     if (
-      link.segments.some(
+      (link.rawTermination === "group-end" || possibleEarlyWideWrap) &&
+      link.rawSegments.some(
         (range) => range.end.y === bottom.index + 1 && range.end.x === contentEnd,
       )
     ) {
@@ -771,44 +867,63 @@ function computeCurrentTerminalLinks(
     cellBudget,
     codeUnitBudget,
   );
-  if (
-    snapshot.guardWholeRequestedRow ||
-    snapshot.clippedBefore ||
-    snapshot.clippedAfter
-  ) {
+  if (snapshot.clippedBefore || snapshot.clippedAfter) {
     const requested = snapshot.rows.find((row) => row.index === requestedRow);
     const localCandidates = requested
       ? computeTerminalLinks([requested], requestedRow)
       : [];
-    if (snapshot.guardWholeRequestedRow) {
-      return [
-        {
-          text: localCandidates[0]?.text ?? "",
-          range: {
-            start: { x: 1, y: requestedRow + 1 },
-            end: { x: source.cols, y: requestedRow + 1 },
-          },
-          requiresConfirmation: false,
-          guard: true,
-        },
-      ];
-    }
-    return requestedLinkSegments(snapshot.rows, requestedRow).map(
+    const candidates = requestedLinkSegments(snapshot.rows, requestedRow).map(
       ({ link, range }) => {
         const guard = linkTouchesClippedEdge(link, snapshot);
+        const rawRange = link.rawSegments.find(
+          (candidateRange) => candidateRange.start.y === requestedRow + 1,
+        );
         const localText = localCandidates.find(
           (candidate) =>
             candidate.range.start.x === range.start.x &&
             candidate.range.end.x === range.end.x,
         )?.text;
+        let candidateRange = guard && rawRange ? rawRange : range;
+        if (
+          guard &&
+          rawRange &&
+          snapshot.requestedResolvedEnd !== null &&
+          rawRange.end.x === snapshot.requestedResolvedEnd
+        ) {
+          candidateRange = {
+            start: rawRange.start,
+            end: { x: source.cols, y: requestedRow + 1 },
+          };
+        }
         return {
           text: guard ? (localText ?? link.text) : link.text,
-          range,
+          range: candidateRange,
           requiresConfirmation: link.requiresConfirmation,
           guard,
         };
       },
     );
+    if (snapshot.requestedResolvedEnd !== null) {
+      const firstUnresolvedX = snapshot.requestedResolvedEnd + 1;
+      const unresolvedCovered = candidates.some(
+        (candidate) =>
+          candidate.guard &&
+          candidate.range.start.x <= firstUnresolvedX &&
+          candidate.range.end.x >= source.cols,
+      );
+      if (firstUnresolvedX <= source.cols && !unresolvedCovered) {
+        candidates.push({
+          text: "",
+          range: {
+            start: { x: firstUnresolvedX, y: requestedRow + 1 },
+            end: { x: source.cols, y: requestedRow + 1 },
+          },
+          requiresConfirmation: false,
+          guard: true,
+        });
+      }
+    }
+    return candidates;
   }
   return computeTerminalLinks(snapshot.rows, requestedRow).map((candidate) => ({
     ...candidate,
@@ -816,10 +931,11 @@ function computeCurrentTerminalLinks(
   }));
 }
 
-function linkIdentity(link: TerminalLinkCandidate): string {
+function linkIdentity(link: ProviderTerminalLinkCandidate): string {
   return [
     link.text,
     link.requiresConfirmation ? "inferred" : "exact",
+    link.guard ? "guard" : "navigable",
     link.range.start.x,
     link.range.start.y,
     link.range.end.x,
@@ -876,7 +992,7 @@ export function createTerminalLinkProvider(
               cellBudget,
               codeUnitBudget,
             ).find((link) => linkIdentity(link) === identity);
-            if (!current) return;
+            if (!current || current.guard) return;
             if (current.requiresConfirmation && !confirm(current.text)) return;
             open(current.text);
           },

--- a/src/components/terminal/terminal-links.ts
+++ b/src/components/terminal/terminal-links.ts
@@ -599,11 +599,30 @@ function lexicalLinksInGroup(
   return result;
 }
 
+function hasHardBoundaryBetween(
+  hardBoundaries: readonly number[],
+  start: number,
+  end: number,
+): boolean {
+  let low = 0;
+  let high = hardBoundaries.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (hardBoundaries[middle] <= start) low = middle + 1;
+    else high = middle;
+  }
+  return low < hardBoundaries.length && hardBoundaries[low] < end;
+}
+
 function linksInGroup(
   group: AssembledGroup,
   lexicalLinks: readonly LexicalTerminalLinkCandidate[],
 ): FullTerminalLinkCandidate[] {
   const result: FullTerminalLinkCandidate[] = [];
+  const hardBoundaries: number[] = [];
+  for (const boundary of group.boundaries) {
+    if (boundary.kind === "hard") hardBoundaries.push(boundary.index);
+  }
   for (const lexical of lexicalLinks) {
     const text = lexical.parsedText;
     if (!text) continue;
@@ -616,11 +635,10 @@ function linksInGroup(
       segments,
       rawSegments: lexical.rawSegments,
       rawTermination: lexical.rawTermination,
-      requiresConfirmation: group.boundaries.some(
-        (boundary) =>
-          boundary.kind === "hard" &&
-          boundary.index > lexical.start &&
-          boundary.index < end,
+      requiresConfirmation: hasHardBoundaryBetween(
+        hardBoundaries,
+        lexical.start,
+        end,
       ),
     });
   }

--- a/src/components/terminal/terminal-links.ts
+++ b/src/components/terminal/terminal-links.ts
@@ -908,6 +908,174 @@ function linkTouchesClippedEdge(
   return lexicalLinkTouchesClippedEdge(link, snapshot);
 }
 
+interface BoundedProviderCandidate {
+  candidate: ProviderTerminalLinkCandidate;
+  start: number;
+  end: number;
+  order: number;
+}
+
+function guardForInterval(
+  interval: readonly BoundedProviderCandidate[],
+  start: number,
+  end: number,
+  row: number,
+): BoundedProviderCandidate {
+  const preferred =
+    interval
+      .filter(({ candidate }) => candidate.guard)
+      .sort(
+        (left, right) =>
+          left.start - right.start ||
+          right.end - left.end ||
+          left.order - right.order,
+      )[0] ?? interval.reduce((left, right) =>
+        left.order <= right.order ? left : right,
+      );
+  return {
+    candidate: {
+      text: preferred.candidate.text,
+      range: {
+        start: { x: start, y: row },
+        end: { x: end, y: row },
+      },
+      requiresConfirmation: false,
+      guard: true,
+    },
+    start,
+    end,
+    order: Math.min(...interval.map(({ order }) => order)),
+  };
+}
+
+function mergeAdjacentGuards(
+  candidates: readonly BoundedProviderCandidate[],
+  row: number,
+): BoundedProviderCandidate[] {
+  const sorted = [...candidates].sort(
+    (left, right) =>
+      left.start - right.start ||
+      right.end - left.end ||
+      left.order - right.order,
+  );
+  const result: BoundedProviderCandidate[] = [];
+  for (const candidate of sorted) {
+    const previous = result[result.length - 1];
+    if (!previous || candidate.start > previous.end + 1) {
+      result.push(candidate);
+      continue;
+    }
+    result[result.length - 1] = guardForInterval(
+      [previous, candidate],
+      previous.start,
+      Math.max(previous.end, candidate.end),
+      row,
+    );
+  }
+  return result;
+}
+
+/**
+ * xterm removes later links when their inclusive ranges intersect an earlier
+ * reply from the same provider. Collapse every guarded component before the
+ * reply crosses that boundary, and turn ambiguous overlapping navigable
+ * candidates into one inert guard. Disjoint exact links remain navigable.
+ */
+function normalizeProviderCandidates(
+  candidates: readonly ProviderTerminalLinkCandidate[],
+  requestedRow: number,
+  cols: number,
+): ProviderTerminalLinkCandidate[] {
+  if (!Number.isFinite(cols) || cols < 1) return [];
+  const row = requestedRow + 1;
+  const maxX = Math.floor(cols);
+  const bounded: BoundedProviderCandidate[] = [];
+  for (let order = 0; order < candidates.length; order++) {
+    const candidate = candidates[order];
+    if (
+      candidate.range.start.y !== row ||
+      candidate.range.end.y !== row ||
+      !Number.isFinite(candidate.range.start.x) ||
+      !Number.isFinite(candidate.range.end.x)
+    ) {
+      continue;
+    }
+    const start = Math.max(1, Math.floor(candidate.range.start.x));
+    const end = Math.min(maxX, Math.floor(candidate.range.end.x));
+    if (start > end) continue;
+    bounded.push({
+      candidate: {
+        ...candidate,
+        range: {
+          start: { x: start, y: row },
+          end: { x: end, y: row },
+        },
+      },
+      start,
+      end,
+      order,
+    });
+  }
+
+  const guardSeeds = mergeAdjacentGuards(
+    bounded.filter(({ candidate }) => candidate.guard),
+    row,
+  );
+  const intervals = [
+    ...guardSeeds,
+    ...bounded.filter(({ candidate }) => !candidate.guard),
+  ].sort(
+    (left, right) =>
+      left.start - right.start ||
+      right.end - left.end ||
+      Number(right.candidate.guard) - Number(left.candidate.guard) ||
+      left.order - right.order,
+  );
+
+  const normalized: BoundedProviderCandidate[] = [];
+  let component: BoundedProviderCandidate[] = [];
+  let componentEnd = 0;
+  const finishComponent = (): void => {
+    if (component.length === 0) return;
+    const start = component[0].start;
+    const hasGuard = component.some(({ candidate }) => candidate.guard);
+    if (hasGuard || component.length > 1) {
+      normalized.push(
+        guardForInterval(component, start, componentEnd, row),
+      );
+    } else {
+      normalized.push(component[0]);
+    }
+    component = [];
+    componentEnd = 0;
+  };
+
+  for (const interval of intervals) {
+    if (component.length > 0 && interval.start > componentEnd) {
+      finishComponent();
+    }
+    component.push(interval);
+    componentEnd = Math.max(componentEnd, interval.end);
+  }
+  finishComponent();
+
+  const guards = mergeAdjacentGuards(
+    normalized.filter(({ candidate }) => candidate.guard),
+    row,
+  );
+  return [
+    ...guards,
+    ...normalized.filter(({ candidate }) => !candidate.guard),
+  ]
+    .sort(
+      (left, right) =>
+        left.start - right.start ||
+        left.end - right.end ||
+        left.order - right.order,
+    )
+    .map(({ candidate }) => candidate);
+}
+
 function computeCurrentTerminalLinks(
   source: TerminalLinkSource,
   requestedRow: number,
@@ -999,12 +1167,16 @@ function computeCurrentTerminalLinks(
         });
       }
     }
-    return candidates;
+    return normalizeProviderCandidates(candidates, requestedRow, source.cols);
   }
-  return computeTerminalLinks(snapshot.rows, requestedRow).map((candidate) => ({
-    ...candidate,
-    guard: false,
-  }));
+  return normalizeProviderCandidates(
+    computeTerminalLinks(snapshot.rows, requestedRow).map((candidate) => ({
+      ...candidate,
+      guard: false,
+    })),
+    requestedRow,
+    source.cols,
+  );
 }
 
 function linkIdentity(link: ProviderTerminalLinkCandidate): string {

--- a/src/components/terminal/terminal-links.ts
+++ b/src/components/terminal/terminal-links.ts
@@ -319,6 +319,24 @@ function connectionBetween(
   };
 }
 
+function isAmbiguousRejectedHardBoundary(
+  previous: TerminalLinkRowSnapshot,
+  next: TerminalLinkRowSnapshot,
+): boolean {
+  if (next.index !== previous.index + 1 || next.isWrapped) return false;
+
+  const previousBounds = contentBounds(previous);
+  const nextBounds = contentBounds(next);
+  if (lastContentEnd(previous, previousBounds.end) !== previousBounds.end) {
+    return false;
+  }
+  const nextStart = firstContentColumn(next, nextBounds.start);
+  if (nextStart !== nextBounds.start || nextStart >= nextBounds.end) return false;
+  return !isHardBoundaryStart(
+    cellsText(next, nextBounds.start, nextBounds.end),
+  );
+}
+
 function appendRowCells(
   group: AssembledGroup,
   row: TerminalLinkRowSnapshot,
@@ -667,6 +685,8 @@ interface StructuralSnapshot {
   rows: TerminalLinkRowSnapshot[];
   clippedBefore: boolean;
   clippedAfter: boolean;
+  /** A visible following hard row could still belong to the edge token. */
+  ambiguousHardBoundaryAfter: boolean;
   requestedResolvedEnd: number | null;
 }
 
@@ -715,6 +735,7 @@ function collectStructuralSnapshot(
       rows: [],
       clippedBefore: false,
       clippedAfter: false,
+      ambiguousHardBoundaryAfter: false,
       requestedResolvedEnd: null,
     };
   }
@@ -731,6 +752,7 @@ function collectStructuralSnapshot(
       rows: [],
       clippedBefore: false,
       clippedAfter: false,
+      ambiguousHardBoundaryAfter: false,
       requestedResolvedEnd: null,
     };
   }
@@ -740,6 +762,7 @@ function collectStructuralSnapshot(
       clippedBefore:
         requestedRow > 0 && couldContinueBefore(initial.row),
       clippedAfter: true,
+      ambiguousHardBoundaryAfter: false,
       requestedResolvedEnd: initial.resolvedEndColumn,
     };
   }
@@ -755,6 +778,7 @@ function collectStructuralSnapshot(
   let bottomOpen = bottom < buffer.length - 1;
   let clippedBefore = false;
   let clippedAfter = false;
+  let ambiguousHardBoundaryAfter = false;
   let expandTopNext = true;
   const initialBounds = contentBounds(initial.row);
   let connectionContext = cellsText(
@@ -811,6 +835,13 @@ function collectStructuralSnapshot(
         : connectionBetween(edge, adjacent, connectionContext)
       : null;
     if (!adjacent || !connection) {
+      if (
+        !expandTop &&
+        adjacent &&
+        isAmbiguousRejectedHardBoundary(edge, adjacent)
+      ) {
+        ambiguousHardBoundaryAfter = true;
+      }
       if (expandTop) topOpen = false;
       else bottomOpen = false;
       continue;
@@ -843,6 +874,7 @@ function collectStructuralSnapshot(
     rows: [...rows.values()].sort((a, b) => a.index - b.index),
     clippedBefore,
     clippedAfter,
+    ambiguousHardBoundaryAfter,
     requestedResolvedEnd: null,
   };
 }
@@ -882,7 +914,10 @@ function lexicalLinkTouchesClippedEdge(
       }
     }
   }
-  if (snapshot.clippedAfter && bottom) {
+  if (
+    (snapshot.clippedAfter || snapshot.ambiguousHardBoundaryAfter) &&
+    bottom
+  ) {
     const bounds = contentBounds(bottom);
     const contentEnd = lastContentEnd(bottom, bounds.end);
     const possibleEarlyWideWrap =
@@ -1128,7 +1163,11 @@ function computeCurrentTerminalLinks(
     cellBudget,
     codeUnitBudget,
   );
-  if (snapshot.clippedBefore || snapshot.clippedAfter) {
+  if (
+    snapshot.clippedBefore ||
+    snapshot.clippedAfter ||
+    snapshot.ambiguousHardBoundaryAfter
+  ) {
     const requested = snapshot.rows.find((row) => row.index === requestedRow);
     const localCandidates = requested
       ? computeTerminalLinks([requested], requestedRow)

--- a/src/components/terminal/terminal-links.ts
+++ b/src/components/terminal/terminal-links.ts
@@ -85,9 +85,21 @@ interface FullTerminalLinkCandidate {
 
 interface LexicalTerminalLinkCandidate {
   rawText: string;
+  parsedText: string | null;
   rawSegments: TerminalLinkCandidate["range"][];
   rawTermination: "separator" | "group-end";
   start: number;
+}
+
+interface TerminalLinkScanWork {
+  remaining: number;
+  exhausted: boolean;
+}
+
+interface TerminalLinkAnalysis {
+  links: FullTerminalLinkCandidate[];
+  lexical: LexicalTerminalLinkCandidate[];
+  exhausted: boolean;
 }
 
 interface ProviderTerminalLinkCandidate extends TerminalLinkCandidate {
@@ -99,6 +111,13 @@ const URL_START = /https?:\/\//gi;
 const URL_STOP = /[\s"'{}|\\^<>`]/u;
 const TRAILING_SENTENCE_PUNCTUATION = new Set([".", ","]);
 const FRESH_HTTP_SCHEME = /^https?:\/\//iu;
+// Assembly remains linear under codeUnitBudget. Candidate suffix work needs a
+// second request-wide ceiling because nested invalid schemes can otherwise
+// remap, trim, and parse the same remaining code units repeatedly.
+const LINK_SCAN_WORK_PER_CODE_UNIT = 32;
+// Reserve the worst-case passes before touching a candidate: raw slicing,
+// trimming, parsing, raw mapping, and parsed mapping.
+const LINK_CANDIDATE_WORK_PER_CODE_UNIT = 5;
 const HARD_BOUNDARY_STARTS = [
   /^(?:[-*#$%+>]\s|(?:\d+|[a-z])[.)]\s|[\w.-]+@[\w.-]+:\S*[$#%]\s|[•◦‣⁃∙·▪▫●○◆◇▶▸])/iu,
   /^PS [a-z]:\\[^>\r\n]*>\s/iu,
@@ -489,24 +508,56 @@ function segmentsForMapping(
   return result;
 }
 
+function reserveLinkScanWork(
+  work: TerminalLinkScanWork,
+  codeUnits: number,
+): boolean {
+  if (codeUnits > work.remaining) {
+    work.exhausted = true;
+    return false;
+  }
+  work.remaining -= codeUnits;
+  return true;
+}
+
 function lexicalLinksInGroup(
   group: AssembledGroup,
+  work: TerminalLinkScanWork,
 ): LexicalTerminalLinkCandidate[] {
   const result: LexicalTerminalLinkCandidate[] = [];
   URL_START.lastIndex = 0;
+  let tokenEnd = 0;
   let startMatch: RegExpExecArray | null;
   while ((startMatch = URL_START.exec(group.text))) {
     const start = startMatch.index;
-    let rawEnd = URL_START.lastIndex;
-    while (rawEnd < group.text.length && !URL_STOP.test(group.text[rawEnd])) {
-      rawEnd++;
+    if (start >= tokenEnd) {
+      tokenEnd = URL_START.lastIndex;
+      while (
+        tokenEnd < group.text.length &&
+        !URL_STOP.test(group.text[tokenEnd])
+      ) {
+        tokenEnd++;
+      }
     }
 
+    const rawEnd = tokenEnd;
+    const candidateCodeUnits = rawEnd - start;
+    if (
+      !reserveLinkScanWork(
+        work,
+        candidateCodeUnits * LINK_CANDIDATE_WORK_PER_CODE_UNIT,
+      )
+    ) {
+      break;
+    }
     const rawText = group.text.slice(start, rawEnd);
+    const text = trimUrlToken(rawText);
+    const parsedText = text && parseHttpUrl(text) ? text : null;
     const rawSegments = segmentsForMapping(group.mapping, start, rawEnd);
     if (rawSegments.length > 0) {
       result.push({
         rawText,
+        parsedText,
         rawSegments,
         rawTermination:
           rawEnd === group.text.length ? "group-end" : "separator",
@@ -516,19 +567,22 @@ function lexicalLinksInGroup(
     // Preserve the previous scanner behavior: a valid outer URL owns nested
     // schemes in its value, while an invalid outer token still lets a later
     // scheme be considered independently.
-    if (parseHttpUrl(trimUrlToken(rawText))) {
+    if (parsedText) {
       URL_START.lastIndex = Math.max(URL_START.lastIndex, rawEnd);
     }
   }
   return result;
 }
 
-function linksInGroup(group: AssembledGroup): FullTerminalLinkCandidate[] {
+function linksInGroup(
+  group: AssembledGroup,
+  lexicalLinks: readonly LexicalTerminalLinkCandidate[],
+): FullTerminalLinkCandidate[] {
   const result: FullTerminalLinkCandidate[] = [];
-  for (const lexical of lexicalLinksInGroup(group)) {
-    const text = trimUrlToken(lexical.rawText);
+  for (const lexical of lexicalLinks) {
+    const text = lexical.parsedText;
+    if (!text) continue;
     const end = lexical.start + text.length;
-    if (!text || !parseHttpUrl(text)) continue;
 
     const segments = segmentsForMapping(group.mapping, lexical.start, end);
     if (segments.length === 0) continue;
@@ -548,18 +602,48 @@ function linksInGroup(group: AssembledGroup): FullTerminalLinkCandidate[] {
   return result;
 }
 
+function linkScanWork(codeUnitBudget: number): TerminalLinkScanWork {
+  return {
+    remaining: Math.min(
+      Number.MAX_SAFE_INTEGER,
+      Math.max(1, Math.floor(codeUnitBudget)) * LINK_SCAN_WORK_PER_CODE_UNIT,
+    ),
+    exhausted: false,
+  };
+}
+
+function analyzeTerminalLinks(
+  rows: readonly TerminalLinkRowSnapshot[],
+  requestedWork?: TerminalLinkScanWork,
+): TerminalLinkAnalysis {
+  const groups = assembleGroups(rows);
+  const assembledCodeUnits = groups.reduce(
+    (total, group) => total + group.text.length,
+    0,
+  );
+  const work = requestedWork ?? linkScanWork(assembledCodeUnits);
+  const links: FullTerminalLinkCandidate[] = [];
+  const lexical: LexicalTerminalLinkCandidate[] = [];
+  for (const group of groups) {
+    const groupLexical = lexicalLinksInGroup(group, work);
+    lexical.push(...groupLexical);
+    if (work.exhausted) break;
+    links.push(...linksInGroup(group, groupLexical));
+  }
+  return { links, lexical, exhausted: work.exhausted };
+}
+
 interface RequestedLinkSegment {
   link: FullTerminalLinkCandidate;
   range: TerminalLinkCandidate["range"];
 }
 
 function requestedLinkSegments(
-  rows: readonly TerminalLinkRowSnapshot[],
+  links: readonly FullTerminalLinkCandidate[],
   requestedRow: number,
 ): RequestedLinkSegment[] {
   const seen = new Set<string>();
-  return assembleGroups(rows)
-    .flatMap(linksInGroup)
+  return links
     .flatMap((link) =>
       link.segments
         .filter((range) => range.start.y === requestedRow + 1)
@@ -581,11 +665,15 @@ export function computeTerminalLinks(
   rows: readonly TerminalLinkRowSnapshot[],
   requestedRow: number,
 ): TerminalLinkCandidate[] {
-  return requestedLinkSegments(rows, requestedRow).map(({ link, range }) => ({
-    text: link.text,
-    range,
-    requiresConfirmation: link.requiresConfirmation,
-  }));
+  const analysis = analyzeTerminalLinks(rows);
+  if (analysis.exhausted) return [];
+  return requestedLinkSegments(analysis.links, requestedRow).map(
+    ({ link, range }) => ({
+      text: link.text,
+      range,
+      requiresConfirmation: link.requiresConfirmation,
+    }),
+  );
 }
 
 interface TerminalLinkBufferCell {
@@ -1151,6 +1239,27 @@ function normalizeProviderCandidates(
     .map(({ candidate }) => candidate);
 }
 
+function exhaustedLinkScanGuard(
+  source: TerminalLinkSource,
+  requestedRow: number,
+): ProviderTerminalLinkCandidate[] {
+  return normalizeProviderCandidates(
+    [
+      {
+        text: "",
+        range: {
+          start: { x: 1, y: requestedRow + 1 },
+          end: { x: source.cols, y: requestedRow + 1 },
+        },
+        requiresConfirmation: false,
+        guard: true,
+      },
+    ],
+    requestedRow,
+    source.cols,
+  );
+}
+
 function computeCurrentTerminalLinks(
   source: TerminalLinkSource,
   requestedRow: number,
@@ -1163,16 +1272,32 @@ function computeCurrentTerminalLinks(
     cellBudget,
     codeUnitBudget,
   );
+  const work = linkScanWork(codeUnitBudget);
+  const analysis = analyzeTerminalLinks(snapshot.rows, work);
+  if (analysis.exhausted) {
+    return exhaustedLinkScanGuard(source, requestedRow);
+  }
   if (
     snapshot.clippedBefore ||
     snapshot.clippedAfter ||
     snapshot.ambiguousHardBoundaryAfter
   ) {
     const requested = snapshot.rows.find((row) => row.index === requestedRow);
-    const localCandidates = requested
-      ? computeTerminalLinks([requested], requestedRow)
-      : [];
-    const candidates = requestedLinkSegments(snapshot.rows, requestedRow).map(
+    const localAnalysis = requested
+      ? analyzeTerminalLinks([requested], work)
+      : { links: [], lexical: [], exhausted: false };
+    if (work.exhausted) {
+      return exhaustedLinkScanGuard(source, requestedRow);
+    }
+    const localCandidates = requestedLinkSegments(
+      localAnalysis.links,
+      requestedRow,
+    ).map(({ link, range }) => ({
+      text: link.text,
+      range,
+      requiresConfirmation: link.requiresConfirmation,
+    }));
+    const candidates = requestedLinkSegments(analysis.links, requestedRow).map(
       ({ link, range }) => {
         const guard = linkTouchesClippedEdge(link, snapshot);
         const rawRange = link.rawSegments.find(
@@ -1203,27 +1328,25 @@ function computeCurrentTerminalLinks(
         };
       },
     );
-    for (const group of assembleGroups(snapshot.rows)) {
-      for (const lexical of lexicalLinksInGroup(group)) {
-        if (parseHttpUrl(trimUrlToken(lexical.rawText))) continue;
-        if (!lexicalLinkTouchesClippedEdge(lexical, snapshot)) continue;
-        for (const rawRange of lexical.rawSegments) {
-          if (rawRange.start.y !== requestedRow + 1) continue;
-          const reachesRequestedClip =
-            snapshot.requestedResolvedEnd !== null &&
-            rawRange.end.x >= snapshot.requestedResolvedEnd;
-          candidates.push({
-            text: lexical.rawText,
-            range: reachesRequestedClip
-              ? {
-                  start: rawRange.start,
-                  end: { x: source.cols, y: requestedRow + 1 },
-                }
-              : rawRange,
-            requiresConfirmation: false,
-            guard: true,
-          });
-        }
+    for (const lexical of analysis.lexical) {
+      if (lexical.parsedText) continue;
+      if (!lexicalLinkTouchesClippedEdge(lexical, snapshot)) continue;
+      for (const rawRange of lexical.rawSegments) {
+        if (rawRange.start.y !== requestedRow + 1) continue;
+        const reachesRequestedClip =
+          snapshot.requestedResolvedEnd !== null &&
+          rawRange.end.x >= snapshot.requestedResolvedEnd;
+        candidates.push({
+          text: lexical.rawText,
+          range: reachesRequestedClip
+            ? {
+                start: rawRange.start,
+                end: { x: source.cols, y: requestedRow + 1 },
+              }
+            : rawRange,
+          requiresConfirmation: false,
+          guard: true,
+        });
       }
     }
     if (snapshot.requestedResolvedEnd !== null) {
@@ -1249,10 +1372,14 @@ function computeCurrentTerminalLinks(
     return normalizeProviderCandidates(candidates, requestedRow, source.cols);
   }
   return normalizeProviderCandidates(
-    computeTerminalLinks(snapshot.rows, requestedRow).map((candidate) => ({
-      ...candidate,
-      guard: false,
-    })),
+    requestedLinkSegments(analysis.links, requestedRow).map(
+      ({ link, range }) => ({
+        text: link.text,
+        range,
+        requiresConfirmation: link.requiresConfirmation,
+        guard: false,
+      }),
+    ),
     requestedRow,
     source.cols,
   );

--- a/src/components/terminal/terminal-links.ts
+++ b/src/components/terminal/terminal-links.ts
@@ -975,6 +975,43 @@ function mergeAdjacentGuards(
   return result;
 }
 
+function partitionGuardAtCandidateBoundaries(
+  guard: BoundedProviderCandidate,
+  originals: readonly BoundedProviderCandidate[],
+  row: number,
+): BoundedProviderCandidate[] {
+  const boundaries = new Set<number>([guard.start, guard.end + 1]);
+  for (const original of originals) {
+    if (
+      original.start > guard.end ||
+      original.end < guard.start
+    ) {
+      continue;
+    }
+    if (original.start > guard.start) boundaries.add(original.start);
+    const afterOriginal = original.end + 1;
+    if (afterOriginal > guard.start && afterOriginal <= guard.end) {
+      boundaries.add(afterOriginal);
+    }
+  }
+  const sorted = [...boundaries].sort((left, right) => left - right);
+  return sorted.slice(0, -1).map((start, index) => {
+    const end = sorted[index + 1] - 1;
+    return {
+      candidate: {
+        ...guard.candidate,
+        range: {
+          start: { x: start, y: row },
+          end: { x: end, y: row },
+        },
+      },
+      start,
+      end,
+      order: guard.order,
+    };
+  });
+}
+
 /**
  * xterm removes later links when their inclusive ranges intersect an earlier
  * reply from the same provider. Collapse every guarded component before the
@@ -1063,8 +1100,11 @@ function normalizeProviderCandidates(
     normalized.filter(({ candidate }) => candidate.guard),
     row,
   );
+  const partitionedGuards = guards.flatMap((guard) =>
+    partitionGuardAtCandidateBoundaries(guard, bounded, row),
+  );
   return [
-    ...guards,
+    ...partitionedGuards,
     ...normalized.filter(({ candidate }) => !candidate.guard),
   ]
     .sort(
@@ -1191,26 +1231,50 @@ function linkIdentity(link: ProviderTerminalLinkCandidate): string {
   ].join("\u0000");
 }
 
-/**
- * Build an xterm provider that snapshots the current active buffer on every
- * request, avoiding stale ranges after TUI repaints and terminal resizes.
- */
-export function createTerminalLinkProvider(
-  source: TerminalLinkSource,
-  options: TerminalLinkProviderOptions = {},
-): ILinkProvider {
-  const confirm = options.confirm ?? defaultHardLinkConfirmation;
-  const open = options.open ?? createHttpLinkOpener();
-  const requestedCellBudget = options.cellBudget ?? DEFAULT_LINK_SCAN_CELL_BUDGET;
-  const cellBudget = Number.isFinite(requestedCellBudget)
-    ? Math.max(1, Math.floor(requestedCellBudget))
-    : DEFAULT_LINK_SCAN_CELL_BUDGET;
+export interface TerminalLinkController {
+  readonly linkProvider: ILinkProvider;
+  /** Record WebLinksAddon's current public hover range. */
+  hoverWebLink(
+    text: string,
+    range: TerminalLinkCandidate["range"],
+  ): void;
+  /** Clear a matching WebLinksAddon hover. */
+  leaveWebLink(text: string): void;
+  /** Re-arbitrate a WebLinksAddon activation against the current buffer. */
+  activateWebLink(text: string): boolean;
+}
+
+interface ResolvedTerminalLinkProviderOptions {
+  confirm: (target: string) => boolean;
+  open: (target: string) => unknown;
+  cellBudget: number;
+  codeUnitBudget: number;
+}
+
+function resolveTerminalLinkProviderOptions(
+  options: TerminalLinkProviderOptions,
+): ResolvedTerminalLinkProviderOptions {
+  const requestedCellBudget =
+    options.cellBudget ?? DEFAULT_LINK_SCAN_CELL_BUDGET;
   const requestedCodeUnitBudget =
     options.codeUnitBudget ?? DEFAULT_LINK_SCAN_CODE_UNIT_BUDGET;
-  const codeUnitBudget = Number.isFinite(requestedCodeUnitBudget)
-    ? Math.max(1, Math.floor(requestedCodeUnitBudget))
-    : DEFAULT_LINK_SCAN_CODE_UNIT_BUDGET;
+  return {
+    confirm: options.confirm ?? defaultHardLinkConfirmation,
+    open: options.open ?? createHttpLinkOpener(),
+    cellBudget: Number.isFinite(requestedCellBudget)
+      ? Math.max(1, Math.floor(requestedCellBudget))
+      : DEFAULT_LINK_SCAN_CELL_BUDGET,
+    codeUnitBudget: Number.isFinite(requestedCodeUnitBudget)
+      ? Math.max(1, Math.floor(requestedCodeUnitBudget))
+      : DEFAULT_LINK_SCAN_CODE_UNIT_BUDGET,
+  };
+}
 
+function createCurrentTerminalLinkProvider(
+  source: TerminalLinkSource,
+  options: ResolvedTerminalLinkProviderOptions,
+): ILinkProvider {
+  const { confirm, open, cellBudget, codeUnitBudget } = options;
   return {
     provideLinks(bufferLineNumber, callback) {
       const requestedRow = bufferLineNumber - 1;
@@ -1249,4 +1313,152 @@ export function createTerminalLinkProvider(
       callback(links.length > 0 ? links : undefined);
     },
   };
+}
+
+function rangesIntersect(
+  leftStart: number,
+  leftEnd: number,
+  rightStart: number,
+  rightEnd: number,
+): boolean {
+  return leftStart <= rightEnd && rightStart <= leftEnd;
+}
+
+function resolveHoveredWebLink(
+  source: TerminalLinkSource,
+  text: string,
+  range: TerminalLinkCandidate["range"],
+  cellBudget: number,
+  codeUnitBudget: number,
+): ProviderTerminalLinkCandidate | null {
+  const cols = Math.floor(source.cols);
+  const bufferLength = source.buffer.active.length;
+  const { start, end } = range;
+  if (
+    !Number.isFinite(cols) ||
+    cols < 1 ||
+    !Number.isInteger(start.x) ||
+    !Number.isInteger(start.y) ||
+    !Number.isInteger(end.x) ||
+    !Number.isInteger(end.y) ||
+    start.x < 1 ||
+    start.x > cols ||
+    end.x < 1 ||
+    end.x > cols ||
+    start.y < 1 ||
+    end.y < start.y ||
+    end.y > bufferLength ||
+    (start.y === end.y && end.x < start.x)
+  ) {
+    return null;
+  }
+  const rowCount = end.y - start.y + 1;
+  if (rowCount * cols > cellBudget) return null;
+
+  let resolved: ProviderTerminalLinkCandidate | null = null;
+  for (let oneBasedRow = start.y; oneBasedRow <= end.y; oneBasedRow++) {
+    const rowStart = oneBasedRow === start.y ? start.x : 1;
+    const rowEnd = oneBasedRow === end.y ? end.x : cols;
+    if (rowStart > rowEnd) return null;
+    const intersecting = computeCurrentTerminalLinks(
+      source,
+      oneBasedRow - 1,
+      cellBudget,
+      codeUnitBudget,
+    ).filter((candidate) =>
+      rangesIntersect(
+        candidate.range.start.x,
+        candidate.range.end.x,
+        rowStart,
+        rowEnd,
+      ),
+    );
+    if (intersecting.length !== 1) return null;
+    const owner = intersecting[0];
+    if (
+      owner.guard ||
+      owner.range.start.x > rowStart ||
+      owner.range.end.x < rowEnd
+    ) {
+      return null;
+    }
+    if (
+      resolved &&
+      (resolved.text !== owner.text ||
+        resolved.requiresConfirmation !== owner.requiresConfirmation)
+    ) {
+      return null;
+    }
+    resolved ??= owner;
+  }
+
+  if (
+    !resolved ||
+    (!resolved.requiresConfirmation && resolved.text !== text) ||
+    !parseHttpUrl(resolved.text)
+  ) {
+    return null;
+  }
+  return resolved;
+}
+
+/**
+ * Share fresh-buffer link semantics between the custom provider and
+ * WebLinksAddon's public hover/activation callbacks. This is the final safety
+ * boundary when xterm's cross-provider cache pruning removes a custom guard.
+ */
+export function createTerminalLinkController(
+  source: TerminalLinkSource,
+  requestedOptions: TerminalLinkProviderOptions = {},
+): TerminalLinkController {
+  const options = resolveTerminalLinkProviderOptions(requestedOptions);
+  let hovered:
+    | { text: string; range: TerminalLinkCandidate["range"] }
+    | undefined;
+
+  return {
+    linkProvider: createCurrentTerminalLinkProvider(source, options),
+    hoverWebLink(text, range) {
+      hovered = {
+        text,
+        range: {
+          start: { ...range.start },
+          end: { ...range.end },
+        },
+      };
+    },
+    leaveWebLink(text) {
+      if (hovered?.text === text) hovered = undefined;
+    },
+    activateWebLink(text) {
+      if (!hovered || hovered.text !== text) return false;
+      const current = resolveHoveredWebLink(
+        source,
+        text,
+        hovered.range,
+        options.cellBudget,
+        options.codeUnitBudget,
+      );
+      if (!current) return false;
+      if (
+        current.requiresConfirmation &&
+        !options.confirm(current.text)
+      ) {
+        return false;
+      }
+      options.open(current.text);
+      return true;
+    },
+  };
+}
+
+/**
+ * Build an xterm provider that snapshots the current active buffer on every
+ * request, avoiding stale ranges after TUI repaints and terminal resizes.
+ */
+export function createTerminalLinkProvider(
+  source: TerminalLinkSource,
+  options: TerminalLinkProviderOptions = {},
+): ILinkProvider {
+  return createTerminalLinkController(source, options).linkProvider;
 }

--- a/src/components/terminal/terminal-links.ts
+++ b/src/components/terminal/terminal-links.ts
@@ -1,0 +1,440 @@
+import type { ILinkProvider } from "@xterm/xterm";
+
+/** Parse an absolute terminal link while enforcing the only protocols we open. */
+export function parseHttpUrl(value: string): URL | null {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+type OpenWindow = (
+  url?: string | URL,
+  target?: string,
+  features?: string,
+) => Window | null;
+
+/** Create the shared opener used by OSC 8, inferred links, and WebLinksAddon. */
+export function createHttpLinkOpener(
+  openWindow: OpenWindow = window.open.bind(window),
+): (value: string) => boolean {
+  return (value) => {
+    const url = parseHttpUrl(value);
+    if (!url) return false;
+    return openWindow(url.href, "_blank", "noopener,noreferrer") !== null;
+  };
+}
+
+export interface TerminalLinkCellSnapshot {
+  readonly chars: string;
+  readonly width: number;
+}
+
+export interface TerminalLinkRowSnapshot {
+  /** Zero-based absolute buffer row. */
+  readonly index: number;
+  readonly isWrapped: boolean;
+  readonly cells: readonly TerminalLinkCellSnapshot[];
+}
+
+export interface TerminalLinkCandidate {
+  readonly text: string;
+  readonly range: {
+    readonly start: { readonly x: number; readonly y: number };
+    readonly end: { readonly x: number; readonly y: number };
+  };
+  readonly requiresConfirmation: boolean;
+}
+
+interface ContentBounds {
+  start: number;
+  end: number;
+  leftBorder?: { column: number; chars: string };
+  rightBorder?: { column: number; chars: string };
+}
+
+interface RowConnection {
+  kind: "soft" | "hard";
+  previousEnd: number;
+  nextStart: number;
+}
+
+interface MappedCodeUnit {
+  row: number;
+  startX: number;
+  endX: number;
+}
+
+interface AssembledGroup {
+  text: string;
+  mapping: MappedCodeUnit[];
+  boundaries: Array<{ index: number; kind: "soft" | "hard" }>;
+}
+
+const BORDER_CHARS = new Set(["│", "┃", "║", "|"]);
+const URL_START = /https?:\/\//gi;
+const URL_STOP = /[\s"'!*(){}|\\^<>`]/u;
+const URL_TRAILING_PUNCTUATION = /[,:.!?;\]}>)]+$/u;
+
+function isBlankCell(cell: TerminalLinkCellSnapshot | undefined): boolean {
+  return !cell || cell.width === 0 || cell.chars === "" || /^\s+$/u.test(cell.chars);
+}
+
+function contentBounds(row: TerminalLinkRowSnapshot): ContentBounds {
+  let first = 0;
+  while (first < row.cells.length && isBlankCell(row.cells[first])) first++;
+
+  let last = row.cells.length - 1;
+  while (last >= first && isBlankCell(row.cells[last])) last--;
+
+  const bounds: ContentBounds = {
+    start: first,
+    end: row.cells.length,
+  };
+
+  const midpoint = Math.floor(row.cells.length / 2);
+  let leftBorderColumn = -1;
+  for (let column = first; column <= midpoint; column++) {
+    const chars = row.cells[column]?.chars;
+    if (
+      chars &&
+      BORDER_CHARS.has(chars) &&
+      (column === first || isBlankCell(row.cells[column + 1]))
+    ) {
+      // The delimiter closest to content wins over a label outside it.
+      leftBorderColumn = column;
+    }
+  }
+  if (leftBorderColumn >= 0) {
+    bounds.leftBorder = {
+      column: leftBorderColumn,
+      chars: row.cells[leftBorderColumn]!.chars,
+    };
+    bounds.start = leftBorderColumn + 1;
+    while (bounds.start < row.cells.length && isBlankCell(row.cells[bounds.start])) {
+      bounds.start++;
+    }
+  }
+
+  let rightBorderColumn = -1;
+  for (let column = midpoint + 1; column <= last; column++) {
+    const chars = row.cells[column]?.chars;
+    if (
+      chars &&
+      BORDER_CHARS.has(chars) &&
+      (column === last || isBlankCell(row.cells[column - 1]))
+    ) {
+      // The first delimiter in the right half is the content boundary; text
+      // after it is a stable label/suffix rather than link content.
+      rightBorderColumn = column;
+      break;
+    }
+  }
+  if (rightBorderColumn >= 0 && rightBorderColumn > bounds.start) {
+    bounds.rightBorder = {
+      column: rightBorderColumn,
+      chars: row.cells[rightBorderColumn]!.chars,
+    };
+    bounds.end = rightBorderColumn;
+    // Treat one cell next to a panel border as its stable inner gutter. Any
+    // additional spaces remain content padding and cannot imply a wrap.
+    if (bounds.end > bounds.start && isBlankCell(row.cells[bounds.end - 1])) {
+      bounds.end--;
+    }
+  }
+
+  return bounds;
+}
+
+function lastContentEnd(row: TerminalLinkRowSnapshot, end: number): number {
+  let column = Math.min(end, row.cells.length) - 1;
+  while (column >= 0 && isBlankCell(row.cells[column])) column--;
+  if (column < 0) return 0;
+  return column + Math.max(1, row.cells[column]?.width ?? 1);
+}
+
+function firstContentColumn(row: TerminalLinkRowSnapshot, start: number): number {
+  let column = Math.max(0, start);
+  while (column < row.cells.length && isBlankCell(row.cells[column])) column++;
+  return column;
+}
+
+function matchingHardLayout(
+  previous: ContentBounds,
+  next: ContentBounds,
+): boolean {
+  const previousHasBorder = Boolean(previous.leftBorder || previous.rightBorder);
+  const nextHasBorder = Boolean(next.leftBorder || next.rightBorder);
+  if (previousHasBorder || nextHasBorder) {
+    return (
+      previous.leftBorder?.column === next.leftBorder?.column &&
+      previous.leftBorder?.chars === next.leftBorder?.chars &&
+      previous.rightBorder?.column === next.rightBorder?.column &&
+      previous.rightBorder?.chars === next.rightBorder?.chars &&
+      previous.start === next.start &&
+      previous.end === next.end
+    );
+  }
+  return previous.start === next.start && previous.end === next.end;
+}
+
+function connectionBetween(
+  previous: TerminalLinkRowSnapshot,
+  next: TerminalLinkRowSnapshot,
+): RowConnection | null {
+  if (next.index !== previous.index + 1) return null;
+
+  if (next.isWrapped) {
+    let previousEnd = previous.cells.length;
+    const contentEnd = lastContentEnd(previous, previousEnd);
+    // When a width-2 glyph cannot fit in the final cell, xterm leaves that
+    // cell blank and starts the wrapped glyph at column 0 on the next row.
+    const hasEarlyWrappedWideGlyph =
+      contentEnd === previousEnd - 1 &&
+      isBlankCell(previous.cells[previousEnd - 1]) &&
+      next.cells[0]?.width === 2;
+    if (hasEarlyWrappedWideGlyph) previousEnd--;
+    const reachesEdge = contentEnd === previousEnd;
+    if (!reachesEdge || firstContentColumn(next, 0) !== 0) return null;
+    return { kind: "soft", previousEnd, nextStart: 0 };
+  }
+
+  const previousBounds = contentBounds(previous);
+  const nextBounds = contentBounds(next);
+  if (!matchingHardLayout(previousBounds, nextBounds)) return null;
+  if (lastContentEnd(previous, previousBounds.end) !== previousBounds.end) return null;
+  if (firstContentColumn(next, nextBounds.start) !== nextBounds.start) return null;
+  return {
+    kind: "hard",
+    previousEnd: previousBounds.end,
+    nextStart: nextBounds.start,
+  };
+}
+
+function appendRowCells(
+  group: AssembledGroup,
+  row: TerminalLinkRowSnapshot,
+  start: number,
+  end: number,
+): void {
+  for (let column = start; column < Math.min(end, row.cells.length); column++) {
+    const cell = row.cells[column];
+    if (!cell || cell.width === 0) continue;
+    const chars = cell.chars || " ";
+    for (let offset = 0; offset < chars.length; offset++) {
+      group.text += chars[offset];
+      group.mapping.push({
+        row: row.index,
+        startX: column + 1,
+        endX: column + Math.max(1, cell.width),
+      });
+    }
+  }
+}
+
+function assembleGroups(rows: readonly TerminalLinkRowSnapshot[]): AssembledGroup[] {
+  if (rows.length === 0) return [];
+  const sortedRows = [...rows].sort((a, b) => a.index - b.index);
+  const connections = sortedRows.slice(0, -1).map((row, index) =>
+    connectionBetween(row, sortedRows[index + 1]),
+  );
+  const groups: AssembledGroup[] = [];
+
+  let rowIndex = 0;
+  while (rowIndex < sortedRows.length) {
+    const group: AssembledGroup = { text: "", mapping: [], boundaries: [] };
+    let current = rowIndex;
+    while (current < sortedRows.length) {
+      const row = sortedRows[current];
+      const incoming = current > rowIndex ? connections[current - 1] : null;
+      const outgoing = connections[current] ?? null;
+      const bounds = contentBounds(row);
+      appendRowCells(
+        group,
+        row,
+        incoming?.nextStart ?? bounds.start,
+        outgoing?.previousEnd ?? bounds.end,
+      );
+
+      if (!outgoing) break;
+      group.boundaries.push({ index: group.text.length, kind: outgoing.kind });
+      current++;
+    }
+    groups.push(group);
+    rowIndex = current + 1;
+  }
+  return groups;
+}
+
+function shouldCrossHardBoundary(prefix: string, suffix: string): boolean {
+  if (!parseHttpUrl(prefix)) return true;
+  if (/[/?.#=&%_~-]$/u.test(prefix)) return true;
+  return /[/?.#=&%_~-]/u.test(suffix);
+}
+
+function linksInGroup(group: AssembledGroup): TerminalLinkCandidate[] {
+  const result: TerminalLinkCandidate[] = [];
+  URL_START.lastIndex = 0;
+  let startMatch: RegExpExecArray | null;
+  while ((startMatch = URL_START.exec(group.text))) {
+    const start = startMatch.index;
+    let end = URL_START.lastIndex;
+    while (end < group.text.length && !URL_STOP.test(group.text[end])) end++;
+
+    const candidateBoundaries = group.boundaries.filter(
+      (boundary) => boundary.index > start && boundary.index < end,
+    );
+    for (const boundary of candidateBoundaries) {
+      if (
+        boundary.kind === "hard" &&
+        !shouldCrossHardBoundary(
+          group.text.slice(start, boundary.index),
+          group.text.slice(boundary.index, end),
+        )
+      ) {
+        end = boundary.index;
+        break;
+      }
+    }
+
+    const rawText = group.text.slice(start, end);
+    const text = rawText.replace(URL_TRAILING_PUNCTUATION, "");
+    end -= rawText.length - text.length;
+    if (!text || !parseHttpUrl(text)) continue;
+
+    const first = group.mapping[start];
+    const last = group.mapping[end - 1];
+    if (!first || !last) continue;
+    result.push({
+      text,
+      range: {
+        start: { x: first.startX, y: first.row + 1 },
+        end: { x: last.endX, y: last.row + 1 },
+      },
+      requiresConfirmation: group.boundaries.some(
+        (boundary) =>
+          boundary.kind === "hard" && boundary.index > start && boundary.index < end,
+      ),
+    });
+    URL_START.lastIndex = Math.max(URL_START.lastIndex, end);
+  }
+  return result;
+}
+
+/**
+ * Compute terminal links from fresh buffer-like rows. The requested row is an
+ * absolute zero-based buffer index; only links intersecting it are returned.
+ */
+export function computeTerminalLinks(
+  rows: readonly TerminalLinkRowSnapshot[],
+  requestedRow: number,
+): TerminalLinkCandidate[] {
+  const seen = new Set<string>();
+  return assembleGroups(rows)
+    .flatMap(linksInGroup)
+    .filter(
+      (link) =>
+        link.range.start.y <= requestedRow + 1 &&
+        link.range.end.y >= requestedRow + 1,
+    )
+    .filter((link) => {
+      const key = `${link.range.start.x}:${link.range.start.y}-${link.range.end.x}:${link.range.end.y}:${link.text}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
+interface TerminalLinkBufferCell {
+  getChars(): string;
+  getWidth(): number;
+}
+
+interface TerminalLinkBufferLine {
+  readonly isWrapped: boolean;
+  readonly length: number;
+  getCell(column: number): TerminalLinkBufferCell | undefined;
+}
+
+interface TerminalLinkSource {
+  readonly cols: number;
+  readonly buffer: {
+    readonly active: {
+      readonly length: number;
+      getLine(row: number): TerminalLinkBufferLine | undefined;
+    };
+  };
+}
+
+export interface TerminalLinkProviderOptions {
+  /** Synchronous confirmation shown only for inferred hard-row links. */
+  readonly confirm?: (target: string) => boolean;
+  /** Protocol-restricted opener, normally createHttpLinkOpener(). */
+  readonly open?: (target: string) => unknown;
+  /** Number of rows examined above and below the requested row. */
+  readonly scanRadius?: number;
+}
+
+function defaultHardLinkConfirmation(target: string): boolean {
+  return window.confirm(
+    `Open this inferred multi-line terminal link?\n\n${target}`,
+  );
+}
+
+function snapshotBufferRow(
+  source: TerminalLinkSource,
+  index: number,
+): TerminalLinkRowSnapshot | null {
+  const line = source.buffer.active.getLine(index);
+  if (!line) return null;
+  const cells: TerminalLinkCellSnapshot[] = [];
+  for (let column = 0; column < source.cols; column++) {
+    const cell = column < line.length ? line.getCell(column) : undefined;
+    cells.push({
+      chars: cell?.getChars() ?? "",
+      width: cell?.getWidth() ?? 1,
+    });
+  }
+  return { index, isWrapped: line.isWrapped, cells };
+}
+
+/**
+ * Build an xterm provider that snapshots the current active buffer on every
+ * request, avoiding stale ranges after TUI repaints and terminal resizes.
+ */
+export function createTerminalLinkProvider(
+  source: TerminalLinkSource,
+  options: TerminalLinkProviderOptions = {},
+): ILinkProvider {
+  const confirm = options.confirm ?? defaultHardLinkConfirmation;
+  const open = options.open ?? createHttpLinkOpener();
+  const scanRadius = Math.max(1, options.scanRadius ?? 8);
+
+  return {
+    provideLinks(bufferLineNumber, callback) {
+      const requestedRow = bufferLineNumber - 1;
+      const start = Math.max(0, requestedRow - scanRadius);
+      const end = Math.min(
+        source.buffer.active.length - 1,
+        requestedRow + scanRadius,
+      );
+      const rows: TerminalLinkRowSnapshot[] = [];
+      for (let index = start; index <= end; index++) {
+        const row = snapshotBufferRow(source, index);
+        if (row) rows.push(row);
+      }
+
+      const links = computeTerminalLinks(rows, requestedRow).map((candidate) => ({
+        text: candidate.text,
+        range: candidate.range,
+        activate: () => {
+          if (candidate.requiresConfirmation && !confirm(candidate.text)) return;
+          open(candidate.text);
+        },
+      }));
+      callback(links.length > 0 ? links : undefined);
+    },
+  };
+}

--- a/src/components/terminal/terminal-links.ts
+++ b/src/components/terminal/terminal-links.ts
@@ -118,6 +118,9 @@ const LINK_SCAN_WORK_PER_CODE_UNIT = 32;
 // Reserve the worst-case passes before touching a candidate: raw slicing,
 // trimming, parsing, raw mapping, and parsed mapping.
 const LINK_CANDIDATE_WORK_PER_CODE_UNIT = 5;
+// Scheme/query classification searches and slices the same connection context
+// several times, so reserve its worst-case passes before scanning it.
+const LINK_CONTEXT_WORK_PER_CODE_UNIT = 10;
 const HARD_BOUNDARY_STARTS = [
   /^(?:[-*#$%+>]\s|(?:\d+|[a-z])[.)]\s|[\w.-]+@[\w.-]+:\S*[$#%]\s|[•◦‣⁃∙·▪▫●○◆◇▶▸])/iu,
   /^PS [a-z]:\\[^>\r\n]*>\s/iu,
@@ -259,8 +262,18 @@ function isHardBoundaryStart(text: string): boolean {
 function hasUrlValueAssignmentSuffix(
   text: string,
   requireScheme: boolean,
+  work?: TerminalLinkScanWork,
 ): boolean {
   if (!text.endsWith("=")) return false;
+  if (
+    work &&
+    !reserveLinkScanWork(
+      work,
+      text.length * LINK_CONTEXT_WORK_PER_CODE_UNIT,
+    )
+  ) {
+    return false;
+  }
   const schemeIndex = text.search(/https?:\/\//iu);
   if (requireScheme && schemeIndex < 0) return false;
   const token = schemeIndex >= 0 ? text.slice(schemeIndex) : text;
@@ -279,8 +292,11 @@ function hasUrlValueAssignmentSuffix(
   return delimiterIndex >= 0 && key.length > 0 && !key.includes("=");
 }
 
-function expectsUrlValue(text: string): boolean {
-  return hasUrlValueAssignmentSuffix(text, true);
+function expectsUrlValue(
+  text: string,
+  work?: TerminalLinkScanWork,
+): boolean {
+  return hasUrlValueAssignmentSuffix(text, true, work);
 }
 
 function connectionBetween(
@@ -288,6 +304,7 @@ function connectionBetween(
   next: TerminalLinkRowSnapshot,
   previousContext?: string,
   allowPartialUrlContext = false,
+  work?: TerminalLinkScanWork,
 ): RowConnection | null {
   if (next.index !== previous.index + 1) return null;
 
@@ -320,12 +337,14 @@ function connectionBetween(
     !expectsUrlValue(
       previousContext ??
         cellsText(previous, previousBounds.start, previousBounds.end),
+      work,
     ) &&
     !(
       allowPartialUrlContext &&
       hasUrlValueAssignmentSuffix(
         cellsText(previous, previousBounds.start, previousBounds.end),
         false,
+        work,
       )
     )
   ) {
@@ -379,6 +398,7 @@ function appendRowCells(
 
 function connectionsForRows(
   rows: readonly TerminalLinkRowSnapshot[],
+  work: TerminalLinkScanWork,
 ): Array<RowConnection | null> {
   const connections: Array<RowConnection | null> = [];
   let context = "";
@@ -393,16 +413,21 @@ function connectionsForRows(
       bounds.end,
     );
     connections.push(
-      connectionBetween(previous, rows[index + 1], context),
+      connectionBetween(previous, rows[index + 1], context, false, work),
     );
+    if (work.exhausted) break;
   }
   return connections;
 }
 
-function assembleGroups(rows: readonly TerminalLinkRowSnapshot[]): AssembledGroup[] {
+function assembleGroups(
+  rows: readonly TerminalLinkRowSnapshot[],
+  work: TerminalLinkScanWork,
+): AssembledGroup[] {
   if (rows.length === 0) return [];
   const sortedRows = [...rows].sort((a, b) => a.index - b.index);
-  const connections = connectionsForRows(sortedRows);
+  const connections = connectionsForRows(sortedRows, work);
+  if (work.exhausted) return [];
   const groups: AssembledGroup[] = [];
 
   let rowIndex = 0;
@@ -612,18 +637,28 @@ function linkScanWork(codeUnitBudget: number): TerminalLinkScanWork {
   };
 }
 
+function codeUnitsInRows(rows: readonly TerminalLinkRowSnapshot[]): number {
+  let result = 0;
+  for (const row of rows) {
+    for (const cell of row.cells) {
+      if (cell.width === 0) continue;
+      result += Math.max(1, cell.chars.length);
+    }
+  }
+  return result;
+}
+
 function analyzeTerminalLinks(
   rows: readonly TerminalLinkRowSnapshot[],
   requestedWork?: TerminalLinkScanWork,
 ): TerminalLinkAnalysis {
-  const groups = assembleGroups(rows);
-  const assembledCodeUnits = groups.reduce(
-    (total, group) => total + group.text.length,
-    0,
-  );
-  const work = requestedWork ?? linkScanWork(assembledCodeUnits);
+  const work = requestedWork ?? linkScanWork(codeUnitsInRows(rows));
+  const groups = assembleGroups(rows, work);
   const links: FullTerminalLinkCandidate[] = [];
   const lexical: LexicalTerminalLinkCandidate[] = [];
+  if (work.exhausted) {
+    return { links, lexical, exhausted: true };
+  }
   for (const group of groups) {
     const groupLexical = lexicalLinksInGroup(group, work);
     lexical.push(...groupLexical);
@@ -811,6 +846,7 @@ function collectStructuralSnapshot(
   requestedRow: number,
   cellBudget: number,
   codeUnitBudget: number,
+  work: TerminalLinkScanWork,
 ): StructuralSnapshot {
   const buffer = source.buffer.active;
   const cols = source.cols;
@@ -919,8 +955,8 @@ function collectStructuralSnapshot(
     const adjacent = adjacentSnapshot?.row;
     const connection = adjacent
       ? expandTop
-        ? connectionBetween(adjacent, edge, undefined, true)
-        : connectionBetween(edge, adjacent, connectionContext)
+        ? connectionBetween(adjacent, edge, undefined, true, work)
+        : connectionBetween(edge, adjacent, connectionContext, false, work)
       : null;
     if (!adjacent || !connection) {
       if (
@@ -1266,13 +1302,17 @@ function computeCurrentTerminalLinks(
   cellBudget: number,
   codeUnitBudget: number,
 ): ProviderTerminalLinkCandidate[] {
+  const work = linkScanWork(codeUnitBudget);
   const snapshot = collectStructuralSnapshot(
     source,
     requestedRow,
     cellBudget,
     codeUnitBudget,
+    work,
   );
-  const work = linkScanWork(codeUnitBudget);
+  if (work.exhausted) {
+    return exhaustedLinkScanGuard(source, requestedRow);
+  }
   const analysis = analyzeTerminalLinks(snapshot.rows, work);
   if (analysis.exhausted) {
     return exhaustedLinkScanGuard(source, requestedRow);

--- a/src/components/terminal/terminal-links.ts
+++ b/src/components/terminal/terminal-links.ts
@@ -51,6 +51,8 @@ export interface TerminalLinkCandidate {
 interface ContentBounds {
   start: number;
   end: number;
+  exteriorPrefix: string;
+  exteriorSuffix: string;
   leftBorder?: { column: number; chars: string };
   rightBorder?: { column: number; chars: string };
 }
@@ -73,13 +75,45 @@ interface AssembledGroup {
   boundaries: Array<{ index: number; kind: "soft" | "hard" }>;
 }
 
+interface FullTerminalLinkCandidate {
+  text: string;
+  segments: TerminalLinkCandidate["range"][];
+  requiresConfirmation: boolean;
+}
+
 const BORDER_CHARS = new Set(["│", "┃", "║", "|"]);
 const URL_START = /https?:\/\//gi;
-const URL_STOP = /[\s"'!*(){}|\\^<>`]/u;
-const URL_TRAILING_PUNCTUATION = /[,:.!?;\]}>)]+$/u;
+const URL_STOP = /[\s"'{}|\\^<>`]/u;
+const SENTENCE_PUNCTUATION = new Set([".", ",", "!", "?", ";", ":"]);
+const HARD_CONTINUATION_START = /^(?:https?:\/\/|[-*#]\s|[•◦‣⁃∙·▪▫●○◆◇▶▸])/iu;
 
 function isBlankCell(cell: TerminalLinkCellSnapshot | undefined): boolean {
   return !cell || cell.width === 0 || cell.chars === "" || /^\s+$/u.test(cell.chars);
+}
+
+function cellsSignature(
+  row: TerminalLinkRowSnapshot,
+  start: number,
+  end: number,
+): string {
+  return row.cells
+    .slice(start, end)
+    .map((cell) => `${cell.width}:${cell.chars || " "}`)
+    .join("\u0000");
+}
+
+function cellsText(
+  row: TerminalLinkRowSnapshot,
+  start: number,
+  end: number,
+): string {
+  let result = "";
+  for (let column = start; column < Math.min(end, row.cells.length); column++) {
+    const cell = row.cells[column];
+    if (!cell || cell.width === 0) continue;
+    result += cell.chars || " ";
+  }
+  return result;
 }
 
 function contentBounds(row: TerminalLinkRowSnapshot): ContentBounds {
@@ -92,6 +126,8 @@ function contentBounds(row: TerminalLinkRowSnapshot): ContentBounds {
   const bounds: ContentBounds = {
     start: first,
     end: row.cells.length,
+    exteriorPrefix: "",
+    exteriorSuffix: "",
   };
 
   const midpoint = Math.floor(row.cells.length / 2);
@@ -145,6 +181,11 @@ function contentBounds(row: TerminalLinkRowSnapshot): ContentBounds {
     }
   }
 
+  bounds.exteriorPrefix = cellsSignature(row, 0, bounds.start);
+  bounds.exteriorSuffix = bounds.rightBorder
+    ? cellsSignature(row, bounds.end, row.cells.length)
+    : "";
+
   return bounds;
 }
 
@@ -165,19 +206,12 @@ function matchingHardLayout(
   previous: ContentBounds,
   next: ContentBounds,
 ): boolean {
-  const previousHasBorder = Boolean(previous.leftBorder || previous.rightBorder);
-  const nextHasBorder = Boolean(next.leftBorder || next.rightBorder);
-  if (previousHasBorder || nextHasBorder) {
-    return (
-      previous.leftBorder?.column === next.leftBorder?.column &&
-      previous.leftBorder?.chars === next.leftBorder?.chars &&
-      previous.rightBorder?.column === next.rightBorder?.column &&
-      previous.rightBorder?.chars === next.rightBorder?.chars &&
-      previous.start === next.start &&
-      previous.end === next.end
-    );
-  }
-  return previous.start === next.start && previous.end === next.end;
+  return (
+    previous.start === next.start &&
+    previous.end === next.end &&
+    previous.exteriorPrefix === next.exteriorPrefix &&
+    previous.exteriorSuffix === next.exteriorSuffix
+  );
 }
 
 function connectionBetween(
@@ -206,6 +240,13 @@ function connectionBetween(
   if (!matchingHardLayout(previousBounds, nextBounds)) return null;
   if (lastContentEnd(previous, previousBounds.end) !== previousBounds.end) return null;
   if (firstContentColumn(next, nextBounds.start) !== nextBounds.start) return null;
+  if (
+    HARD_CONTINUATION_START.test(
+      cellsText(next, nextBounds.start, nextBounds.end),
+    )
+  ) {
+    return null;
+  }
   return {
     kind: "hard",
     previousEnd: previousBounds.end,
@@ -268,14 +309,65 @@ function assembleGroups(rows: readonly TerminalLinkRowSnapshot[]): AssembledGrou
   return groups;
 }
 
-function shouldCrossHardBoundary(prefix: string, suffix: string): boolean {
-  if (!parseHttpUrl(prefix)) return true;
-  if (/[/?.#=&%_~-]$/u.test(prefix)) return true;
-  return /[/?.#=&%_~-]/u.test(suffix);
+function trimUrlToken(token: string): string {
+  let end = token.length;
+  let changed = true;
+  while (changed && end > 0) {
+    changed = false;
+    while (end > 0 && SENTENCE_PUNCTUATION.has(token[end - 1])) {
+      end--;
+      changed = true;
+    }
+
+    const last = token[end - 1];
+    const pairs: Record<string, string> = { ")": "(", "]": "[", "}": "{" };
+    const open = pairs[last];
+    if (open) {
+      const value = token.slice(0, end);
+      const opens = Array.from(value).filter((char) => char === open).length;
+      const closes = Array.from(value).filter((char) => char === last).length;
+      if (closes > opens) {
+        end--;
+        changed = true;
+      }
+    }
+  }
+  return token.slice(0, end);
 }
 
-function linksInGroup(group: AssembledGroup): TerminalLinkCandidate[] {
-  const result: TerminalLinkCandidate[] = [];
+function segmentsForMapping(
+  mapping: readonly MappedCodeUnit[],
+  start: number,
+  end: number,
+): TerminalLinkCandidate["range"][] {
+  const result: TerminalLinkCandidate["range"][] = [];
+  let first = mapping[start];
+  let last = first;
+  for (let index = start + 1; index < end; index++) {
+    const current = mapping[index];
+    if (!current) continue;
+    if (!first || !last || current.row !== last.row) {
+      if (first && last) {
+        result.push({
+          start: { x: first.startX, y: first.row + 1 },
+          end: { x: last.endX, y: last.row + 1 },
+        });
+      }
+      first = current;
+    }
+    last = current;
+  }
+  if (first && last) {
+    result.push({
+      start: { x: first.startX, y: first.row + 1 },
+      end: { x: last.endX, y: last.row + 1 },
+    });
+  }
+  return result;
+}
+
+function linksInGroup(group: AssembledGroup): FullTerminalLinkCandidate[] {
+  const result: FullTerminalLinkCandidate[] = [];
   URL_START.lastIndex = 0;
   let startMatch: RegExpExecArray | null;
   while ((startMatch = URL_START.exec(group.text))) {
@@ -283,36 +375,16 @@ function linksInGroup(group: AssembledGroup): TerminalLinkCandidate[] {
     let end = URL_START.lastIndex;
     while (end < group.text.length && !URL_STOP.test(group.text[end])) end++;
 
-    const candidateBoundaries = group.boundaries.filter(
-      (boundary) => boundary.index > start && boundary.index < end,
-    );
-    for (const boundary of candidateBoundaries) {
-      if (
-        boundary.kind === "hard" &&
-        !shouldCrossHardBoundary(
-          group.text.slice(start, boundary.index),
-          group.text.slice(boundary.index, end),
-        )
-      ) {
-        end = boundary.index;
-        break;
-      }
-    }
-
     const rawText = group.text.slice(start, end);
-    const text = rawText.replace(URL_TRAILING_PUNCTUATION, "");
+    const text = trimUrlToken(rawText);
     end -= rawText.length - text.length;
     if (!text || !parseHttpUrl(text)) continue;
 
-    const first = group.mapping[start];
-    const last = group.mapping[end - 1];
-    if (!first || !last) continue;
+    const segments = segmentsForMapping(group.mapping, start, end);
+    if (segments.length === 0) continue;
     result.push({
       text,
-      range: {
-        start: { x: first.startX, y: first.row + 1 },
-        end: { x: last.endX, y: last.row + 1 },
-      },
+      segments,
       requiresConfirmation: group.boundaries.some(
         (boundary) =>
           boundary.kind === "hard" && boundary.index > start && boundary.index < end,
@@ -334,10 +406,14 @@ export function computeTerminalLinks(
   const seen = new Set<string>();
   return assembleGroups(rows)
     .flatMap(linksInGroup)
-    .filter(
-      (link) =>
-        link.range.start.y <= requestedRow + 1 &&
-        link.range.end.y >= requestedRow + 1,
+    .flatMap((link) =>
+      link.segments
+        .filter((range) => range.start.y === requestedRow + 1)
+        .map((range) => ({
+          text: link.text,
+          range,
+          requiresConfirmation: link.requiresConfirmation,
+        })),
     )
     .filter((link) => {
       const key = `${link.range.start.x}:${link.range.start.y}-${link.range.end.x}:${link.range.end.y}:${link.text}`;
@@ -358,13 +434,15 @@ interface TerminalLinkBufferLine {
   getCell(column: number): TerminalLinkBufferCell | undefined;
 }
 
+interface TerminalLinkBuffer {
+  readonly length: number;
+  getLine(row: number): TerminalLinkBufferLine | undefined;
+}
+
 interface TerminalLinkSource {
   readonly cols: number;
   readonly buffer: {
-    readonly active: {
-      readonly length: number;
-      getLine(row: number): TerminalLinkBufferLine | undefined;
-    };
+    readonly active: TerminalLinkBuffer;
   };
 }
 
@@ -373,9 +451,11 @@ export interface TerminalLinkProviderOptions {
   readonly confirm?: (target: string) => boolean;
   /** Protocol-restricted opener, normally createHttpLinkOpener(). */
   readonly open?: (target: string) => unknown;
-  /** Number of rows examined above and below the requested row. */
-  readonly scanRadius?: number;
+  /** Maximum number of terminal cells inspected for one provider request. */
+  readonly cellBudget?: number;
 }
+
+const DEFAULT_LINK_SCAN_CELL_BUDGET = 16_384;
 
 function defaultHardLinkConfirmation(target: string): boolean {
   return window.confirm(
@@ -384,13 +464,14 @@ function defaultHardLinkConfirmation(target: string): boolean {
 }
 
 function snapshotBufferRow(
-  source: TerminalLinkSource,
+  buffer: TerminalLinkBuffer,
+  cols: number,
   index: number,
 ): TerminalLinkRowSnapshot | null {
-  const line = source.buffer.active.getLine(index);
+  const line = buffer.getLine(index);
   if (!line) return null;
   const cells: TerminalLinkCellSnapshot[] = [];
-  for (let column = 0; column < source.cols; column++) {
+  for (let column = 0; column < cols; column++) {
     const cell = column < line.length ? line.getCell(column) : undefined;
     cells.push({
       chars: cell?.getChars() ?? "",
@@ -398,6 +479,130 @@ function snapshotBufferRow(
     });
   }
   return { index, isWrapped: line.isWrapped, cells };
+}
+
+interface StructuralSnapshot {
+  rows: TerminalLinkRowSnapshot[];
+  clipped: boolean;
+}
+
+function couldContinueBefore(row: TerminalLinkRowSnapshot): boolean {
+  if (row.index === 0) return false;
+  if (row.isWrapped) return true;
+  const bounds = contentBounds(row);
+  if (firstContentColumn(row, bounds.start) !== bounds.start) return false;
+  return !HARD_CONTINUATION_START.test(
+    cellsText(row, bounds.start, bounds.end),
+  );
+}
+
+function couldContinueAfter(row: TerminalLinkRowSnapshot): boolean {
+  const bounds = contentBounds(row);
+  return lastContentEnd(row, bounds.end) === bounds.end;
+}
+
+/**
+ * Expand only through structurally connected rows, alternating upward and
+ * downward from the requested row. Cost is bounded by inspected terminal
+ * cells rather than a fixed row count. If the budget cannot resolve a
+ * potentially connected edge, the snapshot is clipped and must not yield a
+ * navigable candidate.
+ */
+function collectStructuralSnapshot(
+  source: TerminalLinkSource,
+  requestedRow: number,
+  cellBudget: number,
+): StructuralSnapshot {
+  const buffer = source.buffer.active;
+  const cols = source.cols;
+  if (
+    requestedRow < 0 ||
+    requestedRow >= buffer.length ||
+    cols <= 0 ||
+    cellBudget < cols
+  ) {
+    return { rows: [], clipped: false };
+  }
+
+  const initial = snapshotBufferRow(buffer, cols, requestedRow);
+  if (!initial) return { rows: [], clipped: false };
+
+  const rows = new Map<number, TerminalLinkRowSnapshot>([
+    [requestedRow, initial],
+  ]);
+  let inspectedCells = cols;
+  let top = requestedRow;
+  let bottom = requestedRow;
+  let topOpen = top > 0;
+  let bottomOpen = bottom < buffer.length - 1;
+  let clipped = false;
+  let expandTopNext = true;
+
+  while (topOpen || bottomOpen) {
+    const expandTop = topOpen && (!bottomOpen || expandTopNext);
+    expandTopNext = !expandTopNext;
+    const edgeIndex = expandTop ? top : bottom;
+    const edge = rows.get(edgeIndex)!;
+    const adjacentIndex = expandTop ? edgeIndex - 1 : edgeIndex + 1;
+
+    if (inspectedCells + cols > cellBudget) {
+      const couldContinue = expandTop
+        ? couldContinueBefore(edge)
+        : couldContinueAfter(edge);
+      if (couldContinue) clipped = true;
+      if (expandTop) topOpen = false;
+      else bottomOpen = false;
+      continue;
+    }
+
+    const adjacent = snapshotBufferRow(buffer, cols, adjacentIndex);
+    inspectedCells += cols;
+    const connection = adjacent
+      ? expandTop
+        ? connectionBetween(adjacent, edge)
+        : connectionBetween(edge, adjacent)
+      : null;
+    if (!adjacent || !connection) {
+      if (expandTop) topOpen = false;
+      else bottomOpen = false;
+      continue;
+    }
+
+    rows.set(adjacentIndex, adjacent);
+    if (expandTop) {
+      top = adjacentIndex;
+      topOpen = top > 0;
+    } else {
+      bottom = adjacentIndex;
+      bottomOpen = bottom < buffer.length - 1;
+    }
+  }
+
+  return {
+    rows: [...rows.values()].sort((a, b) => a.index - b.index),
+    clipped,
+  };
+}
+
+function computeCurrentTerminalLinks(
+  source: TerminalLinkSource,
+  requestedRow: number,
+  cellBudget: number,
+): TerminalLinkCandidate[] {
+  const snapshot = collectStructuralSnapshot(source, requestedRow, cellBudget);
+  if (snapshot.clipped) return [];
+  return computeTerminalLinks(snapshot.rows, requestedRow);
+}
+
+function linkIdentity(link: TerminalLinkCandidate): string {
+  return [
+    link.text,
+    link.requiresConfirmation ? "inferred" : "exact",
+    link.range.start.x,
+    link.range.start.y,
+    link.range.end.x,
+    link.range.end.y,
+  ].join("\u0000");
 }
 
 /**
@@ -410,30 +615,36 @@ export function createTerminalLinkProvider(
 ): ILinkProvider {
   const confirm = options.confirm ?? defaultHardLinkConfirmation;
   const open = options.open ?? createHttpLinkOpener();
-  const scanRadius = Math.max(1, options.scanRadius ?? 8);
+  const cellBudget = Math.max(
+    1,
+    options.cellBudget ?? DEFAULT_LINK_SCAN_CELL_BUDGET,
+  );
 
   return {
     provideLinks(bufferLineNumber, callback) {
       const requestedRow = bufferLineNumber - 1;
-      const start = Math.max(0, requestedRow - scanRadius);
-      const end = Math.min(
-        source.buffer.active.length - 1,
-        requestedRow + scanRadius,
+      const candidates = computeCurrentTerminalLinks(
+        source,
+        requestedRow,
+        cellBudget,
       );
-      const rows: TerminalLinkRowSnapshot[] = [];
-      for (let index = start; index <= end; index++) {
-        const row = snapshotBufferRow(source, index);
-        if (row) rows.push(row);
-      }
-
-      const links = computeTerminalLinks(rows, requestedRow).map((candidate) => ({
-        text: candidate.text,
-        range: candidate.range,
-        activate: () => {
-          if (candidate.requiresConfirmation && !confirm(candidate.text)) return;
-          open(candidate.text);
-        },
-      }));
+      const links = candidates.map((candidate) => {
+        const identity = linkIdentity(candidate);
+        return {
+          text: candidate.text,
+          range: candidate.range,
+          activate: () => {
+            const current = computeCurrentTerminalLinks(
+              source,
+              requestedRow,
+              cellBudget,
+            ).find((link) => linkIdentity(link) === identity);
+            if (!current) return;
+            if (current.requiresConfirmation && !confirm(current.text)) return;
+            open(current.text);
+          },
+        };
+      });
       callback(links.length > 0 ? links : undefined);
     },
   };

--- a/src/components/terminal/terminal-links.ts
+++ b/src/components/terminal/terminal-links.ts
@@ -83,6 +83,13 @@ interface FullTerminalLinkCandidate {
   requiresConfirmation: boolean;
 }
 
+interface LexicalTerminalLinkCandidate {
+  rawText: string;
+  rawSegments: TerminalLinkCandidate["range"][];
+  rawTermination: "separator" | "group-end";
+  start: number;
+}
+
 interface ProviderTerminalLinkCandidate extends TerminalLinkCandidate {
   readonly guard: boolean;
 }
@@ -238,6 +245,12 @@ function hasUrlValueAssignmentSuffix(
   const schemeIndex = text.search(/https?:\/\//iu);
   if (requireScheme && schemeIndex < 0) return false;
   const token = schemeIndex >= 0 ? text.slice(schemeIndex) : text;
+  // An ampersand has query semantics only after the URL has entered a query
+  // or fragment. When the scheme is outside the inspected snapshot we cannot
+  // know that state, so the partial context remains conservatively eligible.
+  if (schemeIndex >= 0 && !token.includes("?") && !token.includes("#")) {
+    return false;
+  }
   const delimiterIndex = Math.max(
     token.lastIndexOf("?"),
     token.lastIndexOf("&"),
@@ -458,8 +471,10 @@ function segmentsForMapping(
   return result;
 }
 
-function linksInGroup(group: AssembledGroup): FullTerminalLinkCandidate[] {
-  const result: FullTerminalLinkCandidate[] = [];
+function lexicalLinksInGroup(
+  group: AssembledGroup,
+): LexicalTerminalLinkCandidate[] {
+  const result: LexicalTerminalLinkCandidate[] = [];
   URL_START.lastIndex = 0;
   let startMatch: RegExpExecArray | null;
   while ((startMatch = URL_START.exec(group.text))) {
@@ -470,24 +485,47 @@ function linksInGroup(group: AssembledGroup): FullTerminalLinkCandidate[] {
     }
 
     const rawText = group.text.slice(start, rawEnd);
-    const text = trimUrlToken(rawText);
-    const end = rawEnd - (rawText.length - text.length);
+    const rawSegments = segmentsForMapping(group.mapping, start, rawEnd);
+    if (rawSegments.length > 0) {
+      result.push({
+        rawText,
+        rawSegments,
+        rawTermination:
+          rawEnd === group.text.length ? "group-end" : "separator",
+        start,
+      });
+    }
+    // Preserve the previous scanner behavior: a valid outer URL owns nested
+    // schemes in its value, while an invalid outer token still lets a later
+    // scheme be considered independently.
+    if (parseHttpUrl(trimUrlToken(rawText))) {
+      URL_START.lastIndex = Math.max(URL_START.lastIndex, rawEnd);
+    }
+  }
+  return result;
+}
+
+function linksInGroup(group: AssembledGroup): FullTerminalLinkCandidate[] {
+  const result: FullTerminalLinkCandidate[] = [];
+  for (const lexical of lexicalLinksInGroup(group)) {
+    const text = trimUrlToken(lexical.rawText);
+    const end = lexical.start + text.length;
     if (!text || !parseHttpUrl(text)) continue;
 
-    const segments = segmentsForMapping(group.mapping, start, end);
-    const rawSegments = segmentsForMapping(group.mapping, start, rawEnd);
-    if (segments.length === 0 || rawSegments.length === 0) continue;
+    const segments = segmentsForMapping(group.mapping, lexical.start, end);
+    if (segments.length === 0) continue;
     result.push({
       text,
       segments,
-      rawSegments,
-      rawTermination: rawEnd === group.text.length ? "group-end" : "separator",
+      rawSegments: lexical.rawSegments,
+      rawTermination: lexical.rawTermination,
       requiresConfirmation: group.boundaries.some(
         (boundary) =>
-          boundary.kind === "hard" && boundary.index > start && boundary.index < end,
+          boundary.kind === "hard" &&
+          boundary.index > lexical.start &&
+          boundary.index < end,
       ),
     });
-    URL_START.lastIndex = Math.max(URL_START.lastIndex, end);
   }
   return result;
 }
@@ -595,6 +633,7 @@ function snapshotBufferRow(
   const cells: TerminalLinkCellSnapshot[] = [];
   let inspectedCells = 0;
   let inspectedCodeUnits = 0;
+  let resolvedEndColumn = 0;
   for (let column = 0; column < cols; column++) {
     if (inspectedCells >= cellBudget) break;
     const cell = column < line.length ? line.getCell(column) : undefined;
@@ -610,12 +649,16 @@ function snapshotBufferRow(
       chars,
       width,
     });
+    resolvedEndColumn = Math.min(
+      cols,
+      Math.max(resolvedEndColumn, column + Math.max(1, width)),
+    );
   }
   return {
     row: { index, isWrapped: line.isWrapped, cells },
     inspectedCells,
     inspectedCodeUnits,
-    resolvedEndColumn: cells.length,
+    resolvedEndColumn,
     clipped: cells.length < cols,
   };
 }
@@ -804,8 +847,11 @@ function collectStructuralSnapshot(
   };
 }
 
-function linkTouchesClippedEdge(
-  link: FullTerminalLinkCandidate,
+function lexicalLinkTouchesClippedEdge(
+  link: Pick<
+    LexicalTerminalLinkCandidate,
+    "rawSegments" | "rawTermination"
+  >,
   snapshot: StructuralSnapshot,
 ): boolean {
   const top = snapshot.rows[0];
@@ -853,6 +899,13 @@ function linkTouchesClippedEdge(
     }
   }
   return false;
+}
+
+function linkTouchesClippedEdge(
+  link: FullTerminalLinkCandidate,
+  snapshot: StructuralSnapshot,
+): boolean {
+  return lexicalLinkTouchesClippedEdge(link, snapshot);
 }
 
 function computeCurrentTerminalLinks(
@@ -903,6 +956,29 @@ function computeCurrentTerminalLinks(
         };
       },
     );
+    for (const group of assembleGroups(snapshot.rows)) {
+      for (const lexical of lexicalLinksInGroup(group)) {
+        if (parseHttpUrl(trimUrlToken(lexical.rawText))) continue;
+        if (!lexicalLinkTouchesClippedEdge(lexical, snapshot)) continue;
+        for (const rawRange of lexical.rawSegments) {
+          if (rawRange.start.y !== requestedRow + 1) continue;
+          const reachesRequestedClip =
+            snapshot.requestedResolvedEnd !== null &&
+            rawRange.end.x >= snapshot.requestedResolvedEnd;
+          candidates.push({
+            text: lexical.rawText,
+            range: reachesRequestedClip
+              ? {
+                  start: rawRange.start,
+                  end: { x: source.cols, y: requestedRow + 1 },
+                }
+              : rawRange,
+            requiresConfirmation: false,
+            guard: true,
+          });
+        }
+      }
+    }
     if (snapshot.requestedResolvedEnd !== null) {
       const firstUnresolvedX = snapshot.requestedResolvedEnd + 1;
       const unresolvedCovered = candidates.some(


### PR DESCRIPTION
## Summary

- reconstruct HTTP/HTTPS links across genuine xterm soft wraps and conservative cursor-positioned TUI hard-row boundaries
- preserve xterm cell coordinates through wide/combining characters, indentation, and repeated panel gutters
- keep OSC 8 at xterm's highest priority, place the custom provider ahead of WebLinksAddon, and re-arbitrate every WebLinks activation against the current buffer

## Root cause

WebLinksAddon only joins rows marked `isWrapped`. Cursor-positioned TUIs commonly repaint each visible row independently, leaving `isWrapped=false`, so xterm exposes only a clickable first-row URL fragment even though the user sees one wrapped target.

xterm also arbitrates links from OSC 8, custom providers, and WebLinksAddon independently. Its overlap pruning can remove a broad custom guard after an OSC 8 intersection while retaining cached occupied cells, allowing a lower WebLinks match elsewhere in the same token to surface. Provider ordering and range splitting improve ownership, but cannot by themselves be the final activation safety boundary.

## Implementation and impact

The custom provider takes a cell- and UTF-16-code-unit-budgeted fresh snapshot around the requested buffer row. It joins genuine soft wraps directly and infers hard-row continuation only when content reaches compatible effective edges, including stable indentation and repeated bordered/labeled gutters. Inferred hard-row links show the complete reconstructed target in a synchronous confirmation prompt before navigation. Cancellation never opens a window; exact OSC 8 and genuine soft-wrap links open directly.

Each provider request exposes only the segment on the requested row while retaining the complete URL as its target. Hard-row reconstruction rejects blank rows, independent fresh schemes, anchored shell prompts/list markers, and changing exterior gutters. Activation revalidates candidate text, range, confirmation, and guard state against the active buffer so a repaint, alternate-buffer switch, or exact-to-guard transition cannot open a stale URL.

Clipped or ambiguous tokens produce invisible inert guards. Guard coverage is normalized into mutually non-intersecting row-local ranges and partitioned at original candidate boundaries where practical, limiting the damage when a higher-priority OSC 8 range intersects one partition.

WebLinksAddon remains available for ordinary URLs, but its handler no longer opens directly. Public hover callbacks record the addon's actual 1-based inclusive buffer range; activation synchronously recomputes every intersected current row and fails closed for missing, stale, ambiguous, or guarded ownership. Ordinary exact matches open without confirmation. A unique inferred match can open only the complete reconstructed target and only after confirmation. OSC 8 continues to use xterm's direct priority-0 handler.

## Security

OSC 8, the custom provider, and WebLinksAddon share one parsed opener. It accepts only absolute `http:` and `https:` URLs and always uses `_blank` with `noopener,noreferrer`; xterm's OSC 8 handler keeps `allowNonHttpProtocols` disabled.

The controller uses only WebLinksAddon's public hover/leave callbacks and fresh terminal-buffer semantics. It does not depend on xterm's private OSC/linkifier state in production. Deterministic tests cover the controller independently of range partitioning.

## Tests

- `bun run test:run src/components/terminal` — 10 files passed; 192 passed, 1 skipped
- `bun run typecheck` — passed
- targeted ESLint for all changed terminal files — passed
- `bun run build` — Next.js compile-mode production build passed
- `git diff --check` — clean

Coverage includes hard TUI row wraps, natural soft wraps, stable panes/gutters, shell/list boundaries, multi-row query/fragment values, clipping by both budgets, parser-divergent prefixes, wide/combining cells, stale repaint/buffer transitions, normalized/partitioned guards, and safe exact-link preservation. Real-xterm integration uses actual `Terminal`, OSC 8, WebLinksAddon, hover selection, and `mousedown`/`mouseup`: a one-cell OSC 8 at x=1 remains directly clickable while the nested same-line fallback stays inert, and an OSC 8 guard-gap control proves the fresh-buffer WebLinks controller blocks a lower-provider prefix even if it survives pruning.

Refs: remote-dev-psic, remote-dev-psic.1
