### PR TITLE
docs: design UI audit remediation program

### DIFF
--- a/docs/superpowers/specs/2026-08-03-desktop-electron-settings-remediation-design.md
+++ b/docs/superpowers/specs/2026-08-03-desktop-electron-settings-remediation-design.md
@@ -1,0 +1,513 @@
+# Desktop, Electron, and Settings Remediation - Design Spec
+
+**Date:** 2026-08-03
+**Status:** Draft pending written review
+**Groups:** E1, D1-D8
+**Source audit:** `remote-dev-9vik.6`, `.7`, `.9-.20`, `.22-.25`
+
+## 1. Goals
+
+This work restores trustworthy desktop behavior after the global Settings and
+terminal layout refactors. It covers Electron startup, compact layout, the
+Settings host, keyboard and accessibility contracts, theme continuity, async
+feedback, and tmux cleanup safety.
+
+The central sizing objective is not to replace the terminal resize reconciler.
+The audit confirmed xterm and tmux converge after ordinary window and sidebar
+transitions. The defect is the composition around the central terminal: at the
+supported 800 by 600 Electron minimum, app navigation, terminal padding, optional
+sidebars, and a fixed Settings navigation column can leave almost no Settings
+content width. Electron zoom can also cross the web mobile breakpoint and replace
+the entire desktop terminal with mobile onboarding.
+
+## 2. Non-goals
+
+- Do not redesign terminal rendering, change terminal font metrics, or duplicate
+  the refit work in draft PR #451.
+- Do not alter the tmux client-attach capability and
+  `TmuxAttachArgumentResolver` owned by draft PR #450. Renderer link parsing stays
+  with draft PR #451.
+- Do not create a new visual system. Reuse the semantic application tokens and
+  established component primitives.
+- Do not expose Settings as a separate top-level application or URL solely to
+  escape its layout constraints.
+- Do not use destructive cleanup to migrate legacy tmux sessions.
+
+## 3. Layout and shell architecture
+
+### 3.1 One shell decision
+
+Shell selection becomes an explicit application decision rather than several
+independent UA, JavaScript width, and CSS breakpoint decisions.
+
+- Electron always uses the desktop shell. The synchronous discriminator is the
+  existing preload-exposed `window.electron` capability, captured before shell
+  selection. Browser zoom may change available CSS pixels and compact the layout,
+  but it cannot select mobile onboarding or unmount an active terminal.
+- An installed mobile PWA or mobile interaction mode uses the mobile shell and
+  its adaptive navigation defined by M1.
+- The ordinary web app uses the existing responsive selection through one shared
+  selector. Child components consume the selected shell mode; they do not run
+  their own contradictory mobile tests.
+- Changing compact layout within a shell is a CSS/state transition. It preserves
+  terminal component identity, WebSocket ownership, session selection, editor
+  state, and pending input.
+
+The selected shell mode is available before the first meaningful render so a
+desktop Electron window never flashes mobile onboarding during startup or zoom.
+
+### 3.2 Central pane width contract
+
+Every horizontal layer participates in a single min-width contract:
+
+1. App navigation declares fixed or collapsible width.
+2. Optional Files, MCP, task, and related rails declare their open and collapsed
+   widths.
+3. The central pane uses `min-width: 0`, owns overflow, and receives the remaining
+   width.
+4. Plugin surfaces inside the central pane receive the actual content box. They
+   cannot assume the full window width.
+5. xterm remains mounted and receives a reconcile request only after the final
+   measured box changes.
+
+The layout must not produce document-level horizontal scroll. A local surface may
+scroll only when the contained information truly requires it and the region is
+named for assistive technology.
+
+### 3.3 Settings compact composition
+
+`SettingsView` remains a terminal plugin, but its navigation adapts to the central
+pane rather than the window:
+
+- At comfortable widths, retain the current persistent section navigation and
+  content column.
+- At compact widths, replace the fixed section column with one labeled section
+  selector or disclosure at the top of the content. It must expose all 15
+  sections, the current section, and keyboard navigation.
+- The content column uses `min-width: 0`, bounded vertical scrolling, and
+  breakpoint-aware form/action rows. Long IDs, hostnames, commands, and status
+  values wrap or use a named local scroller.
+- Settings does not ask outer terminal padding and inner Settings padding to both
+  preserve desktop gutters when the available content box is narrow.
+- Navigating into and out of Settings preserves the terminal session and restores
+  focus to the invoker or selected section heading.
+- If compact plugin mode temporarily collapses or overlays the saved 220-pixel
+  primary and 320-pixel secondary sidebars, it snapshots their independent states
+  and restores both exactly on exit. The compact mode does not persist those
+  temporary widths as user choices.
+
+Acceptance viewports include 800 by 600, 1024 by 600, 1024 by 768, and 1440 by
+900, with Electron zoom at 100, 125, 150, and 200 percent. Reset Zoom remains
+reachable in every compact state. Dimension verification uses the existing resize
+boundary without modifying #451-owned `Terminal.tsx` or its refit/font-race tests.
+
+### 3.4 New Session compact composition
+
+`NewSessionWizard` receives a bounded dialog/sheet body with a scrollable form
+region and a persistent, non-overlapping action region. The focused or invalid
+field scrolls into view. The wizard remains operable at 800 by 600 and at 200%
+text zoom, including advanced agent/profile/project choices. Fixed-height spacing
+is not used to satisfy one fixture.
+
+Wizard state and step content are presentation-independent. Desktop renders them
+inside one Radix dialog; mobile renders them directly inside one bottom sheet with
+safe-area padding. Mobile never portals a desktop dialog from inside a sheet.
+Header, Back/Close, validation, and primary actions remain reachable at 390 by 667
+and 390 by 844. Focus remains trapped in the one active layer, Escape or platform
+Back closes the expected layer, and focus returns to the trigger.
+
+## 4. Electron startup state machine
+
+E1 replaces the startup spinner as an implicit state with an explicit state
+machine:
+
+| State | Meaning | Available action |
+|---|---|---|
+| `inspecting` | Installation and configuration are being checked. | Cancel window close only. |
+| `setup_required` | Required first-run data or binaries are absent. | Open setup, choose configuration, or exit. |
+| `starting` | The managed server process is launching and health is pending. | Show progress and bounded timeout. |
+| `ready` | The server health contract passed. | Load the application URL. |
+| `stopped` | Auto-start is disabled or the managed servers were deliberately stopped. | Start, change mode, reopen setup, or exit. |
+| `failed` | Spawn, early exit, timeout, or health check failed. | Retry, open diagnostics, return to setup, or exit. |
+
+The setup wizard is reachable from `setup_required` during normal application
+startup, not only through a route that requires the server to have started. It
+uses the existing installation/persistence work tracked by GitHub issue #171.
+Fresh state opens the existing five-step wizard. Completion or the explicit Skip
+path writes a validated `setup-config.json`; corrupt or incomplete config returns
+to a recoverable setup state. Ports, working directory, auto-start, and update
+choices are applied to the following start attempt. A deliberate Settings/menu
+entry reopens setup after first run.
+
+Electron uses a concrete two-phase renderer bootstrap so the React wizard does not
+depend on the terminal server it configures:
+
+1. An `ElectronBootstrapProcess` starts the packaged Next renderer only, on an
+   ephemeral loopback port, with `RDV_ELECTRON_BOOTSTRAP_ONLY=1`. It is independent
+   of configured application/terminal ports.
+2. That mode serves `/electron-bootstrap` for inspecting/starting/stopped/failed
+   states and `/setup` mounting the existing `SetupWizard`. Other application
+   pages redirect to the bootstrap state; platform/configuration and recovery
+   actions use the preload IPC bridge.
+3. Complete or Skip validates and atomically persists configuration through
+   `setup-config-store.ts`. Skip writes explicit validated defaults; it is not an
+   in-memory flag.
+4. Electron keeps the bootstrap process and recovery UI alive while it constructs
+   immutable `RuntimeConfig`, constructs the normal `ProcessManager` and updater,
+   and starts the managed servers. It navigates the same BrowserWindow to the
+   normal application URL only after health succeeds, then stops the bootstrap
+   process after the application load commits.
+5. A second launch loads valid config before constructing either manager. When
+   auto-start is enabled it may show the bootstrap Starting state until Ready; when
+   disabled it keeps the bootstrap Stopped state with a Start action. A later child
+   exit or start failure starts/reuses the bootstrap process and navigates the
+   existing window to recoverable state. Reopen Setup intentionally stops normal
+   servers, returns to bootstrap, and applies saved changes through a full managed
+   restart.
+
+Completing or skipping first-run setup always performs that one immediate managed
+start and transitions without a manual application restart. The persisted
+`autoStart` choice governs subsequent application launches only.
+
+`RuntimeConfig` is dependency-injected instead of mutating the current global
+object after imports. `nextPort` and `terminalPort` drive both child environments
+and health URLs; `workingDirectory` becomes the validated default session/project
+directory passed to the server; `autoStart` gates initial managed-server start;
+`checkForUpdates` gates `AutoUpdater` initialization/check-on-startup; the selected
+WSL distribution is passed only on supported Windows paths. Port ranges,
+distinctness, directory existence/access, and platform-specific values are
+validated before persistence.
+
+A failed child process cannot leave an infinite spinner. The failure view presents
+a sanitized cause, exit code where meaningful, log location, and recovery actions.
+Retry creates a fresh process attempt and tears down listeners from the prior
+attempt. Closing the window or quitting Electron terminates only the child process
+owned by that app instance.
+
+Tray start, restart, stop, and mode changes use the same state machine. Conflicting
+tray actions are disabled while pending and failures bring the existing window to
+the recoverable error state. Reopening a window attaches one persistent status
+listener; it does not accumulate one-shot listeners or load the application URL
+more than once for a Ready transition.
+
+The still-valid automatic dependency-install/web-fallback work currently mixed
+into GitHub #171 is moved to a linked follow-up issue. E1 does not claim or retain
+that extra behavior while rewriting #171 around `.6` and `.22`.
+
+## 5. Desktop interaction primitives
+
+### 5.1 Named icon controls
+
+D2 audits all icon-only controls in the main shell and gives each a task-oriented
+accessible name. A shared icon-control primitive carries:
+
+- Native `button` semantics.
+- A required accessible label.
+- Visible focus and disabled states.
+- Optional tooltip that repeats, but does not replace, the accessible name.
+- At least the established desktop target area and 44 by 44 when used on a
+  coarse-pointer layout.
+
+Decorative SVGs are hidden from the accessibility tree. Dynamic labels describe
+the action, such as `Collapse files`, not the icon shape.
+
+The audit covers header, desktop/mobile rails, project/session tree,
+tasks/Beads/schedules, channels, notifications, GitHub, Files,
+browser/editor/recording, and Electron-facing controls. Representative full-page
+accessibility snapshots must contain no unnamed buttons. A test helper or lint rule
+prevents a new icon-only button from being introduced without a name.
+
+### 5.2 Collapsed rails
+
+Collapsed Files and MCP controls become real disclosure buttons. Activating one
+opens the owned rail, updates `aria-expanded`, preserves the previous internal
+selection, and triggers terminal measurement after the width transition. The
+collapsed control is not a decorative placeholder and cannot trap focus in hidden
+content.
+
+### 5.3 Row actions
+
+Task, schedule, and GitHub row actions that are visually revealed on hover are
+also revealed by `:focus-within` and remain reachable in logical tab order. Touch
+layouts expose an explicit overflow/action control. Visibility never depends on a
+hover-capable pointer.
+
+## 6. Composite trees
+
+D4 implements project and repository navigation as an ARIA tree rather than
+nested buttons:
+
+- The collection uses `role="tree"`; rows use `role="treeitem"` and accurate
+  `aria-level`, `aria-expanded`, `aria-selected`, and set position metadata where
+  needed.
+- One row target participates in a roving tab stop. Secondary menus are sibling
+  buttons, never descendants of another button.
+- Up/Down move between visible rows; Home/End move to the bounds; Right expands or
+  enters children; Left collapses or moves to the parent; Enter activates; Space
+  selects where selection is distinct from activation; printable characters use
+  typeahead over visible labels.
+- Rename, create, drag, context menu, and destructive confirmation behavior remain
+  available without invalid DOM nesting.
+- Focus is repaired predictably when the focused row is removed, moved, filtered,
+  or collapsed under its parent.
+
+Pointer and touch drag behavior must not consume keyboard selection or create a
+second competing focus model.
+
+The GitHub repository expansion surface implements the equivalent list/tree
+contract, including expanded state and keyboard navigation. One Tab enters and one
+Tab exits each composite widget.
+
+## 7. Platform shortcut model
+
+D5 introduces one client-safe shortcut registry. A shortcut is stored as semantic
+modifiers and key, not a preformatted glyph string. The same registry provides:
+
+- Platform formatting: Command glyphs on macOS, `Ctrl` on Windows and Linux.
+- Handler matching through one primary-modifier predicate.
+- Command palette and help-panel labels.
+- Inline hints and keycap rendering.
+- `aria-keyshortcuts` values where supported.
+
+Session previous/next handling accepts Ctrl plus bracket on Windows/Linux and
+Command plus bracket on macOS. Tests inject a platform adapter instead of mutating
+global browser identity unsafely.
+
+## 8. Theme continuity
+
+D6 makes semantic appearance available before route-specific UI renders.
+
+- Root appearance precedence is: validated controlled-embed
+  `rdvAppearance=light|dark`; authenticated database preference once available;
+  validated `rdv_appearance` cookie/local mirror; then
+  `prefers-color-scheme`. Login can therefore render correctly without calling the
+  authenticated appearance API. When authentication loads a different database
+  value, it becomes authoritative and refreshes the mirror for the next prepaint.
+- A static CSP-hashed bootstrap applies the mirror/system value before React and
+  accepts only `system`, `light`, or `dark`. AppShell-skipped login and channel,
+  session, and recording embeds consume the same root result. Controlled Flutter
+  embeds use the authority contract in M5 and cannot be overwritten by a later
+  provider fetch.
+- The no-preference default follows `prefers-color-scheme` without a dark flash.
+- Browser `color-scheme`, focus rings, backgrounds, text, borders, and native form
+  controls match the active mode.
+- CodeMirror chooses a light or dark editor extension from the active semantic
+  mode. Tokyo Night may remain the terminal/editor dark palette where deliberate,
+  but it is not forced inside a light application theme.
+- Route transitions and editor mounting do not reset unsaved editor content.
+
+Login form, OIDC choices, error copy, mobile-app banner, channel list/view/thread,
+and embed empty/loading/failure states receive computed-contrast and visual tests
+in light/dark/system. CodeMirror tests retain source content, undo history, cursor,
+selection, scroll, and rendered Markdown across live system changes. D6 bases on
+D5 and preserves its platform-aware Save shortcut in the shared
+`CodeMirrorEditor.tsx`.
+
+## 9. Async feedback contract
+
+D3 creates a small shared action-result contract for the audited high-value UI
+actions. It standardizes state, not wording or layout:
+
+```
+idle -> pending -> succeeded
+                 -> failed(retryable, message, action)
+```
+
+- Local form validation stays next to the field.
+- A recoverable command failure stays near the initiating control and exposes a
+  retry that reuses the preserved input.
+- Global completion may use the existing toast system when the user can navigate
+  away, but a toast is not the only record of a blocking failure.
+- Pending disables only conflicting actions and prevents duplicate submission.
+- Abort and stale-response handling prevent an earlier request from overwriting a
+  later user choice.
+- Errors are logged with diagnostic detail while user copy remains actionable and
+  sanitized.
+
+D3 applies this contract to worktree deletion, recording save, schedule Run now,
+browser navigation/frame load, agent restart, worktree creation, and Settings
+Trigger load/toggle/delete. Both rejected promises and non-OK HTTP responses are
+failures. A rejected Trigger DELETE retains its row and can never display success.
+D3 owns only those high-value paths named by `.16`; D8 applies the same contract
+to its other Settings mutations.
+
+## 10. Settings state integrity
+
+### 10.1 Controlled section navigation
+
+The Settings session metadata is authoritative. When an existing Settings tab is
+opened with a new valid section, `SettingsView` updates its active section,
+announces the heading, and focuses it when navigation originated outside the tab.
+Invalid section IDs fall back safely and never leave the content and navigation
+out of sync.
+
+Every external open and direct user selection increments one monotonic
+`settingsNavigationRevision` in optimistic SessionContext metadata. The visible
+section applies the highest revision immediately. Persistence acknowledgements and
+failures carry the originating revision; an older response cannot select, revert,
+or overwrite a newer section. A failure on the current revision retains the local
+selection and exposes Retry rather than silently rolling back. Rapid
+Terminal -> SSH -> Logs therefore settles on Logs, while later direct user
+navigation wins over stale singleton-open responses. Rendered SessionManager tests
+exercise the existing-tab singleton fast path, not only the helper call.
+
+### 10.2 Durable debounced values
+
+Settings sliders and similar immediate controls use a shared pending-save
+coordinator owned above lazily mounted sections and retained by the Settings
+session until all work drains. It has these semantics:
+
+1. The visual value updates locally.
+2. A keyed debounce map schedules the latest value independently for every
+   setting, so changing xterm scrollback and tmux history within one debounce
+   interval persists both.
+3. Explicit section navigation, Escape, X, Settings close, and session switch call
+   an awaitable drain before unmount/release. Lazy child cleanup may enqueue its
+   final value but is never expected to await network work or own retry UI.
+4. A failed flush leaves the value visibly unsaved with Retry and Revert actions.
+5. Each preference key serializes its requests and attaches a generation; an older
+   response cannot replace a newer local value.
+
+This controller is reused only for the same persistence semantics. Ordinary form
+submission and unrelated toggles are not forced into a debounce abstraction.
+
+### 10.3 Form semantics
+
+Every Settings control has a stable programmatic name, description, error
+association, and keyboard interaction. Selectable cards use native radio,
+checkbox, or button semantics with visible selected and focus states. Group labels
+do not rely on visual proximity.
+
+### 10.4 Exactly-once SSH creation
+
+Generated-key SSH creation is a guarded client `create -> success` state machine:
+
+- The pending transition issues exactly one POST. Click, Enter, double-click, and
+  component rerender cannot issue another request; no automatic POST retry occurs
+  after an ambiguous network result.
+- The submit action remains pending until the result is known and cannot be
+  activated twice through click, Enter, or remount.
+- Success clears sensitive transient fields only after the canonical record is
+  available. The success step names the created connection, provides Copy public
+  key and Done actions, and has no enabled Create action. Failure preserves
+  correctable input and offers retry.
+- Any edit after creation uses PATCH with the returned connection ID; it cannot
+  implicitly issue another POST.
+
+Request-count and list-integrity tests cover generated, pasted, and uploaded key
+modes. Generated-key success proves Copy and Done behavior and exactly one new
+connection/key identity in the list.
+
+## 11. Instance-safe tmux ownership
+
+D7 creates one random UUID atomically in the canonical data directory and persists
+it in a versioned instance-identity file. Moving the entire data directory retains
+identity; pointing Remote Dev at a different data directory creates a different
+identity. Startup holds an OS-level exclusive lock keyed by UUID for the process
+lifetime, so concurrently copied identity files fail with both canonical data
+paths named rather than sharing a tmux server. Invalid identity files also fail
+safely. A versioned,
+tmux-safe label `rdv-v1-<encoded-uuid>` selects the instance's server through
+`tmux -L` on every command.
+
+New sessions always use that instance-scoped server. Both current creation
+boundaries, `src/server/terminal.ts` and `src/services/tmux-service.ts`, plus the
+application gateway, list API, and cleanup API receive the same
+`TmuxEnvironment`; falling back to the process user's default server is not
+permitted. Every new session also stores the identity in a tmux option for
+diagnostics and defense in depth.
+
+A durable `tmux_session_registry` closes the database-to-tmux deletion race. Rows
+are keyed by tmux session name and store owner identity, lifecycle
+`active|released|cleaning`, and a monotonic version. Creation/resume compare-and-
+swaps the exact row to `active` in the same database transaction that establishes
+the current terminal record. Ending a database session leaves a `released`
+registry row.
+
+Listing classifies sessions as:
+
+- `managed-active`: exact owner match and a current database record.
+- `managed-orphaned`: exact owner match and no current database record.
+- `foreign`: a different owner fingerprint.
+- `legacy-unknown`: no ownership option and no exact current database record.
+
+Only `managed-orphaned` sessions with a matching `released` registry row on the
+instance-scoped server are eligible for cleanup. Foreign and legacy-unknown
+sessions may be reported as informational but never selected or killed. Existing
+database records that point to legacy sessions on the default server may attach
+through a narrow compatibility adapter by exact recorded name. They remain
+ineligible for orphan cleanup and are not adopted or moved destructively; new and
+restarted sessions use the scoped server. Name prefix alone is never ownership
+proof.
+
+Cleanup compare-and-swaps the candidate registry row from `released` to `cleaning`
+with the listed version and confirms no current terminal record in the same
+transaction. Creation or resume therefore wins the registry claim or observes
+`cleaning` and cannot attach; cleanup cannot kill after a resume won. After the
+claim, the endpoint revalidates the scoped tmux server and owner option, kills the
+exact session, and records the result. Failed kills return the registry row to
+`released`; success removes or marks it cleaned. The browser cannot supply an
+arbitrary tmux server or unlisted name.
+
+Regression tests point two temporary data directories at one uniquely named
+disposable legacy `tmux -L` server to reproduce the original shared-server defect,
+then verify ambiguous legacy sessions are fail-closed. Separate scoped labels prove
+new-session isolation. A list -> resume/create -> bulk-delete race proves exactly
+one registry claimant and no live-session kill.
+
+D7 branches only after #450 is rebased on current `origin/master` and its
+`TmuxAttachArgumentResolver`/hyperlink tests pass. D7 preserves that attach
+capability and does not claim renderer link parsing from #451.
+
+## 12. Group-specific acceptance
+
+| Group | Required proof |
+|---|---|
+| E1 | Fresh install reaches the five-step setup; complete/skip persists and applies every setup choice; configured install starts; corrupt config, spawn exit, occupied port, missing executable, timeout, and child exit reach recovery; tray retry and window reopen do not leak processes or listeners. |
+| D1 | New Session uses one accessible layer and remains usable at all named desktop/mobile sizes; all Settings sections remain usable at target compact viewports; temporary rail changes restore saved widths on exit; Electron zoom preserves terminal DOM/session identity, keeps Reset Zoom reachable, and returns correct xterm/tmux dimensions after settling. |
+| D2 | Every audited icon control has a state-aware name; full-page AX snapshots contain no unnamed buttons; collapsed rails open by keyboard and pointer; named task/schedule/GitHub row actions appear on focus and touch; prevention tests reject regressions. |
+| D3 | Every enumerated `.16` action handles rejected and 4xx/5xx outcomes and exposes pending, failure, retry, and success behavior with stale-response protection. |
+| D4 | Accessibility-tree and interaction tests cover tree and repository composites, typeahead, focus repair, context/rename/create/drag behavior, and prove there are no nested interactive controls. |
+| D5 | macOS and Windows/Linux labels, handlers, and accessibility metadata agree for every registered shortcut. |
+| D6 | Login, channel/session/recording embeds, CodeMirror source/rendered modes, and main shell agree in light, dark, system, and runtime preference changes without content, selection, history, or scroll loss. |
+| D7 | Two isolated Remote Dev instances under one OS user cannot classify or terminate each other's tmux sessions; unknown legacy sessions are fail-safe. |
+| D8 | All controls across 15 Settings sections are named and keyboard-operable and active navigation is exposed; rapid deep links update an existing tab without stale rollback; independent pending saves survive every exit path; generated-key success has Copy/Done and repeated submission creates exactly one record while later edits PATCH it. |
+
+## 13. Bead-to-test traceability
+
+Every source Bead acceptance criterion remains normative. The implementation plans
+may add proof, but they cannot replace these minimum cases with only the group
+summary.
+
+| Bead | Design section | Minimum focused proof |
+|---|---|---|
+| `.6` | 4 | Fresh/corrupt/complete config; five steps; complete and Skip defaults; second-launch bypass; reopen; both ports, working directory, auto-start, updater, and WSL application through injected runtime consumers. |
+| `.7` | 3.4 | Every step at 800x600, 1024x600, 1024x768, 1440x900, 390x667, and 390x844; one dialog/sheet layer; internal scroll; header/actions; validation; focus trap; Escape/Back; focus return. |
+| `.9` | 5.1 | Header, desktop/mobile rails, project/session tree, tasks/Beads/schedules, channels, notifications, GitHub, Files, browser/editor/recording, and Electron controls; state descriptions; full-page AX snapshots; prevention helper/lint. |
+| `.10` | 6 | Multi-level groups/projects/sessions and repositories; one Tab in/out; arrows/Home/End/Enter/Space/typeahead; expansion/selection; no nested controls; context, rename/create, drag/drop, active and collapsed focus repair; mobile unchanged. |
+| `.11` | 7 | macOS and Windows/Linux formatting/handlers for palette, help, inline hints, editor Save, and session brackets; `aria-keyshortcuts`; injected platform adapter. |
+| `.12` | 8 | Login, OIDC, error/banner, channel list/view/thread, and embed empty/loading/failure in light/dark/system before paint; `/m/session` and `/m/recording` continuity; no auth 401 theme dependency or avoidable jump. |
+| `.13` | 8 | Light/dark editor surface, gutters, selection, cursor, syntax, source/Markdown, and live System change with content/history/cursor/selection/scroll retained. |
+| `.14` | 5.2 | Real unstubbed Files and MCP zero/nonzero states; click/Enter/Space; named expanded state; parity with adjacent rails. |
+| `.15` | 5.3 | Task delete/subtask removal/issue-to-task, schedule run/delete, and PR worktree actions by keyboard/touch; visibility before focus; order; disabled/loading; destructive confirmation. |
+| `.16` | 9 | Worktree delete, recording save, Run now, browser navigation/frame, agent restart, worktree creation, and Trigger load/toggle/delete; rejected promise and 4xx/5xx for each; retained context and retry; rejected delete retains row. |
+| `.17` | 11 | Two databases under one user; identity relocation and concurrent copied-ID lock; shared legacy socket list/single/bulk fail-closed; scoped creation boundaries; restart; foreign/unowned rejection; exact list-to-resume/create-to-delete CAS race. |
+| `.18` | 3.2, 3.3 | Start with saved 220/320 sidebars at 800x600, 1024x768, 1440x900; all nav/control bounds; no clipped/document overflow; exact restore; Profiles, Secrets, Logs, Terminal, Instances, System and worst-case strings. |
+| `.19` | 3.1, 3.3 | Electron 800x600 at 100/125/150/200%; desktop selector, terminal/session/Settings identity, Reset Zoom; ordinary mobile browser still selects MobileApp; existing resize boundary converges. |
+| `.20` | 10.3 | Computed names for every input/combobox/slider/switch across all 15 sections; active nav state; Project and Secrets cards by Tab/Enter/Space with selected state; no overlap with icon-button naming. |
+| `.22` | 4 | Initial failure/retry success, occupied port, missing executable, child exit, timeout, stop/restart, tray failures, conflicting-action disable, persistent listener cleanup, close/reopen, repeated status events, one URL load per Ready. |
+| `.23` | 10.1 | Existing singleton tab Terminal -> SSH -> Logs last-write-wins; user nav beats stale responses; persistence failure; invalid fallback; visible section and persisted metadata agree. |
+| `.24` | 10.2 | Slider then section/Escape/X/session switch persists; xterm scrollback and tmux history within 500 ms both persist; repeated motion coalesces per key; failure Retry/Revert; fake timers and API state after unmount. |
+| `.25` | 10.4 | Generated/pasted/uploaded modes; generated flow sends one POST; double-click/rerender/after-response cannot recreate; Copy/Done; exactly one list row/key identity; subsequent edit PATCHes returned ID. |
+
+## 14. Verification matrix
+
+Desktop verification includes focused Vitest suites, TypeScript typecheck, ESLint
+for changed files, Electron TypeScript build for Electron changes, and the root
+production build for route/theme changes. Runtime checks use Chromium and an
+Electron development build at the target sizes and zoom levels.
+
+Accessibility verification inspects the browser accessibility tree and exercises
+keyboard-only flows. Tmux verification uses two temporary, explicitly named data
+directories and disposable test sessions; it never runs cleanup against the
+user's default tmux server or live repository sessions.

--- a/docs/superpowers/specs/2026-08-03-mobile-remediation-design.md
+++ b/docs/superpowers/specs/2026-08-03-mobile-remediation-design.md
@@ -1,0 +1,450 @@
+# Mobile PWA and Flutter Remediation - Design Spec
+
+**Date:** 2026-08-03
+**Status:** Draft pending written review
+**Groups:** M1-M6
+**Source audit:** `remote-dev-9vik.8`, `.21`, `.27-.37`
+
+## 1. Goals
+
+This work repairs the shipped mobile paths as one product across the PWA and
+Flutter shell. It restores reachable navigation, truthful project and Profile
+flows, safe terminal input, strict routing identifiers, workspace-qualified
+external navigation, compact layout, system text and theme preferences, and
+actionable recovery states.
+
+The hybrid boundary remains intentional: Flutter owns device, workspace, native
+shell, and native list/form concerns; embedded `/m/*` pages own terminal, channel,
+and recording web content. The fix makes the data contracts crossing that boundary
+explicit rather than replacing the architecture.
+
+## 2. Non-goals
+
+- Do not reimplement xterm, channel history, or recording playback as Flutter
+  widgets.
+- Do not revive the superseded Expo/React Native client.
+- Do not claim full offline operation. The app must explain and recover from
+  offline state, but terminal and server data remain online services.
+- Do not make unsupported Profile tasks appear functional through placeholder
+  screens.
+- Do not reduce device accessibility settings to make a layout test pass.
+
+## 3. Shared mobile contracts
+
+### 3.1 Workspace identity
+
+A workspace is identified externally by a canonical public origin plus normalized
+base path. Local Flutter storage may retain an internal workspace ID, but links and
+push payloads cannot depend on a device-local ID that the server does not know.
+
+The shared locator shape is:
+
+```text
+origin: lowercase HTTPS scheme + host + effective port
+basePath: empty or normalized slash-separated Remote Dev base path
+```
+
+Secrets, cookies, tokens, user IDs, and raw connection labels are never included.
+Flutter resolves this locator against saved workspaces. Two workspaces on one
+Supervisor host remain distinct through `basePath`.
+
+### 3.2 Typed destination identity
+
+Session, channel, and recording IDs are distinct destination types at route and
+API boundaries. TypeScript uses named input types and runtime validation; Dart
+uses distinct route variants/value objects. A session ID is never accepted by a
+recording playback route merely because both are strings.
+
+Every external destination is a pair:
+
+```text
+workspace locator + typed destination(kind, id)
+```
+
+### 3.3 Capability ownership
+
+The PWA and Flutter share `contracts/mobile-profile-capabilities.json`, a
+schema-validated machine-readable registry. TypeScript consumes the JSON directly;
+a checked-in generated Dart fixture is produced by one repository script, and a
+test fails when its source hash differs. Each task has one status per client:
+
+- `native`: implemented in the client shell.
+- `embedded`: implemented by a validated `/m/*` surface.
+- `handoff`: unavailable in this interaction mode, with a supported destination
+  and truthful explanation.
+- `unavailable`: not offered as an enabled action.
+
+Labels and outcomes remain consistent even when the presentation differs.
+
+M6 delivers this explicit registry state:
+
+| Capability | PWA | Flutter | Outcome |
+|---|---|---|---|
+| Account | `native` | `native` | View account and perform supported session/account actions. |
+| GitHub accounts | `native` | `native` | List and perform supported connect/disconnect actions. |
+| Appearance/Settings | `native` | `native` | Change the preferences supported by that client. |
+| Servers | `unavailable` | `native` | Flutter manages saved hosts/workspaces; PWA does not advertise server management. |
+| Projects | `native` | `native` | Browse scope and create through the canonical project contract. |
+| Agent Profiles | `unavailable` | `unavailable` | Both clients explain that desktop management is required and render no enabled row. |
+| Secrets | `native` | `unavailable` | PWA provides authorized redacted management; Flutter does not advertise it. |
+| Ports | `native` | `unavailable` | Existing PWA Ports remains functional; Flutter does not advertise it. |
+| Trash | `unavailable` | `unavailable` | No enabled mobile destination until restore semantics are implemented. |
+| Security | `unavailable` | `native` | Flutter owns biometric security; PWA does not claim an equivalent. |
+| About | `native` | `native` | Both clients expose version and product information. |
+
+`unavailable` entries may show static explanatory copy in the Profile index, but
+they cannot render as enabled navigation rows. A desktop URL that remounts
+`MobileApp` at the current viewport is not a supported handoff.
+
+## 4. M1: PWA shell, projects, scoping, and smart keys
+
+### 4.1 One adaptive shell decision
+
+`MobileViewportSwitch`, `MobileApp`, and `MobileShell` consume one shared shell
+mode. A mobile PWA does not drop its global navigation merely because landscape or
+foldable width crosses 768 CSS pixels.
+
+The mobile shell has two structural presentations:
+
+- Compact phone mode uses the bottom tab bar.
+- Wide-mobile mode uses a compact navigation rail or an equivalently persistent
+  tab control while preserving the same destinations.
+
+Sessions, Notifications, Channels, and Profile remain visible and operable at
+320 by 568, 568 by 320, 812 by 375, and 932 by 430. Rotation, unfold, and keyboard
+resize preserve the selected tab and mounted session view. A keyboard opening is
+not treated as a device-class change. The bounded terminal-height behavior from
+`remote-dev-9rvt` remains intact on both sides of the 768-pixel transition.
+
+### 4.2 Truthful project state
+
+The Sessions empty state derives from actual tree data and selected scope:
+
+- `All projects` with any existing project is a valid project state.
+- No-project copy appears only when the canonical project collection is empty.
+- New project and New group are rendered as enabled only when a functional flow
+  is wired.
+- Opening a create flow does not close the picker until the next surface is known
+  to have opened.
+- Cancel restores the prior picker state; success selects the new node and makes
+  Start session available.
+
+M1 reuses the validated project/group mutations already owned by the desktop
+project-tree context. It does not create a second mobile-only data model.
+
+### 4.3 Descendant group scoping
+
+One pure project-tree selector resolves a group to every descendant project ID,
+including nested groups. Desktop and mobile use this selector for scope semantics.
+Sessions filter by that resolved set. Resolution failure produces an explicit
+error, never an `All sessions` fallback under a selected group label.
+
+The selector responds to live project/session moves without leaving stale rows.
+Tests use sibling groups with overlapping session names, nested and empty groups,
+root/All projects, and direct project selection so label-only assertions cannot
+mask a leaked result set.
+
+### 4.4 Safe smart-key activation
+
+The smart-key rail separates scrolling from activation:
+
+- Native button `click` is the single ordinary activation path for pointer,
+  keyboard, switch, and assistive technology.
+- A horizontal gesture that crosses the scroll threshold cancels key dispatch,
+  including when it began on a key.
+- Pointer cancellation and lost capture dispatch nothing.
+- Intentional key repeat begins only after a stationary hold threshold and stops
+  on movement, release, cancellation, blur, or visibility loss. The following
+  synthetic click is suppressed after a repeat sequence.
+- Latched modifiers expose `aria-pressed`; scrolling does not consume or toggle
+  them.
+- Every target is at least 44 by 44 CSS pixels.
+
+Control sequences such as Enter and Ctrl-C receive the same gesture protections
+as printable keys.
+
+## 5. M2: routing and external navigation
+
+### 5.1 Channel selection
+
+`/m/channel/[id]` consumes and validates its route parameter. The authenticated
+route performs a direct owner-scoped `GET /api/channels/:id` lookup before seeding
+the channel provider. It does not depend on `activeNode`, a saved channel list, or
+the prior provider selection. The returned channel supplies its project/scope to
+the embedded provider, which then renders only that channel. Missing and
+inaccessible IDs share one non-enumerating `Channel unavailable` state; transport
+failure is distinct and retryable. The route never silently selects `#general`.
+
+Flutter channel rows, deep links, and notification taps all pass the same typed
+channel destination. Sending, mark-read, thread takeover, and back behavior bind
+to that selected channel.
+
+### 5.2 Recording discovery and playback
+
+`View recordings` is a session-scoped discovery action, not playback. It opens a
+narrow `GET /api/recordings?sessionId=<id>` query. The authenticated server filters
+by both user ID and exact session ID and returns metadata-only `RecordingSummary`
+objects, never recording event data. The schema gains a `(userId, sessionId)`
+index. Client-side filtering of the all-recordings response is prohibited.
+
+Each list item carries an actual recording ID and
+navigates to `/m/recording/<recording-id>`. The playback route rejects a session ID
+or malformed recording ID explicitly. The PWA shell exposes the same discovery
+contract instead of hard-coding recordings unavailable.
+
+Zero, one, and multiple recording states are all first-class. Direct deep links to
+valid recording IDs continue to work.
+
+### 5.3 HTTPS links
+
+The deep-link router retains the HTTPS origin and base path while parsing the
+typed destination. Before navigation it:
+
+1. Validates scheme, host, normalized base path, and destination syntax.
+2. Resolves the locator to one saved workspace.
+3. Prompts for sign-in or a safe workspace choice when the match is absent or no
+   longer authenticated.
+4. Atomically selects/persists the workspace and invalidates providers tied to the
+   old connection.
+5. Waits for the new active connection, then pushes the destination route.
+
+Unknown or malicious origins never fall back to the currently active workspace.
+The navigation coordinator roots the destination under the selected workspace's
+home stack. Back returns to that workspace, not to a target or provider left from
+the formerly active workspace.
+
+### 5.4 Push taps
+
+Push registration sends the flat string fields `workspaceLocatorVersion`,
+`workspaceOrigin`, and `workspaceBasePath` alongside token, platform, and device
+ID. The server does not trust those fields as arbitrary client input. It derives
+the canonical public locator from `RDV_PUBLIC_URL` or from forwarded host/proto
+headers only when the immediate proxy is explicitly trusted, verifies the supplied
+locator matches, and stores the normalized result on the push-token row. Origins
+lowercase scheme/host, normalize IDNs and effective ports, remove default HTTPS
+port 443, and reject non-HTTPS production values. Base paths use the canonical
+Remote Dev base-path validator.
+
+The push-token schema/repository gains nullable locator version/origin/base-path
+columns. Notification FCM data uses only string values with those exact flat keys.
+Legacy rows and payloads without a locator remain valid but cannot be routed by
+guessing; re-registration backfills them. The same installation token may remain
+registered with multiple workspaces because each server persists its own bound
+locator.
+
+Flutter resolves the payload using the same path as HTTPS links before marking a
+notification read or navigating. Mark-read is sent through the newly selected
+workspace client only after the switch succeeds.
+
+Legacy payloads without a locator show a workspace picker or explanatory state.
+They do not guess the active workspace. Cold-start and warm-start taps share the
+same queued navigation coordinator so only the latest accepted destination is
+applied after authentication and workspace initialization.
+
+Tests cover spoofed supplied origins, untrusted forwarded headers, default-port
+normalization, path-prefixed siblings on one host, removed/signed-out workspaces,
+legacy registration/payloads, and real FCM string-only payload shapes.
+
+Tests use two workspaces with overlapping session, channel, recording, and
+notification fixture IDs to prove that routing does not accidentally pass against
+the active server.
+
+## 6. M3: connection and compatibility recovery
+
+One mobile connection model combines observable events from native HTTP, WebView
+document loading, terminal WebSocket/bridge state, authentication, network
+connectivity, and bridge protocol version.
+
+| State | Presentation | Actions |
+|---|---|---|
+| `connected` | Normal content. | None. |
+| `reconnecting` | Non-blocking status over preserved content. | Show details; allow wait. |
+| `offline` | Device has no network path. | Retry automatically and manually; switch workspace. |
+| `server_unreachable` | Network exists but the selected server/load failed. | Retry; edit or switch workspace. |
+| `authentication_required` | Credentials expired or were rejected. | Reauthenticate; switch workspace. |
+| `version_incompatible` | Native/bridge/server contract is unsupported. | Update action or supported web handoff. |
+| `session_ended` | Server is reachable but the requested session ended or is absent. | Back to sessions; open another session. |
+
+The implementation is one reducer owned above API providers and the WebView. A
+monotonic destination generation increments on workspace selection, destination
+change, and explicit Retry. Every event carries that generation plus workspace and
+destination identity; stale events are ignored.
+
+| Event family | Reducer effect |
+|---|---|
+| Connectivity online/offline | Records network availability; offline dominates transport/reconnect errors until online. |
+| WebView load start/success/HTTP error/load error | Tracks whether content ever loaded and whether the document can be retried in place. |
+| Native API success/401/403/transport failure | Separates authentication from reachability without trusting connectivity alone. |
+| Bridge hello/timeout | Validates the declared bridge version against native minimum and maximum supported versions. |
+| Terminal connecting/open/reconnecting/closed | Drives connected or non-blocking reconnect only after document and bridge are ready. |
+| Session lookup ended/missing | Produces `session_ended` only from a successful server response. |
+| Reauthenticate success / Retry / Switch workspace | Creates a new generation, clears only the relevant diagnosis, and starts the appropriate load. |
+
+State precedence is `version_incompatible`, `authentication_required`,
+`session_ended`, `offline`, `server_unreachable`, `reconnecting`, then `connected`.
+A higher-priority diagnosis is cleared only by its explicit successful transition,
+not by an unrelated late event.
+
+Offline and terminal reconnect preserve a previously loaded WebView. A document
+error before first load shows the blocking server screen while retaining the
+controller for Retry; a generation-changing workspace switch disposes the old
+WebView and all of its event subscriptions. Authentication blocks input, runs the
+existing reauth flow, then reloads under a new generation. Version incompatibility
+disables bridge commands and requires update/handoff; it never attempts commands
+outside the declared `[minBridgeVersion, maxBridgeVersion]` interval.
+
+Transient reconnect keeps terminal output and the WebView instance mounted. A
+route-level blocker may replace interaction but retains enough state for Retry.
+Status changes are announced without repeatedly interrupting screen-reader users.
+
+The existing `ReconnectingBanner`, `ServerUnreachableScreen`, and
+`VersionMismatchScreen` become reachable from production state transitions.
+WebView load and HTTP errors feed the model instead of logging only. The PWA
+disconnection message offers only interactions that exist; the unsupported
+`Pull down for details` instruction is removed unless M3 supplies that gesture.
+`offline` and `server_unreachable` retain structured causes so DNS failure, HTTP
+document failure, and generic reachability can be explained and tested separately
+without multiplying visually identical screens.
+
+## 7. M4: compact Flutter layout and text accessibility
+
+### 7.1 Device text is the baseline
+
+Flutter no longer replaces the operating system `TextScaler` with a fixed app
+value. Default appearance leaves the system scaler untouched, including nonlinear
+accessibility sizes above 130%.
+
+If the existing in-app UI-size preference remains, it becomes an explicit
+multiplier composed on the result of the system scaler. `System` is the default
+and reset value. No composition cap may reduce the OS result. Layouts adapt to
+large text instead of suppressing it globally.
+
+Terminal canvas font sizing remains a separate terminal preference and is not
+confused with application text accessibility.
+
+Large-text coverage spans auth, Edit Host, shell tabs, Notifications, session
+chrome, smart keys, Profile, and dialogs. Tests fail on clipped labels,
+off-screen actions, or `RenderFlex` diagnostics rather than accepting overflow as
+golden churn.
+
+### 7.2 Edit Host
+
+The Edit Host form uses a safe-area and keyboard-aware scroll view. Focus traversal
+follows form order, validation identifies and scrolls the first invalid field into
+view, and Save remains reachable without obscuring the final field. The original
+800 by 600 presentation tests remain at their original size and become green.
+Additional tests cover 568 by 320, keyboard insets, and large text.
+
+### 7.3 Notifications
+
+Notification filters use an adaptive secondary row that wraps or scrolls with a
+clear affordance. Bulk actions move into an overflow menu when title width is
+constrained. The design supports 320, 360, 375, and 430 logical pixels, long
+localized labels, and large text. Empty, unread, populated, and all-read states
+retain every applicable filter and action. Tests no longer widen the fixture to
+450 pixels to avoid overflow.
+
+## 8. M5: Flutter semantic appearance
+
+`AppearanceSettings` gains a persisted `ThemeMode` with System as the fresh-install
+default. `MaterialApp.router` receives semantic light and dark `ThemeData` peers
+and reacts to OS appearance changes while in System mode.
+
+Core screens use `ColorScheme`, text theme, and narrowly scoped theme extensions
+for status colors. Hard-coded Tokyo Night, white, and black application-chrome
+literals are removed from auth, workspace, shell, dialogs, errors, biometrics,
+Profile, and Settings. The terminal content may retain its deliberate Tokyo Night
+palette.
+
+Native status/navigation bars and keyboard-adjacent chrome follow the resolved
+mode. Embedded `/m/*` URLs receive the resolved light/dark mode through the exact
+`rdvAppearance=light|dark` query parameter. D6 owns the CSP-safe root bootstrap
+that validates and applies this parameter before first paint. Missing/invalid input
+uses the ordinary persisted/system web precedence.
+
+When a valid parameter is present, the embed mounts `AppearanceProvider` in a
+controlled mode: native is authoritative and later authenticated preference fetches
+cannot overwrite it. The provider owns semantic variables, browser
+`color-scheme`, and theme color from that one resolved mode. Native runtime changes
+call the versioned bridge command
+`setAppearance({ contractVersion: 1, mode: "light" | "dark" })`; unsupported
+contract versions fail into M3 compatibility recovery. This prevents
+native/WebView disagreement and dark flashes without letting arbitrary query
+values become CSS.
+
+Golden and widget tests cover System resolution, explicit Light/Dark persistence,
+runtime OS changes, contrast-sensitive status roles, and every core screen family.
+
+## 9. M6: truthful PWA Profile capabilities
+
+Production `StubBody` destinations are removed. A typed Profile capability
+registry owns label, description, availability, destination, and client parity.
+Rows render from that registry, so an absent handler cannot appear as an enabled
+generic navigation row.
+
+The first implementation delivers these PWA tasks directly through existing
+service contracts:
+
+- Account summary and account/session actions.
+- GitHub account list and supported connect/disconnect actions.
+- Project/group browsing and creation through the M1 project contract.
+- Mobile Settings and Appearance preferences.
+- Secrets listing and supported create/update/delete actions with existing
+  authorization and redaction rules.
+
+Agent Profiles and Trash are `unavailable` until their full mobile workflows
+exist. The Profile index states the limitation without rendering an enabled row or
+pushing a placeholder. A copied desktop URL may be offered as help text, but is not
+classified as a handoff because opening it on the same mobile client remounts the
+mobile shell.
+
+Ports and About remain real screens. Tests fail if a machine-registry entry marked
+`native` or `embedded` resolves to placeholder copy or a missing handler, if an
+`unavailable` entry renders enabled, or if the generated Dart fixture is stale.
+
+## 10. Group-specific acceptance
+
+| Group | Required proof |
+|---|---|
+| M1 | Navigation remains reachable across portrait, landscape, fold, and keyboard resize without terminal-height or remount regression; project copy matches data; create actions cover cancel/validation/success; live nested-group scope is exact with overlapping names; smart-key tap/drag/cancel/keyboard/repeat behavior is safe. |
+| M2 | Two-workspace end-to-end tests prove channel, recording, HTTPS link, push, mark-read, and Back paths retain both workspace and typed ID; thread-first Back behavior remains; invalid and foreign destinations fail safely. |
+| M3 | Production events reach every connection state; actions recover without killing the app; transient reconnect preserves terminal output; PWA copy is truthful. |
+| M4 | Original 11 Edit Host failures become green; realistic phone widths and large OS text produce no overflow, hidden action, or reduced accessibility scale. |
+| M5 | Fresh install follows OS; System/Light/Dark persists and updates; native bars and embedded routes agree; core chrome uses semantic colors in both modes. |
+| M6 | Every enabled Profile row completes its task; unavailable tasks are not enabled; no production placeholder copy remains; the machine-readable parity registry and both language consumers agree. |
+
+## 11. Bead-to-test traceability
+
+Every source Bead acceptance criterion remains normative. The detailed plan may
+add tests, but it cannot replace these minimum regression proofs with only the
+group summary above.
+
+| Bead | Design section | Minimum focused proof |
+|---|---|---|
+| `.8` | 4.2 | No projects; All Projects with data; active project/group; both create actions; cancel; validation failure; launch failure that keeps the sheet open; success/select/start. |
+| `.21` | 5.1 | Valid, malformed, changed, initially unloaded, unavailable, and cross-workspace channel IDs; active scope starts in another project; send/thread and thread-first Back use the requested channel. |
+| `.27` | 5.2 | Zero/multiple session summaries; metadata-only response; actual recording IDs reach playback; session ID is rejected; direct valid recording link works in Flutter and PWA. |
+| `.28` | 4.1 | 320x568, 568x320, 812x375, 932x430, and Pixel Fold transition; all four destinations; active tab/WebView identity and bounded terminal height survive rotation, unfold, and keyboard resize. |
+| `.29` | 7.2 | Original eleven 800x600 tests, 568x320, keyboard inset, focus traversal, scan/token/validation/final field, and no overflow diagnostics. |
+| `.30` | 7.1 | OS default and accessibility sizes above 130%; reset to System; composed multiplier; auth, form, tabs, notifications, session chrome, smart keys, Profile, and dialogs. |
+| `.31` | 7.3 | 320/360/375/430 widths; empty/unread/populated/all-read; all filters/actions by touch, keyboard, and screen reader; long labels and large text. |
+| `.32` | 4.4 | Tap exactly once; drag from every key; cancel/lost capture; Enter/Space; modifier pressed state; repeat lifecycle; 44x44 target geometry. |
+| `.33` | 4.3 | Nested/empty/root/direct scopes, sibling groups with duplicate session names, live project/session moves, and selected label/result agreement. |
+| `.34` | 3.1, 5.3, 5.4 | A/B both directions with overlapping IDs; HTTPS and FCM shapes; path siblings; removed/signed-out/malicious/legacy locators; cold/warm mark-read; correctly rooted Back. |
+| `.35` | 6 | Offline, DNS, HTTP load, auth expiry, terminal reconnect, ended session, and min/max bridge mismatch from production events; Retry/reauth/switch/update and cold-start recovery. |
+| `.36` | 8 | Fresh/System/Light/Dark persistence and runtime OS change; all core screen families, system bars, keyboard chrome, controlled embeds, no flash, contrast, and no Tokyo Night chrome literals. |
+| `.37` | 3.3, 9 | Account/GitHub/Projects/Settings/Secrets success plus empty/loading/error states; unavailable rows disabled; narrow/large-text Back behavior; no `StubBody` or follow-up copy; generated registry parity. |
+
+## 12. Verification matrix
+
+PWA changes run focused Vitest suites, root typecheck and lint, production build,
+and browser interaction checks at all named viewport transitions. Accessibility
+checks exercise keyboard and browser accessibility-tree output.
+
+Flutter changes run `flutter analyze`, focused domain/application/widget tests,
+the complete presentation suite, and platform builds available in the environment.
+M4 records the pre-change 11-failure baseline before editing. Device-only items
+such as keyboard insets, universal links, notification cold starts, system bars,
+and OS text/theme changes are verified on Android and iOS when runners are
+available; unavailable physical checks remain explicit in the draft pull request
+instead of being implied by widget tests.

--- a/docs/superpowers/specs/2026-08-03-supervisor-remediation-design.md
+++ b/docs/superpowers/specs/2026-08-03-supervisor-remediation-design.md
@@ -1,0 +1,492 @@
+# Supervisor UI and State Remediation - Design Spec
+
+**Date:** 2026-08-03
+**Status:** Draft pending written review
+**Groups:** S1-S3
+**Source audit:** `remote-dev-9vik.1-.5`
+
+## 1. Goals
+
+Supervisor must remain trustworthy when used as the control plane. This work makes
+its light/dark behavior deliberate, gives authenticated operators a complete
+account lifecycle, restores phone-width access and assistive-technology feedback,
+and stops presenting accepted desired state as observed cluster success.
+
+The three groups are stacked because they share protected-route chrome and the
+instance detail UI:
+
+1. S1 establishes semantic theme and authenticated shell boundaries.
+2. S2 makes those boundaries responsive and accessible and adds the shared async
+   feedback presentation.
+3. S3 adds the durable operation model and uses the prior feedback contract for
+   pending and failed reconciliation.
+
+## 2. Non-goals
+
+- Do not import the main Remote Dev application shell or its complete Settings
+  implementation into Supervisor.
+- Do not style Supervisor chrome with terminal palette literals.
+- Do not imply that local OIDC logout terminates Cloudflare Access unless an
+  upstream logout actually occurs.
+- Do not stream Kubernetes watch data to the browser in the first operation-model
+  change. Durable bounded polling is sufficient.
+- Do not let the browser become a second Kubernetes writer. The reconciler remains
+  the sole cluster mutation path.
+
+## 3. S1: semantic theme and authenticated account shell
+
+### 3.1 Theme resolution
+
+Supervisor remains visually standalone but uses semantic roles matching the main
+product: background, foreground, surface/card, muted, border/input, primary,
+destructive, status, and focus ring.
+
+The root theme contract is:
+
+- With no override, CSS media queries render the preferred system scheme before
+  hydration.
+- An explicit System/Light/Dark choice is available from the authenticated account
+  menu and the login surface. It persists locally under a Supervisor-specific key.
+- A minimal pre-hydration resolver applies an explicit override before paint. It
+  accepts only `system`, `light`, or `dark`; any other value is discarded.
+- The root declares matching `color-scheme`. Viewport `theme-color` values are
+  media-aware for System and updated for explicit modes.
+- Runtime OS changes update System mode without reload.
+
+The unconditional `class="dark"` is removed. The mobile-auth callback error page
+uses the same semantic variables, follows system/override mode, names the failure,
+and provides a safe recovery action. Tokyo Night hex literals are not used for
+Supervisor application chrome.
+
+The theme preference is intentionally browser-profile-wide, not operator-specific,
+so login and callback pages can honor it before identity exists. The bootstrap is
+a static CSP-compatible script with a hash or nonce supplied by the app; it does
+not require `unsafe-inline`. Computed-style tests cover contrast for status badges,
+focus rings, native controls, scrollbars, callback chrome, and browser theme color.
+
+### 3.2 Protected route group
+
+Dashboard, new instance, and instance detail move under a URL-transparent protected
+route group with one server-rendered authenticated layout. The layout resolves the
+current operator, applies no-store behavior to privileged output, and provides:
+
+- Product/home link.
+- Current email and role.
+- Theme selection.
+- Account/sign-out menu.
+- A compact slot that S2 can recompose at phone widths.
+
+Page-level owner and role authorization remains in place. The layout is not a
+substitute for API or resource authorization.
+
+Unauthenticated protected-layout requests use a server redirect to `/login`.
+Privileged HTML and action responses are dynamic and send private no-store cache
+semantics. Logout expires the Auth.js cookie, redirects through a server response,
+and forces route revalidation so browser Back cannot reveal cached privileged
+content.
+
+### 3.3 Logout semantics
+
+Native OIDC Sign out calls the existing Auth.js server action, invalidates the
+local session, and redirects to a fixed safe `/login?signedOut=1` destination.
+Back navigation cannot restore privileged server-rendered content from cache.
+
+Authentication modes are presented accurately:
+
+- OIDC only: `Sign out` ends the Supervisor session.
+- Cloudflare Access only: the menu offers `Sign out of organization SSO` only when
+  the application can construct the standard fixed logout path from the validated
+  configured Cloudflare team origin. Otherwise it explains that access is
+  controlled upstream and does not render a fake local action.
+- Dual mode: `End local Supervisor session` clears Auth.js but accurately warns
+  that Cloudflare Access can immediately identify the operator again. `Sign out of
+  organization SSO` performs the full upstream flow. The UI does not promise a
+  signed-out login state after only the local action.
+
+The upstream destination is assembled from validated
+`SUPERVISOR_CF_ACCESS_TEAM` configuration and a fixed logout path. Its safe return
+target is application-owned. An arbitrary origin or return URL cannot be supplied
+through a request query parameter.
+
+## 4. S2: responsive composition
+
+Supervisor layouts recompose at content breakpoints rather than shrinking the
+desktop grid.
+
+### 4.1 Protected header
+
+At phone widths, identity/role and account actions move into a full-width second
+row or compact menu. Nothing is positioned outside the viewport. Focus order
+follows visual order, and all coarse-pointer actions provide at least a 44 by 44
+target area. Desktop retains its current density.
+
+### 4.2 Dashboard and create form
+
+- Dashboard title, create action, identity, instance cards/rows, long URLs, and
+  status values wrap within their containers.
+- Create-form labels and actions stack at the smallest breakpoint.
+- The closed storage select shows a concise target name/kind; resiliency detail
+  remains in associated explanatory text rather than forcing a long option label
+  into the control.
+- Validation messages remain adjacent and programmatically associated.
+
+### 4.3 Instance detail
+
+- Header title, status, namespace, and base URL wrap or reflow.
+- Metadata becomes one column at the smallest width and preserves copyable full
+  identifiers.
+- Action input/button rows stack without hiding either element.
+- Storage, logs, and events own their local overflow.
+- Audit history uses compact labeled event cards on phones and the existing table
+  at desktop widths. The table, when shown, sits in a named local horizontal
+  scroller rather than clipping under `overflow-hidden`.
+
+The dashboard, new-instance, and detail routes have no document-level horizontal
+overflow at 320, 375, or 430 CSS pixels, including 200% text zoom. Layout is also
+checked at 1024 and 1440 pixels to protect desktop density.
+
+## 5. S2: accessibility and async feedback
+
+### 5.1 Shared feedback primitive
+
+A small `AsyncFeedback` presentation distinguishes:
+
+- Polite progress and accepted/success messages through `role="status"`.
+- Assertive failures through `role="alert"`.
+- Stable message identity so the same text is not announced repeatedly on poll.
+- Optional action controls such as Retry without moving focus from a recoverable
+  initiating control.
+
+Live-region elements remain mounted for the workflow lifetime and update atomic
+text content. Polling does not repeatedly mount/unmount a status node or announce
+an unchanged operation revision.
+
+The region being refreshed receives `aria-busy`; the entire page does not. A
+changing button label does not duplicate the live-region announcement.
+
+### 5.2 Form errors and focus
+
+Inputs receive persistent help and error IDs, `aria-invalid`, and
+`aria-describedby` or `aria-errormessage`. After a failed submit, focus moves only
+to the first invalid field or a route-level error summary when continued
+interaction is otherwise impossible. Network and server errors preserve form
+input and leave the submitting control available for retry.
+
+### 5.3 Logs, storage, and events
+
+The read-only log control has a stable name such as `Instance logs`, derived from
+its section heading. Loading and empty text are separate status content and never
+become the textbox name. Logs, storage, and events announce loading, completion,
+and failure while retaining predictable keyboard focus.
+
+S2 applies the pattern to create discovery/submission, lifecycle/spec actions,
+storage, logs, events, and inline validation. S3 later replaces the lifecycle
+accepted message with durable operation state without changing the accessibility
+contract.
+
+## 6. S3: desired, observed, and operation data model
+
+### 6.1 Instance fields
+
+The existing instance row keeps desired configuration and gains explicit observed
+fields:
+
+- `desiredStatus`: nullable steady-state target limited to `ready`, `suspended`,
+  or `deleted`.
+- `imageTag`: desired image, retained for API compatibility.
+- `storageRequest`: desired PVC request, retained for API compatibility.
+- `observedImageTag`: image confirmed on every ready target pod.
+- `observedStorageCapacity`: capacity confirmed on the live PVC.
+- `observedSpecReplicas`, `observedCurrentReplicas`, `observedUpdatedReplicas`, and
+  `observedReadyReplicas`: distinct StatefulSet replica observations.
+- `observedGeneration`, `observedCurrentRevision`, and `observedUpdateRevision`:
+  rollout identity from the live StatefulSet.
+- `observedReady`: readiness confirmed by the live readiness contract.
+- `observedAt`: timestamp of the last successful live observation.
+
+`instance.status` remains the observed lifecycle status and compatibility field.
+Request routes no longer advance it to the desired result. In particular, Resume
+does not write `ready`; it writes `desiredStatus=ready` and creates an operation.
+The reconciler moves `status` only after its live checks succeed.
+
+### 6.2 Durable operations
+
+An additive `instance_operation` table records each asynchronous intent:
+
+| Field | Purpose |
+|---|---|
+| `id` | Stable operation identifier returned by the API. |
+| `instanceId` | Cascading instance reference. |
+| `kind` | `suspend`, `resume`, `image_rollout`, `storage_resize`, or `terminate`. |
+| `domain` | `lifecycle`, `image`, or `storage` conflict domain. |
+| `status` | Stored state: `queued`, `applying`, `succeeded`, `failed`, or `superseded`. |
+| `revision` | Monotonic per-operation revision incremented on every durable update. |
+| `retryOfOperationId` | Immutable link to the prior attempt when Retry creates a new operation. |
+| `desiredValue` | Validated JSON snapshot of the requested target. |
+| `observedValue` | JSON snapshot captured on success or failure. |
+| `errorCode`, `errorMessage` | Sanitized durable failure data. |
+| `actorId`, `actorEmail` | Requesting operator audit identity. |
+| `leaseOwner`, `leaseEpoch`, `leaseExpiresAt` | Crash-recoverable controller claim and fencing epoch. |
+| `fenceInstalledAt` | Time every required external domain fence was installed. |
+| `createdAt`, `startedAt`, `lastObservedAt`, `lastProgressAt`, `completedAt` | Durable lifecycle timestamps. |
+
+The schema source remains `schema.def.ts`; generated SQLite and PostgreSQL schemas
+and migrations are updated together. Operation kinds and statuses are branded
+types with exhaustive transition tests.
+
+An `instance_operation_slot` table serializes active work without relying on
+partial indexes unsupported by the shared schema DSL. Its composite primary key is
+`(instanceId, domain)`, and it stores `operationId`, `version`, and `updatedAt`.
+Each instance owns lifecycle, image, and storage slots.
+
+The API claims a slot and inserts its operation in one transaction using an
+optimistic compare-and-swap update:
+
+```text
+UPDATE slot
+SET operationId = newId, version = version + 1
+WHERE instanceId = ? AND domain = ?
+  AND version = expectedVersion AND operationId IS NULL
+```
+
+Zero changed rows means a concurrent claimant won; the transaction rolls back and
+the API reloads the active operation. Completion clears a slot only where
+`operationId` still equals the completing operation. PostgreSQL retries
+serialization failures; SQLite uses the dialect's immediate write transaction.
+Tests run two concurrent writers against both dialects.
+
+One active operation per conflicting domain is therefore enforced as follows:
+
+- Suspend and resume conflict with each other.
+- Image rollout conflicts with another image rollout but not an independent
+  storage resize.
+- Storage resize conflicts with another resize.
+- Terminate atomically compare-and-swaps all three slots, marks the exact displaced
+  operations `superseded`, and rolls back the entire transaction if any slot
+  changed concurrently.
+
+An `instance_operation_request` ledger makes request idempotency independent from
+operation identity. It has a unique `(instanceId, idempotencyKey)`, canonical
+`requestHash`, immutable serialized response/status, and created/completed
+timestamps. A join table records the ordered operation IDs returned by that
+request. Ledger rows remain until the instance is purged.
+
+The request row, synchronous rename, slot claims, operations, join rows, and final
+response snapshot commit in one transaction. Reusing a key/hash returns that exact
+snapshot, including after a lost HTTP response; a different hash returns 409
+`IDEMPOTENCY_MISMATCH`. When a new key requests an equivalent active target, its
+own ledger row maps durably to the existing operation. A later retry of either key
+therefore cannot create a duplicate. A different conflicting target returns 409
+with the active operation and that response is also ledgered.
+
+### 6.3 API response
+
+Asynchronous endpoints return 202 with:
+
+```json
+{
+  "instance": {
+    "desired": {},
+    "observed": {}
+  },
+  "operations": [
+    {
+      "id": "...",
+      "kind": "...",
+      "status": "queued",
+      "revision": 1,
+      "url": "/api/instances/.../operations/...",
+      "createdAt": "..."
+    }
+  ]
+}
+```
+
+The client sends one required `Idempotency-Key` for the whole mutation. A
+multi-field PATCH may create or reuse independent image and storage operations;
+rename is applied synchronously in the same ledger transaction. The one request
+row records all ordered operation IDs and the rename result. Responses always use
+`operations[]`. A single-operation response sets `Location` to that operation; a
+multi-operation response sets it to the instance operation collection.
+
+`GET /api/instances/:id/operations/:operationId` returns one authorized operation.
+`GET /api/instances/:id/operations?cursor=...&limit=...` returns newest-first
+history with bounded cursor pagination. These endpoints and instance detail send
+`Cache-Control: private, no-store`. Authorization and owner scoping match the
+instance resource and return the same non-enumerating response for missing and
+foreign operation IDs.
+
+Rename remains a synchronous database-only update and returns normal success. It
+does not create a fake reconciliation operation.
+
+### 6.4 Reconciler ownership
+
+The reconciler claims a queued operation by compare-and-swapping its status and
+revision to `applying` with a bounded owner lease. After a crash, another controller
+may claim an expired lease only by matching the prior revision and lease expiry;
+it observes live state before issuing an idempotent mutation. Lease renewal updates
+`lastObservedAt`; `lastProgressAt` advances only when kind-specific cluster state
+actually changes.
+
+Slot version plus lease epoch form a fencing token. The controller must renew its
+lease and verify every occupied slot still points to its operation/fence immediately
+before each external mutation. Kubernetes helpers require that token: they install
+or test a per-domain fence annotation with a `metadata.resourceVersion`
+precondition, and updates/patches test both the current fence and resource version.
+Namespace deletion carries UID/resourceVersion preconditions. A controller does
+not enter `applying` presentation until the external fence is installed. After a
+takeover, completion, Retry supersession, or Terminate claim, an old worker fails
+the database renewal or Kubernetes precondition and exits without a blind write.
+
+On every tick it observes the live StatefulSet, pods, PVC, namespace, and readiness
+contract, then:
+
+- Confirms Resume only after replicas and readiness are healthy; until then the
+  instance remains `suspended` or displays `starting` as a derived presentation.
+- Confirms Suspend only after scale-to-zero is observed.
+- Confirms image rollout only when observed generation has caught up, current and
+  update revisions agree, updated/current/ready replicas all equal the desired
+  replica count, and every ready target pod reports the requested image identity.
+- For a suspended zero-replica instance, an updated StatefulSet template is labeled
+  `Configured for next start`, not observed success. The image operation remains
+  active until a later Resume produces ready pods with that image.
+- Confirms storage resize only when live PVC capacity meets or exceeds the desired
+  quantity.
+- Confirms termination only after the namespace is absent.
+
+Successful observation updates instance observed fields and the operation in one
+database transaction. A Kubernetes or validation failure records the latest
+observation and durable error. No-controller state remains `queued`; it is not
+converted to success or a generic fatal instance error.
+
+A `supervisor_controller_heartbeat` table stores each controller ID and last-seen
+time independently of operation progress. `Stalled` is a derived read state, not a
+stored operation status. The shared pure presentation function derives it from
+created/progress/observation/lease timestamps, fresh controller heartbeats, and a
+server-clock offset. It distinguishes controller offline, queue backlog, and
+cluster no-progress. A stalled active operation continues automatic convergence
+when a controller resumes. Explicit Retry atomically marks the old attempt
+`superseded` and creates one new operation with `retryOfOperationId`; operation
+history is immutable. A stored `failed` operation is terminal and its domain
+pauses until Retry, while desired divergence remains visible.
+
+All downstream writers and consumers use the operation service:
+
+- Label-gated automatic image rollout creates a system-authored idempotent image
+  operation instead of rewriting `imageTag` directly.
+- Idle reaping creates one system suspend operation and deduplicates concurrent
+  reaper passes.
+- `agent-dispatch.ts` requesting a suspended instance creates/reuses Resume and
+  returns explicit 202 `STARTING` plus the operation URL. It does not proxy into an
+  unready instance or retain an opaque request payload for later replay.
+- Delete/terminate and internal ready-route consumers read observed state and the
+  active lifecycle operation, not desired status.
+
+### 6.5 Derived display state and routing
+
+Operator UI derives presentation from observed status plus the newest active
+operation:
+
+- `Queued` and `Applying` appear next to the exact requested value.
+- Desired and observed image/storage are shown side by side while divergent.
+- `Starting` replaces Ready while Resume is active and readiness is false.
+- `Failed` or `Stalled` remains visible with time, reason, observed value, and a
+  permitted Retry action.
+- `Ready` is shown only when observed lifecycle and live readiness agree.
+
+The instance router uses observed readiness, not `desiredStatus` or an accepted
+Resume operation. A temporary 502/503 during Resume is represented as Starting,
+not advertised as successful availability.
+
+### 6.6 Client refresh
+
+After a 202, `InstanceActions` retains the user's submitted value, renders the
+returned operation immediately, and polls its resource with abortable exponential
+backoff while the page is visible. It disables only conflicting actions. Reload or
+a second browser reconstructs the same state from the server.
+
+Polling gates durable operation fields by their revision and gates heartbeat data
+by heartbeat timestamp. The client uses the shared pure presentation function and
+schedules a timer at the next derived-state boundary, so Queued becomes
+controller-offline/Stalled even when no database operation revision changes.
+Equal-revision responses may update server-clock offset and heartbeat but never
+replace durable fields. Switching to a newer operation aborts prior requests, so
+an older operation cannot overwrite current input. Polling slows after the normal
+convergence budget and then offers manual Refresh; durable and derived status
+remain visible. S2 live regions announce derived changes once as well as durable
+revisions.
+
+## 7. Migration and compatibility
+
+The database change is additive, but semantic activation uses a maintenance-window
+deployment because an already-running old binary cannot be forced to understand
+new desired/observed rules:
+
+1. Stop all old API and controller processes using a Recreate/scale-to-zero release
+   step. Mixed old/new writers are unsupported and blocked by deployment policy.
+2. Add desired/observed columns, operation/slot/request-ledger/join and controller-
+   heartbeat tables, and a singleton `supervisor_schema_contract` semantic-version
+   row for both dialects.
+3. Map legacy status to the narrower desired target: requested/provisioning/ready
+   to `ready`, suspended to `suspended`, terminating/deleted to `deleted`, and
+   error to null for explicit operator recovery. Keep current desired image/storage
+   fields and create no synthetic historical operations.
+4. Run one new-controller observe-only pass before opening API traffic. It records
+   live observations without mutating desired state. Rows it cannot inspect remain
+   `Verifying` and are not routed as Ready.
+5. Start the new controller and API only after both check the exact schema contract
+   version in `controller/index.ts` and `instrumentation.ts`.
+
+Future new binaries refuse older or newer semantic versions. The release procedure
+prevents old binaries from starting after activation. Rollback after activation is
+forward-only to a compatible binary or restores the pre-migration database backup;
+it never starts the old writer against the new contract or drops operation data.
+Tests exercise new-binary/old-schema refusal, observe-only activation, and the
+documented prohibition of mixed writer versions.
+
+## 8. Group-specific acceptance
+
+| Group | Required proof |
+|---|---|
+| S1 | Light/dark system preference works before hydration; explicit mode persists; callback uses semantic colors; every protected route exposes accurate identity and logout behavior in OIDC, CF Access, and dual modes. |
+| S2 | No route overflows at 320/375/430; controls remain reachable at large text; names, descriptions, live status, errors, busy states, and focus transitions are correct for every audited workflow. |
+| S3 | Accepted-but-not-applied, delayed success, failure, stall, controller offline, duplicate request, restart, and two-browser cases preserve distinct desired/observed/operation truth through API, controller, router, and UI. |
+
+## 9. Bead-to-test traceability
+
+Every source Bead acceptance criterion remains normative. These cases are the
+minimum proof carried into the detailed plans.
+
+| Bead | Design section | Minimum focused proof |
+|---|---|---|
+| `.1` | 4 | Dashboard/new/detail at 320/375/430 without document overflow; email/role/status/metadata/forms/actions/audit remain reachable; 44x44 coarse targets; long owner/URL/image/storage/event/audit data; 1024/1440 density; keyboard and 200% zoom. |
+| `.2` | 3.1 | Preferred light/dark before hydration; explicit System/Light/Dark persistence/runtime change; body/cards/text/borders/focus/status/native controls/scrollbars/theme color contrast; callback recovery; no Tokyo Night chrome or unconditional dark class. |
+| `.3` | 6, 7 | 202 queued/applying truth; desired/observed image/storage/readiness; delayed rollout revision and ready-pod proof; success/failure/fake-clock derived stall/retry/offline controller; lost-response/equivalent-key/mismatched idempotency ledger; two clients/controllers; restart/lease takeover with stale-worker fencing; router and dispatch never claim early Ready. |
+| `.4` | 5 | Create/lifecycle/rollout/resize/storage/logs/events progress/success/error; mounted polite/assertive regions without duplicates; scoped busy; field error association; stable `Instance logs` name in every state; focus after success/error/retry; browser AX assertions. |
+| `.5` | 3.2, 3.3 | Account control on every protected route; native OIDC cookie invalidation/safe redirect/Back; CF-only and dual-mode accurate labels/full upstream path; email/role at desktop/phone; keyboard/focus. |
+
+## 10. Verification matrix
+
+Supervisor groups run focused Vitest suites in `apps/supervisor`, root and
+Supervisor typechecks, changed-file lint, Supervisor production build, database
+schema generation/drift checks, and SQLite tests. S3 additionally requires an
+ephemeral PostgreSQL service in CI; migration, slot CAS, duplicate idempotency key,
+equivalent-target/lost-response ledger replay, terminate supersession, lease
+takeover, stale-worker Kubernetes fencing, and two-controller/two-request races
+must pass on both dialects. PostgreSQL coverage is not optional for S3.
+
+Automated browser verification covers dashboard, create, detail, login, and mobile
+callback under preferred light/dark before paint and explicit overrides. It checks
+native controls, theme color, computed contrast, OIDC/CF/dual logout and Back
+behavior, document overflow and target bounds at 320/375/430/1024/1440, 200% text
+zoom, keyboard focus, and browser accessibility-tree names/roles/descriptions.
+
+S3 additionally uses an injectable fake clock and Kubernetes gateway to prove
+operation transitions. Integration fixtures cover controller absence, delayed
+readiness, image rollout, PVC growth, scale down/up, terminate, retry, and process
+restart without contacting or mutating a live production cluster. Rollout proof
+asserts generation, current/update revision, spec/current/updated/ready replicas,
+and ready-pod image identity rather than template equality alone.
+Fake-clock UI tests advance Queued through controller-offline and Stalled without
+writing a new operation revision, then prove a fresh heartbeat/revision announces
+recovery exactly once.

--- a/docs/superpowers/specs/2026-08-03-ui-audit-remediation-program-design.md
+++ b/docs/superpowers/specs/2026-08-03-ui-audit-remediation-program-design.md
@@ -1,0 +1,248 @@
+# UI Audit Remediation Program - Design Spec
+
+**Date:** 2026-08-03
+**Status:** Draft pending written review
+**Owner:** btli
+**Source audit:** `remote-dev-9vik`
+**Delivery limit:** 18 implementation pull requests plus this design pull request
+
+## 1. Purpose
+
+The August 3 audit found 36 open UI and UX defects across the desktop web app,
+Electron, the mobile PWA, Flutter, and Supervisor. The visible central-terminal
+sizing regression is real, but it is not an isolated xterm defect: Settings can
+consume four simultaneous horizontal budgets, Electron zoom can select the wrong
+shell, and several neighboring surfaces have broken responsive, accessibility,
+feedback, navigation, identity, and state-model contracts.
+
+This program fixes the complete audited set without combining all surfaces into
+one unsafe change. Work is divided into 18 cohesive implementation groups. Every
+group gets its own Beads ownership, GitHub issue, isolated worktree, branch,
+verification evidence, and draft pull request. Pull requests remain unmerged.
+
+The audited duplicate `remote-dev-9vik.26` is excluded because its evidence was
+consolidated into `remote-dev-9vik.21`. The remaining 36 child bugs are all owned
+by exactly one implementation group below.
+
+## 2. Product principles
+
+The remediation must preserve the product direction in `PRODUCT.md` and
+`DESIGN.md`:
+
+- The desktop app stays keyboard-first and dense without becoming inaccessible.
+- Mobile layouts change structure when space changes; they do not merely shrink.
+- Light and dark are first-class semantic themes. Tokyo Night remains a terminal
+  palette, not default application chrome.
+- Touch targets are at least 44 by 44 CSS or logical pixels on coarse-pointer
+  surfaces.
+- Failure and pending states are explicit and actionable.
+- PWA and Flutter may use different presentation technology, but shared tasks
+  have the same names, identifiers, safety rules, and outcomes.
+- Existing terminal contents and session processes survive layout, zoom, theme,
+  and navigation changes whenever the user did not explicitly end them.
+
+## 3. Scope and pull request map
+
+### 3.1 Supervisor
+
+| Group | Beads | Branch | Outcome |
+|---|---|---|---|
+| S1 | `.2`, `.5` | `agent/ui-supervisor-theme-account` | Semantic system/light/dark Supervisor chrome and an authenticated account/sign-out control on every protected route. |
+| S2 | `.1`, `.4` | `agent/ui-supervisor-responsive-a11y` | Phone-safe Supervisor composition plus consistent names, live status, errors, busy state, and focus behavior. |
+| S3 | `.3` | `agent/ui-supervisor-observed-state` | Durable desired-versus-observed operations from API through controller and operator UI. |
+
+### 3.2 Electron, desktop, and Settings
+
+| Group | Beads | Branch | Outcome |
+|---|---|---|---|
+| E1 | `.6`, `.22` | `agent/ui-electron-startup-recovery` | Reachable first-run setup and a recoverable Electron server-start state machine. |
+| D1 | `.7`, `.18`, `.19` | `agent/ui-desktop-compact-sizing` | Scroll-safe New Session, width-safe Settings, and terminal-preserving Electron zoom behavior. |
+| D2 | `.9`, `.14`, `.15` | `agent/ui-desktop-control-affordances` | Named icon controls, working collapsed rails, and keyboard-visible row actions. |
+| D3 | `.16` | `agent/ui-desktop-async-feedback` | Shared user-visible error and retry feedback for audited high-value actions. |
+| D4 | `.10` | `agent/ui-desktop-tree-semantics` | Valid composite tree semantics and complete keyboard operation. |
+| D5 | `.11` | `agent/ui-desktop-shortcuts` | One platform-aware shortcut model for labels, handlers, and accessibility metadata. |
+| D6 | `.12`, `.13` | `agent/ui-desktop-theme-continuity` | Semantic theme continuity for AppShell-skipped routes and CodeMirror. |
+| D7 | `.17` | `agent/ui-tmux-instance-ownership` | Instance-safe tmux ownership and non-destructive cleanup. |
+| D8 | `.20`, `.23`, `.24`, `.25` | `agent/ui-settings-integrity` | Accessible Settings controls, controlled deep links, durable pending saves, and exactly-once SSH creation. |
+
+### 3.3 Mobile PWA and Flutter
+
+| Group | Beads | Branch | Outcome |
+|---|---|---|---|
+| M1 | `.8`, `.28`, `.32`, `.33` | `agent/ui-mobile-pwa-shell` | Truthful project/session flow, adaptive navigation, safe smart keys, and correct group scoping. |
+| M2 | `.21`, `.27`, `.34` | `agent/ui-mobile-routing-contracts` | Strict channel/recording identifiers and workspace-qualified links and push taps. |
+| M3 | `.35` | `agent/ui-mobile-recovery-states` | Reachable, distinct, actionable connection, authentication, and version recovery. |
+| M4 | `.29`, `.30`, `.31` | `agent/ui-flutter-compact-accessibility` | Compact-height forms, realistic narrow notification layouts, and OS-respecting text scale. |
+| M5 | `.36` | `agent/ui-flutter-semantic-theme` | Persisted System/Light/Dark Flutter theme using semantic color roles. |
+| M6 | `.37` | `agent/ui-mobile-profile-capabilities` | Truthful, tested PWA Profile destinations and a documented PWA/Flutter capability registry. |
+
+## 4. Dependency and publication model
+
+The work uses isolated worktrees under the ignored `.worktrees/` directory.
+Implementation branches are created from current `origin/master` unless a stack
+is listed below. At most three implementation agents run concurrently, leaving
+the primary agent available to coordinate reviews, resolve collisions, and
+publish.
+
+### 4.1 Stacks
+
+- Supervisor publishes S1, then S2 based on S1, then S3 based on S2. These groups
+  share authenticated chrome and instance-detail components.
+- Desktop publishes D1, then D2 based on D1. D3 and D4 branch from the reviewed
+  D2 tip. D5 also bases on D2; D6 bases on D5 because both change
+  `CodeMirrorEditor.tsx`. D8 bases on D3. E1 remains independent from master.
+- Before D7 branches, draft PR #450 is rebased onto current `origin/master`, its
+  `TmuxAttachArgumentResolver` and hyperlink tests pass, and its reviewed head is
+  recorded in the D7 plan. D7 bases on that exact head and does not overwrite its
+  tmux client-attach behavior.
+- The mobile publication chain is exact: D6 -> M1 -> M4 -> M5 -> M2. M3 and M6
+  then branch independently from the reviewed M2 tip. M4 may be developed in
+  parallel from master while M1 is underway, but it is rebased onto M1 before its
+  draft is published; the resulting stack contains no synthetic integration
+  merge. M5/M2/M3/M6 never publish from the temporary development base.
+- D1 owns `NewSessionWizard.tsx` and `NewSessionSheet.tsx`; M1 consumes those
+  reviewed changes and does not reopen them. D6 owns the root/embed appearance
+  bootstrap before M2 changes `/m/channel/[id]`, and M2 preserves that controlled
+  appearance contract.
+
+Logical dependencies do not authorize copying another branch's changes or hiding
+an integration merge. A dependent draft waits for its named base and records that
+base pull request in GitHub.
+
+### 4.2 Existing GitHub ownership
+
+- Existing issue #171 is rewritten as the grouped E1 issue because its setup
+  persistence evidence is stale. Any still-valid automatic-install/web-fallback
+  work outside `.6` and `.22` moves to a separately linked follow-up issue instead
+  of silently expanding E1.
+- Draft PR #450 owns tmux client attach capability in `src/server/terminal.ts`,
+  including `TmuxAttachArgumentResolver`, plus `tmux-hyperlinks.ts`. D7 stacks on
+  its freshly rebased reviewed head and limits its diff to ownership and cleanup
+  safety. Renderer link behavior remains reserved to #451.
+- Draft PR #451 owns `Terminal.tsx`, terminal link behavior, and the named terminal
+  refit/font-race tests. Other groups avoid those files unless a reviewed stack
+  dependency is explicitly established.
+- Unrelated open pull requests and all user-owned untracked files in the primary
+  checkout remain untouched.
+
+## 5. GitHub issue design
+
+One umbrella GitHub issue tracks the program and links the source audit, the four
+design documents, all implementation issues, and the dependency order. There are
+18 implementation issues: 17 new grouped issues plus existing #171 for E1.
+
+Each grouped issue contains:
+
+1. The owned Beads IDs and their priorities.
+2. A concise reproduction and user impact summary.
+3. The agreed architectural boundary and non-goals.
+4. Acceptance criteria copied without weakening the source findings.
+5. Required viewport, accessibility, failure, or state-transition matrices.
+6. Dependencies and known file reservations.
+7. A checklist for TDD, DRY review, simplifier review, final verification, and a
+   draft pull request.
+
+Issue titles use the group prefix, for example `[D1] Restore compact desktop
+sizing and terminal continuity`. Labels reuse repository labels where available;
+the program does not create decorative labels merely to mirror group names.
+
+The umbrella issue remains open while any implementation issue or draft pull
+request remains open. Implementation issues use `Fixes #<issue>` in their pull
+request descriptions so GitHub will close them only if a maintainer later merges
+the pull request. No issue is closed merely because a draft was opened.
+
+## 6. Agent and worktree protocol
+
+Every implementation group follows the same isolated protocol:
+
+1. Fetch `origin` and resolve the exact reviewed base commit.
+2. Create `.worktrees/<group-slug>` and its `agent/ui-*` branch.
+3. Install from the lockfile and record the baseline test result before edits.
+4. Mark the owned Beads issues `in_progress` and add the GitHub issue URL to their
+   notes. No agent claims an issue owned by another group.
+5. Read all scoped `AGENTS.md` files and the group implementation plan before
+   editing.
+6. Work only in the group's worktree. The primary checkout is never used as a
+   scratch area or publication branch.
+7. Push the branch and open a draft pull request. Never merge, squash, or close
+   another pull request.
+
+An implementation agent may request help but may not broaden its issue set. If a
+new defect is discovered, it is filed as follow-up work and linked to the umbrella
+issue; it is not silently folded into the current diff.
+
+## 7. Required development and review pipeline
+
+Every implementation pull request must show all of these gates in order.
+
+### 7.1 Test-driven change
+
+1. Add the smallest behavioral test that demonstrates the bug.
+2. Run it and record the expected failure, including why it proves the defect.
+3. Implement the minimum coherent fix.
+4. Re-run the focused test until green, then run the nearby suite.
+
+Tests must exercise behavior through public boundaries. Mock-only tests that
+assert the mock itself, production test hooks, arbitrary timing sleeps, or tests
+that delete real user state are prohibited.
+
+### 7.2 Independent passes
+
+After the implementer self-review, fresh agents perform these passes:
+
+- **Spec-compliance review:** verifies every owned Bead and every group acceptance
+  criterion is satisfied, with no unauthorized scope.
+- **DRY review:** identifies newly duplicated policy, formatting, state, validation,
+  request, theme, or layout logic. It requires reuse only where the shared concept
+  is genuinely stable; superficial similarity is not extracted.
+- **Simplifier review:** removes accidental indirection, state, branches, wrappers,
+  and comments while preserving the tested behavior. It may not weaken error,
+  accessibility, ownership, or durability semantics to reduce line count.
+- **Code-quality review:** checks correctness, race behavior, cleanup, naming,
+  accessibility, security, migrations, performance, and maintainability after the
+  prior fixes.
+
+The implementer addresses findings after each pass and reruns focused tests. The
+reviewing agent cannot approve its own implementation.
+
+### 7.3 Verification
+
+Each group runs focused tests plus the applicable typecheck, lint, build, and
+runtime checks from its detailed plan. Cross-surface groups verify both sides of
+their contract. Responsive checks use real target widths and heights rather than
+increasing the viewport until a test passes.
+
+The known Flutter baseline has 11 presentation failures centered on Edit Host.
+Only M4 may take ownership of those failures. M4 must first reproduce them, then
+make the original tests green without widening their fixture. Any different
+baseline failure is investigated before work proceeds.
+
+## 8. Pull request contract
+
+Every pull request is opened as a draft and includes:
+
+- Group name, GitHub issue, and Beads IDs.
+- Base branch or parent pull request and all logical dependencies.
+- User-visible before/after behavior.
+- Red test evidence and green verification commands with results.
+- Migration, rollback, accessibility, responsive, and cross-client notes where
+  applicable.
+- Separate checkboxes and reviewer summaries for spec, DRY, simplifier, and final
+  code-quality passes.
+- Screenshots or accessibility-tree evidence for visual changes, without adding
+  generated artifacts to the repository unless the test suite requires them.
+
+No pull request is marked ready for review until its review passes and verification
+are complete. No pull request is merged during this program session.
+
+## 9. Completion and handoff
+
+For this session, success means the design and implementation-plan documents are
+approved, grouped GitHub issues exist, each attempted group has a pushed branch
+and draft pull request, all verification evidence is attached, and unfinished
+work is accurately marked rather than implied complete.
+
+Beads issues remain `in_progress` while their fixes are only in unmerged drafts.
+They can be closed after maintainers merge and verify the changes on the target
+branch. The final handoff lists open drafts in dependency order, known failures,
+review results, and the exact next action for every blocked group.


### PR DESCRIPTION
## Summary

- records the approved 18-group remediation shape for all 36 open UI-audit findings under `remote-dev-9vik`
- defines exact dependency ancestry, worktree isolation, and grouped GitHub publication rules
- adds desktop/Electron, mobile, and Supervisor contracts with per-Bead traceability
- mandates TDD, specification review, DRY, simplifier, and code-quality passes; no PR is to be merged

## Scope

Documentation only. No product code was changed and no implementation issue status was changed.

## Verification

- `bun install --frozen-lockfile`
- `bun run test:run` — 308 files passed, 1 skipped; 3,218 tests passed, 8 skipped
- `git diff --check`
- coverage validation — 18 groups, 36 unique open Beads, duplicate `.26` excluded
- three parallel architecture reviews followed by blocker rechecks; no blocker/high-severity findings remain

## Review gate

This remains a draft pending explicit written-spec approval. Detailed implementation plans, grouped implementation issues, implementation worktrees, and code changes begin only after that approval.
